### PR TITLE
Fixed IIIFv3 manifest parsing to max image dimensions.

### DIFF
--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -1,7 +1,16 @@
-from enum import Enum
+from enum import Enum, auto
 from threading import Lock
 
-Result = Enum("Result", ["DOWNLOADED", "FAILED", "SKIPPED", "UPLOADED", "BYTES"])
+
+class Result(Enum):
+    DOWNLOADED = auto()
+    FAILED = auto()
+    SKIPPED = auto()
+    UPLOADED = auto()
+    BYTES = auto()
+    BAD_IIIF_MANIFEST = auto()
+    NO_MEDIA = auto()
+    BAD_IMAGE_API_V3 = auto()
 
 
 class SingletonBase:
@@ -32,5 +41,6 @@ class Tracker(SingletonBase):
         result = "COUNTS:\n"
         for key in self.data:
             value = self.data[key]
-            result += f"{key.name}: {value}\n"
+            if value > 0:
+                result += f"{key.name}: {value}\n"
         return result

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -119,11 +119,25 @@ def test_iiif_v2_urls():
 def test_iiif_v3_urls():
     iiif = {
         "items": [
-            {"items": [{"items": [{"body": {"id": "http://example.com/image"}}]}]}
+            {
+                "items": [
+                    {
+                        "items": [
+                            {
+                                "body": {
+                                    "id": "https://iiif.oregondigital.org/iiif/f0%2Fdf%2F72%2Fhj%2F15%2Ft-jp2.jp2/full/640,/0/default.jpg"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
         ]
     }
     result = iiif_v3_urls(iiif)
-    assert result == ["http://example.com/image/full/full/0/default.jpg"]
+    assert result == [
+        "https://iiif.oregondigital.org/iiif/f0%2Fdf%2F72%2Fhj%2F15%2Ft-jp2.jp2/full/max/0/default.jpg"
+    ]
 
 
 def test_get_iiif_urls():

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -44,7 +44,6 @@ def test_thread_safety(tracker):
 def test_str_representation(tracker):
     tracker.increment(Result.FAILED, 2)
     tracker.increment(Result.SKIPPED, 3)
-    expected_output = (
-        "COUNTS:\nDOWNLOADED: 0\nFAILED: 2\nSKIPPED: 3\nUPLOADED: 0\nBYTES: 0\n"
-    )
+    expected_output = "COUNTS:\nFAILED: 2\nSKIPPED: 3\n"
+
     assert str(tracker) == expected_output

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -290,7 +290,6 @@ def main(
                 providers_json,
                 api_key,
             )
-            exit()
 
     finally:
         logging.info("\n" + str(tracker))

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -179,7 +179,14 @@ def process_item(
     tracker = Tracker()
     try:
         item_metadata = get_item_metadata(dpla_id, api_key)
+
+        if not item_metadata:
+            logging.info(f"{dpla_id} was not found in the DPLA API.")
+            tracker.increment(Result.SKIPPED)
+            return
+
         write_item_metadata(partner, dpla_id, json.dumps(item_metadata))
+
         provider, data_provider = get_provider_and_data_provider(
             item_metadata, providers_json
         )
@@ -204,9 +211,9 @@ def process_item(
             media_urls = get_iiif_urls(manifest)
 
         else:
-            raise NotImplementedError(
-                f"No {MEDIA_MASTER_FIELD_NAME} or {IIIF_MANIFEST_FIELD_NAME}"
-            )
+            # not sure how we got here
+            tracker.increment(Result.SKIPPED)
+            return
 
         write_file_list(partner, dpla_id, media_urls)
 
@@ -283,6 +290,7 @@ def main(
                 providers_json,
                 api_key,
             )
+            exit()
 
     finally:
         logging.info("\n" + str(tracker))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance IIIFv3 manifest handling by maximizing image URLs to highest resolution and update tracking and tests accordingly.
> 
>   - **Behavior**:
>     - Updated `iiif_v3_urls()` in `metadata.py` to maximize image URLs to highest resolution using `maximize_iiif_v3_url()`.
>     - Added `maximize_iiif_v3_url()` to handle URL transformation for IIIFv3 manifests.
>     - Modified `process_item()` in `downloader.py` to skip items with no media.
>   - **Regex**:
>     - Added `IMAGE_API_UP_THROUGH_IDENTIFIER_REGEX` and `FULL_IMAGE_API_URL_REGEX` in `metadata.py` for URL parsing.
>   - **Tracker**:
>     - Added `BAD_IIIF_MANIFEST`, `NO_MEDIA`, and `BAD_IMAGE_API_V3` to `Result` enum in `tracker.py`.
>     - Updated `Tracker` to increment new result types.
>   - **Tests**:
>     - Updated `test_iiif_v3_urls()` in `test_metadata.py` to test new URL maximization behavior.
>     - Updated `test_str_representation()` in `test_tracker.py` to reflect new result types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 35469ab41df85990d695e36a08d31521dcb7da75. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->