### PR TITLE
Set pywikibot logging to the same as the rest of the project

### DIFF
--- a/ingest_wikimedia/logs.py
+++ b/ingest_wikimedia/logs.py
@@ -45,7 +45,7 @@ def setup_logging(partner: str, event_type: str, level: int = logging.INFO) -> N
     logging.info(f"Logging to {filename}.")
     for d in logging.Logger.manager.loggerDict:
         if d.startswith("pywiki"):
-            logging.getLogger(d).setLevel(logging.ERROR)
+            logging.getLogger(d).setLevel(level)
 
 
 LOGS_DIR_BASE = "./logs"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set pywikibot logging level to match the project's logging level in `setup_logging()` in `logs.py`.
> 
>   - **Logging**:
>     - In `setup_logging()` in `logs.py`, change pywikibot logging level from `ERROR` to match the `level` parameter.
>     - Affects all loggers starting with "pywiki".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 2d8b2a1459dfb6b60587ba1dad9ba9a662ad9530. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->