### PR TITLE
Fixes to maximize iiif presentation api v2 image urls

### DIFF
--- a/ingest_wikimedia/metadata.py
+++ b/ingest_wikimedia/metadata.py
@@ -150,10 +150,13 @@ def iiif_v2_urls(iiif: dict) -> list[str]:
     for canvas in canvases:
         for image in get_list(canvas, IIIF_IMAGES):
             resource = get_dict(image, IIIF_RESOURCE)
-            url = get_str(resource, JSON_LD_AT_ID)
-            # todo do these always max the resolution?
+            service = get_dict(resource, IIIF_SERVICE)
+            url = get_str(service, JSON_LD_AT_ID)
             if url:
-                urls.append(url)
+                print("FOOO")
+                urls.append(maximize_iiif_url(url))
+            else:
+                urls.append("")
     return urls
 
 
@@ -170,7 +173,7 @@ def iiif_v3_urls(iiif: dict) -> list[str]:
             )
             new_url = ""
             if url:
-                new_url = maximize_iiif_v3_url(url)
+                new_url = maximize_iiif_url(url)
             # This always adds something to the list.
             # If we didn't get a URL, it's just an empty string.
             # This prevents getting the page order wrong if we don't
@@ -184,7 +187,7 @@ def iiif_v3_urls(iiif: dict) -> list[str]:
     return urls
 
 
-def maximize_iiif_v3_url(url: str) -> str:
+def maximize_iiif_url(url: str) -> str:
     m = None
 
     if match := FULL_IMAGE_API_URL_REGEX.match(url):
@@ -218,7 +221,7 @@ def maximize_iiif_v3_url(url: str) -> str:
 
         return f"{scheme}://{server}/{identifier}/full/max/0/default.jpg"
 
-    Tracker().increment(Result.BAD_IMAGE_API_V3)
+    Tracker().increment(Result.BAD_IMAGE_API)
     return ""  # we give up
 
 
@@ -289,12 +292,12 @@ def contentdm_iiif_url(is_shown_at: str) -> str | None:
 
 # {scheme}://{server}{/prefix}/{identifier}/
 IMAGE_API_UP_THROUGH_IDENTIFIER_REGEX = re.compile(
-    r"^(?P<scheme>http|https)://(?P<server>[^/]+)(?P<prefix>/[^/]+)/"
+    r"^(?P<scheme>http|https)://(?P<server>[^/]+)/(?P<prefix>[^/]+)/"
     r"(?P<identifier>[^/]+)/?$"
 )
 
 IMAGE_API_UP_THROUGH_IDENTIFIER_REGEX_NO_PREFIX = re.compile(
-    r"^(?P<scheme>http|https)://(?P<server>[^/]+)/" r"(?P<identifier>[^/]+)/?$"
+    r"^(?P<scheme>http|https)://(?P<server>[^/]+)/(?P<identifier>[^/]+)/?$"
 )
 
 
@@ -349,9 +352,12 @@ IIIF_RESOURCE = "resource"
 IIIF_IMAGES = "images"
 IIIF_CANVASES = "canvases"
 IIIF_SEQUENCES = "sequences"
+IIIF_SERVICE = "service"
 IIIF_FULL_RES_JPG_SUFFIX = "/full/max/0/default.jpg"
 IIIF_PRESENTATION_API_MANIFEST_V2 = "http://iiif.io/api/presentation/2/context.json"
 IIIF_PRESENTATION_API_MANIFEST_V3 = "http://iiif.io/api/presentation/3/context.json"
+IIIF_IMAGE_API_V2 = "http://iiif.io/api/image/2/context.json"
+IIIF_IMAGE_API_V3 = "http://iiif.io/api/image/3/context.json"
 CONTENTDM_IIIF_MANIFEST_JSON = "/manifest.json"
 CONTENTDM_IIIF_INFO = "/iiif/info/"
 CONTENT_DM_ISSHOWNAT_REGEX = r"^/cdm/ref/collection/(.*)/id/(.*)$"  # todo

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -10,7 +10,7 @@ class Result(Enum):
     BYTES = auto()
     BAD_IIIF_MANIFEST = auto()
     NO_MEDIA = auto()
-    BAD_IMAGE_API_V3 = auto()
+    BAD_IMAGE_API = auto()
 
 
 class SingletonBase:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -107,13 +107,23 @@ def test_iiif_v2_urls():
         "sequences": [
             {
                 "canvases": [
-                    {"images": [{"resource": {"@id": "http://example.com/image"}}]}
+                    {
+                        "images": [
+                            {
+                                "resource": {
+                                    "service": {
+                                        "@id": "http://server/prefix/identifier"
+                                    }
+                                }
+                            }
+                        ]
+                    }
                 ]
             }
         ]
     }
     result = iiif_v2_urls(iiif)
-    assert result == ["http://example.com/image"]
+    assert result == ["http://server/prefix/identifier/full/max/0/default.jpg"]
 
 
 def test_iiif_v3_urls():


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `iiif_v2_urls()` to maximize IIIF v2 image URLs and update related tests and regex patterns.
> 
>   - **Behavior**:
>     - `iiif_v2_urls()` in `metadata.py` now maximizes image URLs using `maximize_iiif_url()`.
>     - `maximize_iiif_v3_url()` renamed to `maximize_iiif_url()`.
>     - `BAD_IMAGE_API_V3` renamed to `BAD_IMAGE_API` in `tracker.py`.
>   - **Regex**:
>     - Adjusted `IMAGE_API_UP_THROUGH_IDENTIFIER_REGEX` and `IMAGE_API_UP_THROUGH_IDENTIFIER_REGEX_NO_PREFIX` in `metadata.py` to remove redundant slashes.
>   - **Tests**:
>     - Updated `test_iiif_v2_urls()` in `test_metadata.py` to check for maximized URLs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for de0aec6809dcb7d9fbc71f53afbf862cd8313892. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->