### PR TITLE
Refactored temp dir handling

### DIFF
--- a/common.py
+++ b/common.py
@@ -262,7 +262,7 @@ def s3_file_exists(path: str, s3: S3ServiceResource):
 
 def setup_temp_dir() -> None:
     global __temp_dir
-    if __temp_dir is not None:
+    if __temp_dir is None:
         __temp_dir = tempfile.TemporaryDirectory(
             "tmp", "wiki", dir=".", ignore_cleanup_errors=True, delete=False
         )


### PR DESCRIPTION
Made unique temp dir per process so they don't clobber each other
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor temp dir handling in `common.py` to create unique directories per process, updating related functions accordingly.
> 
>   - **Behavior**:
>     - Refactor temp dir handling to create unique temp dirs per process using `__temp_dir` in `common.py`.
>     - Update `setup_temp_dir()` to initialize `__temp_dir` with `TemporaryDirectory`.
>     - Update `cleanup_temp_dir()` to clean up `__temp_dir`.
>     - Modify `get_temp_file()` to raise exception if `__temp_dir` is not initialized.
>   - **Misc**:
>     - Remove unused import `shutil` from `common.py`.
>     - Move `clean_up_tmp_file()` function within `common.py` (no functional change).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for a9cf459df9bd2f18e8dbc74c589e354fde44dc6f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->