### PR TITLE
Fix token whitespace and upload progress percentage overflow

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -97,6 +97,10 @@ def get_phase_and_progress(client, partner: str) -> str:
         processed_count = uploaded_count + skipped_count
         if processed_count == 0:
             return "Uploading (starting...)"
+        # Log is cumulative across runs: processed_count can exceed total once a
+        # full pass completes.  Treat that as "done" rather than show >100%.
+        if total > 0 and processed_count >= total:
+            return f"Upload complete ({uploaded_count:,} uploaded, {skipped_count:,} already on Commons)"
         return f"Uploading ({processed_count:,} / {total:,}, ~{pct(processed_count)}%)"
 
     return "Unknown"

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -128,7 +128,7 @@ def post_to_slack(token: str, rows: list[tuple[str, str]]) -> None:
 
 
 def main() -> None:
-    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
+    token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
     if not token:
         raise RuntimeError(
             "Missing required environment variable: DPLA_SLACK_BOT_TOKEN"


### PR DESCRIPTION
## Summary
- Strip whitespace from `DPLA_SLACK_BOT_TOKEN` — copy-pasting into GitHub Secrets can add a trailing newline, which caused `ValueError: Invalid header value` when posting to Slack
- Fix upload progress showing >100%: upload log files are cumulative across runs, so `uploaded + skipped` can exceed the CSV row count once a full pass completes. Detect `processed_count >= total` and show `"Upload complete (X uploaded, Y already on Commons)"` instead of a nonsensical percentage

## Test plan
- [ ] Merge and trigger `wikimedia-upload-status` workflow — should post to Slack without `ValueError`
- [ ] Texas/Minnesota sessions (which have completed a full pass) should show `"Upload complete"` instead of `~159%` / `~319%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed upload progress indicator showing over 100% completion after consecutive upload operations. Status now correctly displays "Upload complete" when all items finish processing.

* **Improvements**
  * Enhanced token validation to properly identify and reject empty or whitespace-only authentication values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->