### PR TITLE
fix: report Generating IDs when log predates current session

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -51,10 +51,30 @@ def ssm_run(client, cmd: str) -> str:
 
 
 def get_phase_and_progress(client, partner: str) -> str:
+    def _safe_int(s: str) -> int:
+        try:
+            return int(s)
+        except ValueError:
+            return 0
+
     base = f"/home/ec2-user/ingest-wikimedia/{partner}"
     log_dir = shlex.quote(f"{base}/logs")
-    log_file = ssm_run(client, f"ls -t {log_dir}/ 2>/dev/null | head -1")
-    if not log_file:
+    session_name = shlex.quote(f"wikimedia-{partner}")
+
+    # One round-trip: session creation time, most recent log filename, and its mtime.
+    precheck = ssm_run(
+        client,
+        f"tmux display-message -t {session_name} -p '#{{session_created}}' 2>/dev/null || echo 0; "
+        f'f=$(ls -t {log_dir}/ 2>/dev/null | head -1); echo "$f"; '
+        f'[ -n "$f" ] && stat -c %Y {log_dir}/"$f" 2>/dev/null || echo 0',
+    )
+    precheck_lines = precheck.splitlines()
+    session_created = _safe_int(precheck_lines[0]) if precheck_lines else 0
+    log_file = precheck_lines[1].strip() if len(precheck_lines) > 1 else ""
+    log_mtime = _safe_int(precheck_lines[2]) if len(precheck_lines) > 2 else 0
+
+    # Log predates this session → downloader hasn't started yet.
+    if not log_file or (session_created > 0 and log_mtime < session_created):
         return "Generating IDs"
 
     log_path = shlex.quote(f"{base}/logs/{log_file}")
@@ -74,12 +94,6 @@ def get_phase_and_progress(client, partner: str) -> str:
     parts = out.split("---\n", 1)
     tail = parts[0].strip()
     count_lines = parts[1].strip().splitlines() if len(parts) > 1 else []
-
-    def _safe_int(s: str) -> int:
-        try:
-            return int(s)
-        except ValueError:
-            return 0
 
     dpla_id_count = _safe_int(count_lines[0]) if len(count_lines) > 0 else 0
     uploaded_count = _safe_int(count_lines[1]) if len(count_lines) > 1 else 0


### PR DESCRIPTION
## Summary

- `/wikimedia-status` was reporting "Upload complete" with counts from a *prior* run while a new pipeline was still in the `get-ids-es` phase
- Root cause: `ls -t logs/ | head -1` returns the most recent log regardless of age — during ID generation no new log exists yet, so it found the last completed run's log (which contains `COUNTS:`) and reported that
- Fix: one SSM round-trip now fetches the tmux session creation time, the most recent log filename, and that log's mtime together; if `log_mtime < session_created` the log is from a prior run and we return `"Generating IDs"` unconditionally
- Bonus: drops the extra SSM `stat` call that was split across two round-trips in an intermediate version, keeping total SSM calls at 2 (same as before)

## Test plan

- [ ] Trigger a new partner pipeline and immediately run `/wikimedia-status` while `get-ids-es` is still running — should now report `Generating IDs` instead of the prior run's `Upload complete`
- [ ] Verify status progresses correctly to `Downloading` and `Uploading` once those phases begin
- [ ] Verify a partner with no active session still reports idle correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes an issue where `/wikimedia-status` could report an incorrect status ("Upload complete") when a new pipeline run is in the "Generating IDs" phase. The root cause was that the status endpoint was selecting the most recent log file without verifying whether that log belonged to the current tmux session or a previous run.

## Changes

The fix modifies `scripts/wikimedia_upload_status.py` to consolidate SSM calls and add session validation:
- Combines multiple SSM queries into a single round-trip to fetch: tmux session creation time, the most recent log filename, and that log's modification time
- Adds logic to compare the log file's mtime against the session creation timestamp
- Returns "Generating IDs" status when no log exists or when the latest log predates the current session
- Relocates a `_safe_int` helper function earlier in the code to support the new validation logic

The change maintains the same number of SSM API calls (2 round-trips) as the previous implementation while improving accuracy.

## Deployment Considerations

**ECS Redeployment Required**: This script change requires redeployment of the service to take effect.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/144)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->