### PR TITLE
Threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,21 @@ There are three steps for uploading images to Wikimedia.
 - ingest-wikimedia download
 - ingest-wikimedia upload
 
-The first step when running ingests is to start the `wikimedia` ec2 instance
+## Starting up
+Start the `wikimedia` ec2 instance
 
-- log into AWS console
-- go to the ec2 panel
-- find stopped `wikimedia` instances
-- start the instance and SSH in
-  
+```shell
+> ec2-start wikimedia
+```
+
 Creates a new screen session with a name of `nwdh` and attach to that session. Use `-xS` to reattach after disconnecting.
 
 ```shell
-> screen -S nwdh 
+> screen -S nwdh
 > screen -xS nwdh
 ```
 
-[A quick cheat sheet](https://gist.github.com/jctosta/af918e1618682638aa82) for `screen` commands. 
+[A quick cheat sheet](https://gist.github.com/jctosta/af918e1618682638aa82) for `screen` commands.
 
 ## Running download
 
@@ -33,7 +33,7 @@ Running a download requires two pieces of information
 The most recent Wikimedia export from ingestion3 can be identified by using the AWS CLI.
 
 ```shell
-> aws s3 ls s3://dpla-master-dataset/il/wiki/                                                                                                             
+> aws s3 ls s3://dpla-master-dataset/il/wiki/
     PRE 20220719_182758-il-wiki.parquet/
     PRE 20221027_195109-il-wiki.parquet/
     PRE 20230130_201856-il-wiki.parquet/
@@ -46,24 +46,20 @@ We are going to download images from this set of eligible records identified dur
 
 The path to output would be (this is determined by *you* and does not need to confirm to any specific formatting but consistent naming is very useful)
 
-`s3://dpla-wikimedia/il/20230130/`
+`s3://dpla-wikimedia/il/images/`
 
 With these two pieces we are now ready to kick off the download within the previously activated screen session.
 
 ```shell
-> cd ~/ingest-wikimedia/ 
-> source venv-3.10/bin/activate 
-> poetry run python downloade-entry.py \
+> cd ~/ingest-wikimedia/
+> source venv-3.10/bin/activate
+> poetry run python run-download.py \
     --input s3://dpla-master-dataset/il/wiki/20230130_201856-il-wiki.parquet/ \
-    --output s3://dpla-wikimedia/il/20230130/ \
-    --batch_size 500000000000  \
-    --limit 5000000000000 \
+    --output s3://dpla-wikimedia/il/ \
     --partner il
 ```
 
-`--limit` is an optionsal parameter and if omitted it will download all assests. This parameter is useful if a provider has multiple terrabytes of images and you don't want to download all of them in a single session (e.g. NARA or Texas). 
-
-When a downloaded batch is completed then the upload for that batch can be executed.
+`--limit` is an optionsal parameter and if omitted it will download all assests. This parameter is useful if a provider has multiple terrabytes of images and you don't want to download all of them in a single session (e.g. NARA or Texas).
 
 ## Running upload
 
@@ -76,18 +72,24 @@ Starting a new screen session for the uploads is helpful if you uploading multip
 The invocation is very similar to the download
 
 ```shell
-> cd ~/ingest-wikimedia/; 
-> source venv-3.10/bin/activate; 
+> cd ~/ingest-wikimedia/;
+> source venv-3.10/bin/activate;
 > poetry run python upload-entry.py \
---input s3://dpla-wikimedia/il/20230130/batch_1/
+--input s3://dpla-wikimedia/il/
 --partner il
 ```
 
-## Logs 
-Log files are written out on the local file system in `./ingest-wikimedia/logs/` and on sucessful completetion written to the s3 location of the activity (ex )`s3://dpla-wikimedia/il/202309/batch_1/logs/`).
+## Logs
+
+Log files are written out on the local file system in `./ingest-wikimedia/logs/` and on sucessful completetion written to s3 `s3://dpla-wikimedia/il/logs/`).
 
 ## Closing out
