### PR TITLE
Fixes for creator field

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -141,9 +141,17 @@ def get_wiki_text(
     is_shown_at = escape_wiki_strings(get_str(item_metadata, EDM_IS_SHOWN_AT))
     local_id = extract_strings(source_resource, DC_IDENTIFIER_FIELD_NAME)
 
-    template_string = """== {{int:filedesc}} ==
-     {{ Artwork
-        | Other fields 1 = {{ InFi | Creator | $creator }}
+    if creator_string:
+        creator_template = """
+        | Other fields 1 = {{ InFi | Creator | $creator | id=fileinfotpl_aut}}"""
+    else:
+        creator_template = ""
+
+    template_string = (
+        """== {{int:filedesc}} ==
+     {{ Artwork"""
+        + creator_template
+        + """
         | title = $title
         | description = $description
         | date = $date_string
@@ -157,6 +165,7 @@ def get_wiki_text(
         }}
         | Institution = {{ Institution | wikidata = $data_provider }}
      }}"""
+    )
 
     return Template(template_string).substitute(
         creator=creator_string,

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -143,7 +143,28 @@ def test_get_wiki_text():
     expected_text = (
         "== {{int:filedesc}} ==\n"
         "     {{ Artwork\n"
-        "        | Other fields 1 = {{ InFi | Creator | John Doe }}\n"
+        "        | Other fields 1 = {{ InFi | Creator | John Doe | id=fileinfotpl_aut}}\n"
+        "        | title = Sample Title\n"
+        "        | description = Sample Description\n"
+        "        | date = 2023\n"
+        "        | permission = {{NKC | Q12345}}\n"
+        "        | source = {{ DPLA\n"
+        "            | Q12345\n"
+        "            | hub = Q67890\n"
+        "            | url = http://example.com/item/12345\n"
+        "            | dpla_id = 12345\n"
+        "            | local_id = ID12345\n"
+        "        }}\n"
+        "        | Institution = {{ Institution | wikidata = Q12345 }}\n"
+        "     }}"
+    )
+    assert text == expected_text
+
+    item_metadata["sourceResource"].pop("creator")
+    text = get_wiki_text(dpla_id, item_metadata, provider, data_provider)
+    expected_text = (
+        "== {{int:filedesc}} ==\n"
+        "     {{ Artwork\n"
         "        | title = Sample Title\n"
         "        | description = Sample Description\n"
         "        | date = 2023\n"


### PR DESCRIPTION
Made markup different per https://commons.wikimedia.org/wiki/User_talk:Dominic#DPLA_bot_use_of_InFi_for_creator_field

Omit creator when missing.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `get_wiki_text` to conditionally include creator field based on presence, with corresponding test updates.
> 
>   - **Behavior**:
>     - Update `get_wiki_text` in `wikimedia.py` to conditionally include creator field in template only if present.
>     - If creator is missing, omit the creator field from the template.
>   - **Tests**:
>     - Update `test_get_wiki_text` in `test_wikimedia.py` to verify behavior with and without creator field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for f2ebcbc562c0b5d2f63e0b32e730742716638c11. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->