### PR TITLE
Fix fix-unknown-categories: NoPageError compat, remove dry-run

### DIFF
--- a/ingest_wikimedia/categories.py
+++ b/ingest_wikimedia/categories.py
@@ -145,7 +145,7 @@ class CategoryEnsurer:
         try:
             existing = commons_page.data_item()
             return existing.getID()
-        except pywikibot.exceptions.NoWikidataItemError:
+        except pywikibot.exceptions.NoPageError:
             pass
         try:
             return self._create_wikidata_category_item(
@@ -155,7 +155,7 @@ class CategoryEnsurer:
             # Another process may have created the item concurrently. Re-read before failing.
             try:
                 return commons_page.data_item().getID()
-            except pywikibot.exceptions.NoWikidataItemError:
+            except pywikibot.exceptions.NoPageError:
                 raise create_exc
 
     def _item_claim(self, property_id: str, target_qid: str) -> pywikibot.Claim:

--- a/tools/fix_unknown_categories.py
+++ b/tools/fix_unknown_categories.py
@@ -48,18 +48,14 @@ def _extract_hub_qid(wikitext: str) -> str | None:
 
 
 @click.command()
-@click.option("--dry-run", is_flag=True)
 @click.option("--verbose", is_flag=True)
-def main(dry_run: bool, verbose: bool) -> None:
+def main(verbose: bool) -> None:
     setup_logging("fix-unknown-categories", "fix", logging.INFO)
     start_time = time.time()
 
-    if dry_run:
-        logging.warning("---=== DRY RUN ===---")
-
     commons_site = get_site()
     wikidata_site = get_wikidata_site()
-    category_ensurer = CategoryEnsurer(commons_site, wikidata_site, dry_run=dry_run)
+    category_ensurer = CategoryEnsurer(commons_site, wikidata_site)
     repo = wikidata_site.data_repository()
 
     unknown_cat = pywikibot.Category(commons_site, UNKNOWN_INSTITUTION_CATEGORY)
@@ -68,19 +64,13 @@ def main(dry_run: bool, verbose: bool) -> None:
     files_touched = 0
     # Tracks files we cannot parse, so we don't loop on them forever
     cannot_process: set[str] = set()
-    # In dry-run mode, real touches are skipped so files never leave the category.
-    # Track titles already processed so we don't loop on the same institution forever.
-    dry_run_processed: set[str] = set()
 
     while True:
         file_page = None
         category_has_members = False
         for page in unknown_cat.members(namespaces=[6]):
             category_has_members = True
-            if (
-                page.title() not in cannot_process
-                and page.title() not in dry_run_processed
-            ):
+            if page.title() not in cannot_process:
                 file_page = page
                 break
 
@@ -131,29 +121,21 @@ def main(dry_run: bool, verbose: bool) -> None:
             f'insource:"Institution" insource:"wikidata = {institution_qid}"',
             namespaces=[6],
         ):
-            if dry_run:
-                dry_run_processed.add(page.title())
             if verbose:
-                logging.info(
-                    f"  {'Would touch' if dry_run else 'Touching'}: {page.title()}"
-                )
-            if not dry_run:
-                try:
-                    page.touch()
-                except Exception as e:
-                    logging.warning(f"Failed to touch '{page.title()}'", exc_info=e)
+                logging.info(f"  Touching: {page.title()}")
+            try:
+                page.touch()
+            except Exception as e:
+                logging.warning(f"Failed to touch '{page.title()}'", exc_info=e)
             count += 1
 
         files_touched += count
-        logging.info(
-            f"{'Would touch' if dry_run else 'Touched'} {count} files "
-            f"for {institution_name}"
-        )
+        logging.info(f"Touched {count} files for {institution_name}")
 
     elapsed = time.time() - start_time
     logging.info(
         f"Done. Institutions processed: {institutions_processed}, "
-        f"files {'would touch' if dry_run else 'touched'}: {files_touched}, "
+        f"files touched: {files_touched}, "
         f"elapsed: {elapsed:.1f}s"
     )
 

--- a/tools/fix_unknown_categories.py
+++ b/tools/fix_unknown_categories.py
@@ -125,9 +125,9 @@ def main(verbose: bool) -> None:
                 logging.info(f"  Touching: {page.title()}")
             try:
                 page.touch()
+                count += 1
             except Exception as e:
                 logging.warning(f"Failed to touch '{page.title()}'", exc_info=e)
-            count += 1
 
         files_touched += count
         logging.info(f"Touched {count} files for {institution_name}")

--- a/tools/fix_unknown_categories.py
+++ b/tools/fix_unknown_categories.py
@@ -68,13 +68,19 @@ def main(dry_run: bool, verbose: bool) -> None:
     files_touched = 0
     # Tracks files we cannot parse, so we don't loop on them forever
     cannot_process: set[str] = set()
+    # In dry-run mode, real touches are skipped so files never leave the category.
+    # Track titles already processed so we don't loop on the same institution forever.
+    dry_run_processed: set[str] = set()
 
     while True:
         file_page = None
         category_has_members = False
         for page in unknown_cat.members(namespaces=[6]):
             category_has_members = True
-            if page.title() not in cannot_process:
+            if (
+                page.title() not in cannot_process
+                and page.title() not in dry_run_processed
+            ):
                 file_page = page
                 break
 
@@ -125,6 +131,8 @@ def main(dry_run: bool, verbose: bool) -> None:
             f'insource:"Institution" insource:"wikidata = {institution_qid}"',
             namespaces=[6],
         ):
+            if dry_run:
+                dry_run_processed.add(page.title())
             if verbose:
                 logging.info(
                     f"  {'Would touch' if dry_run else 'Touching'}: {page.title()}"


### PR DESCRIPTION
## Summary

- **`NoWikidataItemError` → `NoPageError`**: `NoWikidataItemError` was removed in pywikibot 9.x. Replace with `NoPageError` in both catch sites in `_get_or_create_wikidata_category_item`. This was causing the tool to crash on launch.
- **Remove `--dry-run`**: Dry-run mode was only useful for initial testing and was broken anyway (infinite loop — files never leave the category when no real touches happen, so the main loop re-picked the same institution forever). Now that the tool is proven in production, it's been removed.

## Test plan

- [ ] Live run confirmed working: BRIT (Q2759819) category created and ~1,197 files being touched as of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception handling when checking for associated Wikidata items for Commons file pages, reducing false error paths and improving reliability during category processing.

* **Removed Features**
  * The category-fix tool no longer supports a dry-run mode; it now performs edits directly and reports actual "touched" counts instead of simulated actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->