### PR TITLE
Ohio fixes

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -16,6 +16,7 @@ from ingest_wikimedia.metadata import (
     contentdm_iiif_url,
     check_record_partner,
     maximize_iiif_url,
+    IIIF_V3_FULL_RES_JPG_SUFFIX,
 )
 
 
@@ -216,16 +217,16 @@ def test_contentdm_iiif_url():
 def test_bpl_iiif_imageapi_url():
     url = "https://iiif.digitalcommonwealth.org/iiif/2/commonwealth:c534kh14z"
     expected_url = "https://iiif.digitalcommonwealth.org/iiif/2/commonwealth:c534kh14z/full/max/0/default.jpg"
-    assert maximize_iiif_url(url) == expected_url
+    assert maximize_iiif_url(url, IIIF_V3_FULL_RES_JPG_SUFFIX) == expected_url
 
 
 def test_colorado_imageapi_url():
     url = "https://cudl.colorado.edu/luna/servlet/iiif/UCBOULDERCB1~17~17~33595~102636"
     expected_url = "https://cudl.colorado.edu/luna/servlet/iiif/UCBOULDERCB1~17~17~33595~102636/full/max/0/default.jpg"
-    assert maximize_iiif_url(url) == expected_url
+    assert maximize_iiif_url(url, IIIF_V3_FULL_RES_JPG_SUFFIX) == expected_url
 
 
 def test_texas_imageapi_url():
     url = "https://texashistory.unt.edu/iiif/ark:/67531/metapth540971/m1/1"
     expected_url = "https://texashistory.unt.edu/iiif/ark:/67531/metapth540971/m1/1/full/max/0/default.jpg"
-    assert maximize_iiif_url(url) == expected_url
+    assert maximize_iiif_url(url, IIIF_V3_FULL_RES_JPG_SUFFIX) == expected_url

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -217,6 +217,9 @@ def process_item(
         elif IIIF_MANIFEST_FIELD_NAME in item_metadata:
             manifest_url = get_str(item_metadata, IIIF_MANIFEST_FIELD_NAME)
             manifest = get_iiif_manifest(manifest_url)
+            if not manifest:
+                tracker.increment(Result.SKIPPED)
+                return
             write_iiif_manifest(partner, dpla_id, json.dumps(manifest))
             media_urls = get_iiif_urls(manifest)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance IIIF URL handling by distinguishing v2 and v3 APIs, improve error handling, and update tests accordingly.
> 
>   - **Behavior**:
>     - `maximize_iiif_url` now accepts a `suffix` parameter to handle different IIIF API versions.
>     - `iiif_v2_urls` and `iiif_v3_urls` in `metadata.py` updated to handle v2 and v3 API URL suffixes.
>     - Improved error handling in `get_iiif_manifest` to return `None` instead of raising exceptions.
>   - **Constants**:
>     - Added `IIIF_V2_FULL_RES_JPG_SUFFIX` and `IIIF_V3_FULL_RES_JPG_SUFFIX` constants.
>     - Removed `IIIF_FULL_RES_JPG_SUFFIX` constant.
>   - **Tests**:
>     - Updated tests in `test_metadata.py` to use the new `maximize_iiif_url` signature.
>     - Added tests for handling invalid IIIF manifest URLs.
>   - **Misc**:
>     - Minor logging improvements in `downloader.py` and `metadata.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 10fe752b090766fd9293fb59267bfd7494cb319e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->