### PR TITLE
Increased connection timeout to 45 seconds

### DIFF
--- a/ingest_wikimedia/web.py
+++ b/ingest_wikimedia/web.py
@@ -11,7 +11,7 @@ __thread_local.http_session = None
 
 RETRY_COUNT = 3
 RETRY_BACKOUT_FACTOR = 1
-DEFAULT_CONN_TIMEOUT = 10
+DEFAULT_CONN_TIMEOUT = 45
 
 
 def get_http_session() -> requests.Session:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase connection timeout from 10 to 45 seconds in `ingest_wikimedia/web.py`.
> 
>   - **Behavior**:
>     - Increase `DEFAULT_CONN_TIMEOUT` from 10 to 45 seconds in `ingest_wikimedia/web.py`.
>     - Affects `get_http_session()` function, setting a longer default timeout for HTTP requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 5a7093a9978f7a5735461019de236d63a773bb60. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->