### PR TITLE
fix: downloader efficiency — reuse HTTP session, cache IIIF URLs, repair zero-byte stub bypass

### DIFF
--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,242 @@
+import json
+from io import BytesIO
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from ingest_wikimedia.common import CHECKSUM
+from ingest_wikimedia.dpla import IIIF_MANIFEST_FIELD_NAME, MEDIA_MASTER_FIELD_NAME
+from ingest_wikimedia.tracker import Result
+
+
+@pytest.fixture
+def downloader():
+    from tools.downloader import Downloader
+
+    web = MagicMock()
+    web.get_http_session.return_value = MagicMock()
+
+    return Downloader(
+        provider="test_provider",
+        tracker=MagicMock(),
+        s3_client=MagicMock(),
+        web=web,
+        local_fs=MagicMock(),
+        iiif=MagicMock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: zero-byte stub bypass in upload_file_to_s3
+# ---------------------------------------------------------------------------
+
+
+def _make_s3_obj(sha1: str, content_length):
+    obj = MagicMock()
+    obj.metadata = {CHECKSUM: sha1}
+    obj.content_length = content_length
+    return obj
+
+
+def test_upload_skips_when_checksum_matches_and_nonzero(downloader):
+    sha1 = "abc123"
+    obj = _make_s3_obj(sha1, 1024)
+
+    mock_s3 = MagicMock()
+    mock_s3.Object.return_value = obj
+    downloader.s3_client.get_s3.return_value = mock_s3
+
+    with patch(
+        "builtins.open",
+        return_value=MagicMock(
+            __enter__=lambda s: BytesIO(b"data"), __exit__=MagicMock(return_value=False)
+        ),
+    ):
+        with patch("os.stat") as mock_stat:
+            mock_stat.return_value.st_size = 1024
+            downloader.upload_file_to_s3("/tmp/fake", "dest/path", "image/jpeg", sha1)
+
+    downloader.tracker.increment.assert_called_once_with(Result.SKIPPED)
+    obj.upload_fileobj.assert_not_called()
+
+
+def test_upload_proceeds_when_checksum_matches_but_zero_bytes(downloader):
+    sha1 = "abc123"
+    obj = _make_s3_obj(sha1, 0)
+
+    mock_s3 = MagicMock()
+    mock_s3.Object.return_value = obj
+    downloader.s3_client.get_s3.return_value = mock_s3
+
+    fake_file = BytesIO(b"real content")
+    fake_file.name = "/tmp/fake"
+
+    with patch("builtins.open") as mock_open:
+        mock_open.return_value.__enter__ = lambda s: fake_file
+        mock_open.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("os.stat") as mock_stat:
+            mock_stat.return_value.st_size = len(b"real content")
+            downloader.upload_file_to_s3("/tmp/fake", "dest/path", "image/jpeg", sha1)
+
+    for c in downloader.tracker.increment.call_args_list:
+        assert c != call(Result.SKIPPED), "Should not skip a zero-byte stub"
+    obj.upload_fileobj.assert_called_once()
+
+
+def test_upload_proceeds_when_content_length_unreadable(downloader):
+    sha1 = "abc123"
+    obj = _make_s3_obj(sha1, None)  # None → TypeError on int()
+
+    mock_s3 = MagicMock()
+    mock_s3.Object.return_value = obj
+    downloader.s3_client.get_s3.return_value = mock_s3
+
+    fake_file = BytesIO(b"data")
+    fake_file.name = "/tmp/fake"
+
+    with patch("builtins.open") as mock_open:
+        mock_open.return_value.__enter__ = lambda s: fake_file
+        mock_open.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("os.stat") as mock_stat:
+            mock_stat.return_value.st_size = 4
+            downloader.upload_file_to_s3("/tmp/fake", "dest/path", "image/jpeg", sha1)
+
+    for c in downloader.tracker.increment.call_args_list:
+        assert c != call(Result.SKIPPED)
+    obj.upload_fileobj.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: HTTP session created once at init, reused per download
+# ---------------------------------------------------------------------------
+
+
+def test_http_session_created_once_at_init():
+    from tools.downloader import Downloader
+
+    web_mock = MagicMock()
+    session = MagicMock()
+    web_mock.get_http_session.return_value = session
+
+    d = Downloader(
+        provider="pa",
+        tracker=MagicMock(),
+        s3_client=MagicMock(),
+        web=web_mock,
+        local_fs=MagicMock(),
+        iiif=MagicMock(),
+    )
+
+    web_mock.get_http_session.assert_called_once_with(provider="pa")
+    assert d.http_session is session
+
+
+def test_download_uses_stored_session(downloader):
+    mock_response = MagicMock()
+    mock_response.headers = {"content-length": "8"}
+    mock_response.iter_content.return_value = [b"data" * 2]
+    downloader.http_session.get.return_value = mock_response
+
+    with patch("builtins.open", MagicMock()):
+        downloader.download_file_to_temp_path("http://example.com/img.jpg", "/tmp/out")
+
+    downloader.http_session.get.assert_called_once_with(
+        "http://example.com/img.jpg", stream=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: IIIF manifest fetch skipped when file list is cached
+# ---------------------------------------------------------------------------
+
+
+def _staged_metadata(field: str, value) -> str:
+    return json.dumps({"_staged_by_get_ids_es": True, field: value})
+
+
+def test_process_item_uses_cached_file_list(downloader):
+    cached_urls = ["http://example.com/page1.jpg", "http://example.com/page2.jpg"]
+
+    downloader.s3_client.get_item_metadata.return_value = _staged_metadata(
+        IIIF_MANIFEST_FIELD_NAME, "http://example.com/manifest.json"
+    )
+    downloader.s3_client.get_file_list.return_value = cached_urls
+
+    downloader.process_item(
+        overwrite=False,
+        dry_run=True,
+        verbose=False,
+        partner="bpl",
+        dpla_id="abcd1234",
+        sleep_secs=0,
+    )
+
+    downloader.iiif.get_iiif_manifest.assert_not_called()
+
+
+def test_process_item_fetches_manifest_when_cache_empty(downloader):
+    manifest = {
+        "@context": "http://iiif.io/api/presentation/3/context.json",
+        "items": [],
+    }
+    downloader.s3_client.get_item_metadata.return_value = _staged_metadata(
+        IIIF_MANIFEST_FIELD_NAME, "http://example.com/manifest.json"
+    )
+    downloader.s3_client.get_file_list.return_value = []
+    downloader.iiif.get_iiif_manifest.return_value = manifest
+    downloader.iiif.get_iiif_urls.return_value = []
+
+    downloader.process_item(
+        overwrite=False,
+        dry_run=True,
+        verbose=False,
+        partner="bpl",
+        dpla_id="abcd1234",
+        sleep_secs=0,
+    )
+
+    downloader.iiif.get_iiif_manifest.assert_called_once_with(
+        "http://example.com/manifest.json"
+    )
+
+
+def test_process_item_fetches_manifest_when_overwrite(downloader):
+    cached_urls = ["http://example.com/page1.jpg"]
+    manifest = {
+        "@context": "http://iiif.io/api/presentation/3/context.json",
+        "items": [],
+    }
+    downloader.s3_client.get_item_metadata.return_value = _staged_metadata(
+        IIIF_MANIFEST_FIELD_NAME, "http://example.com/manifest.json"
+    )
+    downloader.s3_client.get_file_list.return_value = cached_urls
+    downloader.iiif.get_iiif_manifest.return_value = manifest
+    downloader.iiif.get_iiif_urls.return_value = cached_urls
+
+    downloader.process_item(
+        overwrite=True,
+        dry_run=True,
+        verbose=False,
+        partner="bpl",
+        dpla_id="abcd1234",
+        sleep_secs=0,
+    )
+
+    downloader.iiif.get_iiif_manifest.assert_called_once()
+
+
+def test_process_item_media_master_skips_manifest(downloader):
+    downloader.s3_client.get_item_metadata.return_value = _staged_metadata(
+        MEDIA_MASTER_FIELD_NAME, ["http://example.com/file.jpg"]
+    )
+
+    downloader.process_item(
+        overwrite=False,
+        dry_run=True,
+        verbose=False,
+        partner="texas",
+        dpla_id="abcd1234",
+        sleep_secs=0,
+    )
+
+    downloader.iiif.get_iiif_manifest.assert_not_called()

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -49,9 +49,9 @@ class Downloader:
         self.provider = provider
         self.tracker = tracker
         self.s3_client = s3_client
-        self.web = web
         self.local_fs = local_fs
         self.iiif = iiif
+        self.http_session = web.get_http_session(provider=provider)
 
     def upload_file_to_s3(
         self,
@@ -79,11 +79,14 @@ class Downloader:
                         # Just in case (dunno why this would happen)
                         raise e
 
-                if obj_metadata and obj_metadata.get(CHECKSUM, None) == sha1:
-                    # Already uploaded, move on.
-                    logging.info("Already exists.")
-                    self.tracker.increment(Result.SKIPPED)
-                    return
+                if obj_metadata and obj_metadata.get(CHECKSUM) == sha1:
+                    try:
+                        if int(obj.content_length) > 0:
+                            logging.info("Already exists.")
+                            self.tracker.increment(Result.SKIPPED)
+                            return
+                    except (TypeError, ValueError):
+                        pass  # zero-byte stub or unreadable length — fall through to upload
 
                 with tqdm(
                     total=os.stat(f.name).st_size,
@@ -115,9 +118,7 @@ class Downloader:
         Tries to get a local copy of a file to stick in S3 later
         """
         try:
-            response = self.web.get_http_session(provider=self.provider).get(
-                media_url, stream=True
-            )
+            response = self.http_session.get(media_url, stream=True)
             response.raise_for_status()
             total_size = int(response.headers.get("content-length", 0))
             with tqdm(
@@ -223,24 +224,28 @@ class Downloader:
 
             if MEDIA_MASTER_FIELD_NAME in item_metadata:
                 media_urls = get_list(item_metadata, MEDIA_MASTER_FIELD_NAME)
+                self.s3_client.write_file_list(partner, dpla_id, media_urls)
 
             elif IIIF_MANIFEST_FIELD_NAME in item_metadata:
-                manifest_url = get_str(item_metadata, IIIF_MANIFEST_FIELD_NAME)
-                manifest = self.iiif.get_iiif_manifest(manifest_url)
-                if not manifest:
-                    self.tracker.increment(Result.SKIPPED)
-                    return
-                self.s3_client.write_iiif_manifest(
-                    partner, dpla_id, json.dumps(manifest)
-                )
-                media_urls = self.iiif.get_iiif_urls(manifest)
+                cached_urls = self.s3_client.get_file_list(partner, dpla_id)
+                if not overwrite and cached_urls:
+                    media_urls = cached_urls
+                else:
+                    manifest_url = get_str(item_metadata, IIIF_MANIFEST_FIELD_NAME)
+                    manifest = self.iiif.get_iiif_manifest(manifest_url)
+                    if not manifest:
+                        self.tracker.increment(Result.SKIPPED)
+                        return
+                    self.s3_client.write_iiif_manifest(
+                        partner, dpla_id, json.dumps(manifest)
+                    )
+                    media_urls = self.iiif.get_iiif_urls(manifest)
+                    self.s3_client.write_file_list(partner, dpla_id, media_urls)
 
             else:
-                # not sure how we got here
+                # item metadata has neither media_master nor IIIF manifest field
                 self.tracker.increment(Result.SKIPPED)
                 return
-
-            self.s3_client.write_file_list(partner, dpla_id, media_urls)
 
         except Exception as e:
             self.tracker.increment(Result.FAILED)


### PR DESCRIPTION
## Summary

- **Zero-byte stub bug**: `upload_file_to_s3` was finding a matching sha1 in S3 metadata and skipping the upload even when `content_length == 0`. Stubs left by interrupted downloads were never repaired. Fixed by checking `content_length > 0` before treating a checksum match as complete.
- **HTTP session reuse**: `download_file_to_temp_path` called `web.get_http_session()` per file, creating a fresh TCP/TLS connection each time. Session is now created once at `__init__` and reused.
- **IIIF manifest cache**: `process_item` unconditionally fetched the remote IIIF manifest on every run. Now checks S3 for a cached file list first and skips the network round trip when available (unless `--overwrite`).

Also adds `tests/test_downloader.py` covering all three fixes.

## Test plan
- [ ] `ruff check` passes (clean)
- [ ] New tests in `tests/test_downloader.py` pass on EC2 (`uv run pytest tests/test_downloader.py`)
- [ ] Re-run PA downloader with fixed code; confirm faster progression through already-staged items

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Performance Improvements & Bug Fix: HTTP Session Reuse, IIIF Manifest Caching, Zero-Byte Stub Repair

This PR addresses three issues in the downloader tool to improve efficiency and fix a data integrity bug:

### Changes Made

**1. Zero-Byte Stub Bug Fix**
Fixed `upload_file_to_s3` to properly handle interrupted downloads. Previously, when an S3 object's checksum matched the local file's checksum, the upload was skipped regardless of whether the remote object was a zero-byte stub from an interrupted download. The code now checks that `content_length > 0` before treating a checksum match as a complete upload, ensuring incomplete downloads are repaired.

**2. HTTP Session Reuse** 
Improved download efficiency by creating a single reusable HTTP session in `Downloader.__init__` and storing it as `self.http_session`. Previously, `download_file_to_temp_path` called `web.get_http_session()` for each file, creating a fresh TCP/TLS connection every time. Session reuse eliminates connection overhead for bulk downloads.

**3. IIIF Manifest Caching**
Optimized `process_item` to skip redundant manifest fetches on re-runs:
- Checks S3 cache for existing file list before fetching remote IIIF manifest
- For `media_master` items, writes URLs directly without manifest fetch
- For IIIF items, only fetches manifest if cache is empty or `--overwrite` is enabled
- Eliminates unnecessary network round trips on already-staged items

### Tests
Added comprehensive test coverage in `tests/test_downloader.py` validating:
- Zero-byte stub detection and re-upload behavior
- HTTP session creation and reuse across downloads
- IIIF manifest caching logic with various cache states and overwrite flags
- Media master field handling

### Deployment Notes
These are application-level changes requiring no infrastructure changes. No database migrations, environment variables, AWS configuration, ECS task definitions, or IAM policy updates are needed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/147)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->