### PR TITLE
Moved sleep call to later in process 

### DIFF
--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -131,6 +131,7 @@ def process_media(
     ordinal: int,
     media_url: str,
     overwrite: bool,
+    sleep_secs: float,
 ) -> None:
     """
     For a given capture for a given item, downloads it if we don't have it or are
@@ -146,6 +147,8 @@ def process_media(
             tracker.increment(Result.SKIPPED)
             return
 
+        if sleep_secs != 0:
+            time.sleep(sleep_secs)
         download_file_to_temp_path(media_url, temp_file_name)
 
         content_type = get_content_type(temp_file_name)
@@ -236,8 +239,6 @@ def process_item(
     for media_url in tqdm(
         media_urls, desc="Downloading Files", leave=False, unit="File"
     ):
-        if sleep_secs != 0:
-            time.sleep(sleep_secs)
         count += 1
         # hack to fix bad nara data
         if media_url.startswith("https/"):
@@ -245,7 +246,7 @@ def process_item(
         logging.info(f"Downloading {partner} {dpla_id} {count} from {media_url}")
         try:
             if not dry_run:
-                process_media(partner, dpla_id, count, media_url, overwrite)
+                process_media(partner, dpla_id, count, media_url, overwrite, sleep_secs)
 
         except Exception as e:
             tracker.increment(Result.FAILED)


### PR DESCRIPTION
... to avoid a sleep when a download doesn't happen.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Moved sleep call in `downloader.py` to occur only when downloads are initiated, avoiding unnecessary delays.
> 
>   - **Behavior**:
>     - Moved `time.sleep(sleep_secs)` from `process_item()` to `process_media()` in `downloader.py`.
>     - Sleep now occurs only if a download is initiated, avoiding unnecessary delay when downloads are skipped.
>   - **Function Calls**:
>     - Updated `process_media()` to accept `sleep_secs` parameter.
>     - Modified `process_item()` to pass `sleep_secs` to `process_media()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for f228562933d7be903f22756edffdbfab2163eed7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->