### PR TITLE
Uploader refactor

### DIFF
--- a/ingest_wikimedia/local.py
+++ b/ingest_wikimedia/local.py
@@ -5,7 +5,6 @@ import tempfile
 import magic
 
 from .common import CHECKSUM
-from .wikimedia import INVALID_CONTENT_TYPES
 
 __temp_dir: tempfile.TemporaryDirectory | None = None
 
@@ -74,6 +73,4 @@ def get_content_type(file: str) -> str:
     Tries to detect the mime type of a downloaded file.
     """
     content_type = magic.from_file(file, mime=True)
-    if content_type in INVALID_CONTENT_TYPES:
-        raise Exception(f"Invalid content-type: {content_type}")
     return content_type

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -1,3 +1,219 @@
+import logging
+import re
+from string import Template
+
+import pywikibot
+from pywikibot import FilePage
+
+from pywikibot.tools.chars import replace_invisible
+
+from .common import get_list, get_str, get_dict
+from .metadata import (
+    WIKIDATA_FIELD_NAME,
+    EDM_RIGHTS_FIELD_NAME,
+    SOURCE_RESOURCE_FIELD_NAME,
+    DC_CREATOR_FIELD_NAME,
+    DC_TITLE_FIELD_NAME,
+    DC_DESCRIPTION_FIELD_NAME,
+    DC_DATE_FIELD_NAME,
+    EDM_TIMESPAN_PREF_LABEL,
+    EDM_IS_SHOWN_AT,
+    DC_IDENTIFIER_FIELD_NAME,
+)
+from .web import get_http_session
+
+
+def get_permissions_template(rights_uri: str) -> str:
+    """Looks up the right wikitext template call for the rights_uri."""
+    if rights_uri.startswith(RS_NKC_URL_BASE):
+        return RS_NKC_TEMPLATE
+    if rights_uri.startswith(RS_NOC_URL_BASE):
+        return NOC_US_TEMPLATE
+    if rights_uri.startswith(CC_PD_URL_BASE):
+        return PD_US_TEMPLATE
+    if rights_uri.startswith(CC_ZERO_URL_BASE):
+        return CC_ZERO_TEMPLATE
+    if rights_uri.startswith(CC_BY_URL_BASE):
+        return license_to_markup_code(rights_uri)
+    if rights_uri.startswith(CC_BY_SA_URL_BASE):
+        return license_to_markup_code(rights_uri)
+    return ""
+
+
+def check_content_type(content_type: str) -> bool:
+    return content_type not in INVALID_CONTENT_TYPES
+
+
+def get_page_title(
+    item_title: str, dpla_identifier: str, suffix: str, page=None
+) -> str:
+    """
+    Makes a proper Wikimedia page title from the DPLA identifier and
+    the title of the image.
+    """
+    escaped_title = (
+        item_title[:181]
+        .replace("[", "(")
+        .replace("]", ")")
+        .replace("{", "(")
+        .replace("}", ")")
+        .replace("/", "-")
+        .replace(":", "-")
+        .replace("#", "-")
+    )
+
+    escaped_visible_title = replace_invisible(escaped_title)
+
+    # Add pagination to page title if needed
+    if page:
+        return (
+            f"{escaped_visible_title} - DPLA - {dpla_identifier} (page {page}){suffix}"
+        )
+    return f"{escaped_visible_title} - DPLA - {dpla_identifier}{suffix}"
+
+
+def license_to_markup_code(rights_uri: str) -> str:
+    match_result = re.match(CC_URL_REGEX, rights_uri)
+    if not match_result:
+        return ""
+    else:
+        port = match_result.group(1).replace("/", "-")[:-1]
+        return f"Cc-{port}"
+
+
+def get_permissions(
+    rights_uri: str, permissions_template_name: str, data_provider_wiki_q: str
+) -> str:
+    """Builds the wikitext for the commons item permissions."""
+    if rights_uri.startswith(RIGHTS_STATEMENTS_URL_BASE):
+        return f"{permissions_template_name} | {data_provider_wiki_q}"
+    else:
+        return permissions_template_name
+
+
+def escape_wiki_strings(unescaped_string: str) -> str:
+    """Removes specific character sequences from string to be safe for wikitext."""
+    for reserved_string in RESERVED_WIKITEXT_STRINGS:
+        unescaped_string = unescaped_string.replace(reserved_string, "")
+    return unescaped_string
+
+
+def join(strs: list[str]) -> str:
+    """Convenience method for joining lists of strings."""
+    return VALUE_JOIN_DELIMITER.join(strs)
+
+
+def extract_strings(data: dict, field_name: str) -> str:
+    """Convenience method for building a string
+    out of escaped strings from a dict field"""
+    return join([escape_wiki_strings(value) for value in get_list(data, field_name)])
+
+
+def extract_strings_dict(data: dict, field_name1: str, field_name2: str) -> str:
+    """Convenience method for building a string
+    out of escaped strings from a dict field from an inner dict"""
+    return join(
+        [
+            escape_wiki_strings(get_str(value, field_name2))
+            for value in get_list(data, field_name1)
+        ]
+    )
+
+
+def get_wiki_text(
+    dpla_id: str, item_metadata: dict, provider: dict, data_provider: dict
+) -> str:
+    """Turns DPLA item info into a wikitext document."""
+    data_provider_wiki_q = escape_wiki_strings(
+        get_str(data_provider, WIKIDATA_FIELD_NAME)
+    )
+    provider_wiki_q = escape_wiki_strings(get_str(provider, WIKIDATA_FIELD_NAME))
+    rights_uri = get_str(item_metadata, EDM_RIGHTS_FIELD_NAME)
+    permissions = get_permissions(
+        rights_uri, get_permissions_template(rights_uri), data_provider_wiki_q
+    )
+    source_resource = get_dict(item_metadata, SOURCE_RESOURCE_FIELD_NAME)
+    creator_string = extract_strings(source_resource, DC_CREATOR_FIELD_NAME)
+    title_string = extract_strings(source_resource, DC_TITLE_FIELD_NAME)
+    description_string = extract_strings(source_resource, DC_DESCRIPTION_FIELD_NAME)
+    date_string = extract_strings_dict(
+        source_resource, DC_DATE_FIELD_NAME, EDM_TIMESPAN_PREF_LABEL
+    )
+    is_shown_at = escape_wiki_strings(get_str(item_metadata, EDM_IS_SHOWN_AT))
+    local_id = extract_strings(source_resource, DC_IDENTIFIER_FIELD_NAME)
+
+    template_string = """== {{int:filedesc}} ==
+     {{ Artwork
+        | Other fields 1 = {{ InFi | Creator | $creator }}
+        | title = $title
+        | description = $description
+        | date = $date_string
+        | permission = {{$permissions}}
+        | source = {{ DPLA
+            | $data_provider
+            | hub = $provider
+            | url = $is_shown_at
+            | dpla_id = $dpla_id
+            | local_id = $local_id
+        }}
+        | Institution = {{ Institution | wikidata = $data_provider }}
+     }}"""
+
+    return Template(template_string).substitute(
+        creator=creator_string,
+        title=title_string,
+        description=description_string,
+        date_string=date_string,
+        permissions=permissions,
+        data_provider=data_provider_wiki_q,
+        provider=provider_wiki_q,
+        is_shown_at=is_shown_at,
+        dpla_id=dpla_id,
+        local_id=local_id,
+    )
+
+
+def wikimedia_url(title: str) -> str:
+    """Return the URL for the Wikimedia page"""
+    return f"{COMMONS_URL_PREFIX}{title.replace(' ', '_')}"
+
+
+def get_page(site: pywikibot.Site, title: str) -> FilePage:
+    """
+    Get the pywikibot object representing the page on Commons.
+    """
+    try:
+        return pywikibot.FilePage(site, title=title)
+    except pywikibot.exceptions.InvalidTitleError as e:
+        raise Exception(f"Invalid title {title}: {str(e)}") from e
+    except Exception as e:
+        raise Exception(f"Unable to create page {title}: {str(e)}") from e
+
+
+def get_site() -> pywikibot.Site:
+    """Returns the Site object for wikimedia commons."""
+    site = pywikibot.Site(COMMONS_SITE_NAME)
+    site.login()
+    logging.info(f"Logged: {site.user()} in {site.family}")
+    return site
+
+
+def wiki_file_exists(sha1: str) -> bool:
+    """Calls the find by hash api on commons to see if the file already exists."""
+    response = get_http_session().get(FIND_BY_HASH_URL_PREFIX + sha1)
+    sha1_response = response.json()
+    if "error" in sha1_response:
+        raise Exception(
+            f"Received bad response from find by hash endpoint.\n{str(sha1_response)}"
+        )
+
+    all_images = get_list(
+        get_dict(sha1_response, FIND_BY_HASH_QUERY_FIELD_NAME),
+        FIND_BY_HASH_ALLIMAGES_FIELD_NAME,
+    )
+    return len(all_images) > 0
+
+
 INVALID_CONTENT_TYPES = [
     "text/html",
     "application/json",
@@ -47,3 +263,17 @@ FIND_BY_HASH_URL_PREFIX: str = (
 )
 FIND_BY_HASH_QUERY_FIELD_NAME = "query"
 FIND_BY_HASH_ALLIMAGES_FIELD_NAME = "allimages"
+
+RIGHTS_STATEMENTS_URL_BASE = "http://rightsstatements.org"
+RS_NKC_URL_BASE = RIGHTS_STATEMENTS_URL_BASE + "/vocab/NKC/"
+RS_NOC_URL_BASE = RIGHTS_STATEMENTS_URL_BASE + "/vocab/NoC-US/"
+CC_URL_BASE = "http://creativecommons.org"
+CC_PD_URL_BASE = CC_URL_BASE + "/publicdomain/mark/"
+CC_ZERO_URL_BASE = CC_URL_BASE + "/publicdomain/zero/"
+CC_BY_URL_BASE = CC_URL_BASE + "/licenses/by/"
+CC_BY_SA_URL_BASE = CC_URL_BASE + "/licenses/by-sa/"
+CC_ZERO_TEMPLATE = "cc-zero"
+RS_NKC_TEMPLATE = "NKC"
+NOC_US_TEMPLATE = "NoC-US"
+PD_US_TEMPLATE = "PD-US"
+CC_URL_REGEX = "^http://creativecommons.org/licenses/(.*)"

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -52,10 +52,3 @@ def test_get_content_type(tmp_path):
     test_file = tmp_path / "test_file.txt"
     test_file.write_bytes(SPACER_GIF)
     assert get_content_type(str(test_file)) == "image/gif"
-
-
-def test_get_invalid_content_type(tmp_path):
-    invalid_file = tmp_path / "invalid_file.invalid"
-    invalid_file.write_text("invalid content")
-    with pytest.raises(Exception, match="Invalid content-type"):
-        get_content_type(str(invalid_file))

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -1,0 +1,162 @@
+from unittest.mock import patch, MagicMock
+from ingest_wikimedia.wikimedia import (
+    get_site,
+    get_page_title,
+    license_to_markup_code,
+    get_permissions_template,
+    get_permissions,
+    escape_wiki_strings,
+    join,
+    extract_strings,
+    extract_strings_dict,
+    get_page,
+    wiki_file_exists,
+    wikimedia_url,
+    get_wiki_text,
+    check_content_type,
+)
+
+
+@patch("ingest_wikimedia.wikimedia.pywikibot.Site")
+def test_get_site(mock_site):
+    mock_site_instance = MagicMock()
+    mock_site.return_value = mock_site_instance
+
+    site = get_site()
+    assert site == mock_site_instance
+    mock_site.assert_called_once_with("commons")
+    mock_site_instance.login.assert_called_once()
+    mock_site_instance.user.assert_called_once()
+
+
+def test_check_content_type_valid():
+    content_type = "image/jpeg"
+    assert check_content_type(content_type)
+
+
+def test_check_content_type_invalid():
+    content_type = "text/html"
+    assert not check_content_type(content_type)
+
+
+def test_get_page_title():
+    title = get_page_title("Sample Title", "abcd1234", ".jpg", 1)
+    expected_title = "Sample Title - DPLA - abcd1234 (page 1).jpg"
+    assert title == expected_title
+
+
+def test_license_to_markup_code():
+    rights_uri = "http://creativecommons.org/licenses/by/4.0/"
+    markup_code = license_to_markup_code(rights_uri)
+    expected_code = "Cc-by-4.0"
+    assert markup_code == expected_code
+
+
+def test_get_permissions_template():
+    rights_uri = "http://rightsstatements.org/vocab/NKC/1.0/"
+    template = get_permissions_template(rights_uri)
+    expected_template = "NKC"
+    assert template == expected_template
+
+
+def test_get_permissions():
+    permissions = get_permissions(
+        "http://rightsstatements.org/vocab/NKC/1.0/", "NKC", "Q12345"
+    )
+    expected_permissions = "NKC | Q12345"
+    assert permissions == expected_permissions
+
+
+def test_escape_wiki_strings():
+    unescaped_string = "This is a [[test]] string with {{reserved}} characters."
+    escaped_string = escape_wiki_strings(unescaped_string)
+    expected_string = "This is a test string with reserved characters."
+    assert escaped_string == expected_string
+
+
+def test_join():
+    strings = ["one", "two", "three"]
+    joined_string = join(strings)
+    expected_string = "one; two; three"
+    assert joined_string == expected_string
+
+
+def test_extract_strings():
+    data = {"field": ["value1", "value2"]}
+    extracted_string = extract_strings(data, "field")
+    expected_string = "value1; value2"
+    assert extracted_string == expected_string
+
+
+def test_extract_strings_dict():
+    data = {"field1": [{"field2": "value1"}, {"field2": "value2"}]}
+    extracted_string = extract_strings_dict(data, "field1", "field2")
+    expected_string = "value1; value2"
+    assert extracted_string == expected_string
+
+
+@patch("ingest_wikimedia.wikimedia.get_http_session")
+def test_wiki_file_exists(mock_get_http_session):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "query": {"allimages": [{"name": "file1"}, {"name": "file2"}]}
+    }
+    mock_get_http_session.return_value.get.return_value = mock_response
+
+    exists = wiki_file_exists("fakehash")
+    assert exists
+    mock_get_http_session.return_value.get.assert_called_once()
+
+
+@patch("ingest_wikimedia.wikimedia.pywikibot.FilePage")
+def test_get_page(mock_file_page):
+    mock_site = MagicMock()
+    title = "Sample Title"
+    page = get_page(mock_site, title)
+    assert page == mock_file_page.return_value
+    mock_file_page.assert_called_once_with(mock_site, title=title)
+
+
+def test_wikimedia_url():
+    title = "Sample Title"
+    url = wikimedia_url(title)
+    expected_url = "https://commons.wikimedia.org/wiki/File:Sample_Title"
+    assert url == expected_url
+
+
+def test_get_wiki_text():
+    dpla_id = "12345"
+    item_metadata = {
+        "sourceResource": {
+            "creator": ["John Doe"],
+            "title": ["Sample Title"],
+            "description": ["Sample Description"],
+            "date": [{"prefLabel": "2023"}],
+            "identifier": ["ID12345"],
+        },
+        "rights": "http://rightsstatements.org/vocab/NKC/1.0/",
+        "isShownAt": "http://example.com/item/12345",
+    }
+    provider = {"Wikidata": "Q67890"}
+    data_provider = {"Wikidata": "Q12345"}
+
+    text = get_wiki_text(dpla_id, item_metadata, provider, data_provider)
+    expected_text = (
+        "== {{int:filedesc}} ==\n"
+        "     {{ Artwork\n"
+        "        | Other fields 1 = {{ InFi | Creator | John Doe }}\n"
+        "        | title = Sample Title\n"
+        "        | description = Sample Description\n"
+        "        | date = 2023\n"
+        "        | permission = {{NKC | Q12345}}\n"
+        "        | source = {{ DPLA\n"
+        "            | Q12345\n"
+        "            | hub = Q67890\n"
+        "            | url = http://example.com/item/12345\n"
+        "            | dpla_id = 12345\n"
+        "            | local_id = ID12345\n"
+        "        }}\n"
+        "        | Institution = {{ Institution | wikidata = Q12345 }}\n"
+        "     }}"
+    )
+    assert text == expected_text

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -49,6 +49,7 @@ from ingest_wikimedia.local import (
     get_temp_file,
 )
 from ingest_wikimedia.tracker import Result, Tracker
+from ingest_wikimedia.wikimedia import check_content_type
 
 
 def upload_file_to_s3(file: str, destination_path: str, content_type: str, sha1: str):
@@ -146,7 +147,13 @@ def process_media(
             return
 
         download_file_to_temp_path(media_url, temp_file_name)
+
         content_type = get_content_type(temp_file_name)
+        if not check_content_type(content_type):
+            logging.info(f"Bad content type: {content_type}")
+            tracker.increment(Result.SKIPPED)
+            return
+
         sha1 = get_file_hash(temp_file_name)
         upload_file_to_s3(temp_file_name, destination_path, content_type, sha1)
 

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -50,7 +50,7 @@ from ingest_wikimedia.wikimedia import (
 )
 
 
-def proces_file(
+def process_file(
     dpla_id: str,
     title: str,
     item_metadata: dict,
@@ -205,7 +205,7 @@ def process_item(
             logging.info(f"Page {ordinal}")
             # one-pagers don't have page numbers in their titles
             page_label = None if len(files) == 1 else ordinal
-            proces_file(
+            process_file(
                 dpla_id,
                 title,
                 item_metadata,

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1,18 +1,12 @@
 import logging
 import mimetypes
-import re
 import time
-from string import Template
 
 import click
-import pywikibot
 
 from tqdm import tqdm
-from pywikibot import FilePage
-from pywikibot.tools.chars import replace_invisible
 
 from ingest_wikimedia.common import (
-    get_str,
     get_list,
     get_dict,
     load_ids,
@@ -35,238 +29,200 @@ from ingest_wikimedia.metadata import (
     get_providers_data,
     provider_str,
     SOURCE_RESOURCE_FIELD_NAME,
-    EDM_IS_SHOWN_AT,
-    EDM_RIGHTS_FIELD_NAME,
-    EDM_TIMESPAN_PREF_LABEL,
-    DC_CREATOR_FIELD_NAME,
-    DC_DATE_FIELD_NAME,
-    DC_DESCRIPTION_FIELD_NAME,
     DC_TITLE_FIELD_NAME,
-    DC_IDENTIFIER_FIELD_NAME,
-    WIKIDATA_FIELD_NAME,
     extract_urls,
 )
-from ingest_wikimedia.web import get_http_session
 from ingest_wikimedia.wikimedia import (
-    INVALID_CONTENT_TYPES,
-    COMMONS_URL_PREFIX,
     ERROR_FILEEXISTS,
     ERROR_MIME,
     ERROR_BANNED,
     ERROR_DUPLICATE,
     ERROR_NOCHANGE,
-    COMMONS_SITE_NAME,
     WMC_UPLOAD_CHUNK_SIZE,
-    VALUE_JOIN_DELIMITER,
-    RESERVED_WIKITEXT_STRINGS,
     IGNORE_WIKIMEDIA_WARNINGS,
-    FIND_BY_HASH_URL_PREFIX,
-    FIND_BY_HASH_QUERY_FIELD_NAME,
-    FIND_BY_HASH_ALLIMAGES_FIELD_NAME,
+    get_page_title,
+    get_wiki_text,
+    wikimedia_url,
+    get_page,
+    wiki_file_exists,
+    check_content_type,
+    get_site,
 )
 
-CC_URL_REGEX = "^http://creativecommons.org/licenses/(.*)"
 
-RIGHTS_STATEMENTS_URL_BASE = "http://rightsstatements.org"
-RS_NKC_URL_BASE = RIGHTS_STATEMENTS_URL_BASE + "/vocab/NKC/"
-RS_NOC_URL_BASE = RIGHTS_STATEMENTS_URL_BASE + "/vocab/NoC-US/"
-CC_URL_BASE = "http://creativecommons.org"
-CC_PD_URL_BASE = CC_URL_BASE + "/publicdomain/mark/"
-CC_ZERO_URL_BASE = CC_URL_BASE + "/publicdomain/zero/"
-CC_BY_URL_BASE = CC_URL_BASE + "/licenses/by/"
-CC_BY_SA_URL_BASE = CC_URL_BASE + "/licenses/by-sa/"
+def proces_file(
+    dpla_id: str,
+    title: str,
+    item_metadata: dict,
+    provider: dict,
+    data_provider: dict,
+    ordinal: int,
+    partner: str,
+    page_label: str,
+    verbose: bool,
+    dry_run: bool,
+):
+    tracker = Tracker()
+    temp_file = get_temp_file()
+    s3 = get_s3()
+    site = get_site()
 
-CC_ZERO_TEMPLATE = "cc-zero"
-RS_NKC_TEMPLATE = "NKC"
-NOC_US_TEMPLATE = "NoC-US"
-PD_US_TEMPLATE = "PD-US"
-
-
-def get_page(site: pywikibot.Site, title: str) -> FilePage:
-    """
-    Get the pywikibot object representing the page on Commons.
-    """
     try:
-        return pywikibot.FilePage(site, title=title)
-    except pywikibot.exceptions.InvalidTitleError as e:
-        raise Exception(f"Invalid title {title}: {str(e)}") from e
-    except Exception as e:
-        raise Exception(f"Unable to create page {title}: {str(e)}") from e
+        wiki_markup = get_wiki_text(dpla_id, item_metadata, provider, data_provider)
+        s3_path = get_media_s3_path(dpla_id, ordinal, partner)
+        upload_comment = f'Uploading DPLA ID "[[dpla:{dpla_id}|{dpla_id}]]".'
+        if not s3_file_exists(s3_path):
+            logging.info(f"{dpla_id} {ordinal} not present.")
+            tracker.increment(Result.SKIPPED)
+            return
 
+        s3_object = s3.Object(S3_BUCKET, s3_path)
+        file_size = s3_object.content_length
+        sha1 = s3_object.metadata.get(CHECKSUM, "")
+        mime = s3_object.content_type
 
-def get_page_title(
-    item_title: str, dpla_identifier: str, suffix: str, page=None
-) -> str:
-    """
-    Makes a proper Wikimedia page title from the DPLA identifier and
-    the title of the image.
-    """
-    escaped_title = (
-        item_title[:181]
-        .replace("[", "(")
-        .replace("]", ")")
-        .replace("{", "(")
-        .replace("}", ")")
-        .replace("/", "-")
-        .replace(":", "-")
-        .replace("#", "-")
-    )
+        if not check_content_type(mime):
+            logging.info(f"Skipping {dpla_id} {ordinal}: Bad content type: {mime}")
+            tracker.increment(Result.SKIPPED)
+            return
 
-    escaped_visible_title = replace_invisible(escaped_title)
+        ext = mimetypes.guess_extension(mime)
 
-    # Add pagination to page title if needed
-    if page:
-        return (
-            f"{escaped_visible_title} - DPLA - {dpla_identifier} (page {page}){suffix}"
-        )
-    return f"{escaped_visible_title} - DPLA - {dpla_identifier}{suffix}"
+        if not ext:
+            logging.info(
+                f"Skipping {dpla_id} {ordinal}: "
+                f"Unable to guess extension for {mime}"
+            )
+            tracker.increment(Result.SKIPPED)
+            return
 
-
-def license_to_markup_code(rights_uri: str) -> str:
-    match_result = re.match(CC_URL_REGEX, rights_uri)
-    if not match_result:
-        return ""
-    else:
-        port = match_result.group(1).replace("/", "-")[:-1]
-        return f"Cc-{port}"
-
-
-def get_permissions_template(rights_uri: str) -> str:
-    """Looks up the right wikitext template call for the rights_uri."""
-    if rights_uri.startswith(RS_NKC_URL_BASE):
-        return RS_NKC_TEMPLATE
-    if rights_uri.startswith(RS_NOC_URL_BASE):
-        return NOC_US_TEMPLATE
-    if rights_uri.startswith(CC_PD_URL_BASE):
-        return PD_US_TEMPLATE
-    if rights_uri.startswith(CC_ZERO_URL_BASE):
-        return CC_ZERO_TEMPLATE
-    if rights_uri.startswith(CC_BY_URL_BASE):
-        return license_to_markup_code(rights_uri)
-    if rights_uri.startswith(CC_BY_SA_URL_BASE):
-        return license_to_markup_code(rights_uri)
-    return ""
-
-
-def get_permissions(
-    rights_uri: str, permissions_template_name: str, data_provider_wiki_q: str
-) -> str:
-    """Builds the wikitext for the commons item permissions."""
-    if rights_uri.startswith(RIGHTS_STATEMENTS_URL_BASE):
-        return f"{permissions_template_name} | {data_provider_wiki_q}"
-    else:
-        return permissions_template_name
-
-
-def escape_wiki_strings(unescaped_string: str) -> str:
-    """Removes specific character sequences from string to be safe for wikitext."""
-    for reserved_string in RESERVED_WIKITEXT_STRINGS:
-        unescaped_string = unescaped_string.replace(reserved_string, "")
-    return unescaped_string
-
-
-def join(strs: list[str]) -> str:
-    """Convenience method for joining lists of strings."""
-    return VALUE_JOIN_DELIMITER.join(strs)
-
-
-def extract_strings(data: dict, field_name: str) -> str:
-    """Convenience method for building a string
-    out of escaped strings from a dict field"""
-    return join([escape_wiki_strings(value) for value in get_list(data, field_name)])
-
-
-def extract_strings_dict(data: dict, field_name1: str, field_name2: str) -> str:
-    """Convenience method for building a string
-    out of escaped strings from a dict field from an inner dict"""
-    return join(
-        [
-            escape_wiki_strings(get_str(value, field_name2))
-            for value in get_list(data, field_name1)
-        ]
-    )
-
-
-def get_wiki_text(
-    dpla_id: str, item_metadata: dict, provider: dict, data_provider: dict
-) -> str:
-    """Turns DPLA item info into a wikitext document."""
-    data_provider_wiki_q = escape_wiki_strings(
-        get_str(data_provider, WIKIDATA_FIELD_NAME)
-    )
-    provider_wiki_q = escape_wiki_strings(get_str(provider, WIKIDATA_FIELD_NAME))
-    rights_uri = get_str(item_metadata, EDM_RIGHTS_FIELD_NAME)
-    permissions = get_permissions(
-        rights_uri, get_permissions_template(rights_uri), data_provider_wiki_q
-    )
-    source_resource = get_dict(item_metadata, SOURCE_RESOURCE_FIELD_NAME)
-    creator_string = extract_strings(source_resource, DC_CREATOR_FIELD_NAME)
-    title_string = extract_strings(source_resource, DC_TITLE_FIELD_NAME)
-    description_string = extract_strings(source_resource, DC_DESCRIPTION_FIELD_NAME)
-    date_string = extract_strings_dict(
-        source_resource, DC_DATE_FIELD_NAME, EDM_TIMESPAN_PREF_LABEL
-    )
-    is_shown_at = escape_wiki_strings(get_str(item_metadata, EDM_IS_SHOWN_AT))
-    local_id = extract_strings(source_resource, DC_IDENTIFIER_FIELD_NAME)
-
-    template_string = """== {{int:filedesc}} ==
-     {{ Artwork
-        | Other fields 1 = {{ InFi | Creator | $creator }}
-        | title = $title
-        | description = $description
-        | date = $date_string
-        | permission = {{$permissions}}
-        | source = {{ DPLA
-            | $data_provider
-            | hub = $provider
-            | url = $is_shown_at
-            | dpla_id = $dpla_id
-            | local_id = $local_id
-        }}
-        | Institution = {{ Institution | wikidata = $data_provider }}
-     }}"""
-
-    return Template(template_string).substitute(
-        creator=creator_string,
-        title=title_string,
-        description=description_string,
-        date_string=date_string,
-        permissions=permissions,
-        data_provider=data_provider_wiki_q,
-        provider=provider_wiki_q,
-        is_shown_at=is_shown_at,
-        dpla_id=dpla_id,
-        local_id=local_id,
-    )
-
-
-def wikimedia_url(title: str) -> str:
-    """Return the URL for the Wikimedia page"""
-    return f"{COMMONS_URL_PREFIX}{title.replace(' ', '_')}"
-
-
-def get_site() -> pywikibot.Site:
-    """Returns the Site object for wikimedia commons."""
-    site = pywikibot.Site(COMMONS_SITE_NAME)
-    site.login()
-    logging.info(f"Logged: {site.user()} in {site.family}")
-    return site
-
-
-def wiki_file_exists(sha1: str) -> bool:
-    """Calls the find by hash api on commons to see if the file already exists."""
-    response = get_http_session().get(FIND_BY_HASH_URL_PREFIX + sha1)
-    sha1_response = response.json()
-    if "error" in sha1_response:
-        raise Exception(
-            f"Received bad response from find by hash endpoint.\n{str(sha1_response)}"
+        page_title = get_page_title(
+            item_title=title,
+            dpla_identifier=dpla_id,
+            suffix=ext,
+            page=page_label,
         )
 
-    all_images = get_list(
-        get_dict(sha1_response, FIND_BY_HASH_QUERY_FIELD_NAME),
-        FIND_BY_HASH_ALLIMAGES_FIELD_NAME,
-    )
-    return len(all_images) > 0
+        if verbose:
+            logging.info(f"DPLA ID: {dpla_id}")
+            logging.info(f"Title: {title}")
+            logging.info(f"Page title: {page_title}")
+            logging.info(f"Provider: {provider_str(provider)}")
+            logging.info(f"Data Provider: {provider_str(data_provider)}")
+            logging.info(f"MIME: {mime}")
+            logging.info(f"Extension: {ext}")
+            logging.info(f"File size: {file_size}")
+            logging.info(f"SHA-1: {sha1}")
+            logging.info(f"Upload comment: {upload_comment}")
+            logging.info(f"Wikitext: \n {wiki_markup}")
+
+        if wiki_file_exists(sha1):
+            logging.info(f"Skipping {dpla_id} {ordinal}: Already exists on commons.")
+            tracker.increment(Result.SKIPPED)
+            return
+
+        if not dry_run:
+            with tqdm(
+                total=s3_object.content_length,
+                leave=False,
+                desc="S3 Download",
+                unit="B",
+                unit_scale=1024,
+                unit_divisor=True,
+                delay=2,
+            ) as t:
+                s3_object.download_file(
+                    temp_file.name,
+                    Callback=lambda bytes_xfer: t.update(bytes_xfer),
+                )
+
+            wiki_file_page = get_page(site, page_title)
+
+            result = site.upload(
+                filepage=wiki_file_page,
+                source_filename=temp_file.name,
+                comment=upload_comment,
+                text=wiki_markup,
+                ignore_warnings=IGNORE_WIKIMEDIA_WARNINGS,
+                asynchronous=True,
+                chunk_size=WMC_UPLOAD_CHUNK_SIZE,
+            )
+
+            if not result:
+                # These error message accounts for Page does not exist,
+                # but File does exist and is linked to another Page
+                # (ex. DPLA ID drift)
+                tracker.increment(Result.FAILED)
+                raise Exception("File linked to another page (possible ID drift)")
+
+            logging.info(f"Uploaded to {wikimedia_url(page_title)}")
+            tracker.increment(Result.UPLOADED)
+            tracker.increment(Result.BYTES, file_size)
+
+    except Exception as ex:
+        handle_upload_exception(ex)
+
+    finally:
+        clean_up_tmp_file(temp_file)
+
+
+def process_item(
+    dpla_id: str,
+    api_key: str,
+    providers_json: dict,
+    partner: str,
+    verbose: bool,
+    dry_run: bool,
+):
+    tracker = Tracker()
+    try:
+        logging.info(f"DPLA ID: {dpla_id}")
+
+        item_metadata = get_item_metadata(dpla_id, api_key)
+
+        provider, data_provider = get_provider_and_data_provider(
+            item_metadata, providers_json
+        )
+
+        if not is_wiki_eligible(item_metadata, provider, data_provider):
+            tracker.increment(Result.SKIPPED)
+            return
+
+        titles = get_list(
+            get_dict(item_metadata, SOURCE_RESOURCE_FIELD_NAME),
+            DC_TITLE_FIELD_NAME,
+        )
+
+        # playing it safe in case titles is empty
+        title = titles[0] if titles else ""
+
+        ordinal = 0
+        # todo manifest of files?
+        files = extract_urls(partner, dpla_id, item_metadata)
+
+        for _ in tqdm(files, desc="Uploading Files", leave=False, unit="File"):
+            ordinal += 1  # todo if we're walking s3, this comes from the name
+            logging.info(f"Page {ordinal}")
+            # one-pagers don't have page numbers in their titles
+            page_label = None if len(files) == 1 else ordinal
+            proces_file(
+                dpla_id,
+                title,
+                item_metadata,
+                provider,
+                data_provider,
+                ordinal,
+                partner,
+                page_label,
+                verbose,
+                dry_run,
+            )
+
+    except Exception as ex:
+        logging.warning(
+            f"Caught exception getting item info for {dpla_id}", exc_info=ex
+        )
+        tracker.increment(Result.FAILED)
 
 
 @click.command()
@@ -286,162 +242,14 @@ def main(ids_file, partner: str, api_key: str, dry_run: bool, verbose: bool) -> 
         setup_logging(partner, "upload", logging.INFO)
         if dry_run:
             logging.warning("---=== DRY RUN ===---")
-        s3 = get_s3()
-        site = get_site()
+
         providers_json = get_providers_data()
         logging.info(f"Starting upload for {partner}")
 
         dpla_ids = load_ids(ids_file)
 
         for dpla_id in tqdm(dpla_ids, desc="Uploading Items", unit="Item"):
-            try:
-                logging.info(f"DPLA ID: {dpla_id}")
-
-                item_metadata = get_item_metadata(dpla_id, api_key)
-
-                provider, data_provider = get_provider_and_data_provider(
-                    item_metadata, providers_json
-                )
-
-                if not is_wiki_eligible(item_metadata, provider, data_provider):
-                    tracker.increment(Result.SKIPPED)
-                    continue
-
-                titles = get_list(
-                    get_dict(item_metadata, SOURCE_RESOURCE_FIELD_NAME),
-                    DC_TITLE_FIELD_NAME,
-                )
-
-                # playing it safe in case titles is empty
-                title = titles[0] if titles else ""
-
-                ordinal = 0
-                # todo manifest of files?
-                files = extract_urls(partner, dpla_id, item_metadata)
-
-                for file in tqdm(
-                    files, desc="Uploading Files", leave=False, unit="File"
-                ):
-                    ordinal += 1  # todo if we're walking s3, this comes from the name
-                    logging.info(f"Page {ordinal}")
-                    # one-pagers don't have page numbers in their titles
-                    page_label = None if len(files) == 1 else ordinal
-                    temp_file = get_temp_file()
-                    try:
-                        wiki_markup = get_wiki_text(
-                            dpla_id, item_metadata, provider, data_provider
-                        )
-                        s3_path = get_media_s3_path(dpla_id, ordinal, partner)
-                        upload_comment = (
-                            f'Uploading DPLA ID "[[dpla:{dpla_id}|{dpla_id}]]".'
-                        )
-                        if not s3_file_exists(s3_path):
-                            logging.info(f"{dpla_id} {ordinal} not present.")
-                            tracker.increment(Result.SKIPPED)
-                            continue
-
-                        s3_object = s3.Object(S3_BUCKET, s3_path)
-                        file_size = s3_object.content_length
-                        sha1 = s3_object.metadata.get(CHECKSUM, "")
-                        mime = s3_object.content_type
-
-                        if mime in INVALID_CONTENT_TYPES:
-                            logging.info(
-                                f"Skipping {dpla_id} {ordinal}: Bad content type: {mime}"
-                            )
-                            tracker.increment(Result.SKIPPED)
-                            continue
-
-                        ext = mimetypes.guess_extension(mime)
-
-                        if not ext:
-                            logging.info(
-                                f"Skipping {dpla_id} {ordinal}: "
-                                f"Unable to guess extension for {mime}"
-                            )
-                            tracker.increment(Result.SKIPPED)
-                            continue
-
-                        page_title = get_page_title(
-                            item_title=title,
-                            dpla_identifier=dpla_id,
-                            suffix=ext,
-                            page=page_label,
-                        )
-
-                        if verbose:
-                            logging.info(f"DPLA ID: {dpla_id}")
-                            logging.info(f"Title: {title}")
-                            logging.info(f"Page title: {page_title}")
-                            logging.info(f"Provider: {provider_str(provider)}")
-                            logging.info(
-                                f"Data Provider: {provider_str(data_provider)}"
-                            )
-                            logging.info(f"MIME: {mime}")
-                            logging.info(f"Extension: {ext}")
-                            logging.info(f"File size: {file_size}")
-                            logging.info(f"SHA-1: {sha1}")
-                            logging.info(f"Upload comment: {upload_comment}")
-                            logging.info(f"Wikitext: \n {wiki_markup}")
-
-                        if wiki_file_exists(sha1):
-                            logging.info(
-                                f"Skipping {dpla_id} {ordinal}: Already exists on commons."
-                            )
-                            tracker.increment(Result.SKIPPED)
-                            continue
-
-                        if not dry_run:
-                            with tqdm(
-                                total=s3_object.content_length,
-                                leave=False,
-                                desc="S3 Download",
-                                unit="B",
-                                unit_scale=1024,
-                                unit_divisor=True,
-                                delay=2,
-                            ) as t:
-                                s3_object.download_file(
-                                    temp_file.name,
-                                    Callback=lambda bytes_xfer: t.update(bytes_xfer),
-                                )
-
-                            wiki_file_page = get_page(site, page_title)
-
-                            result = site.upload(
-                                filepage=wiki_file_page,
-                                source_filename=temp_file.name,
-                                comment=upload_comment,
-                                text=wiki_markup,
-                                ignore_warnings=IGNORE_WIKIMEDIA_WARNINGS,
-                                asynchronous=True,
-                                chunk_size=WMC_UPLOAD_CHUNK_SIZE,
-                            )
-
-                            if not result:
-                                # These error message accounts for Page does not exist,
-                                # but File does exist and is linked to another Page
-                                # (ex. DPLA ID drift)
-                                tracker.increment(Result.FAILED)
-                                raise Exception(
-                                    "File linked to another page (possible ID drift)"
-                                )
-
-                            logging.info(f"Uploaded to {wikimedia_url(page_title)}")
-                            tracker.increment(Result.UPLOADED)
-                            tracker.increment(Result.BYTES, file_size)
-
-                    except Exception as ex:
-                        handle_upload_exception(ex)
-
-                    finally:
-                        clean_up_tmp_file(temp_file)
-
-            except Exception as ex:
-                logging.warning(
-                    f"Caught exception getting item info for {dpla_id}", exc_info=ex
-                )
-                tracker.increment(Result.FAILED)
+            process_item(dpla_id, api_key, providers_json, partner, verbose, dry_run)
 
     finally:
         logging.info("\n" + str(tracker))


### PR DESCRIPTION
Split content-type checking from content-type calculating

Refactored uploader to use same item-level and file-level methods as downloader rather than one enormous main().
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor uploader by separating content-type checking from calculation and aligning its structure with downloader, adding `check_content_type()` and updating tests.
> 
>   - **Behavior**:
>     - Split content-type checking from content-type calculation by introducing `check_content_type()` in `wikimedia.py`.
>     - Refactor `uploader.py` to use item-level and file-level methods similar to `downloader.py`.
>     - Remove content-type validation from `get_content_type()` in `local.py`.
>   - **Functions**:
>     - Add `check_content_type()` in `wikimedia.py` to validate content types against `INVALID_CONTENT_TYPES`.
>     - Refactor `process_item()` and `process_file()` in `uploader.py` to handle file processing and uploading.
>   - **Tests**:
>     - Add tests for `check_content_type()` in `test_wikimedia.py`.
>     - Remove `test_get_invalid_content_type()` from `test_local.py`.
>   - **Misc**:
>     - Minor logging adjustments in `uploader.py` and `downloader.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 79e4bfca53a82e60e83d08a0fdadf083627dba38. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->