-When all the downloads and uploads for the month have been completed go back to the ec2 console and **stop** the `wikimedia` instance.
+
+When all the downloads and uploads for the month have been completed stop the `wikimedia` instance.
+
+```shell
+> ec2-stop wikimedia
+```
 
 # Useful links
 

--- a/wikimedia/entries/download.py
+++ b/wikimedia/entries/download.py
@@ -112,7 +112,7 @@ class DownloadEntry():
         """
         """
         # Read data in
-        data_in = self.load_data(self.args.get('input_data'), self.args.get('file_filter', None))
+        data_in = self.load_data(self.args.get('input_data'), self.args.get('file_filter', None)).head(25)
         # Set the total number of DPLA items to be attempted
         self.downloader._tracker.set_dpla_count(len(data_in))
         # Full path to the output parquet file
@@ -142,7 +142,7 @@ class DownloadEntry():
 
     def process_rows(self, rows):
         iiif = IIIF()
-        urls = []
+        images = []
 
         dpla_id = rows.get('id')
         title = rows.get('title')
@@ -153,15 +153,15 @@ class DownloadEntry():
         # If the IIIF manfiest is defined that parse the manfiest to get the download urls
         # otherwise use the media_master url
         try:
-            urls = iiif.get_iiif_urls(manifest) if manifest else media_master
+            images = iiif.get_iiif_urls(manifest) if manifest else media_master
         except IIIFException as iffex:
             self.log.error(f"Error getting IIIF urls for \n{dpla_id} from {manifest}\n- {str(iffex)}")
             return images
 
         # TODO this will raise an exception if downloads fail. We should catch that and continue
         try:
-            self.log.info(f"https://dp.la/item/{dpla_id} has {len(urls)} assets")
-            images = self.get_images(urls, dpla_id)
+            self.log.info(f"https://dp.la/item/{dpla_id} has {len(images)} assets")
+            images = self.get_images(images, dpla_id)
             # update images with metadata applicable to all images
             images = self.update_metadata(images, title, wiki_markup)
         except DownloadException as de:

--- a/wikimedia/entries/download.py
+++ b/wikimedia/entries/download.py
@@ -11,7 +11,9 @@ from utilities.exceptions import DownloadException, IIIFException
 from utilities.format import sizeof_fmt
 from utilities.arguements import get_download_args
 
+import logging
 
+import pandas as pd
 class DownloadEntry():
     """
     Downloads Wikimedia eligible images from a DPLA partner
@@ -30,12 +32,13 @@ class DownloadEntry():
 
     downloader = None
     args = None
-    log = None
+    log = logging.getLogger(__name__)
 
-    def __init__(self, args, log):
+
+    def __init__(self, args, log=None):
         self.args = args
-        self.log = log
-        self.downloader = Downloader(logger=self.log)
+
+        self.downloader = Downloader(logger=logging.getLogger('wikimedia_logger'))
 
     def load_data(self, data_in, file_filter = None):
         """
@@ -50,7 +53,7 @@ class DownloadEntry():
                 exclude_ids = [line.rstrip() for line in f]
             return fs.read_parquet(data_in, cols=self.READ_COLUMNS).filter(lambda x: x.id in exclude_ids)
 
