### PR TITLE
Pinned 3rd party actions to hashes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a
         with:
           version: "0.5.3"
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,4 +5,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v1
+      - uses: astral-sh/ruff-action@f2e32211077f40bfeab40e16285216924ebea4cb


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pinned third-party GitHub actions to specific commit hashes in `pytest.yml` and `ruff.yml`.
> 
>   - **Workflows**:
>     - Pinned `astral-sh/setup-uv` action to commit `38f3f104447c67c051c4a08e39b64a148898af3a` in `pytest.yml`.
>     - Pinned `astral-sh/ruff-action` action to commit `f2e32211077f40bfeab40e16285216924ebea4cb` in `ruff.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 7acb28294dbd4b1047de7aa1021d3bdeedf12409. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->