### PR TITLE
Debugged and fixed maximize_iiif_url.

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -196,3 +196,9 @@ def test_bpl_iiif_imageapi_url():
     url = "https://iiif.digitalcommonwealth.org/iiif/2/commonwealth:c534kh14z"
     expected_url = "https://iiif.digitalcommonwealth.org/iiif/2/commonwealth:c534kh14z/full/max/0/default.jpg"
     assert maximize_iiif_url(url) == expected_url
+
+
+def test_colorado_imageapi_url():
+    url = "https://cudl.colorado.edu/luna/servlet/iiif/UCBOULDERCB1~17~17~33595~102636"
+    expected_url = "https://cudl.colorado.edu/luna/servlet/iiif/UCBOULDERCB1~17~17~33595~102636/full/max/0/default.jpg"
+    assert maximize_iiif_url(url) == expected_url


### PR DESCRIPTION
Added support for 3 prefixes.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `maximize_iiif_url` to support URLs with up to three prefixes and add corresponding tests.
> 
>   - **Enhancements**:
>     - `maximize_iiif_url` in `metadata.py` now supports URLs with up to three prefixes.
>     - Added regex patterns `IMAGE_API_UP_THROUGH_IDENTIFIER_W_TRIPLE_PREFIX_REGEX` and `FULL_IMAGE_API_URL_W_TRIPLE_PREFIX_REGEX`.
>     - Added helper functions `no_prefix`, `one_prefix`, `two_prefixes`, and `three_prefixes` to handle different URL structures.
>   - **Tests**:
>     - Added `test_colorado_imageapi_url` in `test_metadata.py` to test URLs with three prefixes.
>     - Updated existing tests to ensure compatibility with new URL handling logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for ff77fa50e4fd69f5c8467ca63c8ceb5795fd37f3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->