### PR TITLE
Fix false upload-complete status for multi-page items

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -94,14 +94,14 @@ def get_phase_and_progress(client, partner: str) -> str:
         return "Generating IDs"
 
     if log_file.endswith("-upload.log"):
-        processed_count = uploaded_count + skipped_count
-        if processed_count == 0:
+        if dpla_id_count == 0:
             return "Uploading (starting...)"
-        # Log is cumulative across runs: processed_count can exceed total once a
-        # full pass completes.  Treat that as "done" rather than show >100%.
-        if total > 0 and processed_count >= total:
+        # Use DPLA ID count (one per item) for progress and completion detection.
+        # uploaded_count + skipped_count overcounts multi-page items (one line per
+        # page) and triggers false "complete" status before the run finishes.
+        if total > 0 and dpla_id_count >= total:
             return f"Upload complete ({uploaded_count:,} uploaded, {skipped_count:,} already on Commons)"
-        return f"Uploading ({processed_count:,} / {total:,}, ~{pct(processed_count)}%)"
+        return f"Uploading ({dpla_id_count:,} / {total:,}, ~{pct(dpla_id_count)}%)"
 
     return "Unknown"
 

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -67,7 +67,8 @@ def get_phase_and_progress(client, partner: str) -> str:
         f"grep -c 'DPLA ID:' {log_path} 2>/dev/null || true; "
         f"grep -c 'Uploaded to' {log_path} 2>/dev/null || true; "
         f"grep -c 'Skipping.*Already exists on commons' {log_path} 2>/dev/null || true; "
-        f"wc -l < {csv_path} 2>/dev/null || echo 0",
+        f"wc -l < {csv_path} 2>/dev/null || echo 0; "
+        f"grep -c 'COUNTS:' {log_path} 2>/dev/null || true",
     )
 
     parts = out.split("---\n", 1)
@@ -84,6 +85,7 @@ def get_phase_and_progress(client, partner: str) -> str:
     uploaded_count = _safe_int(count_lines[1]) if len(count_lines) > 1 else 0
     skipped_count = _safe_int(count_lines[2]) if len(count_lines) > 2 else 0
     total = _safe_int(count_lines[3]) if len(count_lines) > 3 else 0
+    counts_marker = _safe_int(count_lines[4]) if len(count_lines) > 4 else 0
 
     def pct(n: int) -> str:
         return f"{n / total * 100:.1f}" if total > 0 else "?"
@@ -96,10 +98,10 @@ def get_phase_and_progress(client, partner: str) -> str:
     if log_file.endswith("-upload.log"):
         if dpla_id_count == 0:
             return "Uploading (starting...)"
-        # Use DPLA ID count (one per item) for progress and completion detection.
-        # uploaded_count + skipped_count overcounts multi-page items (one line per
-        # page) and triggers false "complete" status before the run finishes.
-        if total > 0 and dpla_id_count >= total:
+        # Use the COUNTS: terminal marker as the definitive completion signal.
+        # dpla_id_count is logged at the start of each item, not after all its
+        # files finish, so count arithmetic alone can fire too early.
+        if counts_marker > 0:
             return f"Upload complete ({uploaded_count:,} uploaded, {skipped_count:,} already on Commons)"
         return f"Uploading ({dpla_id_count:,} / {total:,}, ~{pct(dpla_id_count)}%)"
 


### PR DESCRIPTION
## Summary

- `uploaded_count + skipped_count` counts individual file uploads — one per page for multi-page items like Texas newspapers. This easily exceeds the CSV line count (one per DPLA ID) mid-run, causing the status script to report \"Upload complete\" falsely.
- Fix: use `dpla_id_count` (`grep -c 'DPLA ID:'`) for both progress percentage and completion detection. This count is already collected; it just wasn't being used in the upload branch.
- The `uploaded_count` and `skipped_count` values are preserved in the completion message for informational display.

## Test plan

- [ ] Verify Texas shows \"Uploading (N / total, ~X%)\" on next status check rather than \"Upload complete\"
- [ ] Verify completion message still shows uploaded + skipped counts when a run genuinely finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate Wikimedia upload progress reporting: progress now reflects actual IDs uploaded versus total with updated percentage calculation, and start/completion states are detected more reliably for clearer status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->