### PR TITLE
fix: avoid shell variable in precheck SSM command

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -61,27 +61,28 @@ def get_phase_and_progress(client, partner: str) -> str:
     log_dir = shlex.quote(f"{base}/logs")
     session_name = shlex.quote(f"wikimedia-{partner}")
 
-    # One round-trip: session creation time, most recent log filename, and its mtime.
+    # Get session creation time and most recent log filename — no shell variables
+    # needed, avoiding outer-bash expansion of $f inside the bash -c double-quote.
     precheck = ssm_run(
         client,
         f"tmux display-message -t {session_name} -p '#{{session_created}}' 2>/dev/null || echo 0; "
-        f'f=$(ls -t {log_dir}/ 2>/dev/null | head -1); echo "$f"; '
-        f'[ -n "$f" ] && stat -c %Y {log_dir}/"$f" 2>/dev/null || echo 0',
+        f"ls -t {log_dir}/ 2>/dev/null | head -1",
     )
     precheck_lines = precheck.splitlines()
     session_created = _safe_int(precheck_lines[0]) if precheck_lines else 0
     log_file = precheck_lines[1].strip() if len(precheck_lines) > 1 else ""
-    log_mtime = _safe_int(precheck_lines[2]) if len(precheck_lines) > 2 else 0
 
-    # Log predates this session → downloader hasn't started yet.
-    if not log_file or (session_created > 0 and log_mtime < session_created):
+    if not log_file:
         return "Generating IDs"
 
     log_path = shlex.quote(f"{base}/logs/{log_file}")
     csv_path = shlex.quote(f"{base}/{partner}.csv")
 
+    # stat mtime first so we can detect logs from prior runs before reading content.
     out = ssm_run(
         client,
+        f"stat -c %Y {log_path} 2>/dev/null || echo 0; "
+        f"echo '---'; "
         f"tail -5 {log_path}; "
         f"echo '---'; "
         f"grep -c 'DPLA ID:' {log_path} 2>/dev/null || true; "
@@ -91,9 +92,15 @@ def get_phase_and_progress(client, partner: str) -> str:
         f"grep -c 'COUNTS:' {log_path} 2>/dev/null || true",
     )
 
-    parts = out.split("---\n", 1)
-    tail = parts[0].strip()
-    count_lines = parts[1].strip().splitlines() if len(parts) > 1 else []
+    sections = out.split("---\n", 2)
+    log_mtime = _safe_int(sections[0].strip()) if sections else 0
+
+    # Log predates this session → downloader hasn't started yet.
+    if session_created > 0 and log_mtime < session_created:
+        return "Generating IDs"
+
+    tail = sections[1].strip() if len(sections) > 1 else ""
+    count_lines = sections[2].strip().splitlines() if len(sections) > 2 else []
 
     dpla_id_count = _safe_int(count_lines[0]) if len(count_lines) > 0 else 0
     uploaded_count = _safe_int(count_lines[1]) if len(count_lines) > 1 else 0

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -78,13 +78,13 @@ def get_phase_and_progress(client, partner: str) -> str:
     log_path = shlex.quote(f"{base}/logs/{log_file}")
     csv_path = shlex.quote(f"{base}/{partner}.csv")
 
-    # stat mtime first so we can detect logs from prior runs before reading content.
+    sep = "__WM_SEP__"
     out = ssm_run(
         client,
         f"stat -c %Y {log_path} 2>/dev/null || echo 0; "
-        f"echo '---'; "
+        f"echo {sep}; "
         f"tail -5 {log_path}; "
-        f"echo '---'; "
+        f"echo {sep}; "
         f"grep -c 'DPLA ID:' {log_path} 2>/dev/null || true; "
         f"grep -c 'Uploaded to' {log_path} 2>/dev/null || true; "
         f"grep -c 'Skipping.*Already exists on commons' {log_path} 2>/dev/null || true; "
@@ -92,7 +92,7 @@ def get_phase_and_progress(client, partner: str) -> str:
         f"grep -c 'COUNTS:' {log_path} 2>/dev/null || true",
     )
 
-    sections = out.split("---\n", 2)
+    sections = out.split(f"{sep}\n", 2)
     log_mtime = _safe_int(sections[0].strip()) if sections else 0
 
     # Log predates this session → downloader hasn't started yet.


### PR DESCRIPTION
## Summary

- Fixes a bug introduced in #144 that caused `/wikimedia-status` to always report `Generating IDs` regardless of actual pipeline phase
- Root cause: the precheck used a bash variable `$f` inside the `bash -c` double-quoted string that `ssm_run` constructs via `json.dumps()`. The outer bash shell expands `$f` (unset → empty) before the inner `bash -c` sees it, so `echo "$f"` always outputs an empty line and `log_file` is always empty
- Fix: replace the `$f` shell variable with two simple commands (`tmux display-message` + `ls -t`) that need no variables, and move `stat` into the second SSM call where `log_path` is a Python variable substituted safely before any shell sees it

## Test plan

- [ ] Trigger a partner pipeline and run `/wikimedia-status` while `get-ids-es` is running — should report `Generating IDs`
- [ ] Run `/wikimedia-status` once the downloader starts — should report `Downloading (N / M items, ~X%)`
- [ ] Run `/wikimedia-status` once the uploader starts — should report `Uploading (N / M, ~X%)`
- [ ] Confirm a partner with only old logs (no active session) is not misreported

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a bug in the /wikimedia-status Slack command that caused it to always report "Generating IDs" by eliminating improper shell-variable usage inside SSM commands.

### Root Cause
The precheck previously relied on a bash variable ($f) inside a double-quoted `bash -c` string built via `json.dumps()` for ssm_run. The outer shell expanded `$f` (unset → empty) before the inner bash ran, so the detected log path was empty and the command misreported status.

### Changes Made
scripts/wikimedia_upload_status.py:
- Precheck SSM call now uses `tmux display-message -p '#{session_created}'` and `ls -t … | head -1` (no shell-variable dependence) to get session creation time and the most recent log filename.
- Moved `stat -c %Y` (log mtime) into the second SSM call where `log_path` is constructed by Python and substituted before shell execution.
- Second SSM call now returns three sections (mtime, tail, and several count lines) and the code parses those sections to compute phase/progress.
- Replaced the previous '---' separator with a collision-resistant sentinel (`__WM_SEP__`) to avoid log lines corrupting section boundaries and breaking parsing.
- Updated the "log predates this session" check to use the mtime parsed from the second SSM call; preserved existing phase logic for downloading/uploading/completion.

### Deployment / Impact Notes
- No pipeline trigger, ECS redeployment, environment variable changes, database migrations, or infrastructure/IAM changes required. This is a localized bug fix to a utility script.
- No changes to public APIs or secrets handling. No additional security review indicated.

### Testing
Test plan (as provided):
- Trigger a partner pipeline and run /wikimedia-status while get-ids-es is running — expect "Generating IDs".
- Run /wikimedia-status once the downloader starts — expect "Downloading (N / M items, ~X%)".
- Run /wikimedia-status once the uploader starts — expect "Uploading (N / M, ~X%)".
- Confirm a partner with only old logs (no active session) is not misreported.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/145)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->