### PR TITLE
Adds script for detecting incomplete items (missing media payloads).

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,5 @@ downloader = "tools.downloader:main"
 sign = "tools.sign:main"
 nuke = "tools.nuke:main"
 get-ids-api = "tools.get_ids_api:main"
+get-incomplete-items = "tools.get_incomplete_items:main"
 

--- a/tools/get_incomplete_items.py
+++ b/tools/get_incomplete_items.py
@@ -1,0 +1,44 @@
+import click
+
+from ingest_wikimedia.s3 import get_s3, S3_BUCKET
+
+
+def get_incomplete_items(prefix) -> list[str]:
+    """Gets a list of incomplete items from S3."""
+    s3 = get_s3()
+    bucket = s3.Bucket(S3_BUCKET)
+    incomplete_items = []
+
+    for object_summary in bucket.objects.filter(Prefix=f"{prefix}/images/"):
+        key = object_summary.key
+        if key.endswith("file-list.txt"):
+            dpla_id = key.split("/")[-2]
+            folder = "/".join(key.split("/")[0:-1])
+            file_list = object_summary.get()["Body"].read().decode("utf-8")
+            file_count = len(file_list.split("\n"))
+            media_files = []
+            for object_summary2 in bucket.objects.filter(Prefix=folder):
+                key = object_summary2.key
+                if (
+                    key.endswith("file-list.txt")
+                    or key.endswith("dpla-map.json")
+                    or key.endswith("iiif.json")
+                ):
+                    continue
+                media_files.append(key)
+
+            if len(media_files) != file_count:
+                incomplete_items.append(dpla_id)
+
+    return incomplete_items
+
+
+@click.command()
+@click.argument("partner")
+def main(partner: str):
+    for item_id in get_incomplete_items(partner):
+        print(item_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `get_incomplete_items.py` script to detect incomplete items in S3 by comparing media files against a file list.
> 
>   - **New Script**:
>     - Adds `get_incomplete_items.py` to detect incomplete items in S3 by comparing media files against a file list.
>     - Uses `get_s3()` and `S3_BUCKET` from `ingest_wikimedia.s3` to access S3 bucket.
>     - Filters objects with `Prefix` and checks if media files match the count in `file-list.txt`.
>   - **Command-Line Interface**:
>     - Adds `get-incomplete-items` script entry in `pyproject.toml`.
>     - Uses Click to define `main()` function, accepting `partner` argument to specify S3 prefix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 2c687cc021ebc7772c5f88e8e5b516493cf5b2dd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->