### PR TITLE
Extract shared SSM helpers into ingest_wikimedia/ssm.py

### DIFF
--- a/ingest_wikimedia/ssm.py
+++ b/ingest_wikimedia/ssm.py
@@ -1,0 +1,36 @@
+"""Shared SSM helpers for Wikimedia pipeline scripts."""
+
+import json
+import time
+
+INSTANCE_ID = "i-033eff6c8c168f999"
+REGION = "us-east-1"
+SSM_POLL_INTERVAL = 5
+SSM_MAX_POLLS = 60  # 5 minutes
+
+
+def ssm_run(client, cmd: str) -> str:
+    resp = client.send_command(
+        InstanceIds=[INSTANCE_ID],
+        DocumentName="AWS-RunShellScript",
+        Parameters={"commands": [f"sudo -u ec2-user bash -c {json.dumps(cmd)}"]},
+    )
+    cmd_id = resp["Command"]["CommandId"]
+    for attempt in range(SSM_MAX_POLLS):
+        if attempt > 0:
+            time.sleep(SSM_POLL_INTERVAL)
+        try:
+            inv = client.get_command_invocation(
+                CommandId=cmd_id, InstanceId=INSTANCE_ID
+            )
+        except client.exceptions.InvocationDoesNotExist:
+            continue
+        status = inv["Status"]
+        if status == "Success":
+            return inv.get("StandardOutputContent", "").strip()
+        if status in ("Failed", "TimedOut", "Cancelled"):
+            stderr = inv.get("StandardErrorContent", "").strip()
+            raise RuntimeError(
+                f"SSM command {cmd_id} ended with {status}: {stderr or 'no stderr'}"
+            )
+    raise TimeoutError(f"SSM command {cmd_id} did not complete within polling window")

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -12,23 +12,18 @@ Environment variables:
 """
 
 import argparse
-import json
 import logging
 import os
 import sys
-import time
 
 import boto3
 import requests
 
 from ingest_wikimedia.dpla import DPLA_PARTNERS
+from ingest_wikimedia.ssm import REGION, ssm_run
 
-INSTANCE_ID = "i-033eff6c8c168f999"
-REGION = "us-east-1"
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
-SSM_POLL_INTERVAL = 5
-SSM_MAX_POLLS = 60  # 5 minutes
 
 # NARA requires a separate process and is excluded from automated launch
 VALID_PARTNERS = frozenset(DPLA_PARTNERS) - {"nara"}
@@ -37,33 +32,6 @@ VALID_PARTNERS = frozenset(DPLA_PARTNERS) - {"nara"}
 PARTNER_DIR = {
     "si": "smithsonian",
 }
-
-
-def ssm_run(client, cmd: str) -> str:
-    resp = client.send_command(
-        InstanceIds=[INSTANCE_ID],
-        DocumentName="AWS-RunShellScript",
-        Parameters={"commands": [f"sudo -u ec2-user bash -c {json.dumps(cmd)}"]},
-    )
-    cmd_id = resp["Command"]["CommandId"]
-    for attempt in range(SSM_MAX_POLLS):
-        if attempt > 0:
-            time.sleep(SSM_POLL_INTERVAL)
-        try:
-            inv = client.get_command_invocation(
-                CommandId=cmd_id, InstanceId=INSTANCE_ID
-            )
-        except client.exceptions.InvocationDoesNotExist:
-            continue
-        status = inv["Status"]
-        if status == "Success":
-            return inv.get("StandardOutputContent", "").strip()
-        if status in ("Failed", "TimedOut", "Cancelled"):
-            stderr = inv.get("StandardErrorContent", "").strip()
-            raise RuntimeError(
-                f"SSM command {cmd_id} ended with {status}: {stderr or 'no stderr'}"
-            )
-    raise TimeoutError(f"SSM command {cmd_id} did not complete within polling window")
 
 
 def post_to_slack(token: str, text: str) -> None:

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -5,49 +5,18 @@ Runs as a GitHub Action on a schedule and on workflow_dispatch (triggered by
 the /wikimedia-status Slack slash command via Lambda).
 """
 
-import json
 import logging
 import os
 import shlex
-import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import boto3
 import requests
 
-INSTANCE_ID = "i-033eff6c8c168f999"
+from ingest_wikimedia.ssm import REGION, ssm_run
+
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
-REGION = "us-east-1"
-SSM_POLL_INTERVAL = 5
-SSM_MAX_POLLS = 24  # 2 minutes
-
-
-def ssm_run(client, cmd: str) -> str:
-    resp = client.send_command(
-        InstanceIds=[INSTANCE_ID],
-        DocumentName="AWS-RunShellScript",
-        Parameters={"commands": [f"sudo -u ec2-user bash -c {json.dumps(cmd)}"]},
-    )
-    cmd_id = resp["Command"]["CommandId"]
-    for _ in range(SSM_MAX_POLLS):
-        try:
-            inv = client.get_command_invocation(
-                CommandId=cmd_id, InstanceId=INSTANCE_ID
-            )
-        except client.exceptions.InvocationDoesNotExist:
-            time.sleep(SSM_POLL_INTERVAL)
-            continue
-        status = inv["Status"]
-        if status == "Success":
-            return inv.get("StandardOutputContent", "").strip()
-        if status in ("Failed", "TimedOut", "Cancelled"):
-            stderr = inv.get("StandardErrorContent", "").strip()
-            raise RuntimeError(
-                f"SSM command {cmd_id} ended with {status}: {stderr or 'no stderr'}"
-            )
-        time.sleep(SSM_POLL_INTERVAL)
-    raise TimeoutError(f"SSM command {cmd_id} did not complete within polling window")
 
 
 def get_phase_and_progress(client, partner: str) -> str:


### PR DESCRIPTION
## Summary

- Adds `ingest_wikimedia/ssm.py` with shared `INSTANCE_ID`, `REGION`, `SSM_POLL_INTERVAL`, `SSM_MAX_POLLS`, and `ssm_run()`.
- Removes the duplicated implementations from `scripts/wikimedia_upload_status.py` and `scripts/wikimedia_launch.py`; both now import from the shared module.
- Pure refactor — no behavior change, except `wikimedia_upload_status.py` picks up the improved poll loop (sleep before subsequent attempts, not after `InvocationDoesNotExist`) and the 5-minute polling window from `wikimedia_launch.py`.

**Note**: targets `wikimedia-launch-workflow` because `wikimedia_launch.py` only exists on that branch. After #148 merges to main, this PR can be rebased onto main.

## Test plan

- [ ] Trigger `wikimedia-upload-status.yml` manually and confirm it completes successfully
- [ ] Trigger `wikimedia-launch.yml` manually with a partner and confirm EC2 update + pipeline launch still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)