### PR TITLE
Download buffer sized

### DIFF
--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -31,6 +31,8 @@ from ingest_wikimedia.tools_context import ToolsContext
 from ingest_wikimedia.tracker import Result, Tracker
 from ingest_wikimedia.wikimedia import check_content_type
 
+DOWNLOAD_BUFFER_SIZE = 4 * 1024 * 1024  # 4 MB
+
 
 class Downloader:
     """
@@ -128,7 +130,7 @@ class Downloader:
                 ncols=100,
             ) as t:
                 with open(local_file, "wb") as f:
-                    for chunk in response.iter_content(None):
+                    for chunk in response.iter_content(DOWNLOAD_BUFFER_SIZE):
                         t.update(len(chunk))
                         f.write(chunk)
 


### PR DESCRIPTION
Requests doesn't stream to a file if you specify None for a chunk size (it'll do one chunk).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a 4 MB buffer size for streaming file downloads in `Downloader` class to improve efficiency.
> 
>   - **Behavior**:
>     - Introduces `DOWNLOAD_BUFFER_SIZE` constant set to 4 MB in `downloader.py`.
>     - Updates `download_file_to_temp_path()` in `Downloader` class to use `DOWNLOAD_BUFFER_SIZE` for `iter_content()` instead of `None`, enabling efficient streaming of file downloads.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 44729ed076eebe595c728366582511c52dd8a85d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->