### PR TITLE
Sonar lint, plus

### DIFF
--- a/ingest_wikimedia/logs.py
+++ b/ingest_wikimedia/logs.py
@@ -19,7 +19,7 @@ class TqdmLoggingHandler(logging.Handler):
             msg = self.format(record)
             tqdm.write(msg)
             self.flush()
-        except Exception:
+        except (IOError, OSError):
             self.handleError(record)
 
 
@@ -40,7 +40,7 @@ def setup_logging(partner: str, event_type: str, level: int = logging.INFO) -> N
             TqdmLoggingHandler(),
             logging.FileHandler(filename=filename, mode="w"),
         ],
-        format="[%(levelname)s] " "%(asctime)s: " "%(message)s",
+        format="[%(levelname)s] %(asctime)s: %(message)s",
     )
     logging.info(f"Logging to {filename}.")
     for d in logging.Logger.manager.loggerDict:

--- a/ingest_wikimedia/metadata.py
+++ b/ingest_wikimedia/metadata.py
@@ -410,9 +410,9 @@ def contentdm_iiif_url(is_shown_at: str) -> str | None:
     link to the object in ContentDM
 
     We want to go from
-    http://www.ohiomemory.org/cdm/ref/collection/p16007coll33/id/126923
+    https://www.ohiomemory.org/cdm/ref/collection/p16007coll33/id/126923
     to
-    http://www.ohiomemory.org/iiif/info/p16007coll33/126923/manifest.json
+    https://www.ohiomemory.org/iiif/info/p16007coll33/126923/manifest.json
 
     """
     parsed_url = urlparse(is_shown_at)

--- a/ingest_wikimedia/web.py
+++ b/ingest_wikimedia/web.py
@@ -33,10 +33,7 @@ def get_http_session() -> requests.Session:
     session = requests.Session()
     # To have a default session-level connection init timeout,
     # you have to result to this:
-    session.get_orig, session.get = (
-        session.get,
-        functools.partial(session.get, timeout=DEFAULT_CONN_TIMEOUT),
-    )
+    session.get = functools.partial(session.get, timeout=DEFAULT_CONN_TIMEOUT)
     session.mount("https://", adapter)
     session.mount("http://", adapter)
     __thread_local.http_session = session
@@ -44,6 +41,6 @@ def get_http_session() -> requests.Session:
 
 
 HTTP_REQUEST_HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
-            (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) "
+    "Gecko/20100101 Firefox/135.0"
 }

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -68,7 +68,8 @@ def get_page_title(
         return (
             f"{escaped_visible_title} - DPLA - {dpla_identifier} (page {page}){suffix}"
         )
-    return f"{escaped_visible_title} - DPLA - {dpla_identifier}{suffix}"
+    else:
+        return f"{escaped_visible_title} - DPLA - {dpla_identifier}{suffix}"
 
 
 def license_to_markup_code(rights_uri: str) -> str:
@@ -193,9 +194,9 @@ def get_page(site: pywikibot.Site, title: str) -> FilePage:
     try:
         return pywikibot.FilePage(site, title=title)
     except pywikibot.exceptions.InvalidTitleError as e:
-        raise Exception(f"Invalid title {title}: {str(e)}") from e
+        raise ValueError(f"Invalid title {title}: {str(e)}") from e
     except Exception as e:
-        raise Exception(f"Unable to create page {title}: {str(e)}") from e
+        raise RuntimeError(f"Unable to create page {title}: {str(e)}") from e
 
 
 def get_site() -> pywikibot.Site:
@@ -210,7 +211,7 @@ def wiki_file_exists(sha1: str) -> bool:
     response = get_http_session().get(FIND_BY_HASH_URL_PREFIX + sha1)
     sha1_response = response.json()
     if "error" in sha1_response:
-        raise Exception(
+        raise RuntimeError(
             f"Received bad response from find by hash endpoint.\n{str(sha1_response)}"
         )
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,6 @@
+import functools
 from unittest.mock import patch, MagicMock
-from ingest_wikimedia.web import get_http_session
+from ingest_wikimedia.web import get_http_session, __thread_local
 
 
 @patch("ingest_wikimedia.web.requests.Session")
@@ -10,3 +11,13 @@ def test_get_http_session(mock_session):
     session = get_http_session()
     assert session == mock_sess
     mock_session.assert_called_once()
+    patch.stopall()
+    if hasattr(__thread_local, "http_session"):
+        __thread_local.http_session = None
+
+
+def test_exercise_monkey_patched_session():
+    session = get_http_session()
+    assert isinstance(session.get, functools.partial)
+    response = session.get("https://example.com")
+    assert response.status_code == 200

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -97,7 +97,7 @@ def upload_file_to_s3(file: str, destination_path: str, content_type: str, sha1:
 
     except Exception as e:
         raise RuntimeError(
-            f"Error uploading to s3RuntimeError{S3_BUCKET}/{destination_path}"
+            f"Error uploading to s3://{S3_BUCKET}/{destination_path}"
         ) from e
 
 

--- a/tools/nuke.py
+++ b/tools/nuke.py
@@ -22,7 +22,7 @@ def main(ids_file: IO, partner: str, dry_run: bool):
     setup_logging(partner, "nuke-items", logging.INFO)
     logging.info(f"Nuking items for {partner}")
     dpla_ids = load_ids(ids_file)
-    for dpla_id in tqdm(dpla_ids, desc="Nuking Items", unit="Item"):
+    for dpla_id in tqdm(dpla_ids, desc="Nuking Items", unit="Item", ncols=100):
         logging.info(f"DPLA ID: {dpla_id}")
         s3_path = get_item_s3_path(dpla_id, "", partner)
         command = f"aws s3 rm s3://{S3_BUCKET}/{s3_path} --recursive"


### PR DESCRIPTION
- TQDM max width
- Fixed is_wiki_eligible call in downloader
- Updated User Agent
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This pull request refines exception handling, updates the user agent, standardizes progress bar width, and fixes a function call in the Wikimedia ingestion scripts.
> 
>   - **Exception Handling**:
>     - Replace generic `Exception` with specific exceptions like `IOError`, `OSError`, `ValueError`, and `RuntimeError` in `logs.py`, `wikimedia.py`, `downloader.py`, and `web.py`.
>   - **User Agent Update**:
>     - Update `User-Agent` string in `web.py` to reflect a Firefox browser.
>   - **Progress Bar Configuration**:
>     - Set `ncols=100` for `tqdm` progress bars in `downloader.py`, `nuke.py`, `sign.py`, and `uploader.py` to standardize width.
>   - **Miscellaneous**:
>     - Fix `is_wiki_eligible` call in `downloader.py` to include `dpla_id` as the first argument.
>     - Remove redundant `session.get_orig` assignment in `web.py`.
>     - Correct URL scheme from `http` to `https` in `metadata.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 0fedcae1e8bd167fe3611a2636638725f860746b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->