### PR TITLE
fix: install ingest_wikimedia package in wikimedia workflows

### DIFF
--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - run: pip install boto3==1.42.87 requests==2.32.5
+      - run: pip install boto3==1.42.87 requests==2.32.5 && pip install -e . --no-deps
 
       - name: Launch pipeline
         env:

--- a/.github/workflows/wikimedia-upload-status.yml
+++ b/.github/workflows/wikimedia-upload-status.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - run: pip install boto3==1.42.87 requests==2.32.5
+      - run: pip install boto3==1.42.87 requests==2.32.5 && pip install -e . --no-deps
 
       - name: Check status and post to Slack
         env:


### PR DESCRIPTION
Regression from #150. Both `wikimedia_upload_status.py` and `wikimedia_launch.py` now import from `ingest_wikimedia.ssm`, but the workflows only installed `boto3` and `requests`, causing:

```
ModuleNotFoundError: No module named 'ingest_wikimedia'
```

Fix: add `pip install -e . --no-deps` to make the package importable. `--no-deps` avoids pulling in the full dependency tree since `boto3` and `requests` are already installed with pinned versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Bug Fix: Install `ingest_wikimedia` Package in GitHub Actions Workflows

This PR fixes a regression introduced in PR #150 where the Python scripts wikimedia_launch.py and wikimedia_upload_status.py import from the ingest_wikimedia package, but the GitHub Actions workflows did not install the package. Workflows failed with ModuleNotFoundError: No module named 'ingest_wikimedia'.

### Changes
- Added pip install -e . --no-deps to the pip installation step in:
  - .github/workflows/wikimedia-launch.yml
  - .github/workflows/wikimedia-upload-status.yml
- The existing pinned boto3 and requests installs remain; --no-deps prevents reinstalling full dependency trees.

### Impact / Notes
- No runtime infrastructure changes, environment variable or AWS Secrets Manager key changes, database migrations, or public API changes.
- No CI/CD pipeline or ECS redeployment is required beyond merging the workflow change (workflows take effect once merged).
- No IAM, CodeBuild/CodePipeline, or ECS task definition changes.
- Security: no credential-handling changes; the change only ensures the repo package is importable in CI by installing it in editable mode.
- Intended effect: prevents ModuleNotFoundError by making ingest_wikimedia importable in GitHub Actions jobs that run the Wikimedia launch and status scripts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/151)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->