### PR TITLE
Using pywikibot feature for checking already uploaded by sha1.

### DIFF
--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -126,7 +126,7 @@ class Uploader:
                 logging.info(f"Upload comment: {upload_comment}")
                 logging.info(f"Wikitext: \n {wiki_markup}")
 
-            if wiki_file_exists(self.http_session, sha1):
+            if wiki_file_exists(self.site, sha1):
                 logging.info(
                     f"Skipping {dpla_id} {ordinal}: Already exists on commons."
                 )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `wiki_file_exists` to use `pywikibot`'s `allimages` method, updating related code and tests.
> 
>   - **Behavior**:
>     - Refactor `wiki_file_exists` in `ingest_wikimedia/wikimedia.py` to use `pywikibot`'s `allimages` method instead of HTTP requests.
>     - Update `process_file` in `tools/uploader.py` to use the refactored `wiki_file_exists`.
>   - **Tests**:
>     - Update `test_wiki_file_exists` in `tests/test_wikimedia.py` to mock `pywikibot` site instead of HTTP session.
>   - **Imports**:
>     - Remove `Session` import from `ingest_wikimedia/wikimedia.py` and `tools/uploader.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dpla%2Fingest-wikimedia&utm_source=github&utm_medium=referral)<sup> for 4cde369d5c4235c6b47a8c521bf260c464e6cafe. You can [customize](https://app.ellipsis.dev/dpla/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->