### PR TITLE
fix: hardcode VALID_PARTNERS in wikimedia_launch.py to avoid transitive deps

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -19,14 +19,28 @@ import sys
 import boto3
 import requests
 
-from ingest_wikimedia.dpla import DPLA_PARTNERS
 from ingest_wikimedia.ssm import REGION, ssm_run
 
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
 
 # NARA requires a separate process and is excluded from automated launch
-VALID_PARTNERS = frozenset(DPLA_PARTNERS) - {"nara"}
+VALID_PARTNERS = frozenset(
+    {
+        "bpl",
+        "georgia",
+        "indiana",
+        "northwest-heritage",
+        "ohio",
+        "p2p",
+        "pa",
+        "si",
+        "texas",
+        "minnesota",
+        "mwdl",
+        "heartland",
+    }
+)
 
 # Partners whose EC2 directory name differs from their partner key
 PARTNER_DIR = {


### PR DESCRIPTION
`wikimedia_launch.py` imported `DPLA_PARTNERS` from `ingest_wikimedia.dpla`, which transitively imports `ingest_wikimedia.iiif`, which requires the `validators` package — not installed in the GH Actions environment:

```
ModuleNotFoundError: No module named 'validators'
```

Fix: hardcode `VALID_PARTNERS` as a frozenset literal, matching the Lambda handler's approach. The script only needs `ingest_wikimedia.ssm`, which has no external dependencies beyond stdlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/153)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->