### PR TITLE
Add Wikimedia upload status GH Action + Slack slash command

### DIFF
--- a/.github/workflows/wikimedia-upload-status.yml
+++ b/.github/workflows/wikimedia-upload-status.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 */6 * * *"  # every 6 hours
   workflow_dispatch:         # also triggerable via API (Slack slash command)
 
+permissions:
+  contents: read
+
 jobs:
   check-status:
     runs-on: ubuntu-latest

--- a/.github/workflows/wikimedia-upload-status.yml
+++ b/.github/workflows/wikimedia-upload-status.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: wikimedia-upload-status
+  cancel-in-progress: false
+
 jobs:
   check-status:
     runs-on: ubuntu-latest
@@ -24,7 +28,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - run: pip install boto3 requests
+      - run: pip install boto3==1.42.87 requests==2.32.5
 
       - name: Check status and post to Slack
         env:

--- a/.github/workflows/wikimedia-upload-status.yml
+++ b/.github/workflows/wikimedia-upload-status.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 */6 * * *"  # every 6 hours
   workflow_dispatch:         # also triggerable via API (Slack slash command)
+    inputs:
+      notify_if_idle:
+        description: "Post to Slack even if no sessions are active (set by slash command)"
+        required: false
+        default: "false"
 
 permissions:
   contents: read
@@ -27,4 +32,5 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.WIKIMEDIA_STATUS_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
           DPLA_SLACK_BOT_TOKEN: ${{ secrets.DPLA_SLACK_BOT_TOKEN }}
+          NOTIFY_IF_IDLE: ${{ github.event.inputs.notify_if_idle || 'false' }}
         run: python scripts/wikimedia_upload_status.py

--- a/.github/workflows/wikimedia-upload-status.yml
+++ b/.github/workflows/wikimedia-upload-status.yml
@@ -1,0 +1,26 @@
+name: Wikimedia Upload Status
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"  # every 6 hours
+  workflow_dispatch:         # also triggerable via API (Slack slash command)
+
+jobs:
+  check-status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install boto3 requests
+
+      - name: Check status and post to Slack
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.WIKIMEDIA_STATUS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.WIKIMEDIA_STATUS_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+          DPLA_SLACK_BOT_TOKEN: ${{ secrets.DPLA_SLACK_BOT_TOKEN }}
+        run: python scripts/wikimedia_upload_status.py

--- a/.github/workflows/wikimedia-upload-status.yml
+++ b/.github/workflows/wikimedia-upload-status.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   check-status:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -13,6 +13,7 @@ Environment variables (set on the Lambda function):
   GH_WORKFLOW           — e.g. wikimedia-upload-status.yml
 """
 
+import base64
 import hashlib
 import hmac
 import json
@@ -57,6 +58,8 @@ def _dispatch_workflow(token: str, repo: str, workflow: str) -> int:
 def handler(event, context):
     headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
     body = event.get("body") or ""
+    if event.get("isBase64Encoded"):
+        body = base64.b64decode(body).decode("utf-8")
 
     timestamp = headers.get("x-slack-request-timestamp", "")
     signature = headers.get("x-slack-signature", "")

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -14,6 +14,7 @@ Environment variables (set on the Lambda function):
 """
 
 import base64
+import binascii
 import hashlib
 import hmac
 import json
@@ -59,7 +60,10 @@ def handler(event, context):
     headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
     body = event.get("body") or ""
     if event.get("isBase64Encoded"):
-        body = base64.b64decode(body).decode("utf-8")
+        try:
+            body = base64.b64decode(body).decode("utf-8")
+        except (binascii.Error, UnicodeDecodeError):
+            return {"statusCode": 400, "body": "Invalid request body encoding"}
 
     timestamp = headers.get("x-slack-request-timestamp", "")
     signature = headers.get("x-slack-signature", "")

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -16,6 +16,7 @@ Environment variables (set on the Lambda function):
 import hashlib
 import hmac
 import json
+import logging
 import os
 import time
 import urllib.error
@@ -25,7 +26,11 @@ import urllib.request
 def _verify_slack_signature(
     signing_secret: str, timestamp: str, body: str, signature: str
 ) -> bool:
