### PR TITLE
Skip files with application/octet-stream content type

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -235,6 +235,7 @@ INVALID_CONTENT_TYPES = [
     "text/xml",
     "text/plain",
     "application/msword",
+    "application/octet-stream",
 ]
 COMMONS_URL_PREFIX = "https://commons.wikimedia.org/wiki/File:"
 ERROR_FILEEXISTS = "fileexists-shared-forbidden"

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -35,6 +35,11 @@ def test_check_content_type_invalid():
     assert not check_content_type(content_type)
 
 
+def test_check_content_type_octet_stream_invalid():
+    content_type = "application/octet-stream"
+    assert not check_content_type(content_type)
+
+
 def test_get_page_title():
     title = get_page_title("Sample Title", "abcd1234", ".jpg", 1)
     expected_title = "Sample Title - DPLA - abcd1234 (page 1).jpg"


### PR DESCRIPTION
## Summary
- Adds `application/octet-stream` to the MIME type skip list in `wikimedia.py`
- `mimetypes.guess_extension('application/octet-stream')` returns `.bin`, which Commons rejects as an invalid extension — files with an unidentifiable MIME type should be skipped, not attempted

## Test plan
- [ ] Verify uploads skip files with `application/octet-stream` content type instead of failing
- [ ] Confirm no regression for valid MIME types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Content-type validation now treats generic binary ("application/octet-stream") as invalid, preventing binary files from being ingested.
* **Tests**
  * Added coverage to assert the new content-type behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->