### PR TITLE
Disabling IL for the time being per their request.

### DIFF
--- a/ingest_wikimedia/metadata.py
+++ b/ingest_wikimedia/metadata.py
@@ -363,7 +363,7 @@ CONTENT_DM_ISSHOWNAT_REGEX = r"^/cdm/ref/collection/(.*)/id/(.*)$"  # todo
 DPLA_PARTNERS = {
     "bpl": "Digital Commonwealth",
     "georgia": "Digital Library of Georgia",
-    "il": "Illinois Digital Heritage Hub",
+    # hold off on illinois "il": "Illinois Digital Heritage Hub",
     "indiana": "Indiana Memory",
     "nara": "National Archives and Records Administration",
     "northwest-heritage": "Northwest Digital Heritage",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Temporarily disables "il" in `DPLA_PARTNERS` in `metadata.py`.
> 
>   - **Behavior**:
>     - Temporarily disables "il" (Illinois Digital Heritage Hub) in `DPLA_PARTNERS` in `metadata.py` by commenting it out.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 4402b68e4b01fac143512dc0cb70d6a2f9e8cf5e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->