### PR TITLE
Added parameter for sleeping in between media requests.

### DIFF
--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -171,6 +171,7 @@ def process_item(
     dpla_id: str,
     providers_json: dict,
     api_key: str,
+    sleep_secs: float,
 ) -> None:
     """
     For every item, makes sure it's eligible, tries to get a list of files for it, and
@@ -235,6 +236,8 @@ def process_item(
     for media_url in tqdm(
         media_urls, desc="Downloading Files", leave=False, unit="File"
     ):
+        if sleep_secs != 0:
+            time.sleep(sleep_secs)
         count += 1
         # hack to fix bad nara data
         if media_url.startswith("https/"):
@@ -255,7 +258,12 @@ def process_item(
 @click.argument("api_key")
 @click.option("--dry-run", is_flag=True)
 @click.option("--verbose", is_flag=True)
-@click.option("--overwrite", is_flag=True)
+@click.option("--overwrite", is_flag=True, help="Overwrite already downloaded media.")
+@click.option(
+    "--sleep",
+    default=0.0,
+    help="Interval to wait in between http requests in float seconds.",
+)
 def main(
     ids_file: IO,
     partner: str,
@@ -263,6 +271,7 @@ def main(
     dry_run: bool,
     verbose: bool,
     overwrite: bool,
+    sleep: float,
 ):
     start_time = time.time()
     tracker = Tracker()
@@ -289,6 +298,7 @@ def main(
                 dpla_id,
                 providers_json,
                 api_key,
+                sleep,
             )
 
     finally:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `sleep_secs` parameter and `--sleep` CLI option to introduce delay between media requests in `downloader.py`.
> 
>   - **Behavior**:
>     - Adds `sleep_secs` parameter to `process_item()` in `downloader.py` to introduce delay between media requests.
>     - Implements delay using `time.sleep(sleep_secs)` in the media download loop.
>   - **CLI**:
>     - Adds `--sleep` option to `main()` in `downloader.py` to specify delay interval in seconds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for d3960a675efe2d69596b5892d15162bd104ca560. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->