### PR TITLE
Misc fixes

### DIFF
--- a/ingest_wikimedia/web.py
+++ b/ingest_wikimedia/web.py
@@ -15,11 +15,7 @@ def get_http_session() -> requests.Session:
     if __thread_local.http_session is not None:
         return __thread_local.http_session
     retry_strategy = Retry(
-        connect=3,
-        read=3,
-        redirect=5,
-        status=5,
-        other=5,
+        total=3,
         backoff_factor=1,
         status_forcelist=[429, 500, 502, 503, 504],
         allowed_methods=["HEAD", "GET", "OPTIONS"],

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from string import Template
 
@@ -194,7 +193,6 @@ def get_site() -> pywikibot.Site:
     """Returns the Site object for wikimedia commons."""
     site = pywikibot.Site(COMMONS_SITE_NAME)
     site.login()
-    logging.info(f"Logged: {site.user()} in {site.family}")
     return site
 
 

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -26,7 +26,6 @@ def test_get_site(mock_site):
     assert site == mock_site_instance
     mock_site.assert_called_once_with("commons")
     mock_site_instance.login.assert_called_once()
-    mock_site_instance.user.assert_called_once()
 
 
 def test_check_content_type_valid():


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplified retry strategy in `web.py` and removed unnecessary logging in `wikimedia.py` and its test.
> 
>   - **Behavior**:
>     - Simplified retry strategy in `get_http_session()` in `web.py` by using `total=3` instead of individual retry counts.
>   - **Logging**:
>     - Removed logging of user login in `get_site()` in `wikimedia.py`.
>   - **Tests**:
>     - Removed `mock_site_instance.user.assert_called_once()` in `test_get_site()` in `test_wikimedia.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 9c3dd897455be388c89d4384ddda021eedba2d6f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->