-        return fs.read_parquet(data_in, cols=self.READ_COLUMNS).head(20)
+        return fs.read_parquet(data_in, cols=self.READ_COLUMNS).head(40)
 
     def data_out_path(self, base, name):
         """
@@ -126,41 +129,131 @@ class DownloadEntry():
         self.log.info(f"Data out:        {data_out}")
         self.log.info(f"DPLA records:    {self.downloader._tracker.dpla_count}")
 
-        for row in data_in.itertuples(index=False):
-            dpla_id = row.id
-            title = row.title
-            wiki_markup = row.wiki_markup
-            manifest = row.iiif
-            media_master = row.media_master
+        # TODO thread around this around processing rows and not images within a row
+        # FIXME hardcoded for testing with 20 images
+        from concurrent.futures import ThreadPoolExecutor
+        import os
 
-            # If the IIIF manfiest is defined that parse the manfiest to get the download urls
-            # otherwise use the media_master url
-            try:
-                urls = iiif.get_iiif_urls(manifest) if manifest else media_master
-                self.log.info(f"https://dp.la/item/{dpla_id} has {len(urls)} assets")
-            except IIIFException as iffex:
-                self.log.error(f"Unable to get IIIF urls: {dpla_id} from {manifest}\n- {str(iffex)}")
-                continue
+        processors = os.cpu_count()
 
-            # TODO this will raise an exception if downloads fail. We should catch that and continue
-            try:
-                images = self.get_images(urls, dpla_id)
-                # update images with metadata applicable to all images
-                images = self.update_metadata(images, title, wiki_markup)
-            except DownloadException as de:
-                self.log.error(f"Failed download(s) for {dpla_id}\n - {str(de)}")
-                continue
+        df = data_in.to_dict('records')
+        batches = [df[i:i+processors] for i in range(0,len(df),processors)]
+        with ThreadPoolExecutor() as executor:
+            results = [executor.submit(self.process_rows, chunk) for chunk in df]
 
-            # Add all assets/rows for a given metadata record. len(images) check is necessary because
-            # we'd get [a,b,[]] extending with an empty list
-            if len(images) > 0:
-                image_rows.extend(images)
+        df_processed = [result.result() for result in results]
 
-            # If the total limit is set and we've exceeded it then stop processing
-            if 0 < self.args.get('total_limit', 0) < self.downloader._tracker.get_size():
-                break
+        ## SEE BELOW
+
+        ###
 
         self.log.info(f"Downloaded {self.downloader._tracker.success_count} images ({sizeof_fmt(self.downloader._tracker.get_size())})")
 
         # Write data out
+        fs = FileSystem()
         fs.write_parquet(path=data_out, data=image_rows, columns=self.WRITE_COLUMNS)
+
+    def process_rows(self, rows):
+        iiif = IIIF()
+
+        urls = []
+        # print(rows)
+        dpla_id = rows.get('id')
+        title = rows.get('title')
+        wiki_markup = rows.get('wiki_markup')
+        manifest = rows.get('iiif')
+        media_master = rows.get('media_master')
+        # If the IIIF manfiest is defined that parse the manfiest to get the download urls
+        # otherwise use the media_master url
+        try:
+            urls = iiif.get_iiif_urls(manifest) if manifest else media_master
+        except IIIFException as iffex:
+            self.log.error(f"Error getting IIIF urls for \n{dpla_id} from {manifest}\n- {str(iffex)}")
+            return images
+
+        # TODO this will raise an exception if downloads fail. We should catch that and continue
+        try:
+            self.log.info(f"https://dp.la/item/{dpla_id} has {len(urls)} assets")
+            images = self.get_images(urls, dpla_id)
+            # update images with metadata applicable to all images
+            images = self.update_metadata(images, title, wiki_markup)
+        except DownloadException as de:
+            raise DownloadException(f"Failed download(s) for {dpla_id}\n - {str(de)}")
+
+        # Add all assets/rows for a given metadata record. len(images) check is necessary because
+        # we'd get [a,b,[]] extending with an empty list
+        if len(images) > 0:
+            return images
+
+        return images
+
+
+
+
+
+###############
+################
+
+        # If the total limit is set and we've exceeded it then stop processing
+        # if 0 < self.args.get('total_limit', 0) < self.downloader._tracker.get_size():
+        #     return None
+
+
+
+
+
+        # print(result)
+
+        # tuples = data_in.itertuples(index=False)
+
+        # start = time.time()
+        # number_of_chunks = 4
+        # chunk_size = 5
+        # executor = ThreadPoolExecutor(max_workers=number_of_chunks)
+        # futures = []
+
+        # for i in range(number_of_chunks):
+        #     chunk = tuples[i*chunk_size:(i+1)*chunk_size]
+        #     futures.append(executor.submit(self.process_rows, chunk))
+
+        # for future in concurrent.futures.as_completed(futures):
+        #     pass
+        # print('Time:', time.time() - start)
+
+
+
+
+
+        # for row in data_in.itertuples(index=False):
+            # dpla_id = row.id
+            # title = row.title
+            # wiki_markup = row.wiki_markup
+            # manifest = row.iiif
+            # media_master = row.media_master
+
+            # If the IIIF manfiest is defined that parse the manfiest to get the download urls
+            # otherwise use the media_master url
+            # try:
+            #     urls = iiif.get_iiif_urls(manifest) if manifest else media_master
+            #     self.log.info(f"https://dp.la/item/{dpla_id} has {len(urls)} assets")
+            # except IIIFException as iffex:
+            #     self.log.error(f"Unable to get IIIF urls: {dpla_id} from {manifest}\n- {str(iffex)}")
+            #     continue
+
+            # # TODO this will raise an exception if downloads fail. We should catch that and continue
+            # try:
+            #     images = self.get_images(urls, dpla_id)
+            #     # update images with metadata applicable to all images
+            #     images = self.update_metadata(images, title, wiki_markup)
+            # except DownloadException as de:
+            #     self.log.error(f"Failed download(s) for {dpla_id}\n - {str(de)}")
+            #     continue
+
+            # # Add all assets/rows for a given metadata record. len(images) check is necessary because
+            # # we'd get [a,b,[]] extending with an empty list
+            # if len(images) > 0:
+            #     image_rows.extend(images)
+
+            # # If the total limit is set and we've exceeded it then stop processing
+            # if 0 < self.args.get('total_limit', 0) < self.downloader._tracker.get_size():
+            #     break

--- a/wikimedia/entries/download.py
+++ b/wikimedia/entries/download.py
@@ -24,6 +24,7 @@ class DownloadEntry():
                     "_5": "title"}
 
     TUPLE_INDEX = list(READ_COLUMNS.values())
+
     # Column names for the output parquet file
     WRITE_COLUMNS = ['dpla_id','path','size','title','markup','page']
 

--- a/wikimedia/entries/download.py
+++ b/wikimedia/entries/download.py
@@ -24,7 +24,6 @@ class DownloadEntry():
                     "_5": "title"}
 
     TUPLE_INDEX = list(READ_COLUMNS.values())
-
     # Column names for the output parquet file
     WRITE_COLUMNS = ['dpla_id','path','size','title','markup','page']
 

--- a/wikimedia/executors/downloader.py
+++ b/wikimedia/executors/downloader.py
@@ -22,9 +22,8 @@ class Downloader:
     # Column names for the output parquet file
     UPLOAD_PARQUET_COLUMNS = ['dpla_id', 'path', 'size', 'title', 'markup', 'page']
 
-    def __init__(self, logger = None):
+    def __init__(self):
         pass
-        # self.log = logging.getLogger('wikimedia_logger') if not logger else logger
 
     def get_status(self):
         """

