### PR TITLE
fix: use subprocess list form in nuke.py to prevent shell injection

### DIFF
--- a/tools/nuke.py
+++ b/tools/nuke.py
@@ -29,10 +29,10 @@ def main(ids_file: IO, partner: str, dry_run: bool):
     for dpla_id in tqdm(dpla_ids, desc="Nuking Items", unit="Item", ncols=100):
         logging.info(f"DPLA ID: {dpla_id}")
         s3_path = s3.get_item_s3_path(dpla_id, "", partner)
-        command = f"aws s3 rm s3://{S3_BUCKET}/{s3_path} --recursive"
+        command = ["aws", "s3", "rm", f"s3://{S3_BUCKET}/{s3_path}", "--recursive"]
         if dry_run:
-            command = command + " --dryrun"
-        subprocess.run(command, shell=True, check=True)
+            command.append("--dryrun")
+        subprocess.run(command, check=True)
 
     logging.info(f"{time.time() - start_time} seconds.")
 


### PR DESCRIPTION
## Summary

Replace `shell=True` with a command list in `nuke.py` so that DPLA IDs or S3 paths containing spaces or shell metacharacters cannot be interpreted by the shell. This eliminates the injection risk flagged in the lessons audit.

Before:
\`\`\`python
command = f"aws s3 rm s3://{S3_BUCKET}/{s3_path} --recursive"
subprocess.run(command, shell=True, check=True)
\`\`\`

After:
\`\`\`python
command = ["aws", "s3", "rm", f"s3://{S3_BUCKET}/{s3_path}", "--recursive"]
subprocess.run(command, check=True)
\`\`\`

## Test plan

- [ ] Run `nuke.py --dry-run` against a partner with a known item — verify the correct S3 path is logged
- [ ] Verify no change in behaviour for well-formed DPLA IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a shell injection vulnerability in `tools/nuke.py` by replacing the use of `subprocess.run()` with `shell=True` and string-based command construction with the safer list form of the command.

### Changes

**tools/nuke.py:**
- Changed S3 deletion command from an f-string (`f"aws s3 rm s3://{S3_BUCKET}/{s3_path} --recursive"`) to an argv list (`["aws", "s3", "rm", f"s3://{S3_BUCKET}/{s3_path}", "--recursive"]`)
- Removed `shell=True` parameter from `subprocess.run()` call
- Updated `--dryrun` flag handling to use `command.append("--dryrun")` instead of string concatenation

### Security Implications

**This PR addresses a shell injection vulnerability.** Previously, if an S3 path or DPLA ID contained spaces or shell metacharacters (e.g., `$`, `&`, `;`), those characters would be interpreted by the shell rather than treated as literal values. By switching to the argv list form, command arguments are passed directly to the subprocess without shell interpretation, eliminating this attack surface.

### Deployment Impact

- No manual pipeline trigger or ECS redeployment required
- No environment variables or AWS Secrets Manager keys added/removed/modified
- No database migrations
- No shared infrastructure configuration changes
- No public-facing API changes
- Changes are isolated to the `nuke.py` operational tool script

<!-- end of auto-generated comment: release notes by coderabbit.ai -->