### PR TITLE
fix: use PYTHONPATH to make ingest_wikimedia importable in workflows

### DIFF
--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - run: pip install boto3==1.42.87 requests==2.32.5 && pip install -e . --no-deps
+      - run: pip install boto3==1.42.87 requests==2.32.5
 
       - name: Launch pipeline
         env:
@@ -41,6 +41,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.WIKIMEDIA_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
           DPLA_SLACK_BOT_TOKEN: ${{ secrets.DPLA_SLACK_BOT_TOKEN }}
+          PYTHONPATH: .
         run: |
           python scripts/wikimedia_launch.py \
             --partner "${{ github.event.inputs.partner }}" \

--- a/.github/workflows/wikimedia-upload-status.yml
+++ b/.github/workflows/wikimedia-upload-status.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - run: pip install boto3==1.42.87 requests==2.32.5 && pip install -e . --no-deps
+      - run: pip install boto3==1.42.87 requests==2.32.5
 
       - name: Check status and post to Slack
         env:
@@ -40,4 +40,5 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           DPLA_SLACK_BOT_TOKEN: ${{ secrets.DPLA_SLACK_BOT_TOKEN }}
           NOTIFY_IF_IDLE: ${{ github.event.inputs.notify_if_idle || 'false' }}
+          PYTHONPATH: .
         run: python scripts/wikimedia_upload_status.py


### PR DESCRIPTION
Follow-up to #151. The `pip install -e . --no-deps` approach fails because `pyproject.toml` requires Python `>=3.13` but the workflows run 3.12:

```
ERROR: Package 'ingest-wikimedia' requires a different Python: 3.12.13 not in '>=3.13'
```

Fix: set `PYTHONPATH: .` in the run step env, which adds the repo root to Python's module search path. `ingest_wikimedia` becomes importable without any installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Summary

This PR resolves a Python version compatibility issue in GitHub Actions workflows that prevented the `ingest_wikimedia` package from being importable. 

### Changes Made

**Both workflow files** (`wikimedia-launch.yml` and `wikimedia-upload-status.yml`) were updated with the same fix:

1. **Removed editable package installation**: Replaced `pip install -e . --no-deps` with explicit installation of only the required third-party dependencies (`boto3==1.42.87` and `requests==2.32.5`)
2. **Added PYTHONPATH environment variable**: Set `PYTHONPATH: .` in the respective workflow step environments to ensure the repository root is in Python's module search path, making local modules importable

### Context

This is a follow-up to PR #151. The prior approach of using `pip install -e . --no-deps` failed in CI because the project's `pyproject.toml` specifies Python >= 3.13, while the GitHub Actions workflows run on Python 3.12. The new approach uses `PYTHONPATH` to make modules discoverable without requiring package installation, avoiding the Python version conflict.

### Impact

- Both affected workflows will now successfully import and execute their respective Python scripts without package installation failures
- No manual intervention, redeployment, or infrastructure changes are required
- The fix is purely configuration-level with no impact on the codebase logic

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/152)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->