--- a/wikimedia/executors/downloader.py
+++ b/wikimedia/executors/downloader.py
@@ -8,19 +8,23 @@ from utilities.fs import S3Helper
 from utilities.exceptions import DownloadException
 from trackers.tracker import Tracker
 
+from utilities.logger import WikimediaLogger
+import logging
+
 class Downloader:
     """
     Download images from parters
     """
-    log = None
+    log = logging.getLogger(__name__)
     _s3 = S3Helper()
     _tracker = Tracker()
 
     # Column names for the output parquet file
     UPLOAD_PARQUET_COLUMNS = ['dpla_id', 'path', 'size', 'title', 'markup', 'page']
 
-    def __init__(self, logger):
-        self.log = logger
+    def __init__(self, logger = None):
+        pass
+        # self.log = logging.getLogger('wikimedia_logger') if not logger else logger
 
     def get_status(self):
         """

--- a/wikimedia/run-download.py
+++ b/wikimedia/run-download.py
@@ -5,44 +5,40 @@ Downloads Wikimedia eligible images from a DPLA partner
 import sys
 import boto3
 
-from utilities.fs import S3Helper
+from utilities.fs import S3Helper, log_file
 from utilities.logger import WikimediaLogger
 from utilities.emailer import SesMailSender, SesDestination, DownloadSummary
 from utilities.arguements import get_download_args
 from entries.download import DownloadEntry
 
-import time
-import os
 import logging
 
 def main():
     args = get_download_args(sys.argv[1:])
 
-    timestamp = time.strftime("%Y%m%d-%H%M%S")
-    # FIX THIS
-    # I have now hard coded some really wonky shit together to get the s3 public access to log files work
-    # this probably has a lot of downstream consequences I don't know about yet and need to be patched up together.
-    # the filesytem path is relative to this project directory (.logs/*.log)
-    # the s3 log file path is bucket/name/logs/name-event_type-date.log
-    os.makedirs("./logs/", exist_ok=True)
-    log_file_name = f"{args.get('partner_name')}-download-{timestamp}.log"
-    log_file = f"./logs/{log_file_name}"
+    EMAIL_SOURCE = "tech@dp.la"
+    EMAMIL_REPLY = ["tech@dp.la"]
+    EMAIL_TO = ["scott@dp.la"]
 
-    log = logging
-    log.basicConfig(
-        level=logging.INFO,
-        datefmt='%H:%M:%S',
-        handlers=[logging.StreamHandler(),
-                  logging.FileHandler(log_file, mode="w")],
-        format= '[%(levelname)s] '
-                '%(asctime)s: '
-                '%(message)s'
-    )
     s3 = S3Helper()
     entry = DownloadEntry(args)
 
-    log.info("Starting download")
+    file = log_file(partner_name=args.get('partner_name'), event_type="download")
 
+    print(file)
+
+    # log_config = logging.basicConfig()
+
+    log = logging
+    log.basicConfig(level=logging.INFO,
+                    datefmt='%H:%M:%S',
+                    handlers=[logging.StreamHandler(),
+                              logging.FileHandler(filename=file, mode="w")],
+                              format='[%(levelname)s] '
+                              '%(asctime)s: '
+                              '%(message)s')
+
+    log.info("Starting download")
     # kick off the download
     entry.execute()
 
@@ -51,8 +47,7 @@ def main():
 
     # Save the log file to S3
     bucket, key = s3.get_bucket_key(args.get('output_base'))
-    log_file_key = f"{key}/logs/{log_file_name}"
-    public_url = s3.write_log_s3(bucket=bucket, key=log_file_key, file=log_file)
+    public_url = s3.write_log_s3(bucket=bucket, key=key, file=file)
 
     # Statement does not write to file but useful in the console
     log.info(f"Log file saved to {public_url}")
@@ -65,12 +60,13 @@ def main():
     # Send email notification
     ses_client = boto3.client('ses', region_name='us-east-1')
     emailer = SesMailSender(ses_client)
-    emailer.send_email(source="tech@dp.la",
-                    destination=SesDestination(tos=["scott@dp.la"]),  # FIXME dominic@dp.la should be here. Who else?
-                    subject=summary.subject(),
-                    text=summary.body_text(),
-                    html=summary.body_html(),
-                    reply_tos=["tech@dp.la"])
+    emailer.send_email(source=EMAIL_SOURCE,
+                       destination=SesDestination(tos=EMAIL_TO),
+                       reply_tos=EMAMIL_REPLY,
+                       subject=summary.subject(),
+                       text=summary.body_text(),
+                       html=summary.body_html()
+                    )
 
 
 if __name__ == "__main__":

--- a/wikimedia/run-download.py
+++ b/wikimedia/run-download.py
@@ -11,13 +11,18 @@ from utilities.emailer import SesMailSender, SesDestination, DownloadSummary
 from utilities.arguements import get_download_args
 from entries.download import DownloadEntry
 
+import os
+import logging
 
 def main():
     args = get_download_args(sys.argv[1:])
 
     s3 = S3Helper()
-    log = WikimediaLogger(partner_name=args.get('partner_name'), event_type="download")
-    entry = DownloadEntry(args, log)
+    # log = WikimediaLogger(partner_name=args.get('partner_name'), event_type="download")
+
+    entry = DownloadEntry(args)
+
+    log.info("Starting download")
 
     # kick off the download
     entry.execute()
@@ -27,7 +32,11 @@ def main():
 
     # Save the log file to S3
     bucket, key = s3.get_bucket_key(args.get('output_base'))
-    public_url = log.write_log_s3(bucket=bucket, key=key)
+    log_file_key = f"{key}/logs/{_log_file}"
+
+    public_url = s3.write_log_s3(bucket=bucket, key=log_file_key, file=log_file)
+
+    # public_url = log.write_log_s3(bucket=bucket, key=key)
 
     # Statement does not write to file but useful in the console
     log.info(f"Log file saved to {public_url}")
@@ -49,4 +58,25 @@ def main():
 
 
 if __name__ == "__main__":
+    import time
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    # FIX THIS
+    # I have now hard coded some really wonky shit together to get the s3 public access to log files work
+    # this probably has a lot of downstream consequences I don't know about yet and need to be patched up together.
+    # the filesytem path is relative to this project directory (.logs/*.log)
+    # the s3 log file path is bucket/name/logs/name-event_type-date.log
+    _log_file = f"{timestamp}.log"
+    os.makedirs("./logs/", exist_ok=True)
+    log_file = f"./logs/{_log_file}"
+
+    log = logging
+    log.basicConfig(
+        level=logging.INFO,
+        datefmt='%H:%M:%S',
+        handlers=[logging.StreamHandler(),
+                  logging.FileHandler(log_file, mode="w")],
+        format= '[%(levelname)s] '
+                '%(asctime)s: '
+                '%(message)s'
+    )
     main()

--- a/wikimedia/run-download.py
+++ b/wikimedia/run-download.py
@@ -11,15 +11,34 @@ from utilities.emailer import SesMailSender, SesDestination, DownloadSummary
 from utilities.arguements import get_download_args
 from entries.download import DownloadEntry
 
+import time
 import os
 import logging
 
 def main():
     args = get_download_args(sys.argv[1:])
 
-    s3 = S3Helper()
-    # log = WikimediaLogger(partner_name=args.get('partner_name'), event_type="download")
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    # FIX THIS
+    # I have now hard coded some really wonky shit together to get the s3 public access to log files work
+    # this probably has a lot of downstream consequences I don't know about yet and need to be patched up together.
+    # the filesytem path is relative to this project directory (.logs/*.log)
+    # the s3 log file path is bucket/name/logs/name-event_type-date.log
+    os.makedirs("./logs/", exist_ok=True)
+    log_file_name = f"{args.get('partner_name')}-download-{timestamp}.log"
+    log_file = f"./logs/{log_file_name}"
 
+    log = logging
+    log.basicConfig(
+        level=logging.INFO,
+        datefmt='%H:%M:%S',
+        handlers=[logging.StreamHandler(),
+                  logging.FileHandler(log_file, mode="w")],
+        format= '[%(levelname)s] '
+                '%(asctime)s: '
+                '%(message)s'
+    )
+    s3 = S3Helper()
     entry = DownloadEntry(args)
 
     log.info("Starting download")
@@ -32,11 +51,8 @@ def main():
 
     # Save the log file to S3
     bucket, key = s3.get_bucket_key(args.get('output_base'))
-    log_file_key = f"{key}/logs/{_log_file}"
-
+    log_file_key = f"{key}/logs/{log_file_name}"
     public_url = s3.write_log_s3(bucket=bucket, key=log_file_key, file=log_file)
-
-    # public_url = log.write_log_s3(bucket=bucket, key=key)
 
     # Statement does not write to file but useful in the console
     log.info(f"Log file saved to {public_url}")
@@ -58,25 +74,4 @@ def main():
 
 
 if __name__ == "__main__":
-    import time
-    timestamp = time.strftime("%Y%m%d-%H%M%S")
-    # FIX THIS
-    # I have now hard coded some really wonky shit together to get the s3 public access to log files work
-    # this probably has a lot of downstream consequences I don't know about yet and need to be patched up together.
-    # the filesytem path is relative to this project directory (.logs/*.log)
-    # the s3 log file path is bucket/name/logs/name-event_type-date.log
-    _log_file = f"{timestamp}.log"
-    os.makedirs("./logs/", exist_ok=True)
-    log_file = f"./logs/{_log_file}"
-
-    log = logging
-    log.basicConfig(
-        level=logging.INFO,
-        datefmt='%H:%M:%S',
-        handlers=[logging.StreamHandler(),
-                  logging.FileHandler(log_file, mode="w")],
-        format= '[%(levelname)s] '
-                '%(asctime)s: '
-                '%(message)s'
-    )
     main()

--- a/wikimedia/utilities/arguements.py
+++ b/wikimedia/utilities/arguements.py
@@ -52,3 +52,7 @@ def get_download_args(args):
             params["file_filter"] = arg
 
     return params
+
+
+
+# TODO add upload param to this

--- a/wikimedia/utilities/arguements.py
+++ b/wikimedia/utilities/arguements.py
@@ -9,10 +9,10 @@ def get_download_args(args):
         opts, args = getopt.getopt(args,
                                 "hi:u:o:",
                                 ["partner=",
-                                    "limit=",
-                                    "input=",
-                                    "output=",
-                                    "file_filter="])
+                                 "limit=",
+                                 "input=",
+                                 "output=",
+                                 "file_filter="])
     except getopt.GetoptError:
         print(
             "downloader.py\n" \
@@ -30,27 +30,21 @@ def get_download_args(args):
                 "downloader.py\n" \
                     "--partner <dpla partner name>\n" \
                     "--limit <total limit in bytes>\n" \
-                    "--input <path to wikimedia parquet file>\n" \
+                    "--input <ingestion3 wiki ouput>\n" \
                     "--output <path to save files>\n" \
                     "--file_filter <file that specifies DPLA ids to download>"
                     )
             sys.exit()
         elif opt in ("-p", "--partner"):
-            # self.partner_name = arg
             params["partner_name"] = arg
         elif opt in ("-l", "--limit"):
-            # self.total_limit = int(arg)
             params["total_limit"] = int(arg)
         elif opt in ("-i", "--input"):
-            # self.input_data = arg
             params["input_data"] = arg
         elif opt in ("-o", "--output"):
-            # self.output_base = arg.rstrip('/')
             params["output_base"] = arg.rstrip('/')
         elif opt in ("-f", "--file_filter"):
-            # self.file_filter = arg
             params["file_filter"] = arg
-
     return params
 
 

--- a/wikimedia/utilities/fs.py
+++ b/wikimedia/utilities/fs.py
@@ -38,9 +38,9 @@ class S3Helper:
 
     # Remove retry handler for s3, this is to prevent the botocore retry
     # handler from retrying. Taken from https://tinyurl.com/jd27xjz4
-    deq = s3_client.meta.events._emitter._handlers.prefix_search("needs-retry.s3")
-    while len(deq) > 0:
-        s3_client.meta.events.unregister("needs-retry.s3", handler=deq.pop())
+    # deq = s3_client.meta.events._emitter._handlers.prefix_search("needs-retry.s3")
+    # while len(deq) > 0:
+    #     s3_client.meta.events.unregister("needs-retry.s3", handler=deq.pop())
 
     def __init__(self):
         pass

--- a/wikimedia/utilities/fs.py
+++ b/wikimedia/utilities/fs.py
@@ -4,7 +4,7 @@ Filesystem utilities
 __author__ = "DPLA"
 __version__ = "0.0.1"
 __license__ = "MIT"
-
+import os
 from time import strftime
 from pathlib import Path
 from urllib.parse import urlparse
@@ -28,6 +28,13 @@ def get_datetime_prefix():
     time = strftime("%H%M%S")
     return f"{date}_{time}"
 
+def log_file(partner_name, event_type, log_dir="./logs"):
+    """
+    """
+    os.makedirs("./logs", exist_ok=True)
+    log_file_name = f"{partner_name}-{event_type}-{get_datetime_prefix()}.log"
+    return f"{log_dir}/{log_file_name}"
+
 class S3Helper:
     """
     """
@@ -35,12 +42,6 @@ class S3Helper:
     s3_resource = boto3.resource('s3')
     # Used for head operation in file_exists and upload_fileobj in upload
     s3_client = boto3.client(service_name='s3', config=Config(signature_version='s3v4', max_pool_connections=25, retries={'max_attempts': 3}))
-
-    # Remove retry handler for s3, this is to prevent the botocore retry
-    # handler from retrying. Taken from https://tinyurl.com/jd27xjz4
-    # deq = s3_client.meta.events._emitter._handlers.prefix_search("needs-retry.s3")
-    # while len(deq) > 0:
-    #     s3_client.meta.events.unregister("needs-retry.s3", handler=deq.pop())
 
     def __init__(self):
         pass
@@ -53,8 +54,8 @@ class S3Helper:
         :param extra_args: Extra arguments to pass to s3 upload_fileobj
         :return: The URL of the uploaded log file
         """
