### PR TITLE
Added parsing for image api urls with two prefixes.

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -15,6 +15,7 @@ from ingest_wikimedia.metadata import (
     get_iiif_manifest,
     contentdm_iiif_url,
     check_record_partner,
+    maximize_iiif_url,
 )
 
 
@@ -189,3 +190,9 @@ def test_contentdm_iiif_url():
         "http://www.ohiomemory.org/iiif/info/p16007coll33/126923/manifest.json"
     )
     assert contentdm_iiif_url(is_shown_at) == expected_url
+
+
+def test_bpl_iiif_imageapi_url():
+    url = "https://iiif.digitalcommonwealth.org/iiif/2/commonwealth:c534kh14z"
+    expected_url = "https://iiif.digitalcommonwealth.org/iiif/2/commonwealth:c534kh14z/full/max/0/default.jpg"
+    assert maximize_iiif_url(url) == expected_url


### PR DESCRIPTION
 Added more is_wiki_eligible logging.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added logging to `is_wiki_eligible` and enhanced `maximize_iiif_url` to handle URLs with two prefixes, with corresponding tests and regex updates.
> 
>   - **Behavior**:
>     - Added logging in `is_wiki_eligible` in `metadata.py` for provider, rights category, and asset checks.
>     - Enhanced `maximize_iiif_url` in `metadata.py` to parse URLs with two prefixes using new regex patterns.
>   - **Regex**:
>     - Added `IMAGE_API_UP_THROUGH_IDENTIFIER_W_DOUBLE_PREFIX_REGEX` and `FULL_IMAGE_API_URL_W_DOUBLE_PREFIX_REGEX` in `metadata.py`.
>   - **Tests**:
>     - Added `test_bpl_iiif_imageapi_url` in `test_metadata.py` to verify URL parsing with two prefixes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 978ea838155fefc814bbd62e96296bc991d4bf05. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->