-    if abs(time.time() - int(timestamp)) > 300:
+    try:
+        ts = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+    if abs(time.time() - ts) > 300:
         return False
     sig_base = f"v0:{timestamp}:{body}".encode()
     mac = hmac.new(signing_secret.encode(), sig_base, hashlib.sha256)
@@ -70,9 +75,11 @@ def handler(event, context):
     try:
         status = _dispatch_workflow(os.environ["GH_TOKEN"], repo, workflow)
     except urllib.error.HTTPError as e:
+        logging.error("GitHub API error: HTTP %s", e.code)
         msg = f"Failed to trigger workflow (HTTP {e.code})"
-    except Exception as e:
-        msg = f"Error: {e}"
+    except Exception:
+        logging.exception("Unexpected error dispatching workflow")
+        msg = "Failed to trigger workflow due to an internal error."
     else:
         msg = (
             "Checking Wikimedia upload status — results will post to #tech-alerts shortly."

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -79,11 +79,16 @@ def handler(event, context):
     if not _verify_slack_signature(signing_secret, timestamp, body, signature):
         return {"statusCode": 401, "body": "Invalid signature"}
 
+    gh_token = os.environ.get("GH_TOKEN")
+    if not gh_token:
+        logging.error("Missing required environment variable: GH_TOKEN")
+        return {"statusCode": 500, "body": "Server misconfiguration"}
+
     repo = os.environ.get("GH_REPO", "dpla/ingest-wikimedia")
     workflow = os.environ.get("GH_WORKFLOW", "wikimedia-upload-status.yml")
 
     try:
-        status = _dispatch_workflow(os.environ["GH_TOKEN"], repo, workflow)
+        status = _dispatch_workflow(gh_token, repo, workflow)
     except urllib.error.HTTPError as e:
         logging.error("GitHub API error: HTTP %s", e.code)
         msg = f"Failed to trigger workflow (HTTP {e.code})"

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -51,7 +51,7 @@ def _dispatch_workflow(token: str, repo: str, workflow: str) -> int:
     url = f"https://api.github.com/repos/{repo}/actions/workflows/{workflow}/dispatches"
     req = urllib.request.Request(
         url,
-        data=json.dumps({"ref": "main"}).encode(),
+        data=json.dumps({"ref": "main", "inputs": {"notify_if_idle": "true"}}).encode(),
         headers={
             "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github+json",

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -60,7 +60,7 @@ def _dispatch_workflow(token: str, repo: str, workflow: str) -> int:
         },
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=10) as resp:
+    with urllib.request.urlopen(req, timeout=2) as resp:
         return resp.status
 
 

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -71,9 +71,12 @@ def handler(event, context):
     if not timestamp or not signature:
         return {"statusCode": 400, "body": "Missing Slack headers"}
 
-    if not _verify_slack_signature(
-        os.environ["SLACK_SIGNING_SECRET"], timestamp, body, signature
-    ):
+    signing_secret = os.environ.get("SLACK_SIGNING_SECRET")
+    if not signing_secret:
+        logging.error("Missing required environment variable: SLACK_SIGNING_SECRET")
+        return {"statusCode": 500, "body": "Server misconfiguration"}
+
+    if not _verify_slack_signature(signing_secret, timestamp, body, signature):
         return {"statusCode": 401, "body": "Invalid signature"}
 
     repo = os.environ.get("GH_REPO", "dpla/ingest-wikimedia")

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -1,0 +1,87 @@
+"""
+Lambda handler for the /wikimedia-status Slack slash command.
+
+Validates the incoming Slack request signature, dispatches the
+wikimedia-upload-status GitHub Actions workflow, and returns an
+immediate acknowledgment to Slack (results post to #tech-alerts
+once the workflow completes, typically ~2 minutes later).
+
+Environment variables (set on the Lambda function):
+  SLACK_SIGNING_SECRET  — from Slack app Basic Information page
+  GH_TOKEN              — GitHub fine-grained PAT with actions:write
+  GH_REPO               — e.g. dpla/ingest-wikimedia
+  GH_WORKFLOW           — e.g. wikimedia-upload-status.yml
+"""
+
+import hashlib
+import hmac
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+
+def _verify_slack_signature(
+    signing_secret: str, timestamp: str, body: str, signature: str
+) -> bool:
+    if abs(time.time() - int(timestamp)) > 300:
+        return False
+    sig_base = f"v0:{timestamp}:{body}".encode()
+    mac = hmac.new(signing_secret.encode(), sig_base, hashlib.sha256)
+    return hmac.compare_digest("v0=" + mac.hexdigest(), signature)
+
+
+def _dispatch_workflow(token: str, repo: str, workflow: str) -> int:
+    url = f"https://api.github.com/repos/{repo}/actions/workflows/{workflow}/dispatches"
+    req = urllib.request.Request(
+        url,
+        data=json.dumps({"ref": "main"}).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return resp.status
+
+
+def handler(event, context):
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+    body = event.get("body") or ""
+
+    timestamp = headers.get("x-slack-request-timestamp", "")
+    signature = headers.get("x-slack-signature", "")
+
+    if not timestamp or not signature:
+        return {"statusCode": 400, "body": "Missing Slack headers"}
+
+    if not _verify_slack_signature(
+        os.environ["SLACK_SIGNING_SECRET"], timestamp, body, signature
+    ):
+        return {"statusCode": 401, "body": "Invalid signature"}
+
+    repo = os.environ.get("GH_REPO", "dpla/ingest-wikimedia")
+    workflow = os.environ.get("GH_WORKFLOW", "wikimedia-upload-status.yml")
+
+    try:
+        status = _dispatch_workflow(os.environ["GH_TOKEN"], repo, workflow)
+    except urllib.error.HTTPError as e:
+        msg = f"Failed to trigger workflow (HTTP {e.code})"
+    except Exception as e:
+        msg = f"Error: {e}"
+    else:
+        msg = (
+            "Checking Wikimedia upload status — results will post to #tech-alerts shortly."
+            if status == 204
+            else f"Unexpected response from GitHub (HTTP {status})"
+        )
+
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps({"response_type": "in_channel", "text": msg}),
+    }

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -39,6 +39,14 @@ def _verify_slack_signature(
     return hmac.compare_digest("v0=" + mac.hexdigest(), signature)
 
 
+def _require_env(key: str) -> str:
+    value = os.environ.get(key)
+    if not value:
+        logging.error("Missing required environment variable: %s", key)
+        raise RuntimeError(key)
+    return value
+
+
 def _dispatch_workflow(token: str, repo: str, workflow: str) -> int:
     url = f"https://api.github.com/repos/{repo}/actions/workflows/{workflow}/dispatches"
     req = urllib.request.Request(
@@ -71,18 +79,14 @@ def handler(event, context):
     if not timestamp or not signature:
         return {"statusCode": 400, "body": "Missing Slack headers"}
 
-    signing_secret = os.environ.get("SLACK_SIGNING_SECRET")
-    if not signing_secret:
-        logging.error("Missing required environment variable: SLACK_SIGNING_SECRET")
+    try:
+        signing_secret = _require_env("SLACK_SIGNING_SECRET")
+        gh_token = _require_env("GH_TOKEN")
+    except RuntimeError:
         return {"statusCode": 500, "body": "Server misconfiguration"}
 
     if not _verify_slack_signature(signing_secret, timestamp, body, signature):
         return {"statusCode": 401, "body": "Invalid signature"}
-
-    gh_token = os.environ.get("GH_TOKEN")
-    if not gh_token:
-        logging.error("Missing required environment variable: GH_TOKEN")
-        return {"statusCode": 500, "body": "Server misconfiguration"}
 
     repo = os.environ.get("GH_REPO", "dpla/ingest-wikimedia")
     workflow = os.environ.get("GH_WORKFLOW", "wikimedia-upload-status.yml")

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -7,7 +7,6 @@ the /wikimedia-status Slack slash command via Lambda).
 
 import json
 import os
-import sys
 import time
 
 import boto3

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -153,7 +153,11 @@ def main() -> None:
             print(f"{session}: {phase}")
 
     rows = [(s, results[s]) for s in sessions if s in results]
-    token = os.environ["DPLA_SLACK_BOT_TOKEN"]
+    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
+    if not token:
+        raise RuntimeError(
+            "Missing required environment variable: DPLA_SLACK_BOT_TOKEN"
+        )
     post_to_slack(token, rows)
     print("Posted to Slack.")
 

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -64,9 +64,9 @@ def get_phase_and_progress(client, partner: str) -> str:
         client,
         f"tail -5 {log_path}; "
         f"echo '---'; "
-        f"grep -c 'DPLA ID:' {log_path} 2>/dev/null || echo 0; "
-        f"grep -c 'Uploaded to' {log_path} 2>/dev/null || echo 0; "
-        f"grep -c 'Skipping.*Already exists on commons' {log_path} 2>/dev/null || echo 0; "
+        f"grep -c 'DPLA ID:' {log_path} 2>/dev/null || true; "
+        f"grep -c 'Uploaded to' {log_path} 2>/dev/null || true; "
+        f"grep -c 'Skipping.*Already exists on commons' {log_path} 2>/dev/null || true; "
         f"wc -l < {csv_path} 2>/dev/null || echo 0",
     )
 

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -82,12 +82,12 @@ def get_phase_and_progress(client, partner: str) -> str:
     def pct(n: int) -> str:
         return f"{n / total * 100:.1f}" if total > 0 else "?"
 
-    if "download" in log_file:
+    if log_file.endswith("-download.log"):
         if "Downloading" in tail or "Key already in S3" in tail:
             return f"Downloading ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%)"
         return "Generating IDs"
 
-    if "upload" in log_file:
+    if log_file.endswith("-upload.log"):
         processed_count = uploaded_count + skipped_count
         if processed_count == 0:
             return "Uploading (starting...)"

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -130,14 +130,20 @@ def main() -> None:
 
     ssm = boto3.client("ssm", region_name=REGION)
 
-    session_out = ssm_run(ssm, "tmux ls 2>/dev/null | grep '^wikimedia-' || echo NONE")
-    if not session_out or session_out == "NONE":
-        print("No active wikimedia sessions — skipping Slack post.")
-        return
+    notify_if_idle = os.environ.get("NOTIFY_IF_IDLE", "false").lower() == "true"
 
-    sessions = [line.split(":")[0].strip() for line in session_out.splitlines()]
+    session_out = ssm_run(ssm, "tmux ls 2>/dev/null | grep '^wikimedia-' || echo NONE")
+    sessions = (
+        [line.split(":")[0].strip() for line in session_out.splitlines()]
+        if session_out and session_out != "NONE"
+        else []
+    )
+
     if not sessions:
-        print("No active wikimedia sessions — skipping Slack post.")
+        print("No active wikimedia sessions.")
+        if notify_if_idle:
+            post_to_slack(token, [("(none)", "No active Wikimedia upload sessions.")])
+            print("Posted idle status to Slack.")
         return
 
     results: dict[str, str] = {}

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Check Wikimedia upload session status on EC2 and post a summary to Slack.
+
+Runs as a GitHub Action on a schedule and on workflow_dispatch (triggered by
+the /wikimedia-status Slack slash command via Lambda).
+"""
+
+import json
+import os
+import sys
+import time
+
+import boto3
+import requests
+
+INSTANCE_ID = "i-033eff6c8c168f999"
+SLACK_CHANNEL = "C02HEU2L3"
+SLACK_API_URL = "https://slack.com/api/chat.postMessage"
+REGION = "us-east-1"
+SSM_POLL_INTERVAL = 5
+SSM_MAX_POLLS = 24  # 2 minutes
+
+
+def ssm_run(client, cmd: str) -> str:
+    resp = client.send_command(
+        InstanceIds=[INSTANCE_ID],
+        DocumentName="AWS-RunShellScript",
+        Parameters={"commands": [f"sudo -u ec2-user bash -c {json.dumps(cmd)}"]},
+    )
+    cmd_id = resp["Command"]["CommandId"]
+    for _ in range(SSM_MAX_POLLS):
+        time.sleep(SSM_POLL_INTERVAL)
+        inv = client.get_command_invocation(CommandId=cmd_id, InstanceId=INSTANCE_ID)
+        if inv["Status"] in ("Success", "Failed", "TimedOut", "Cancelled"):
+            return inv["StandardOutputContent"].strip()
+    return ""
+
+
+def get_phase_and_progress(client, partner: str) -> str:
+    log_file = ssm_run(
+        client,
+        f"ls -t /home/ec2-user/ingest-wikimedia/{partner}/logs/ 2>/dev/null | head -1",
+    )
+    if not log_file:
+        return "Generating IDs"
+
+    log_path = f"/home/ec2-user/ingest-wikimedia/{partner}/logs/{log_file}"
+    csv_path = f"/home/ec2-user/ingest-wikimedia/{partner}/{partner}.csv"
+
+    # Get tail + item count + CSV total in one round-trip
+    out = ssm_run(
+        client,
+        f"tail -5 {log_path}; "
+        f"echo '---'; "
+        f"grep -c 'DPLA ID:' {log_path} 2>/dev/null || echo 0; "
+        f"grep -c 'Uploaded to' {log_path} 2>/dev/null || echo 0; "
+        f"wc -l < {csv_path} 2>/dev/null || echo 0",
+    )
+
+    parts = out.split("---\n", 1)
+    tail = parts[0].strip()
+    count_lines = parts[1].strip().splitlines() if len(parts) > 1 else []
+
+    dpla_id_count = int(count_lines[0]) if len(count_lines) > 0 else 0
+    uploaded_count = int(count_lines[1]) if len(count_lines) > 1 else 0
+    total = int(count_lines[2]) if len(count_lines) > 2 else 0
+
+    def pct(n: int) -> str:
+        return f"{n / total * 100:.1f}" if total > 0 else "?"
+
+    if "download" in log_file:
+        if "Downloading" in tail or "Key already in S3" in tail:
+            return f"Downloading ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%)"
+        return "Generating IDs"
+
+    if "upload" in log_file:
+        if uploaded_count == 0:
+            return "Uploading (starting...)"
+        return f"Uploading ({uploaded_count:,} / {total:,}, ~{pct(uploaded_count)}%)"
+
+    return "Unknown"
+
+
+def post_to_slack(token: str, rows: list[tuple[str, str]]) -> None:
+    lines = "\n".join(f"`{session:<32}` {phase}" for session, phase in rows)
+    payload = {
+        "channel": SLACK_CHANNEL,
+        "text": "Wikimedia Upload Status",
+        "blocks": [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": "Wikimedia Upload Status"},
+            },
+            {"type": "section", "text": {"type": "mrkdwn", "text": lines}},
+        ],
+    }
+    resp = requests.post(
+        SLACK_API_URL,
+        headers={"Authorization": f"Bearer {token}"},
+        json=payload,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    if not data.get("ok"):
+        raise RuntimeError(f"Slack API error: {data.get('error')}")
+
+
+def main() -> None:
+    ssm = boto3.client("ssm", region_name=REGION)
+
+    session_out = ssm_run(ssm, "tmux ls 2>/dev/null | grep wikimedia- || echo NONE")
+    if not session_out or session_out == "NONE":
+        print("No active wikimedia sessions — skipping Slack post.")
+        return
+
+    sessions = [
+        line.split(":")[0].strip()
+        for line in session_out.splitlines()
+        if line.startswith("wikimedia-")
+    ]
+
+    rows = []
+    for session in sessions:
+        partner = session.removeprefix("wikimedia-")
+        phase = get_phase_and_progress(ssm, partner)
+        rows.append((session, phase))
+        print(f"{session}: {phase}")
+
+    token = os.environ["DPLA_SLACK_BOT_TOKEN"]
+    post_to_slack(token, rows)
+    print("Posted to Slack.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -157,7 +157,7 @@ def main() -> None:
             phase = "Unknown (error)"
         return session, phase
 
-    with ThreadPoolExecutor(max_workers=len(sessions)) as executor:
+    with ThreadPoolExecutor(max_workers=min(len(sessions), 8)) as executor:
         futures = {executor.submit(fetch, s): s for s in sessions}
         for future in as_completed(futures):
             session, phase = future.result()

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -10,6 +10,7 @@ import logging
 import os
 import shlex
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import boto3
 import requests
@@ -30,12 +31,12 @@ def ssm_run(client, cmd: str) -> str:
     )
     cmd_id = resp["Command"]["CommandId"]
     for _ in range(SSM_MAX_POLLS):
-        time.sleep(SSM_POLL_INTERVAL)
         try:
             inv = client.get_command_invocation(
                 CommandId=cmd_id, InstanceId=INSTANCE_ID
             )
         except client.exceptions.InvocationDoesNotExist:
+            time.sleep(SSM_POLL_INTERVAL)
             continue
         status = inv["Status"]
         if status == "Success":
@@ -45,6 +46,7 @@ def ssm_run(client, cmd: str) -> str:
             raise RuntimeError(
                 f"SSM command {cmd_id} ended with {status}: {stderr or 'no stderr'}"
             )
+        time.sleep(SSM_POLL_INTERVAL)
     raise TimeoutError(f"SSM command {cmd_id} did not complete within polling window")
 
 
@@ -55,10 +57,9 @@ def get_phase_and_progress(client, partner: str) -> str:
     if not log_file:
         return "Generating IDs"
 
-    log_path = shlex.quote(f"/home/ec2-user/ingest-wikimedia/{partner}/logs/{log_file}")
-    csv_path = shlex.quote(f"/home/ec2-user/ingest-wikimedia/{partner}/{partner}.csv")
+    log_path = shlex.quote(f"{base}/logs/{log_file}")
+    csv_path = shlex.quote(f"{base}/{partner}.csv")
 
-    # Get tail + item count + CSV total in one round-trip
     out = ssm_run(
         client,
         f"tail -5 {log_path}; "
@@ -123,28 +124,35 @@ def post_to_slack(token: str, rows: list[tuple[str, str]]) -> None:
 def main() -> None:
     ssm = boto3.client("ssm", region_name=REGION)
 
-    session_out = ssm_run(ssm, "tmux ls 2>/dev/null | grep wikimedia- || echo NONE")
+    session_out = ssm_run(ssm, "tmux ls 2>/dev/null | grep '^wikimedia-' || echo NONE")
     if not session_out or session_out == "NONE":
         print("No active wikimedia sessions — skipping Slack post.")
         return
 
-    sessions = [
-        line.split(":")[0].strip()
-        for line in session_out.splitlines()
-        if line.startswith("wikimedia-")
-    ]
+    sessions = [line.split(":")[0].strip() for line in session_out.splitlines()]
+    if not sessions:
+        print("No active wikimedia sessions — skipping Slack post.")
+        return
 
-    rows = []
-    for session in sessions:
+    results: dict[str, str] = {}
+
+    def fetch(session: str) -> tuple[str, str]:
         partner = session.removeprefix("wikimedia-")
         try:
             phase = get_phase_and_progress(ssm, partner)
         except Exception:
             logging.exception("Failed to get status for %s", session)
             phase = "Unknown (error)"
-        rows.append((session, phase))
-        print(f"{session}: {phase}")
+        return session, phase
 
+    with ThreadPoolExecutor(max_workers=len(sessions)) as executor:
+        futures = {executor.submit(fetch, s): s for s in sessions}
+        for future in as_completed(futures):
+            session, phase = future.result()
+            results[session] = phase
+            print(f"{session}: {phase}")
+
+    rows = [(s, results[s]) for s in sessions if s in results]
     token = os.environ["DPLA_SLACK_BOT_TOKEN"]
     post_to_slack(token, rows)
     print("Posted to Slack.")

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -44,8 +44,9 @@ def ssm_run(client, cmd: str) -> str:
 
 
 def get_phase_and_progress(client, partner: str) -> str:
-    base = f"/home/ec2-user/ingest-wikimedia/{shlex.quote(partner)}"
-    log_file = ssm_run(client, f"ls -t {base}/logs/ 2>/dev/null | head -1")
+    base = f"/home/ec2-user/ingest-wikimedia/{partner}"
+    log_dir = shlex.quote(f"{base}/logs")
+    log_file = ssm_run(client, f"ls -t {log_dir}/ 2>/dev/null | head -1")
     if not log_file:
         return "Generating IDs"
 

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -122,6 +122,12 @@ def post_to_slack(token: str, rows: list[tuple[str, str]]) -> None:
 
 
 def main() -> None:
+    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
+    if not token:
+        raise RuntimeError(
+            "Missing required environment variable: DPLA_SLACK_BOT_TOKEN"
+        )
+
     ssm = boto3.client("ssm", region_name=REGION)
 
     session_out = ssm_run(ssm, "tmux ls 2>/dev/null | grep '^wikimedia-' || echo NONE")
@@ -153,11 +159,6 @@ def main() -> None:
             print(f"{session}: {phase}")
 
     rows = [(s, results[s]) for s in sessions if s in results]
-    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
-    if not token:
-        raise RuntimeError(
-            "Missing required environment variable: DPLA_SLACK_BOT_TOKEN"
-        )
     post_to_slack(token, rows)
     print("Posted to Slack.")
 

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -74,10 +74,16 @@ def get_phase_and_progress(client, partner: str) -> str:
     tail = parts[0].strip()
     count_lines = parts[1].strip().splitlines() if len(parts) > 1 else []
 
-    dpla_id_count = int(count_lines[0]) if len(count_lines) > 0 else 0
-    uploaded_count = int(count_lines[1]) if len(count_lines) > 1 else 0
-    skipped_count = int(count_lines[2]) if len(count_lines) > 2 else 0
-    total = int(count_lines[3]) if len(count_lines) > 3 else 0
+    def _safe_int(s: str) -> int:
+        try:
+            return int(s)
+        except ValueError:
+            return 0
+
+    dpla_id_count = _safe_int(count_lines[0]) if len(count_lines) > 0 else 0
+    uploaded_count = _safe_int(count_lines[1]) if len(count_lines) > 1 else 0
+    skipped_count = _safe_int(count_lines[2]) if len(count_lines) > 2 else 0
+    total = _safe_int(count_lines[3]) if len(count_lines) > 3 else 0
 
     def pct(n: int) -> str:
         return f"{n / total * 100:.1f}" if total > 0 else "?"

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -31,7 +31,12 @@ def ssm_run(client, cmd: str) -> str:
     cmd_id = resp["Command"]["CommandId"]
     for _ in range(SSM_MAX_POLLS):
         time.sleep(SSM_POLL_INTERVAL)
-        inv = client.get_command_invocation(CommandId=cmd_id, InstanceId=INSTANCE_ID)
+        try:
+            inv = client.get_command_invocation(
+                CommandId=cmd_id, InstanceId=INSTANCE_ID
+            )
+        except client.exceptions.InvocationDoesNotExist:
+            continue
         status = inv["Status"]
         if status == "Success":
             return inv.get("StandardOutputContent", "").strip()

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -6,7 +6,9 @@ the /wikimedia-status Slack slash command via Lambda).
 """
 
 import json
+import logging
 import os
+import shlex
 import time
 
 import boto3
@@ -30,21 +32,25 @@ def ssm_run(client, cmd: str) -> str:
     for _ in range(SSM_MAX_POLLS):
         time.sleep(SSM_POLL_INTERVAL)
         inv = client.get_command_invocation(CommandId=cmd_id, InstanceId=INSTANCE_ID)
-        if inv["Status"] in ("Success", "Failed", "TimedOut", "Cancelled"):
-            return inv["StandardOutputContent"].strip()
-    return ""
+        status = inv["Status"]
+        if status == "Success":
+            return inv.get("StandardOutputContent", "").strip()
+        if status in ("Failed", "TimedOut", "Cancelled"):
+            stderr = inv.get("StandardErrorContent", "").strip()
+            raise RuntimeError(
+                f"SSM command {cmd_id} ended with {status}: {stderr or 'no stderr'}"
+            )
+    raise TimeoutError(f"SSM command {cmd_id} did not complete within polling window")
 
 
 def get_phase_and_progress(client, partner: str) -> str:
-    log_file = ssm_run(
-        client,
-        f"ls -t /home/ec2-user/ingest-wikimedia/{partner}/logs/ 2>/dev/null | head -1",
-    )
+    base = f"/home/ec2-user/ingest-wikimedia/{shlex.quote(partner)}"
+    log_file = ssm_run(client, f"ls -t {base}/logs/ 2>/dev/null | head -1")
     if not log_file:
         return "Generating IDs"
 
-    log_path = f"/home/ec2-user/ingest-wikimedia/{partner}/logs/{log_file}"
-    csv_path = f"/home/ec2-user/ingest-wikimedia/{partner}/{partner}.csv"
+    log_path = shlex.quote(f"/home/ec2-user/ingest-wikimedia/{partner}/logs/{log_file}")
+    csv_path = shlex.quote(f"/home/ec2-user/ingest-wikimedia/{partner}/{partner}.csv")
 
     # Get tail + item count + CSV total in one round-trip
     out = ssm_run(
@@ -122,7 +128,11 @@ def main() -> None:
     rows = []
     for session in sessions:
         partner = session.removeprefix("wikimedia-")
-        phase = get_phase_and_progress(ssm, partner)
+        try:
+            phase = get_phase_and_progress(ssm, partner)
+        except Exception:
+            logging.exception("Failed to get status for %s", session)
+            phase = "Unknown (error)"
         rows.append((session, phase))
         print(f"{session}: {phase}")
 

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -60,6 +60,7 @@ def get_phase_and_progress(client, partner: str) -> str:
         f"echo '---'; "
         f"grep -c 'DPLA ID:' {log_path} 2>/dev/null || echo 0; "
         f"grep -c 'Uploaded to' {log_path} 2>/dev/null || echo 0; "
+        f"grep -c 'Skipping.*Already exists on commons' {log_path} 2>/dev/null || echo 0; "
         f"wc -l < {csv_path} 2>/dev/null || echo 0",
     )
 
@@ -69,7 +70,8 @@ def get_phase_and_progress(client, partner: str) -> str:
 
     dpla_id_count = int(count_lines[0]) if len(count_lines) > 0 else 0
     uploaded_count = int(count_lines[1]) if len(count_lines) > 1 else 0
-    total = int(count_lines[2]) if len(count_lines) > 2 else 0
+    skipped_count = int(count_lines[2]) if len(count_lines) > 2 else 0
+    total = int(count_lines[3]) if len(count_lines) > 3 else 0
 
     def pct(n: int) -> str:
         return f"{n / total * 100:.1f}" if total > 0 else "?"
@@ -80,9 +82,10 @@ def get_phase_and_progress(client, partner: str) -> str:
         return "Generating IDs"
 
     if "upload" in log_file:
-        if uploaded_count == 0:
+        processed_count = uploaded_count + skipped_count
+        if processed_count == 0:
             return "Uploading (starting...)"
-        return f"Uploading ({uploaded_count:,} / {total:,}, ~{pct(uploaded_count)}%)"
+        return f"Uploading ({processed_count:,} / {total:,}, ~{pct(processed_count)}%)"
 
     return "Unknown"
 


### PR DESCRIPTION
## Summary

- Replaces the Claude scheduled task with a GitHub Actions workflow that runs every 6 hours (and on `workflow_dispatch`) — faster, cheaper, fully auditable in version control
- Adds per-phase progress to uploading rows: `Uploading (220,355 / 252,485, ~87.3%)` instead of `Uploading (in progress)`
- Adds a Lambda function (`wikimedia-slack-dispatch`) that validates Slack requests and dispatches the workflow — wired to a `/wikimedia-status` slash command

## New files

| File | Purpose |
|---|---|
| `scripts/wikimedia_upload_status.py` | Checks EC2 sessions via SSM, formats progress, posts to #tech-alerts |
| `.github/workflows/wikimedia-upload-status.yml` | Schedule + dispatch trigger |
| `lambda/wikimedia-slack-dispatch/handler.py` | Slack slash command → GitHub dispatch |

## Setup required after merge (see PR description)

Three GitHub secrets and one Slack app configuration — see the deployment checklist in the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slash command to trigger an on-demand Wikimedia upload status check (responds publicly and confirms dispatch).
  * Scheduled automated status check running every 6 hours, also runnable manually.
  * Remote checks of ingestion hosts for active sessions, summarizing recent log highlights, per-session phase, and approximate progress.
  * Posts concise Slack summaries to the alert channel; skips posting when no active sessions unless explicitly requested; reports errors per-session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->