-        s3_log_key = f"{key}"
-
+        s3_name = Path(file).name
+        log_key = f"{key}/logs/{s3_name}"
         # Default extra_args for log files are text/plain and public read.
         # These can be overridden by passing in extra_args
         default_args = {"ACL": "public-read", "ContentType": "text/plain"}
@@ -64,11 +65,11 @@ class S3Helper:
         with open(file, "rb") as file:
             self.upload(file=file,
                             bucket=bucket,
-                            key=key,
+                            key=log_key,
                             extra_args=default_args)
 
         # The publicly accessible S3 url for the log file
-        return f"https://{bucket}.s3.amazonaws.com/{key}"
+        return f"https://{bucket}.s3.amazonaws.com/{log_key}"
 
     def file_exists(self, bucket, key):
         """

--- a/wikimedia/utilities/iiif.py
+++ b/wikimedia/utilities/iiif.py
@@ -11,6 +11,9 @@ import validators
 
 from utilities.exceptions import IIIFException
 
+headers = {'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36'
+          }
 class IIIF:
     """
     """
@@ -58,9 +61,10 @@ class IIIF:
         :return: JSON object
         """
         if not validators.url(url):
+            print(url)
             raise IIIFException(f"Invalid url {url}")
         try:
-            request = requests.get(url, timeout=30)
+            request = requests.get(url, timeout=30, headers=headers)
             if request.status_code not in [200, 301, 302]:
                 raise IIIFException(f"Unable to request: {url} - Status code {request.status_code}")
             data = request.content

