### PR TITLE
Handle SSM timeout gracefully; opt in to Node.js 24

### DIFF
--- a/.github/workflows/cim-pageviews.yml
+++ b/.github/workflows/cim-pageviews.yml
@@ -16,6 +16,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   categories:
     name: Category request management

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,10 @@ name: Pytest
 on: [push, pull_request]
 permissions:
   contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   uv:
     name: python

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -2,6 +2,10 @@ name: Ruff
 on: [push, pull_request]
 permissions:
   contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/wikimedia-upload-status.yml
+++ b/.github/workflows/wikimedia-upload-status.yml
@@ -13,6 +13,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: wikimedia-upload-status
   cancel-in-progress: false

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -142,7 +142,23 @@ def main() -> None:
 
     notify_if_idle = os.environ.get("NOTIFY_IF_IDLE", "false").lower() == "true"
 
-    session_out = ssm_run(ssm, "tmux ls 2>/dev/null | grep '^wikimedia-' || echo NONE")
+    try:
+        session_out = ssm_run(
+            ssm, "tmux ls 2>/dev/null | grep '^wikimedia-' || echo NONE"
+        )
+    except TimeoutError as e:
+        logging.error("SSM poll timed out: %s", e)
+        post_to_slack(
+            token,
+            [
+                (
+                    "(error)",
+                    "Status check timed out — SSM did not respond. Try again shortly.",
+                )
+            ],
+        )
+        return
+
     sessions = (
         [line.split(":")[0].strip() for line in session_out.splitlines()]
         if session_out and session_out != "NONE"


### PR DESCRIPTION
## Summary

- **SSM timeout crash**: When a transient SSM API blip causes `GetCommandInvocation` to time out, the status script now catches `TimeoutError` and posts a Slack message ("Status check timed out — SSM did not respond. Try again shortly.") instead of crashing silently with exit code 1. Triggered by [run 24295031944](https://github.com/dpla/ingest-wikimedia/actions/runs/24295031944) where the SSM command completed in 81ms but the poller timed out — the instance was healthy, sessions were running.
- **Node.js 24**: Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to all four workflows (`wikimedia-upload-status`, `pytest`, `ruff`, `cim-pageviews`) to silence the Node.js 20 deprecation warning ahead of the June 2, 2026 forced cutover.

## Test plan

- [ ] Confirm next scheduled run of Wikimedia Upload Status posts to Slack without error
- [ ] Confirm no Node.js 20 deprecation warnings in any workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for timeout scenarios with automated status notifications.

* **Chores**
  * Updated GitHub Actions workflow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->