### PR TITLE
stripping line endings from banlist file

### DIFF
--- a/ingest_wikimedia/metadata.py
+++ b/ingest_wikimedia/metadata.py
@@ -27,7 +27,7 @@ def setup_dpla_id_banlist() -> None:
     global __dpla_id_banlist
     banlist_path = Path(__file__).parent.parent / BANLIST_FILE_NAME
     with open(banlist_path, "r") as file:
-        __dpla_id_banlist = set(file.readlines())
+        __dpla_id_banlist = set([line.rstrip() for line in file])
 
 
 def check_partner(partner: str) -> None:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -117,7 +117,7 @@ def test_not_wiki_eligible_dpla_id(
 ):
     banlist_path = Path(__file__).parent.parent / BANLIST_FILE_NAME
     with open(banlist_path, "r") as file:
-        banlist = file.readlines()
+        banlist = [line.rstrip() for line in file]
 
     assert not is_wiki_eligible(
         banlist[0], good_item_metadata, good_provider, good_data_provider


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Strip line endings from banlist file entries in `metadata.py` and `test_metadata.py` for accurate set membership checks.
> 
>   - **Behavior**:
>     - In `setup_dpla_id_banlist()` in `metadata.py`, lines from the banlist file are now stripped of line endings before being added to `__dpla_id_banlist`.
>     - In `test_not_wiki_eligible_dpla_id()` in `test_metadata.py`, lines from the banlist file are stripped of line endings before being used in assertions.
>   - **Tests**:
>     - Adjusts `test_not_wiki_eligible_dpla_id()` to strip line endings from banlist entries for accurate testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 348fcd223027a524169b44bf04e40c643169eabc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->