--- a/wikimedia/utilities/iiif.py
+++ b/wikimedia/utilities/iiif.py
@@ -61,7 +61,6 @@ class IIIF:
         :return: JSON object
         """
         if not validators.url(url):
-            print(url)
             raise IIIFException(f"Invalid url {url}")
         try:
             request = requests.get(url, timeout=30, headers=headers)

--- a/wikimedia/utilities/logger.py
+++ b/wikimedia/utilities/logger.py
@@ -63,7 +63,9 @@ class WikimediaLogger(logging.Logger):
         :return: The URL of the uploaded log file
         """
         s3_log_key = f"{key}/logs/{self._log_file}"
-        # default extra_args for log files are text/plain and public read. These can be overridden by passing in extra_args
+
+        # Default extra_args for log files are text/plain and public read.
+        # These can be overridden by passing in extra_args
         default_args = {"ACL": "public-read", "ContentType": "text/plain"}
         if extra_args:
             default_args.update(extra_args)
@@ -73,5 +75,6 @@ class WikimediaLogger(logging.Logger):
                                     bucket=bucket,
                                     key=s3_log_key,
                                     extra_args=default_args)
+
         # The publicly accessible S3 url for the log file
         return f"https://{bucket}.s3.amazonaws.com/{s3_log_key}"


### PR DESCRIPTION
Implement threading for the downloader. The processing of DPLA objects is what is threaded, not the downloading, so a multi-page object will work on a single thread.

This also reimplements the logging (but only on the Download side) and uses the better approach of calling `logging.__getLogger(__name__)` in child modules rather than passing a logger into the class. This also moves `write_log_s3` out of `WikimediaLogger` and into the `S3Helper` class. `WikimediaLogger` will eventually be completely removed. 

Minor changes
- Add a fake User-Agent to the download requests (we might have been getting throttled) 
- Simplify var names 