### PR TITLE
IIIF v3 manifest support

### DIFF
--- a/wikimedia/executors/downloader.py
+++ b/wikimedia/executors/downloader.py
@@ -56,9 +56,10 @@ class Downloader:
             destination, size = self._save_to_s3(source=source, bucket=bucket, key=key)
             self.tracker.increment(Result.DOWNLOADED, size=size)
             return destination, size
-        except Exception as exec:
+        except Exception as err:
             self.tracker.increment(Result.FAILED)
-            raise exec  # DownloadException(f"Failed download {source} - {str(exec)}") from exec
+            raise err
+            # DownloadException(f"Failed download {source} - {str(exec)}") from exec
 
     # TODO This maybe better in the FileSystem class
     def save_to_local(self, source, file):
@@ -84,8 +85,6 @@ class Downloader:
                     raise DownloadException(
                         f"Invalid content-type: {response.headers['content-type']}"
                     )
-            # if response.headers['content-type'] in invalid_types:
-            #     raise DownloadException(f"Invalid content-type: {response.headers['content-type']}")
             with open(file, "wb") as f:
                 f.write(response.content)
             file_size = os.path.getsize(file)

--- a/wikimedia/utilities/iiif.py
+++ b/wikimedia/utilities/iiif.py
@@ -46,7 +46,8 @@ class IIIF:
         for item in iiif.get("items", []):
             try:
                 url = item["items"][0]["items"][0].get("body", {}).get("id", None)
-                # This is a hack to get around that v3 presumes the user supplies the resolution in the URL
+                # This is a hack to get around that v3 presumes the user supplies the
+                # resolution in the URL
                 if url:
                     # This condition may not be necessary but I'm leaving it in for now
                     if url.endswith("default.jpg"):

--- a/wikimedia/utilities/iiif.py
+++ b/wikimedia/utilities/iiif.py
@@ -52,7 +52,7 @@ class IIIF:
                     if url.endswith("default.jpg"):
                         urls.append(url)
                     else:
-                        urls.append(f"${url}{resolution}")
+                        urls.append(f"{url}{resolution}")
             except (IndexError, TypeError, KeyError):
                 return []
         return urls

--- a/wikimedia/utilities/iiif.py
+++ b/wikimedia/utilities/iiif.py
@@ -47,9 +47,14 @@ class IIIF:
         urls = []
         for item in iiif.get("items", []):
             try:
-                urls = item["items"][0]["items"][0].get("body", {}).get("id", None)
+                url = item["items"][0]["items"][0].get("body", {}).get("id", None)
+                (
+                    urls.append(url)
+                    if url.endswith("default.jpg")
+                    else urls.append(url + "/full/full/0/default.jpg")
+                )
             except (IndexError, TypeError, KeyError):
-                pass
+                return []
         return urls
 
     def get_iiif_urls(self, iiif):
@@ -86,10 +91,7 @@ class IIIF:
         try:
             request = requests.get(url, timeout=30, headers=self.HEADERS)
             if request.status_code not in [200, 301, 302]:
-                raise IIIFException(
-                    f"Unable to request: {url} - \
-                                    Status code {request.status_code}"
-                )
+                raise IIIFException(f"HTTP Error {request.status_code}")
             data = request.content
             return json.loads(data)
         except json.decoder.JSONDecodeError as jdex:
@@ -98,4 +100,4 @@ class IIIF:
                                 {str(jdex)}"
             ) from jdex
         except requests.exceptions.RequestException as re:
-            raise IIIFException(f"Unable to request: {url} - {str(re)}") from re
+            raise IIIFException(f"{str(re)}") from re

--- a/wikimedia/utilities/iiif.py
+++ b/wikimedia/utilities/iiif.py
@@ -25,12 +25,12 @@ class IIIF:
     def iiif_v2_urls(self, iiif):
         """
         Extracts image URLs from IIIF manfiest and returns them as a list
-        # TODO
         """
         urls = []
         sequences = iiif.get("sequences", [])
         sequence = sequences[0:1] if len(sequences) == 1 else None
         canvases = sequence[0].get("canvases", []) if sequence else []
+
         for canvase in canvases:
             for image in canvase.get("images", []):
                 url = image.get("resource", {}).get("@id", None)
@@ -39,20 +39,20 @@ class IIIF:
         return urls
 
     def iiif__v3_urls(self, iiif):
-        """
-        Needs to be implemented for Georgia uploads to Wikimedia Commons
-        To be done by October 2023
-        """
+        """ """
         # items[0] \ items[x] \ items[0] \ body \ id
+        resolution = "/full/full/0/default.jpg"
         urls = []
         for item in iiif.get("items", []):
             try:
                 url = item["items"][0]["items"][0].get("body", {}).get("id", None)
-                (
-                    urls.append(url)
-                    if url.endswith("default.jpg")
-                    else urls.append(url + "/full/full/0/default.jpg")
-                )
+                # This is a hack to get around that v3 presumes the user supplies the resolution in the URL
+                if url:
+                    # This condition may not be necessary but I'm leaving it in for now
+                    if url.endswith("default.jpg"):
+                        urls.append(url)
+                    else:
+                        urls.append(f"${url}{resolution}")
             except (IndexError, TypeError, KeyError):
                 return []
         return urls
@@ -80,7 +80,7 @@ class IIIF:
         ):
             return self.iiif_v2_urls(manifest)
         else:
-            raise IIIFException(f"Unknown IIIF version: {iiif}")
+            raise IIIFException("Unknown IIIF version")
 
     def _get_iiif_manifest(self, url):
         """
@@ -89,15 +89,16 @@ class IIIF:
         if not validators.url(url):
             raise IIIFException(f"Invalid url {url}")
         try:
-            request = requests.get(url, timeout=30, headers=self.HEADERS)
+            request = requests.get(
+                url, timeout=30, allow_redirects=True, headers=self.HEADERS
+            )
             if request.status_code not in [200, 301, 302]:
-                raise IIIFException(f"HTTP Error {request.status_code}")
+                raise IIIFException(f"Invalid response code: {request.status_code}")
             data = request.content
             return json.loads(data)
         except json.decoder.JSONDecodeError as jdex:
-            raise IIIFException(
-                f"Unable to decode JSON: {url} - \
-                                {str(jdex)}"
-            ) from jdex
+            raise IIIFException(f"Unable to decode JSON: {url} - {str(jdex)}") from jdex
         except requests.exceptions.RequestException as re:
             raise IIIFException(f"{str(re)}") from re
+        except Exception as ex:
+            raise Exception(f"Unknown error: {str(ex)}") from ex


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit affb326117617762f3dbf74f45c53514fdf7fade  | 
|--------|--------|

### Summary:
Added support for IIIF v3 manifests and improved error handling in the downloader.

**Key points**:
- Added `iiif__v3_urls` method in `wikimedia/utilities/iiif.py` to extract image URLs from IIIF v3 manifests.
- Updated `get_iiif_urls` method in `wikimedia/utilities/iiif.py` to support both IIIF v2 and v3 manifests.
- Improved error handling in `download` and `save_to_local` methods in `wikimedia/executors/downloader.py`.
- Added checks for invalid content types in `save_to_local` method in `wikimedia/executors/downloader.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->