### PR TITLE
Add multi-target chaining, kill subcommand, institution-level filtering, and Wikidata QID support

### DIFF
--- a/.github/workflows/wikimedia-kill.yml
+++ b/.github/workflows/wikimedia-kill.yml
@@ -1,16 +1,12 @@
-name: Wikimedia Upload Launch
+name: Wikimedia Upload Kill
 
 on:
   workflow_dispatch:
     inputs:
       partner:
-        description: "shlex-encoded target list, e.g. 'bpl' or 'bpl pa' or 'bpl \"indiana|Indiana State Library\"'"
+        description: "Hub slug(s) to kill (space-separated, e.g. 'bpl pa')"
         required: true
         type: string
-      force:
-        description: "Kill existing session if one is already running"
-        type: boolean
-        default: false
       response_url:
         description: "Slack response_url for ephemeral user feedback on failure"
         required: false
@@ -23,14 +19,10 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
-concurrency:
-  group: wikimedia-launch-${{ github.event.inputs.partner }}
-  cancel-in-progress: false
-
 jobs:
-  launch:
+  kill:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
@@ -40,7 +32,7 @@ jobs:
 
       - run: pip install boto3==1.42.87 requests==2.32.5
 
-      - name: Launch pipeline
+      - name: Kill pipeline
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.WIKIMEDIA_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.WIKIMEDIA_AWS_SECRET_ACCESS_KEY }}
@@ -48,7 +40,6 @@ jobs:
           DPLA_SLACK_BOT_TOKEN: ${{ secrets.DPLA_SLACK_BOT_TOKEN }}
           PYTHONPATH: .
         run: |
-          python scripts/wikimedia_launch.py \
+          python scripts/wikimedia_kill.py \
             --partner "${{ github.event.inputs.partner }}" \
-            --force "${{ github.event.inputs.force }}" \
             --response-url "${{ github.event.inputs.response_url }}"

--- a/README.md
+++ b/README.md
@@ -1,40 +1,66 @@
 ![Build Badge](https://github.com/dpla/ingest-wikimedia/actions/workflows/pytest.yml/badge.svg)
----
+
 # ingest-wikimedia
 
-PREREQUISITE: This project is managed with [uv](https://docs.astral.sh/uv/).
+Uploads public-domain media from DPLA partner collections to [Wikimedia Commons](https://commons.wikimedia.org/). Each pipeline run fetches item IDs from DPLA's Elasticsearch index, stages media files to S3, then uploads them to Commons with structured metadata.
 
-To set the project up for execution:
+## Development setup
 
-1. Run `uv build` 
-2. Run `source .venv/bin/activate`
+This project is managed with [uv](https://docs.astral.sh/uv/).
 
-```downloader [OPTIONS] IDS_FILE PARTNER API_KEY```
+```bash
+uv sync
+source .venv/bin/activate
+```
 
-```uploader [OPTIONS] IDS_FILE PARTNER```
+Pre-commit hooks use [ruff](https://docs.astral.sh/ruff/) for linting and formatting, and [ggshield](https://www.gitguardian.com/ggshield) for secret scanning. Install with `pre-commit install`.
 
+## Running the pipeline
 
-Options:
-- `--dry-run`: Does everything save for actually write to Commons.
-- `--verbose`: Logs all the data generated for each file for inspection.
+The pipeline has three sequential phases, each invoked as a CLI command:
 
-`IDS_FILE` is a simple text/csv file with one DPLA ID per line.
+```bash
+# 1. Generate IDs and stage metadata (writes <partner>.csv)
+get-ids-es <partner>
+get-ids-es <partner> --institution "Institution Name"   # institution-level run
 
-`PARTNER` is one of the strings in the `DPLA_PARTNERS` list in `constants.py`.
+# 2. Download media to S3
+downloader <partner>.csv <partner>
 
-`API_KEY` is a DPLA API key.
+# 3. Upload from S3 to Wikimedia Commons
+uploader <partner>.csv <partner>
+```
 
-You can provide `--help` to these commands to see more options.
+All three must run from the partner's working directory on EC2 (e.g. `/home/ec2-user/ingest-wikimedia/bpl/`), where `config.toml` is resolved from CWD.
 
-## Logs
+**In practice, pipelines are launched via Slack or GitHub Actions** — see [docs/operations.md](docs/operations.md) for the full operations guide.
 
-Log files are written out on the local file system in `logs`. This directory is specified in `logs.py`.
+## Project structure
 
-This project makes use of a temporary directory that it creates with a unique name locally.
+| Path | Purpose |
+|------|---------|
+| `ingest_wikimedia/` | Shared library (partner registry, S3, Slack, SSM, Wikimedia API) |
+| `tools/` | CLI entry points (`get-ids-es`, `downloader`, `uploader`) |
+| `scripts/` | GitHub Actions step scripts (`wikimedia_launch.py`, `wikimedia_kill.py`, `wikimedia_upload_status.py`) |
+| `lambda/wikimedia-slack-dispatch/` | Lambda handler for Slack slash commands |
+| `.github/workflows/` | Workflow definitions for launch, kill, and status checks |
 
-## Development
+## Options
 
-This project makes use of [ruff](https://docs.astral.sh/ruff/), 
-[ggshield](https://www.gitguardian.com/ggshield), and 
-[pre-commit](https://pre-commit.com/) to enforce standards prior to commits to source 
-control. You may want to configure your editor to run ruff on save, as well.
+```
+get-ids-es <partner> [--institution NAME] [--dry-run]
+downloader <partner>.csv <partner> [--dry-run] [--verbose]
+uploader   <partner>.csv <partner> [--dry-run] [--verbose]
+```
+
+Pass `--help` to any command for full option details.
+
+## Operations
+
+See **[docs/operations.md](docs/operations.md)** for:
+- Slack slash command reference
+- Target formats (hub slugs, institution-level runs, Wikidata QIDs)
+- Partner hub registry
+- Upload eligibility system
+- EC2 infrastructure details
+- Monitoring and troubleshooting

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ All three must run from the partner's working directory on EC2 (e.g. `/home/ec2-
 
 ## Options
 
-```
+```text
 get-ids-es <partner> [--institution NAME] [--dry-run]
 downloader <partner>.csv <partner> [--dry-run] [--verbose]
 uploader   <partner>.csv <partner> [--dry-run] [--verbose]

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -23,7 +23,7 @@ This guide covers running, monitoring, and troubleshooting the DPLA Wikimedia up
 
 ## Architecture overview
 
-```
+```text
 Slack user
     │
     │  POST /wikimedia-upload bpl pa
@@ -59,7 +59,7 @@ Results (success or failure) post to **#tech-alerts** via the `DPLA_SLACK_BOT_TO
 
 Launches the full upload pipeline (ID generation → download → upload) for one or more targets. All targets run sequentially in a single tmux session. If any step fails, the chain stops.
 
-```
+```text
 /wikimedia-upload bpl
 /wikimedia-upload bpl pa
 /wikimedia-upload "indiana|Indiana State Library"
@@ -70,13 +70,14 @@ Launches the full upload pipeline (ID generation → download → upload) for on
 
 The immediate Slack reply confirms that the workflow was dispatched. A confirmation with the actual tmux session name posts to **#tech-alerts** once the session starts (~1–2 minutes later).
 
-### `/wikimedia-upload kill <hub> [<hub> ...]`
+### `/wikimedia-upload kill <label> [<label> ...]`
 
-Stops one or more running pipeline sessions. Kills any tmux session whose name contains the specified hub(s) as a `+`-delimited component.
+Stops one or more running pipeline sessions. Use the session label suffix shown by `/wikimedia-status` — for example, `indiana-state-library` kills `wikimedia-indiana-state-library`. Wikidata QIDs are also accepted and resolved to their label.
 
-```
+```text
 /wikimedia-upload kill bpl
 /wikimedia-upload kill bpl pa
+/wikimedia-upload kill indiana-state-library
 /wikimedia-upload kill Q72380652
 ```
 
@@ -98,7 +99,7 @@ Targets can be specified in three formats:
 
 A short identifier for a DPLA partner hub. Runs the full hub.
 
-```
+```text
 bpl          → Digital Commonwealth (full hub)
 pa           → PA Digital (full hub)
 indiana      → Indiana Memory (full hub)
@@ -110,7 +111,7 @@ See [Partner hub registry](#partner-hub-registry) for all valid slugs and aliase
 
 Runs only a specific institution within a hub. The institution name must match exactly as it appears in `institutions_v2.json`. Quote the argument in Slack if the institution name contains spaces.
 
-```
+```text
 indiana|Indiana State Library
 indiana|Indiana University
 "pa|Free Library of Philadelphia"
@@ -253,17 +254,19 @@ All three phases are idempotent — re-running is safe and picks up where it lef
 
 When multiple targets are specified, they all run in a single tmux session. The session name is:
 
+```text
+wikimedia-<label1>+<label2>+...
 ```
-wikimedia-<canonical1>+<canonical2>+...
-```
+
+The label for a full-hub target is its canonical slug. The label for an institution-level target is the institution name, lowercased with spaces replaced by hyphens. This is what `/wikimedia-status` reports and what `/wikimedia-upload kill` accepts.
 
 Examples:
 - `/wikimedia-upload bpl` → session `wikimedia-bpl`
 - `/wikimedia-upload bpl pa` → session `wikimedia-bpl+pa`
-- `/wikimedia-upload bpl "indiana|Indiana State Library"` → session `wikimedia-bpl+indiana`
-  (session name uses canonical slugs only; institution detail is in the pipeline command)
+- `/wikimedia-upload "indiana|Indiana State Library"` → session `wikimedia-indiana-state-library`
+- `/wikimedia-upload bpl "indiana|Indiana State Library"` → session `wikimedia-bpl+indiana-state-library`
 
-The `+` separator is unambiguous because canonical slugs use `-` as their only separator character.
+The `+` separator is unambiguous because labels use `-` as their only separator character.
 
 Within the session, targets run sequentially with `&&` chaining — if `bpl`'s upload fails, `pa` does not start.
 
@@ -300,10 +303,10 @@ Steps:
 Triggered by: Slack `/wikimedia-upload kill`, or manually from the Actions tab.
 
 Inputs:
-- `partner` (required): space-separated hub slugs or QIDs to kill
+- `partner` (required): space-separated session label suffixes or QIDs to kill (e.g. `bpl`, `indiana-state-library`, `Q72380652`)
 - `response_url` (optional): Slack response URL for ephemeral error feedback
 
-Steps: runs `scripts/wikimedia_kill.py`, which lists all `wikimedia-*` tmux sessions, kills any that contain the specified hub(s), and posts the result to #tech-alerts.
+Steps: runs `scripts/wikimedia_kill.py`, which lists all `wikimedia-*` tmux sessions, kills any whose `+`-delimited components intersect the specified labels, and posts the result to #tech-alerts.
 
 ### `wikimedia-upload-status.yml`
 
@@ -388,7 +391,7 @@ Or trigger `/wikimedia-status` from Slack.
 
 Logs are written to `/home/ec2-user/ingest-wikimedia/<partner>/logs/` with names like:
 
-```
+```text
 20240601-120000-bpl-download.log
 20240601-140000-bpl-upload.log
 ```
@@ -423,9 +426,9 @@ The hub exists in the registry but `institutions_v2.json` does not mark it (or a
 
 ### "Session already running" / conflict error
 
-A tmux session with an overlapping hub slug is already active. Options:
+A tmux session with an overlapping hub is already active. Options:
 1. Wait for it to finish
-2. Kill it with `/wikimedia-upload kill <hub>`
+2. Kill it with `/wikimedia-upload kill <label>` (use the label shown by `/wikimedia-status`)
 3. Re-trigger `wikimedia-launch.yml` from GitHub Actions with `force: true`
 
 ### "Only N% memory available" error

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,479 @@
+# Wikimedia Upload Pipeline — Operations Guide
+
+This guide covers running, monitoring, and troubleshooting the DPLA Wikimedia upload pipeline. The pipeline uploads public-domain media from DPLA partner collections to Wikimedia Commons.
+
+---
+
+## Table of contents
+
+1. [Architecture overview](#architecture-overview)
+2. [Slack slash commands](#slack-slash-commands)
+3. [Target formats](#target-formats)
+4. [Partner hub registry](#partner-hub-registry)
+5. [Upload eligibility](#upload-eligibility)
+6. [Pipeline phases](#pipeline-phases)
+7. [Session naming and chaining](#session-naming-and-chaining)
+8. [GitHub Actions workflows](#github-actions-workflows)
+9. [Lambda dispatch mechanism](#lambda-dispatch-mechanism)
+10. [EC2 infrastructure](#ec2-infrastructure)
+11. [Monitoring](#monitoring)
+12. [Troubleshooting](#troubleshooting)
+
+---
+
+## Architecture overview
+
+```
+Slack user
+    │
+    │  POST /wikimedia-upload bpl pa
+    ▼
+Lambda (wikimedia-slack-dispatch)
+    │  Validates Slack signature
+    │  Validates hub slugs / QID format
+    │  Returns immediate ack to Slack (<3s)
+    ▼
+GitHub Actions (wikimedia-launch.yml)
+    │  Resolves targets, checks eligibility
+    │  Updates EC2 code (git clone → cp)
+    │  Checks memory headroom on EC2
+    │  Checks for conflicting tmux sessions
+    ▼
+EC2 (i-033eff6c8c168f999) via AWS SSM
+    │  tmux session: wikimedia-bpl+pa
+    │  Runs three phases per target (sequentially):
+    │    1. get-ids-es → <partner>.csv
+    │    2. downloader <partner>.csv <partner>
+    │    3. uploader   <partner>.csv <partner>
+    ▼
+S3 (s3://dpla-wikimedia/)     Wikimedia Commons
+```
+
+Results (success or failure) post to **#tech-alerts** via the `DPLA_SLACK_BOT_TOKEN` bot.
+
+---
+
+## Slack slash commands
+
+### `/wikimedia-upload <target> [<target> ...]`
+
+Launches the full upload pipeline (ID generation → download → upload) for one or more targets. All targets run sequentially in a single tmux session. If any step fails, the chain stops.
+
+```
+/wikimedia-upload bpl
+/wikimedia-upload bpl pa
+/wikimedia-upload "indiana|Indiana State Library"
+/wikimedia-upload bpl "indiana|Indiana State Library" pa
+/wikimedia-upload Q72380652
+/wikimedia-upload Q72380652 Q14688462
+```
+
+The immediate Slack reply confirms that the workflow was dispatched. A confirmation with the actual tmux session name posts to **#tech-alerts** once the session starts (~1–2 minutes later).
+
+### `/wikimedia-upload kill <hub> [<hub> ...]`
+
+Stops one or more running pipeline sessions. Kills any tmux session whose name contains the specified hub(s) as a `+`-delimited component.
+
+```
+/wikimedia-upload kill bpl
+/wikimedia-upload kill bpl pa
+/wikimedia-upload kill Q72380652
+```
+
+Result posts to **#tech-alerts**.
+
+### `/wikimedia-status`
+
+Checks for active upload sessions and posts a status summary to **#tech-alerts**. Shows each session's current phase and progress (e.g. `Downloading (1,234 / 5,678 items, ~21.7%)`).
+
+The status workflow also runs automatically every 6 hours; it only posts when sessions are active (unlike `/wikimedia-status`, which always posts).
+
+---
+
+## Target formats
+
+Targets can be specified in three formats:
+
+### Hub slug
+
+A short identifier for a DPLA partner hub. Runs the full hub.
+
+```
+bpl          → Digital Commonwealth (full hub)
+pa           → PA Digital (full hub)
+indiana      → Indiana Memory (full hub)
+```
+
+See [Partner hub registry](#partner-hub-registry) for all valid slugs and aliases.
+
+### Hub|institution pair
+
+Runs only a specific institution within a hub. The institution name must match exactly as it appears in `institutions_v2.json`. Quote the argument in Slack if the institution name contains spaces.
+
+```
+indiana|Indiana State Library
+indiana|Indiana University
+"pa|Free Library of Philadelphia"
+```
+
+Multiple `hub|institution` targets for the same hub are allowed when they refer to different institutions. They run as part of the same tmux session.
+
+### Wikidata QID
+
+A Wikidata entity identifier (e.g. `Q72380652`). The launch script resolves the QID against `institutions_v2.json`:
+
+- If the QID matches a **hub-level** Wikidata field → full hub run (equivalent to a plain slug)
+- If the QID matches an **institution-level** Wikidata field → institution-level run (equivalent to `hub|Institution Name`)
+- If the QID maps to multiple institutions (same or different hubs) → all matching entries run as separate targets
+
+The Lambda handler validates QID format (`^Q\d+$`) and passes QIDs through unchanged; resolution happens in the launch script where `institutions_v2.json` is already cached.
+
+---
+
+## Partner hub registry
+
+Canonical slugs and their hub display names:
+
+| Slug | Hub name |
+|------|----------|
+| `artstor` | Artstor |
+| `bhl` | Biodiversity Heritage Library |
+| `bpl` | Digital Commonwealth |
+| `cdl` | California Digital Library |
+| `community-webs` | Community Webs |
+| `ct` | Connecticut Digital Archive |
+| `david-rumsey` | David Rumsey |
+| `dc` | District Digital |
+| `digitalnc` | North Carolina Digital Heritage Center |
+| `florida` | Sunshine State Digital Network |
+| `georgia` | Digital Library of Georgia |
+| `getty` | J. Paul Getty Trust |
+| `gpo` | United States Government Publishing Office (GPO) |
+| `harvard` | Harvard Library |
+| `hathi` | HathiTrust |
+| `heartland` | Heartland Hub |
+| `ia` | Internet Archive |
+| `il` | Illinois Digital Heritage Hub |
+| `indiana` | Indiana Memory |
+| `jh3` | Jewish Heritage and History Hub |
+| `lc` | Library of Congress |
+| `maine` | Digital Maine |
+| `maryland` | Digital Maryland |
+| `mi` | Michigan Service Hub |
+| `minnesota` | Minnesota Digital Library |
+| `mississippi` | Mississippi Digital Library |
+| `mwdl` | Mountain West Digital Library |
+| `nara` | National Archives and Records Administration |
+| `njde` | NJ/DE Digital Collective |
+| `northwest-heritage` | Northwest Digital Heritage |
+| `nypl` | The New York Public Library |
+| `ohio` | Ohio Digital Network |
+| `oklahoma` | OKHub |
+| `p2p` | Plains to Peaks Collective |
+| `pa` | PA Digital |
+| `scdl` | South Carolina Digital Library |
+| `si` | Smithsonian Institution |
+| `texas` | The Portal to Texas History |
+| `tn` | Digital Library of Tennessee |
+| `txdl` | Texas Digital Library |
+| `virginias` | Digital Virginias |
+| `vt` | Vermont Green Mountain Digital Archive |
+| `washington` | University of Washington |
+| `wisconsin` | Recollection Wisconsin |
+
+**Accepted aliases** (map to the canonical slug above):
+
+| Alias | Canonical |
+|-------|-----------|
+| `ma`, `mass` | `bpl` |
+| `in` | `indiana` |
+| `oh`, `odn` | `ohio` |
+| `mn` | `minnesota` |
+| `ga`, `dlg` | `georgia` |
+| `fl`, `ssdn` | `florida` |
+| `ms` | `mississippi` |
+| `rw` | `wisconsin` |
+| `hh` | `heartland` |
+| `idhh` | `il` |
+| `jhn` | `jh3` |
+| `nwdh` | `northwest-heritage` |
+| `ppc` | `p2p` |
+| `smithsonian` | `si` |
+
+**NARA** cannot be launched via this pipeline. It requires a separate process.
+
+---
+
+## Upload eligibility
+
+Not every hub in the registry is upload-eligible. Eligibility is determined per-hub (and per-institution within a hub) by the `upload: true` flag in [`institutions_v2.json`](https://github.com/dpla/ingestion3/blob/main/src/main/resources/wiki/institutions_v2.json) in the ingestion3 repository.
+
+The launch script checks eligibility before launching and rejects ineligible targets with an ephemeral Slack error. A hub is eligible if:
+- The hub-level object has `"upload": true`, **or**
+- Any institution within the hub has `"upload": true`
+
+Hub-level eligibility does not imply every institution within it is eligible — institution-level runs respect individual eligibility flags.
+
+---
+
+## Pipeline phases
+
+Each target runs three sequential phases within the tmux session. The `&&` chain ensures a later phase only starts if the previous one succeeded.
+
+### Phase 1: ID generation (`get-ids-es`)
+
+Queries DPLA's Elasticsearch index for items belonging to the partner hub (or a specific institution). Writes a CSV of DPLA IDs and associated metadata to `<partner>.csv` in the partner's working directory.
+
+```bash
+get-ids-es <partner>                              # full hub
+get-ids-es <partner> --institution "Inst Name"   # single institution
+```
+
+### Phase 2: Download (`downloader`)
+
+Reads `<partner>.csv`, downloads the original media files, and stages them to `s3://dpla-wikimedia/`. Skips files already present in S3 (by key existence). Re-downloads zero-byte S3 stubs automatically.
+
+```bash
+downloader <partner>.csv <partner>
+```
+
+### Phase 3: Upload (`uploader`)
+
+Reads `<partner>.csv`, retrieves media from S3, and uploads each file to Wikimedia Commons with structured SDC (Structured Data on Commons) metadata. Skips files already present on Commons.
+
+```bash
+uploader <partner>.csv <partner>
+```
+
+All three phases are idempotent — re-running is safe and picks up where it left off.
+
+---
+
+## Session naming and chaining
+
+When multiple targets are specified, they all run in a single tmux session. The session name is:
+
+```
+wikimedia-<canonical1>+<canonical2>+...
+```
+
+Examples:
+- `/wikimedia-upload bpl` → session `wikimedia-bpl`
+- `/wikimedia-upload bpl pa` → session `wikimedia-bpl+pa`
+- `/wikimedia-upload bpl "indiana|Indiana State Library"` → session `wikimedia-bpl+indiana`
+  (session name uses canonical slugs only; institution detail is in the pipeline command)
+
+The `+` separator is unambiguous because canonical slugs use `-` as their only separator character.
+
+Within the session, targets run sequentially with `&&` chaining — if `bpl`'s upload fails, `pa` does not start.
+
+**Conflict detection**: before launching, the script checks whether any existing tmux session contains any of the requested hub slugs. If a conflict is found, the launch fails with an ephemeral error listing the conflicting session(s). To override, trigger `wikimedia-launch.yml` manually from GitHub Actions with `force: true`.
+
+**Memory check**: the launch script verifies that at least 30% of RAM is available on EC2 before starting. Each ingest session uses ~300–500 MB; the EC2 instance has 7.6 GB total. At the 30% threshold (~2.3 GB free), 4–5 concurrent sessions are the practical limit.
+
+---
+
+## GitHub Actions workflows
+
+### `wikimedia-launch.yml`
+
+Triggered by: Slack `/wikimedia-upload`, or manually from the Actions tab.
+
+Inputs:
+- `partner` (required): shlex-encoded target list, e.g. `bpl` or `bpl pa` or `bpl "indiana|Indiana State Library"` or `Q72380652`
+- `force` (boolean, default `false`): kill any conflicting sessions before launching
+- `response_url` (optional): Slack response URL for ephemeral error feedback
+
+Steps:
+1. Installs `boto3` and `requests`
+2. Runs `scripts/wikimedia_launch.py`, which:
+   - Resolves and validates all targets
+   - Checks EC2 memory headroom
+   - Checks for conflicting tmux sessions (kills them if `force=true`)
+   - Updates EC2 code from GitHub
+   - Launches the tmux session
+   - Verifies the session started
+   - Posts confirmation to #tech-alerts
+
+### `wikimedia-kill.yml`
+
+Triggered by: Slack `/wikimedia-upload kill`, or manually from the Actions tab.
+
+Inputs:
+- `partner` (required): space-separated hub slugs or QIDs to kill
+- `response_url` (optional): Slack response URL for ephemeral error feedback
+
+Steps: runs `scripts/wikimedia_kill.py`, which lists all `wikimedia-*` tmux sessions, kills any that contain the specified hub(s), and posts the result to #tech-alerts.
+
+### `wikimedia-upload-status.yml`
+
+Triggered by: schedule (every 6 hours), or Slack `/wikimedia-status`.
+
+When scheduled: posts to #tech-alerts only if sessions are active.
+When triggered by Slack: always posts (even if no sessions are running).
+
+For each active session, reports the current phase and progress percentage by inspecting the most recent log file.
+
+---
+
+## Lambda dispatch mechanism
+
+The Lambda function (`wikimedia-slack-dispatch`) sits behind a Lambda Function URL and handles all Slack slash commands for the `dpla` workspace.
+
+**Validation**:
+1. Checks `x-slack-request-timestamp` and `x-slack-signature` headers are present
+2. Decodes base64 body if `isBase64Encoded` is set
+3. Verifies HMAC-SHA256 signature using `SLACK_SIGNING_SECRET`
+4. Rejects requests with a timestamp more than 5 minutes old
+
+**Dispatch**: after validation, the handler calls the GitHub API to trigger the appropriate `workflow_dispatch` event, then returns an immediate acknowledgement to Slack. The GitHub API call has a 2-second timeout to stay within Slack's 3-second ack limit.
+
+**QID handling in Lambda**: the Lambda validates QID format (`^Q\d+$`) but does **not** resolve QIDs against `institutions_v2.json` — that would require a network call within the 3-second window. QIDs are passed through to the launch/kill scripts, which resolve them after the workflow starts.
+
+**Hub slug validation in Lambda**: the Lambda resolves hub slugs and validates them against the local `PARTNER_HUBS` registry before dispatching. This catches typos immediately with an ephemeral error, before a GitHub Actions run is started.
+
+**Environment variables**:
+- `SLACK_SIGNING_SECRET`: from the Slack app's Basic Information page
+- `GH_TOKEN`: GitHub fine-grained PAT with `actions:write` on `dpla/ingest-wikimedia`
+- `GH_REPO`: repository (default: `dpla/ingest-wikimedia`)
+
+---
+
+## EC2 infrastructure
+
+- **Instance**: `i-033eff6c8c168f999` (name: "wiki downloads") — always running
+- **Access**: AWS SSM (`ssm:SendCommand` / `ssm:GetCommandInvocation`)
+- **Region**: `us-east-1`
+- **Repo root**: `/home/ec2-user/ingest-wikimedia/`
+- **Per-partner working directory**: `/home/ec2-user/ingest-wikimedia/<partner>/`
+  - Exception: `si` (Smithsonian) maps to `smithsonian/`, not `si/`
+- **Venv**: `/home/ec2-user/ingest-wikimedia/.venv/bin/activate`
+- **uv binary**: `/home/ec2-user/.local/bin/uv`
+
+The EC2 directory is **not a git repo** — code is deployed by cloning to `/tmp` and copying files. The package is an editable install, so updating the `.py` source files changes the running code immediately.
+
+The launch script updates EC2 code on every run before launching:
+
+```bash
+cd /tmp && rm -rf ingest-wikimedia-update && \
+git clone --depth 1 https://github.com/dpla/ingest-wikimedia.git ingest-wikimedia-update && \
+cp -r ingest-wikimedia-update/ingest_wikimedia/* /home/ec2-user/ingest-wikimedia/ingest_wikimedia/ && \
+cp -r ingest-wikimedia-update/tools/* /home/ec2-user/ingest-wikimedia/tools/ && \
+cp ingest-wikimedia-update/pyproject.toml /home/ec2-user/ingest-wikimedia/pyproject.toml && \
+cp ingest-wikimedia-update/uv.lock /home/ec2-user/ingest-wikimedia/uv.lock && \
+/home/ec2-user/.local/bin/uv sync --project /home/ec2-user/ingest-wikimedia
+```
+
+**S3 staging bucket**: `s3://dpla-wikimedia/`
+
+---
+
+## Monitoring
+
+### Active sessions
+
+Check what's running via SSM:
+
+```bash
+aws ssm send-command \
+  --instance-ids i-033eff6c8c168f999 \
+  --document-name AWS-RunShellScript \
+  --parameters '{"commands":["sudo -u ec2-user tmux ls 2>/dev/null"]}' \
+  --query 'Command.CommandId' --output text
+```
+
+Or trigger `/wikimedia-status` from Slack.
+
+### Log files
+
+Logs are written to `/home/ec2-user/ingest-wikimedia/<partner>/logs/` with names like:
+
+```
+20240601-120000-bpl-download.log
+20240601-140000-bpl-upload.log
+```
+
+Key log lines:
+
+| Line | Meaning |
+|------|---------|
+| `Downloading https://...` | Downloading a file from source |
+| `Key already in S3: ...` | File already staged, skipping download |
+| `Uploaded to https://commons.wikimedia.org/wiki/File:...` | Successful upload |
+| `Skipping <id>: Already exists on commons.` | File already on Commons, skipping |
+| `COUNTS:` followed by `UPLOADED: N`, `SKIPPED: N`, `FAILED: N`, `BYTES: N` | Phase complete |
+| `Bad provider.` | Data provider not configured for upload |
+
+### Slack notifications
+
+- **#tech-alerts** receives: launch confirmation, kill confirmation, status reports, and phase completion summaries (when `DPLA_SLACK_BOT_TOKEN` is set in the Actions environment)
+- Ephemeral errors (invalid hub, ineligible hub, conflicting session) go only to the user who ran the slash command
+
+---
+
+## Troubleshooting
+
+### "Unknown hub" error in Slack
+
+The slug is not in the hub registry. Check `ingest_wikimedia/partners.py` for valid slugs and aliases. Hub display names (e.g. "Digital Commonwealth") are also accepted and resolve to the canonical slug.
+
+### "Hub is not upload-eligible"
+
+The hub exists in the registry but `institutions_v2.json` does not mark it (or any of its institutions) as `upload: true`. This is a data-side setting in the [ingestion3 repo](https://github.com/dpla/ingestion3/blob/main/src/main/resources/wiki/institutions_v2.json).
+
+### "Session already running" / conflict error
+
+A tmux session with an overlapping hub slug is already active. Options:
+1. Wait for it to finish
+2. Kill it with `/wikimedia-upload kill <hub>`
+3. Re-trigger `wikimedia-launch.yml` from GitHub Actions with `force: true`
+
+### "Only N% memory available" error
+
+EC2 is below the 30% memory threshold. Check what sessions are running (`/wikimedia-status`) and wait for one to complete, or kill a session to free memory.
+
+### Pipeline started but no #tech-alerts confirmation
+
+1. Check the GitHub Actions run for the workflow — look for errors in the launch script output
+2. Verify `DPLA_SLACK_BOT_TOKEN` is set as a repository secret
+3. Check if the tmux session actually started: run `/wikimedia-status` or check via SSM directly
+
+### Session disappeared but no completion message
+
+The pipeline likely crashed. Check the most recent log file:
+
+```bash
+ls -t /home/ec2-user/ingest-wikimedia/<partner>/logs/ | head -3
+tail -50 /home/ec2-user/ingest-wikimedia/<partner>/logs/<latest>.log
+```
+
+Common crash causes:
+- **`RuntimeError: File linked to another page`**: DPLA ID drift — file already on Commons under a different title. Known/expected, not fixable per-run.
+- **`titleblacklist-forbidden`**: Title contains `''` (double apostrophes), `&`, or `=` matching Wikimedia's blacklist. Requires fix in title generation.
+- **`fileexists-shared-forbidden`**: File name collides with an existing Wikimedia shared repo file. Not fixable; these items are skipped.
+- **`.bin` extension / `ValueError: does not have a valid extension`**: Downloader couldn't determine MIME type; stored with `.bin` fallback. Commons rejects it.
+- **`protectedpage`**: Target file page is protected on Commons. Not fixable; skip.
+
+### Re-running after a crash
+
+All phases are idempotent — re-launching is safe. The downloader skips already-staged S3 objects; the uploader skips files already on Commons. Just trigger `/wikimedia-upload <hub>` again.
+
+If the ID file (`<partner>.csv`) is partial or empty, delete it before re-running — the launch script will regenerate it from scratch.
+
+### Orphaned temp files
+
+An interrupted download can leave `wiki-tmp-*.tmp` files in partner directories:
+
+```bash
+find /home/ec2-user/ingest-wikimedia -name 'wiki-tmp-*' -type f -delete
+```
+
+### Log disk usage
+
+Logs accumulate over time and can reach several GB per partner for long-running jobs. Check usage:
+
+```bash
+du -sh /home/ec2-user/ingest-wikimedia/*/logs/
+```
+
+Old logs can be deleted safely — they are not read by the pipeline after the run completes.

--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -5,6 +5,7 @@ GitHub Actions without installing the full ingest_wikimedia package dependencies
 """
 
 import json
+import re
 import urllib.request
 
 # Module-level cache so warm Lambda invocations skip repeated network fetches.
@@ -14,6 +15,9 @@ INSTITUTIONS_URL = (
     "https://raw.githubusercontent.com/dpla/ingestion3"
     "/refs/heads/main/src/main/resources/wiki/institutions_v2.json"
 )
+
+# Wikidata QID pattern (e.g. Q12345).
+_QID_RE = re.compile(r"^Q\d+$")
 
 # All DPLA partner hubs: canonical slug → hub display name (as used in institutions_v2.json)
 PARTNER_HUBS: dict[str, str] = {
@@ -102,16 +106,48 @@ def resolve_slug(slug: str) -> str | None:
     return _SLUG_BY_HUB_NAME.get(s)
 
 
-def is_upload_eligible(canonical_slug: str, timeout: int = 5) -> bool:
-    """Return True if institutions_v2.json marks this hub (or any child) upload=True."""
+def _get_institutions(timeout: int = 5) -> dict:
+    """Fetch institutions_v2.json from GitHub, caching after the first call."""
     global _institutions_cache
-    hub_name = PARTNER_HUBS.get(canonical_slug)
-    if not hub_name:
-        return False
     if _institutions_cache is None:
         with urllib.request.urlopen(INSTITUTIONS_URL, timeout=timeout) as resp:
             _institutions_cache = json.loads(resp.read())
-    hub = _institutions_cache.get(hub_name, {})
+    return _institutions_cache
+
+
+def is_upload_eligible(canonical_slug: str, timeout: int = 5) -> bool:
+    """Return True if institutions_v2.json marks this hub (or any child) upload=True."""
+    hub_name = PARTNER_HUBS.get(canonical_slug)
+    if not hub_name:
+        return False
+    hub = _get_institutions(timeout).get(hub_name, {})
     return hub.get("upload", False) or any(
         inst.get("upload", False) for inst in hub.get("institutions", {}).values()
     )
+
+
+def is_wikidata_id(s: str) -> bool:
+    """Return True if s is a Wikidata QID (e.g. 'Q12345')."""
+    return bool(_QID_RE.match(s))
+
+
+def resolve_wikidata_id(qid: str, timeout: int = 5) -> list[tuple[str, str | None]]:
+    """Return (canonical_slug, institution_or_None) pairs matching a Wikidata QID.
+
+    Searches hub-level and institution-level Wikidata fields in institutions_v2.json.
+    Returns an empty list if no match. Multiple matches are possible when the same
+    QID appears under different hubs or institutions in the JSON.
+    """
+    institutions = _get_institutions(timeout)
+    results: list[tuple[str, str | None]] = []
+    for hub_name, hub_data in institutions.items():
+        canonical = _SLUG_BY_HUB_NAME.get(hub_name.lower())
+        if canonical is None:
+            continue
+        if hub_data.get("Wikidata") == qid:
+            results.append((canonical, None))
+        else:
+            for inst_name, inst_data in hub_data.get("institutions", {}).items():
+                if inst_data.get("Wikidata") == qid:
+                    results.append((canonical, inst_name))
+    return results

--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -131,6 +131,26 @@ def is_wikidata_id(s: str) -> bool:
     return bool(_QID_RE.match(s))
 
 
+def canonical_matches_session_component(
+    canonical: str, component: str, timeout: int = 5
+) -> bool:
+    """Return True if a tmux session component represents the given canonical hub.
+
+    Components are either the canonical slug (full-hub sessions) or a
+    hyphenated-lowercase institution name (institution-level sessions).
+    """
+    if component == canonical:
+        return True
+    hub_name = PARTNER_HUBS.get(canonical)
+    if not hub_name:
+        return False
+    hub_data = _get_institutions(timeout).get(hub_name, {})
+    return any(
+        inst.lower().replace(" ", "-") == component
+        for inst in hub_data.get("institutions", {})
+    )
+
+
 def resolve_wikidata_id(qid: str, timeout: int = 5) -> list[tuple[str, str | None]]:
     """Return (canonical_slug, institution_or_None) pairs matching a Wikidata QID.
 

--- a/ingest_wikimedia/ssm.py
+++ b/ingest_wikimedia/ssm.py
@@ -1,6 +1,6 @@
 """Shared SSM helpers for Wikimedia pipeline scripts."""
 
-import json
+import shlex
 import time
 
 INSTANCE_ID = "i-033eff6c8c168f999"
@@ -13,7 +13,7 @@ def ssm_run(client, cmd: str) -> str:
     resp = client.send_command(
         InstanceIds=[INSTANCE_ID],
         DocumentName="AWS-RunShellScript",
-        Parameters={"commands": [f"sudo -u ec2-user bash -c {json.dumps(cmd)}"]},
+        Parameters={"commands": [f"sudo -u ec2-user bash -c {shlex.quote(cmd)}"]},
     )
     cmd_id = resp["Command"]["CommandId"]
     for attempt in range(SSM_MAX_POLLS):

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -4,9 +4,12 @@ Lambda handler for Wikimedia Slack slash commands.
 Handles:
   /wikimedia-status  — dispatches wikimedia-upload-status.yml; results post to
                        #tech-alerts once the workflow completes (~2 minutes).
-  /wikimedia-upload <partner>
-                     — dispatches wikimedia-launch.yml with the given partner slug;
-                       a confirmation posts to #tech-alerts once the session starts.
+  /wikimedia-upload <target> [<target> ...]
+                     — dispatches wikimedia-launch.yml; one tmux session runs all
+                       targets sequentially. Each target is a hub slug ("bpl") or
+                       a hub|institution pair ("indiana|Indiana State Library").
+  /wikimedia-upload kill <hub> [<hub> ...]
+                     — dispatches wikimedia-kill.yml to stop running sessions.
 
 Validates the incoming Slack request signature before dispatching.
 
@@ -23,6 +26,7 @@ import hmac
 import json
 import logging
 import os
+import shlex
 import time
 import urllib.error
 import urllib.parse
@@ -163,46 +167,103 @@ def handler(event, context):
         raw = fields.get("text", "").strip()
         if not raw:
             return _slack_reply(
-                "Usage: `/wikimedia-upload <partner>`",
+                "Usage: `/wikimedia-upload <hub> [<hub> ...]` or"
+                " `/wikimedia-upload <hub>|<institution>` or"
+                " `/wikimedia-upload kill <hub> [<hub> ...]`",
                 ephemeral=True,
             )
-        canonical = resolve_slug(raw)
-        if canonical is None:
-            return _slack_reply(
-                f"Unknown hub: `{raw}`. Check the hub slug and try again.",
-                ephemeral=True,
-            )
-        if canonical == "nara":
-            return _slack_reply(
-                "NARA requires a separate process and cannot be launched here.",
-                ephemeral=True,
-            )
+
         try:
-            response_url = fields.get("response_url", "")
+            tokens = shlex.split(raw)
+        except ValueError as e:
+            return _slack_reply(f"Could not parse command: {e}", ephemeral=True)
+
+        response_url = fields.get("response_url", "")
+
+        # Kill subcommand: /wikimedia-upload kill <hub> [<hub> ...]
+        if tokens[0] == "kill":
+            kill_slugs = tokens[1:]
+            if not kill_slugs:
+                return _slack_reply(
+                    "Usage: `/wikimedia-upload kill <hub> [<hub> ...]`",
+                    ephemeral=True,
+                )
+            kill_canonicals: list[str] = []
+            for slug in kill_slugs:
+                canonical = resolve_slug(slug)
+                if canonical is None:
+                    return _slack_reply(
+                        f"Unknown hub: `{slug}`. Check the hub slug and try again.",
+                        ephemeral=True,
+                    )
+                kill_canonicals.append(canonical)
+            partner_input = shlex.join(kill_canonicals)
+            label = ", ".join(f"`{c}`" for c in kill_canonicals)
+            return _dispatch_and_reply(
+                gh_token,
+                repo,
+                "wikimedia-kill.yml",
+                {"partner": partner_input, "response_url": response_url},
+                f"Kill signal sent for {label} — result will post to #tech-alerts shortly.",
+            )
+
+        # Launch subcommand: /wikimedia-upload <target> [<target> ...]
+        # Dict preserves insertion order for stable session naming.
+        seen_hubs: dict[str, None] = {}
+        launch_targets: list[str] = []
+        for token in tokens:
+            hub_part, institution = (
+                token.split("|", 1) if "|" in token else (token, None)
+            )
+            canonical = resolve_slug(hub_part)
+            if canonical is None:
+                return _slack_reply(
+                    f"Unknown hub: `{hub_part}`. Check the hub slug and try again.",
+                    ephemeral=True,
+                )
+            if canonical == "nara":
+                return _slack_reply(
+                    "NARA requires a separate process and cannot be launched here.",
+                    ephemeral=True,
+                )
+            if canonical in seen_hubs:
+                return _slack_reply(
+                    f"Hub `{canonical}` appears more than once.",
+                    ephemeral=True,
+                )
+            seen_hubs[canonical] = None
+            launch_targets.append(
+                f"{canonical}|{institution}" if institution else canonical
+            )
+
+        partner_input = shlex.join(launch_targets)
+        session_label = "wikimedia-" + "+".join(seen_hubs)
+
+        try:
             status = _dispatch_workflow(
                 gh_token,
                 repo,
                 "wikimedia-launch.yml",
-                {"partner": canonical, "response_url": response_url},
+                {"partner": partner_input, "response_url": response_url},
             )
         except urllib.error.HTTPError as e:
             logging.error("GitHub API error: HTTP %s", e.code)
-            return _slack_reply(f"Failed to launch `{canonical}` (HTTP {e.code}).")
+            return _slack_reply(f"Failed to launch `{session_label}` (HTTP {e.code}).")
         except TimeoutError:
             logging.warning(
-                "Timeout waiting for GitHub dispatch response for %s", canonical
+                "Timeout waiting for GitHub dispatch response for %s", session_label
             )
             return _slack_reply(
-                f"GitHub API was slow — `wikimedia-{canonical}` may have been dispatched anyway. "
+                f"GitHub API was slow — `{session_label}` may have been dispatched anyway. "
                 "Check #tech-alerts in ~2 minutes or the Actions tab to confirm."
             )
         except Exception:
             logging.exception("Unexpected error dispatching workflow")
             return _slack_reply(
-                f"Failed to launch `{canonical}` due to an internal error."
+                f"Failed to launch `{session_label}` due to an internal error."
             )
         text = (
-            f"Launching `wikimedia-{canonical}` pipeline — confirmation will post to #tech-alerts shortly."
+            f"Launching `{session_label}` pipeline — confirmation will post to #tech-alerts shortly."
             if status == 204
             else f"Unexpected response from GitHub (HTTP {status})"
         )

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -183,37 +183,17 @@ def handler(event, context):
 
         response_url = fields.get("response_url", "")
 
-        # Kill subcommand: /wikimedia-upload kill <hub|QID|hub|institution> [...]
+        # Kill subcommand: /wikimedia-upload kill <label> [<label> ...]
+        # Targets are session label suffixes as shown by /wikimedia-status
+        # (e.g. "bpl", "indiana-state-library"). QIDs are also accepted.
         if tokens[0] == "kill":
-            kill_slugs = tokens[1:]
-            if not kill_slugs:
+            kill_targets = tokens[1:]
+            if not kill_targets:
                 return _slack_reply(
-                    "Usage: `/wikimedia-upload kill <hub> [<hub> ...]`"
-                    " or `/wikimedia-upload kill <hub>|<institution>`",
+                    "Usage: `/wikimedia-upload kill <label> [<label> ...]`"
+                    " — use the session label from `/wikimedia-status`",
                     ephemeral=True,
                 )
-            kill_targets: list[str] = []
-            for slug in kill_slugs:
-                if _QID_RE.match(slug):
-                    # QID: pass through; kill script resolves it
-                    kill_targets.append(slug)
-                elif "|" in slug:
-                    hub_part, institution = slug.split("|", 1)
-                    canonical = resolve_slug(hub_part)
-                    if canonical is None:
-                        return _slack_reply(
-                            f"Unknown hub: `{hub_part}`. Check the hub slug and try again.",
-                            ephemeral=True,
-                        )
-                    kill_targets.append(f"{canonical}|{institution}")
-                else:
-                    canonical = resolve_slug(slug)
-                    if canonical is None:
-                        return _slack_reply(
-                            f"Unknown hub: `{slug}`. Check the hub slug and try again.",
-                            ephemeral=True,
-                        )
-                    kill_targets.append(canonical)
             partner_input = shlex.join(kill_targets)
             label = ", ".join(f"`{t}`" for t in kill_targets)
             return _dispatch_and_reply(

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -26,6 +26,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import shlex
 import time
 import urllib.error
@@ -33,6 +34,8 @@ import urllib.parse
 import urllib.request
 
 from ingest_wikimedia.partners import resolve_slug
+
+_QID_RE = re.compile(r"^Q\d+$")
 
 
 def _verify_slack_signature(
@@ -180,7 +183,7 @@ def handler(event, context):
 
         response_url = fields.get("response_url", "")
 
-        # Kill subcommand: /wikimedia-upload kill <hub> [<hub> ...]
+        # Kill subcommand: /wikimedia-upload kill <hub|QID> [<hub|QID> ...]
         if tokens[0] == "kill":
             kill_slugs = tokens[1:]
             if not kill_slugs:
@@ -190,13 +193,17 @@ def handler(event, context):
                 )
             kill_canonicals: list[str] = []
             for slug in kill_slugs:
-                canonical = resolve_slug(slug)
-                if canonical is None:
-                    return _slack_reply(
-                        f"Unknown hub: `{slug}`. Check the hub slug and try again.",
-                        ephemeral=True,
-                    )
-                kill_canonicals.append(canonical)
+                if _QID_RE.match(slug):
+                    # QID: pass through; kill script resolves it
+                    kill_canonicals.append(slug)
+                else:
+                    canonical = resolve_slug(slug)
+                    if canonical is None:
+                        return _slack_reply(
+                            f"Unknown hub: `{slug}`. Check the hub slug and try again.",
+                            ephemeral=True,
+                        )
+                    kill_canonicals.append(canonical)
             partner_input = shlex.join(kill_canonicals)
             label = ", ".join(f"`{c}`" for c in kill_canonicals)
             return _dispatch_and_reply(
@@ -208,36 +215,46 @@ def handler(event, context):
             )
 
         # Launch subcommand: /wikimedia-upload <target> [<target> ...]
+        # QIDs are passed through; the launch script resolves them.
         # Dict preserves insertion order for stable session naming.
-        seen_hubs: dict[str, None] = {}
+        seen_tokens: set[str] = set()
         launch_targets: list[str] = []
         for token in tokens:
-            hub_part, institution = (
-                token.split("|", 1) if "|" in token else (token, None)
-            )
-            canonical = resolve_slug(hub_part)
-            if canonical is None:
-                return _slack_reply(
-                    f"Unknown hub: `{hub_part}`. Check the hub slug and try again.",
-                    ephemeral=True,
+            if _QID_RE.match(token):
+                # Wikidata QID — validate format, pass through unchanged.
+                if token in seen_tokens:
+                    return _slack_reply(
+                        f"Target `{token}` appears more than once.",
+                        ephemeral=True,
+                    )
+                seen_tokens.add(token)
+                launch_targets.append(token)
+            else:
+                hub_part, institution = (
+                    token.split("|", 1) if "|" in token else (token, None)
                 )
-            if canonical == "nara":
-                return _slack_reply(
-                    "NARA requires a separate process and cannot be launched here.",
-                    ephemeral=True,
-                )
-            if canonical in seen_hubs:
-                return _slack_reply(
-                    f"Hub `{canonical}` appears more than once.",
-                    ephemeral=True,
-                )
-            seen_hubs[canonical] = None
-            launch_targets.append(
-                f"{canonical}|{institution}" if institution else canonical
-            )
+                canonical = resolve_slug(hub_part)
+                if canonical is None:
+                    return _slack_reply(
+                        f"Unknown hub: `{hub_part}`. Check the hub slug and try again.",
+                        ephemeral=True,
+                    )
+                if canonical == "nara":
+                    return _slack_reply(
+                        "NARA requires a separate process and cannot be launched here.",
+                        ephemeral=True,
+                    )
+                target_str = f"{canonical}|{institution}" if institution else canonical
+                if target_str in seen_tokens:
+                    return _slack_reply(
+                        f"Target `{target_str}` appears more than once.",
+                        ephemeral=True,
+                    )
+                seen_tokens.add(target_str)
+                launch_targets.append(target_str)
 
         partner_input = shlex.join(launch_targets)
-        session_label = "wikimedia-" + "+".join(seen_hubs)
+        targets_display = ", ".join(f"`{t}`" for t in launch_targets)
 
         try:
             status = _dispatch_workflow(
@@ -248,22 +265,25 @@ def handler(event, context):
             )
         except urllib.error.HTTPError as e:
             logging.error("GitHub API error: HTTP %s", e.code)
-            return _slack_reply(f"Failed to launch `{session_label}` (HTTP {e.code}).")
+            return _slack_reply(
+                f"Failed to launch pipeline for {targets_display} (HTTP {e.code})."
+            )
         except TimeoutError:
             logging.warning(
-                "Timeout waiting for GitHub dispatch response for %s", session_label
+                "Timeout waiting for GitHub dispatch response for targets: %s",
+                targets_display,
             )
             return _slack_reply(
-                f"GitHub API was slow — `{session_label}` may have been dispatched anyway. "
+                f"GitHub API was slow — pipeline for {targets_display} may have been dispatched anyway. "
                 "Check #tech-alerts in ~2 minutes or the Actions tab to confirm."
             )
         except Exception:
             logging.exception("Unexpected error dispatching workflow")
             return _slack_reply(
-                f"Failed to launch `{session_label}` due to an internal error."
+                f"Failed to launch pipeline for {targets_display} due to an internal error."
             )
         text = (
-            f"Launching `{session_label}` pipeline — confirmation will post to #tech-alerts shortly."
+            f"Launching pipeline for {targets_display} — confirmation will post to #tech-alerts shortly."
             if status == 204
             else f"Unexpected response from GitHub (HTTP {status})"
         )

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -183,19 +183,29 @@ def handler(event, context):
 
         response_url = fields.get("response_url", "")
 
-        # Kill subcommand: /wikimedia-upload kill <hub|QID> [<hub|QID> ...]
+        # Kill subcommand: /wikimedia-upload kill <hub|QID|hub|institution> [...]
         if tokens[0] == "kill":
             kill_slugs = tokens[1:]
             if not kill_slugs:
                 return _slack_reply(
-                    "Usage: `/wikimedia-upload kill <hub> [<hub> ...]`",
+                    "Usage: `/wikimedia-upload kill <hub> [<hub> ...]`"
+                    " or `/wikimedia-upload kill <hub>|<institution>`",
                     ephemeral=True,
                 )
-            kill_canonicals: list[str] = []
+            kill_targets: list[str] = []
             for slug in kill_slugs:
                 if _QID_RE.match(slug):
                     # QID: pass through; kill script resolves it
-                    kill_canonicals.append(slug)
+                    kill_targets.append(slug)
+                elif "|" in slug:
+                    hub_part, institution = slug.split("|", 1)
+                    canonical = resolve_slug(hub_part)
+                    if canonical is None:
+                        return _slack_reply(
+                            f"Unknown hub: `{hub_part}`. Check the hub slug and try again.",
+                            ephemeral=True,
+                        )
+                    kill_targets.append(f"{canonical}|{institution}")
                 else:
                     canonical = resolve_slug(slug)
                     if canonical is None:
@@ -203,9 +213,9 @@ def handler(event, context):
                             f"Unknown hub: `{slug}`. Check the hub slug and try again.",
                             ephemeral=True,
                         )
-                    kill_canonicals.append(canonical)
-            partner_input = shlex.join(kill_canonicals)
-            label = ", ".join(f"`{c}`" for c in kill_canonicals)
+                    kill_targets.append(canonical)
+            partner_input = shlex.join(kill_targets)
+            label = ", ".join(f"`{t}`" for t in kill_targets)
             return _dispatch_and_reply(
                 gh_token,
                 repo,

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -220,9 +220,21 @@ def handler(event, context):
                 seen_tokens.add(token)
                 launch_targets.append(token)
             else:
-                hub_part, institution = (
-                    token.split("|", 1) if "|" in token else (token, None)
-                )
+                if "|" in token:
+                    if token.count("|") != 1:
+                        return _slack_reply(
+                            f"Invalid target: `{token}`. Use `<hub>|<institution>`.",
+                            ephemeral=True,
+                        )
+                    hub_part, institution = token.split("|", 1)
+                    institution = institution.strip()
+                    if not institution:
+                        return _slack_reply(
+                            "Institution cannot be empty in `<hub>|<institution>`.",
+                            ephemeral=True,
+                        )
+                else:
+                    hub_part, institution = token, None
                 canonical = resolve_slug(hub_part)
                 if canonical is None:
                     return _slack_reply(

--- a/scripts/wikimedia_kill.py
+++ b/scripts/wikimedia_kill.py
@@ -100,6 +100,7 @@ def main() -> None:
 
     component_set = set(kill_components)
     killed: list[str] = []
+    failed: list[str] = []
     for line in tmux_list.splitlines():
         session_name = line.split(":")[0].strip()
         if not session_name.startswith("wikimedia-"):
@@ -112,10 +113,18 @@ def main() -> None:
                 killed.append(session_name)
             except Exception as e:
                 logging.warning("Failed to kill session %s: %s", session_name, e)
+                failed.append(session_name)
 
     slack_token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
 
-    if killed:
+    if failed:
+        msg = (
+            f"⚠️ Failed to kill Wikimedia pipeline session(s): "
+            f"{', '.join(f'`{s}`' for s in failed)}"
+        )
+        if killed:
+            msg += f"\n🛑 Also killed: {', '.join(f'`{s}`' for s in killed)}"
+    elif killed:
         msg = f"🛑 Killed Wikimedia pipeline session(s): {', '.join(f'`{s}`' for s in killed)}"
     else:
         msg = f"No running Wikimedia sessions found matching: {', '.join(f'`{c}`' for c in kill_components)}"

--- a/scripts/wikimedia_kill.py
+++ b/scripts/wikimedia_kill.py
@@ -64,8 +64,13 @@ def main() -> None:
     except ValueError as e:
         _slack_fail(response_url, f"Could not parse --partner: {e}")
 
-    canonicals: list[str] = []
-    seen: set[str] = set()
+    # hub_canonicals: kill any session containing an institution from this hub
+    # inst_labels: kill only the session with this specific institution label
+    hub_canonicals: list[str] = []
+    inst_labels: list[str] = []
+    seen_canonicals: set[str] = set()
+    seen_labels: set[str] = set()
+
     for token in target_tokens:
         if is_wikidata_id(token):
             resolved = resolve_wikidata_id(token)
@@ -74,20 +79,35 @@ def main() -> None:
                     response_url,
                     f"No hub or institution found for Wikidata ID {token!r} in institutions_v2.json.",
                 )
-            for canonical, _ in resolved:
-                if canonical not in seen:
-                    seen.add(canonical)
-                    canonicals.append(canonical)
+            for canonical, institution in resolved:
+                if institution is not None:
+                    label = institution.lower().replace(" ", "-")
+                    if label not in seen_labels:
+                        seen_labels.add(label)
+                        inst_labels.append(label)
+                else:
+                    if canonical not in seen_canonicals:
+                        seen_canonicals.add(canonical)
+                        hub_canonicals.append(canonical)
+        elif "|" in token:
+            hub_part, institution = token.split("|", 1)
+            canonical = resolve_slug(hub_part)
+            if canonical is None:
+                _slack_fail(response_url, f"Unknown hub: {hub_part!r}")
+            label = institution.lower().replace(" ", "-")
+            if label not in seen_labels:
+                seen_labels.add(label)
+                inst_labels.append(label)
         else:
             canonical = resolve_slug(token)
             if canonical is None:
                 _slack_fail(response_url, f"Unknown hub: {token!r}")
-            if canonical not in seen:
-                seen.add(canonical)
-                canonicals.append(canonical)
+            if canonical not in seen_canonicals:
+                seen_canonicals.add(canonical)
+                hub_canonicals.append(canonical)
 
-    if not canonicals:
-        _slack_fail(response_url, "No hub slugs specified.")
+    if not hub_canonicals and not inst_labels:
+        _slack_fail(response_url, "No targets specified.")
 
     ssm = boto3.client("ssm", region_name=REGION)
 
@@ -97,17 +117,18 @@ def main() -> None:
     except Exception as e:
         _slack_fail(response_url, f"⚠️ Failed to list tmux sessions: {e}")
 
-    canonical_set = set(canonicals)
+    label_set = set(inst_labels)
+    canonical_set = set(hub_canonicals)
     killed: list[str] = []
     for line in tmux_list.splitlines():
         session_name = line.split(":")[0].strip()
         if not session_name.startswith("wikimedia-"):
             continue
-        session_hubs = set(session_name[len("wikimedia-") :].split("+"))
-        if any(
+        components = set(session_name[len("wikimedia-") :].split("+"))
+        if components & label_set or any(
             canonical_matches_session_component(c, comp)
             for c in canonical_set
-            for comp in session_hubs
+            for comp in components
         ):
             print(f"Killing session {session_name}...")
             try:
@@ -118,10 +139,11 @@ def main() -> None:
 
     slack_token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
 
+    all_targets = [f"`{c}`" for c in hub_canonicals] + [f"`{lb}`" for lb in inst_labels]
     if killed:
         msg = f"🛑 Killed Wikimedia pipeline session(s): {', '.join(f'`{s}`' for s in killed)}"
     else:
-        msg = f"No running Wikimedia sessions found for: {', '.join(f'`{c}`' for c in canonicals)}"
+        msg = f"No running Wikimedia sessions found for: {', '.join(all_targets)}"
 
     print(msg)
     if slack_token:

--- a/scripts/wikimedia_kill.py
+++ b/scripts/wikimedia_kill.py
@@ -19,7 +19,12 @@ import sys
 import boto3
 import requests
 
-from ingest_wikimedia.partners import is_wikidata_id, resolve_slug, resolve_wikidata_id
+from ingest_wikimedia.partners import (
+    canonical_matches_session_component,
+    is_wikidata_id,
+    resolve_slug,
+    resolve_wikidata_id,
+)
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run
 
@@ -99,7 +104,11 @@ def main() -> None:
         if not session_name.startswith("wikimedia-"):
             continue
         session_hubs = set(session_name[len("wikimedia-") :].split("+"))
-        if canonical_set & session_hubs:
+        if any(
+            canonical_matches_session_component(c, comp)
+            for c in canonical_set
+            for comp in session_hubs
+        ):
             print(f"Killing session {session_name}...")
             try:
                 ssm_run(ssm, f"tmux kill-session -t {shlex.quote(session_name)}")

--- a/scripts/wikimedia_kill.py
+++ b/scripts/wikimedia_kill.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 """Kill a running Wikimedia upload pipeline session on EC2.
 
-Finds all tmux sessions whose name contains any of the given hub slugs as a
-+ -delimited component (e.g. "wikimedia-bpl+indiana" matches both "bpl" and
-"indiana"), kills them, and posts a Slack notification.
+Finds all tmux sessions whose name contains any of the given label components
+(e.g. "indiana-state-library" matches "wikimedia-indiana-state-library" and
+"wikimedia-bpl+indiana-state-library"), kills them, and posts a Slack notification.
+
+Targets are the session label suffix shown by /wikimedia-status (e.g. "bpl",
+"indiana-state-library"). Wikidata QIDs are also accepted and resolved to labels.
 
 Environment variables:
   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY  — IAM credentials with ssm:SendCommand
@@ -19,12 +22,7 @@ import sys
 import boto3
 import requests
 
-from ingest_wikimedia.partners import (
-    canonical_matches_session_component,
-    is_wikidata_id,
-    resolve_slug,
-    resolve_wikidata_id,
-)
+from ingest_wikimedia.partners import is_wikidata_id, resolve_wikidata_id
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run
 
@@ -64,12 +62,10 @@ def main() -> None:
     except ValueError as e:
         _slack_fail(response_url, f"Could not parse --partner: {e}")
 
-    # hub_canonicals: kill any session containing an institution from this hub
-    # inst_labels: kill only the session with this specific institution label
-    hub_canonicals: list[str] = []
-    inst_labels: list[str] = []
-    seen_canonicals: set[str] = set()
-    seen_labels: set[str] = set()
+    # Each token is a session label component to match exactly (e.g. "bpl",
+    # "indiana-state-library"). QIDs are resolved to the appropriate component.
+    kill_components: list[str] = []
+    seen: set[str] = set()
 
     for token in target_tokens:
         if is_wikidata_id(token):
@@ -80,33 +76,18 @@ def main() -> None:
                     f"No hub or institution found for Wikidata ID {token!r} in institutions_v2.json.",
                 )
             for canonical, institution in resolved:
-                if institution is not None:
-                    label = institution.lower().replace(" ", "-")
-                    if label not in seen_labels:
-                        seen_labels.add(label)
-                        inst_labels.append(label)
-                else:
-                    if canonical not in seen_canonicals:
-                        seen_canonicals.add(canonical)
-                        hub_canonicals.append(canonical)
-        elif "|" in token:
-            hub_part, institution = token.split("|", 1)
-            canonical = resolve_slug(hub_part)
-            if canonical is None:
-                _slack_fail(response_url, f"Unknown hub: {hub_part!r}")
-            label = institution.lower().replace(" ", "-")
-            if label not in seen_labels:
-                seen_labels.add(label)
-                inst_labels.append(label)
+                component = (
+                    institution.lower().replace(" ", "-") if institution else canonical
+                )
+                if component not in seen:
+                    seen.add(component)
+                    kill_components.append(component)
         else:
-            canonical = resolve_slug(token)
-            if canonical is None:
-                _slack_fail(response_url, f"Unknown hub: {token!r}")
-            if canonical not in seen_canonicals:
-                seen_canonicals.add(canonical)
-                hub_canonicals.append(canonical)
+            if token not in seen:
+                seen.add(token)
+                kill_components.append(token)
 
-    if not hub_canonicals and not inst_labels:
+    if not kill_components:
         _slack_fail(response_url, "No targets specified.")
 
     ssm = boto3.client("ssm", region_name=REGION)
@@ -117,19 +98,14 @@ def main() -> None:
     except Exception as e:
         _slack_fail(response_url, f"⚠️ Failed to list tmux sessions: {e}")
 
-    label_set = set(inst_labels)
-    canonical_set = set(hub_canonicals)
+    component_set = set(kill_components)
     killed: list[str] = []
     for line in tmux_list.splitlines():
         session_name = line.split(":")[0].strip()
         if not session_name.startswith("wikimedia-"):
             continue
         components = set(session_name[len("wikimedia-") :].split("+"))
-        if components & label_set or any(
-            canonical_matches_session_component(c, comp)
-            for c in canonical_set
-            for comp in components
-        ):
+        if component_set & components:
             print(f"Killing session {session_name}...")
             try:
                 ssm_run(ssm, f"tmux kill-session -t {shlex.quote(session_name)}")
@@ -139,11 +115,10 @@ def main() -> None:
 
     slack_token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
 
-    all_targets = [f"`{c}`" for c in hub_canonicals] + [f"`{lb}`" for lb in inst_labels]
     if killed:
         msg = f"🛑 Killed Wikimedia pipeline session(s): {', '.join(f'`{s}`' for s in killed)}"
     else:
-        msg = f"No running Wikimedia sessions found for: {', '.join(all_targets)}"
+        msg = f"No running Wikimedia sessions found matching: {', '.join(f'`{c}`' for c in kill_components)}"
 
     print(msg)
     if slack_token:

--- a/scripts/wikimedia_kill.py
+++ b/scripts/wikimedia_kill.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Kill a running Wikimedia upload pipeline session on EC2.
+
+Finds all tmux sessions whose name contains any of the given hub slugs as a
++ -delimited component (e.g. "wikimedia-bpl+indiana" matches both "bpl" and
+"indiana"), kills them, and posts a Slack notification.
+
+Environment variables:
+  AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY  — IAM credentials with ssm:SendCommand
+  DPLA_SLACK_BOT_TOKEN                       — optional; skips Slack post if absent
+"""
+
+import argparse
+import logging
+import os
+import shlex
+import sys
+
+import boto3
+import requests
+
+from ingest_wikimedia.partners import resolve_slug
+from ingest_wikimedia.slack import post_message
+from ingest_wikimedia.ssm import REGION, ssm_run
+
+
+def _slack_fail(response_url: str, msg: str) -> None:
+    """Print msg to stderr, post ephemeral reply to response_url if set, then exit 1."""
+    print(msg, file=sys.stderr)
+    if response_url:
+        try:
+            resp = requests.post(
+                response_url,
+                json={"response_type": "ephemeral", "text": msg},
+                timeout=5,
+            )
+            resp.raise_for_status()
+        except Exception as e:
+            logging.warning("Failed to post to Slack response_url: %s", e)
+    sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--partner", required=True)
+    parser.add_argument("--response-url", default="")
+    args = parser.parse_args()
+
+    raw_url = args.response_url.strip()
+    # Only accept genuine Slack response_url values — reject arbitrary POST targets.
+    response_url = (
+        raw_url if raw_url.startswith("https://hooks.slack.com/commands/") else ""
+    )
+    if raw_url and not response_url:
+        print(f"Ignoring invalid response_url: {raw_url!r}", file=sys.stderr)
+
+    try:
+        target_tokens = shlex.split(args.partner)
+    except ValueError as e:
+        _slack_fail(response_url, f"Could not parse --partner: {e}")
+
+    canonicals: list[str] = []
+    for token in target_tokens:
+        canonical = resolve_slug(token)
+        if canonical is None:
+            _slack_fail(response_url, f"Unknown hub: {token!r}")
+        canonicals.append(canonical)
+
+    if not canonicals:
+        _slack_fail(response_url, "No hub slugs specified.")
+
+    ssm = boto3.client("ssm", region_name=REGION)
+
+    print("Listing tmux sessions...")
+    try:
+        tmux_list = ssm_run(ssm, "tmux ls 2>/dev/null || true")
+    except Exception as e:
+        _slack_fail(response_url, f"⚠️ Failed to list tmux sessions: {e}")
+
+    canonical_set = set(canonicals)
+    killed: list[str] = []
+    for line in tmux_list.splitlines():
+        session_name = line.split(":")[0].strip()
+        if not session_name.startswith("wikimedia-"):
+            continue
+        session_hubs = set(session_name[len("wikimedia-") :].split("+"))
+        if canonical_set & session_hubs:
+            print(f"Killing session {session_name}...")
+            try:
+                ssm_run(ssm, f"tmux kill-session -t {shlex.quote(session_name)}")
+                killed.append(session_name)
+            except Exception as e:
+                logging.warning("Failed to kill session %s: %s", session_name, e)
+
+    slack_token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
+
+    if killed:
+        msg = f"🛑 Killed Wikimedia pipeline session(s): {', '.join(f'`{s}`' for s in killed)}"
+    else:
+        msg = f"No running Wikimedia sessions found for: {', '.join(f'`{c}`' for c in canonicals)}"
+
+    print(msg)
+    if slack_token:
+        try:
+            post_message(slack_token, msg)
+        except Exception as e:
+            logging.warning("Slack notification failed: %s", e)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/wikimedia_kill.py
+++ b/scripts/wikimedia_kill.py
@@ -19,7 +19,7 @@ import sys
 import boto3
 import requests
 
-from ingest_wikimedia.partners import resolve_slug
+from ingest_wikimedia.partners import is_wikidata_id, resolve_slug, resolve_wikidata_id
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run
 
@@ -60,11 +60,26 @@ def main() -> None:
         _slack_fail(response_url, f"Could not parse --partner: {e}")
 
     canonicals: list[str] = []
+    seen: set[str] = set()
     for token in target_tokens:
-        canonical = resolve_slug(token)
-        if canonical is None:
-            _slack_fail(response_url, f"Unknown hub: {token!r}")
-        canonicals.append(canonical)
+        if is_wikidata_id(token):
+            resolved = resolve_wikidata_id(token)
+            if not resolved:
+                _slack_fail(
+                    response_url,
+                    f"No hub or institution found for Wikidata ID {token!r} in institutions_v2.json.",
+                )
+            for canonical, _ in resolved:
+                if canonical not in seen:
+                    seen.add(canonical)
+                    canonicals.append(canonical)
+        else:
+            canonical = resolve_slug(token)
+            if canonical is None:
+                _slack_fail(response_url, f"Unknown hub: {token!r}")
+            if canonical not in seen:
+                seen.add(canonical)
+                canonicals.append(canonical)
 
     if not canonicals:
         _slack_fail(response_url, "No hub slugs specified.")

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -26,6 +26,7 @@ import boto3
 import requests
 
 from ingest_wikimedia.partners import (
+    canonical_matches_session_component,
     is_upload_eligible,
     is_wikidata_id,
     resolve_slug,
@@ -85,7 +86,10 @@ def main() -> None:
     # Dedup by full target string so the same hub may appear with different institutions
     # (e.g. two QIDs that both resolve into the same hub but different institutions).
     seen_target_strs: set[str] = set()
-    seen_canonicals: dict[str, None] = {}  # insertion-ordered; drives session naming
+    seen_canonicals: dict[str, None] = {}  # insertion-ordered; for conflict detection
+    seen_session_labels: dict[
+        str, None
+    ] = {}  # insertion-ordered; drives session naming
     targets: list[tuple[str, str | None]] = []
 
     def _add_target(canonical: str, institution: str | None) -> None:
@@ -114,6 +118,8 @@ def main() -> None:
             )
         seen_target_strs.add(target_str)
         seen_canonicals[canonical] = None
+        label = institution.lower().replace(" ", "-") if institution else canonical
+        seen_session_labels[label] = None
         targets.append((canonical, institution))
 
     for token in target_tokens:
@@ -141,8 +147,10 @@ def main() -> None:
     if not targets:
         _slack_fail(response_url, "No targets specified.")
 
-    # Session name uses + as separator (unambiguous since slugs use -).
-    session_name = "wikimedia-" + "+".join(seen_canonicals)
+    # Session name uses + as separator (unambiguous since slugs/institution names use -).
+    # Institution-level targets use the institution name (hyphenated) rather than the
+    # hub slug, so "indiana|Indiana State Library" → wikimedia-indiana-state-library.
+    session_name = "wikimedia-" + "+".join(seen_session_labels)
 
     slack_token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
     ssm = boto3.client("ssm", region_name=REGION)
@@ -180,7 +188,13 @@ def main() -> None:
         if not existing_name.startswith("wikimedia-"):
             continue
         existing_hubs = set(existing_name[len("wikimedia-") :].split("+"))
-        overlap = set(seen_canonicals) & existing_hubs
+        overlap = {
+            c
+            for c in seen_canonicals
+            if any(
+                canonical_matches_session_component(c, comp) for comp in existing_hubs
+            )
+        }
         if overlap:
             conflicts.append((existing_name, overlap))
     if conflicts:

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
-"""Launch a Wikimedia upload pipeline session on EC2 for a partner hub.
+"""Launch a Wikimedia upload pipeline session on EC2 for one or more partner hubs.
 
 Runs as a GitHub Actions workflow step triggered by workflow_dispatch or the
 /wikimedia-upload Slack slash command via Lambda. Updates EC2 code, checks for
-a conflicting session, launches the full pipeline in tmux, and posts a Slack
-confirmation to #tech-alerts on success.
+conflicting sessions, launches the full pipeline in a single tmux session (with
+all targets chained via &&), and posts a Slack confirmation to #tech-alerts.
+
+Each target in --partner is either a hub slug ("bpl") or a hub|institution pair
+("indiana|Indiana State Library"). Multiple targets run sequentially in one tmux
+session; if any step fails the chain stops.
 
 Environment variables:
   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY  — IAM credentials with ssm:SendCommand
@@ -14,6 +18,8 @@ Environment variables:
 import argparse
 import logging
 import os
+import re
+import shlex
 import sys
 
 import boto3
@@ -64,29 +70,56 @@ def main() -> None:
     if raw_url and not response_url:
         print(f"Ignoring invalid response_url: {raw_url!r}", file=sys.stderr)
 
-    canonical = resolve_slug(args.partner)
-    if canonical is None:
-        _slack_fail(response_url, f"Unknown hub: {args.partner.strip()}")
-    if canonical == "nara":
-        _slack_fail(
-            response_url,
-            "NARA requires a separate process and cannot be launched here.",
-        )
+    # --partner may be a shlex-encoded list: 'bpl "indiana|Indiana State Library"'
     try:
-        eligible = is_upload_eligible(canonical)
-    except Exception as e:
-        _slack_fail(
-            response_url,
-            f"Failed to check upload eligibility for '{canonical}': {e}",
-        )
-    if not eligible:
-        _slack_fail(
-            response_url,
-            f"Hub '{canonical}' is not upload-eligible per institutions_v2.json.",
-        )
+        target_tokens = shlex.split(args.partner)
+    except ValueError as e:
+        _slack_fail(response_url, f"Could not parse --partner: {e}")
 
-    pdir = PARTNER_DIR.get(canonical, canonical)
-    base = f"/home/ec2-user/ingest-wikimedia/{pdir}"
+    # Validate each target and build (canonical, institution_or_None) pairs.
+    seen_hubs: set[str] = set()
+    targets: list[tuple[str, str | None]] = []
+    for token in target_tokens:
+        if "|" in token:
+            hub_part, institution = token.split("|", 1)
+            canonical = resolve_slug(hub_part)
+        else:
+            canonical = resolve_slug(token)
+            institution = None
+
+        if canonical is None:
+            _slack_fail(response_url, f"Unknown hub: {token!r}")
+        if canonical == "nara":
+            _slack_fail(
+                response_url,
+                "NARA requires a separate process and cannot be launched here.",
+            )
+        try:
+            eligible = is_upload_eligible(canonical)
+        except Exception as e:
+            _slack_fail(
+                response_url,
+                f"Failed to check upload eligibility for '{canonical}': {e}",
+            )
+        if not eligible:
+            _slack_fail(
+                response_url,
+                f"Hub '{canonical}' is not upload-eligible per institutions_v2.json.",
+            )
+        if canonical in seen_hubs:
+            _slack_fail(
+                response_url,
+                f"Hub '{canonical}' appears more than once in the target list.",
+            )
+        seen_hubs.add(canonical)
+        targets.append((canonical, institution))
+
+    if not targets:
+        _slack_fail(response_url, "No targets specified.")
+
+    # Session name uses + as separator (unambiguous since slugs use -).
+    session_name = "wikimedia-" + "+".join(c for c, _ in targets)
+
     slack_token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
     ssm = boto3.client("ssm", region_name=REGION)
 
@@ -107,23 +140,36 @@ def main() -> None:
     if pct_available < MEMORY_HEADROOM_PCT:
         _slack_fail(
             response_url,
-            f"⚠️ Cannot launch `wikimedia-{canonical}`: only {pct_available}% memory available"
+            f"⚠️ Cannot launch `{session_name}`: only {pct_available}% memory available"
             f" ({available_mb} MB of {total_mb} MB). Threshold is {MEMORY_HEADROOM_PCT}%.",
         )
 
-    print(f"Checking for existing wikimedia-{canonical} session...")
-    existing = ssm_run(
-        ssm, f"tmux ls 2>/dev/null | grep -E '^wikimedia-{canonical}(:|$)' || echo NONE"
-    )
-    if f"wikimedia-{canonical}" in existing:
+    # Check for any existing session that includes one of the requested hubs.
+    print(f"Checking for existing sessions that overlap with {session_name}...")
+    try:
+        tmux_list = ssm_run(ssm, "tmux ls 2>/dev/null || true")
+    except Exception as e:
+        _slack_fail(response_url, f"⚠️ Failed to list tmux sessions: {e}")
+    conflicts = []
+    for line in tmux_list.splitlines():
+        existing_name = line.split(":")[0].strip()
+        if not existing_name.startswith("wikimedia-"):
+            continue
+        existing_hubs = set(existing_name[len("wikimedia-") :].split("+"))
+        overlap = seen_hubs & existing_hubs
+        if overlap:
+            conflicts.append((existing_name, overlap))
+    if conflicts:
         if force:
-            print("Existing session found; killing it (--force).")
-            ssm_run(ssm, f"tmux kill-session -t wikimedia-{canonical}")
+            for existing_name, _ in conflicts:
+                print(f"Existing session found: {existing_name}; killing it (--force).")
+                ssm_run(ssm, f"tmux kill-session -t {shlex.quote(existing_name)}")
         else:
+            conflict_names = ", ".join(f"`{n}`" for n, _ in conflicts)
             _slack_fail(
                 response_url,
-                f"⚠️ `wikimedia-{canonical}` is already running."
-                " To restart it, trigger the launch workflow from GitHub Actions with force=true.",
+                f"⚠️ Session(s) already running with overlapping hubs: {conflict_names}."
+                " To restart, trigger the launch workflow from GitHub Actions with force=true.",
             )
 
     print("Updating EC2 code...")
@@ -142,36 +188,56 @@ def main() -> None:
         sys.exit(1)
     print("EC2 code updated.")
 
-    print(f"Launching wikimedia-{canonical} pipeline...")
-    pipeline_cmd = (
-        f"source ~/.bashrc && "
-        f"source /home/ec2-user/ingest-wikimedia/.venv/bin/activate && "
-        f"get-ids-es {canonical} > {canonical}.csv && "
-        f"downloader {canonical}.csv {canonical} && "
-        f"uploader {canonical}.csv {canonical}"
-    )
+    # Build a chained pipeline command for all targets.
+    # Each target block: cd into partner dir, run get-ids-es (with optional --institution),
+    # downloader, uploader. The cd is required because config.toml is read from CWD.
+    steps = [
+        "source ~/.bashrc",
+        "source /home/ec2-user/ingest-wikimedia/.venv/bin/activate",
+    ]
+    for canonical, institution in targets:
+        pdir = PARTNER_DIR.get(canonical, canonical)
+        base = f"/home/ec2-user/ingest-wikimedia/{pdir}"
+        get_ids_cmd = f"get-ids-es {canonical}"
+        if institution is not None:
+            get_ids_cmd += f" --institution {shlex.quote(institution)}"
+        get_ids_cmd += f" > {canonical}.csv"
+        steps += [
+            f"cd {base}",
+            get_ids_cmd,
+            f"downloader {canonical}.csv {canonical}",
+            f"uploader {canonical}.csv {canonical}",
+        ]
+    pipeline_cmd = " && ".join(steps)
+
+    print(f"Launching {session_name} pipeline...")
+    # Use double quotes around the pipeline so single-quoted institution names inside are preserved.
     tmux_cmd = (
-        f"tmux new-session -d -s wikimedia-{canonical} -c {base}/ '{pipeline_cmd}'"
+        f"tmux new-session -d -s {shlex.quote(session_name)} -c /home/ec2-user/ingest-wikimedia/"
+        f' "{pipeline_cmd}"'
     )
     ssm_run(ssm, tmux_cmd)
 
     print("Verifying session started...")
     result = ssm_run(
-        ssm, f"tmux ls 2>/dev/null | grep -E '^wikimedia-{canonical}(:|$)' || echo NONE"
+        ssm,
+        f"tmux ls 2>/dev/null | grep -E '^{re.escape(session_name)}(:|$)' || echo NONE",
     )
-    if f"wikimedia-{canonical}" not in result:
+    if session_name not in result:
         _slack_fail(
             response_url,
-            f"⚠️ `wikimedia-{canonical}` failed to start — tmux session not found after launch."
+            f"⚠️ `{session_name}` failed to start — tmux session not found after launch."
             " Check the GitHub Actions run for details.",
         )
-    print(f"Session wikimedia-{canonical} confirmed running.")
+    print(f"Session {session_name} confirmed running.")
 
     if slack_token:
+        target_labels = [f"`{c}|{inst}`" if inst else f"`{c}`" for c, inst in targets]
         try:
             post_message(
                 slack_token,
-                f"▶ Started `wikimedia-{canonical}` pipeline (ID generation → download → upload).",
+                f"▶ Started `{session_name}` pipeline: {', '.join(target_labels)}"
+                " (ID generation → download → upload).",
             )
         except Exception as e:
             logging.warning("Slack notification failed: %s", e)

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -25,7 +25,12 @@ import sys
 import boto3
 import requests
 
-from ingest_wikimedia.partners import is_upload_eligible, resolve_slug
+from ingest_wikimedia.partners import (
+    is_upload_eligible,
+    is_wikidata_id,
+    resolve_slug,
+    resolve_wikidata_id,
+)
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run
 
@@ -77,18 +82,13 @@ def main() -> None:
         _slack_fail(response_url, f"Could not parse --partner: {e}")
 
     # Validate each target and build (canonical, institution_or_None) pairs.
-    seen_hubs: set[str] = set()
+    # Dedup by full target string so the same hub may appear with different institutions
+    # (e.g. two QIDs that both resolve into the same hub but different institutions).
+    seen_target_strs: set[str] = set()
+    seen_canonicals: dict[str, None] = {}  # insertion-ordered; drives session naming
     targets: list[tuple[str, str | None]] = []
-    for token in target_tokens:
-        if "|" in token:
-            hub_part, institution = token.split("|", 1)
-            canonical = resolve_slug(hub_part)
-        else:
-            canonical = resolve_slug(token)
-            institution = None
 
-        if canonical is None:
-            _slack_fail(response_url, f"Unknown hub: {token!r}")
+    def _add_target(canonical: str, institution: str | None) -> None:
         if canonical == "nara":
             _slack_fail(
                 response_url,
@@ -106,19 +106,43 @@ def main() -> None:
                 response_url,
                 f"Hub '{canonical}' is not upload-eligible per institutions_v2.json.",
             )
-        if canonical in seen_hubs:
+        target_str = f"{canonical}|{institution}" if institution else canonical
+        if target_str in seen_target_strs:
             _slack_fail(
                 response_url,
-                f"Hub '{canonical}' appears more than once in the target list.",
+                f"Target '{target_str}' appears more than once in the target list.",
             )
-        seen_hubs.add(canonical)
+        seen_target_strs.add(target_str)
+        seen_canonicals[canonical] = None
         targets.append((canonical, institution))
+
+    for token in target_tokens:
+        if is_wikidata_id(token):
+            resolved = resolve_wikidata_id(token)
+            if not resolved:
+                _slack_fail(
+                    response_url,
+                    f"No hub or institution found for Wikidata ID {token!r} in institutions_v2.json.",
+                )
+            for canonical, institution in resolved:
+                _add_target(canonical, institution)
+        elif "|" in token:
+            hub_part, institution = token.split("|", 1)
+            canonical = resolve_slug(hub_part)
+            if canonical is None:
+                _slack_fail(response_url, f"Unknown hub: {token!r}")
+            _add_target(canonical, institution)
+        else:
+            canonical = resolve_slug(token)
+            if canonical is None:
+                _slack_fail(response_url, f"Unknown hub: {token!r}")
+            _add_target(canonical, None)
 
     if not targets:
         _slack_fail(response_url, "No targets specified.")
 
     # Session name uses + as separator (unambiguous since slugs use -).
-    session_name = "wikimedia-" + "+".join(c for c, _ in targets)
+    session_name = "wikimedia-" + "+".join(seen_canonicals)
 
     slack_token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
     ssm = boto3.client("ssm", region_name=REGION)
@@ -156,7 +180,7 @@ def main() -> None:
         if not existing_name.startswith("wikimedia-"):
             continue
         existing_hubs = set(existing_name[len("wikimedia-") :].split("+"))
-        overlap = seen_hubs & existing_hubs
+        overlap = set(seen_canonicals) & existing_hubs
         if overlap:
             conflicts.append((existing_name, overlap))
     if conflicts:

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -147,7 +147,12 @@ def stage_to_s3(s3_client: S3Client, partner: str, dpla_id: str, source: dict) -
 
 @click.command()
 @click.argument("partner")
-def main(partner: str) -> None:
+@click.option(
+    "--institution",
+    default=None,
+    help="Restrict to a single institution name (must be upload-eligible).",
+)
+def main(partner: str, institution: str | None) -> None:
     """Print wiki-eligible DPLA IDs for PARTNER to stdout, one per line.
 
     Also stages each item's full metadata to S3 (dpla-map.json) so the
@@ -168,6 +173,15 @@ def main(partner: str) -> None:
             file=sys.stderr,
         )
         sys.exit(0)
+
+    if institution is not None:
+        if institution not in eligible_dp_names:
+            print(
+                f"Institution '{institution}' is not upload-eligible for {partner}.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        eligible_dp_names = [institution]
 
     banlist = Banlist()
     s3_client = S3Client()


### PR DESCRIPTION
## Summary

- **Chaining**: `/wikimedia-upload bpl pa` launches both hubs sequentially in a single tmux session (`wikimedia-bpl+pa`); all targets are chained with `&&` so failure stops the chain
- **Kill switch**: `/wikimedia-upload kill bpl` dispatches the new `wikimedia-kill.yml` workflow which kills any tmux session containing `bpl` as a `+`-delimited component; posts result to #tech-alerts
- **Institution filter**: `/wikimedia-upload "indiana|Indiana State Library"` restricts `get-ids-es` to a single institution via a new `--institution` click option; validates the institution is upload-eligible before querying ES
- **Combinable**: `/wikimedia-upload bpl "indiana|Indiana State Library"` chains a full bpl run with an institution-only indiana run in one session (`wikimedia-bpl+indiana`)

Slack command text is parsed with `shlex.split` so quoted arguments with spaces work as expected.

## New files
- `scripts/wikimedia_kill.py` — kill script; lists tmux sessions, kills those matching any requested hub slug
- `.github/workflows/wikimedia-kill.yml` — GH Actions workflow that runs the kill script

## Test plan
- [ ] Trigger launch workflow with `partner = bpl` (single hub, existing behavior unchanged)
- [ ] Trigger launch workflow with `partner = bpl pa` (two hubs, verify session name `wikimedia-bpl+pa`)
- [ ] Trigger launch workflow with `partner = 'bpl "indiana|Indiana State Library"'` (institution filter)
- [ ] Trigger kill workflow with `partner = bpl` while a session is running
- [ ] `/wikimedia-upload kill bpl` from Slack dispatches kill workflow
- [ ] `/wikimedia-upload "indiana|Indiana State Library"` from Slack dispatches launch workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Adds multi-target chaining for sequential runs in a single tmux session, a kill subcommand/workflow to terminate running sessions, institution-level filtering for ID generation, and Wikidata QID support. Slack command parsing now uses shlex so quoted multi-word institution names work. Also fixes SSM command escaping and adds operational docs and a kill workflow/script.

## Key Changes
- Multi-target chaining
  - Launch multiple targets in one tmux session named wikimedia-<component>+<component>….
  - Per-target pipeline steps are chained with && so a failure stops the remainder.
  - Targets may be hub slugs, hub|institution pairs, or Wikidata QIDs (QIDs resolve to one-or-more (hub, institution) tuples). Targets are normalized/deduplicated and upload eligibility enforced via institutions_v2.json.

- Kill subcommand & workflow
  - New workflow: .github/workflows/wikimedia-kill.yml (workflow_dispatch).
  - New script: scripts/wikimedia_kill.py — parses tokens (shlex), resolves QIDs, lists tmux sessions via AWS SSM, and kills any wikimedia-<...> session whose +‑delimited components intersect the requested components; posts a summary to Slack when configured.
  - Lambda handler supports `/wikimedia-upload kill ...` and dispatches the kill workflow using the verbatim tokens.

- Institution-level filtering
  - tools/get_ids_es.py adds `--institution` to restrict ES ID generation to a single upload-eligible institution name (validated against institutions_v2.json).

- Wikidata QID support & partner utilities
  - ingest_wikimedia/partners.py: adds is_wikidata_id(), resolve_wikidata_id(), canonical_matches_session_component(), and institution JSON caching helper used for resolution and eligibility checks.
  - Lambda, launch, and kill flows accept QIDs and resolve/dedupe them against institutions_v2.json.

- Slack parsing / UX
  - Lambda now uses shlex.split for tokenization; quoted multi-word institution names are handled correctly. Ephemeral help/error messages updated and success/failure messages enumerate full requested target sets.

- SSM escaping fix
  - ingest_wikimedia/ssm.py now uses shlex.quote(cmd) instead of json.dumps when constructing the AWS-RunShellScript invocation to avoid premature shell expansion.

- Docs & tests
  - README.md rewritten; docs/operations.md authored with end-to-end operations, session naming, workflows, and troubleshooting.
  - Test/checklist entries updated for single-hub, multi-hub, institution-filter runs, and kill workflow dispatch.

## Files Added / Modified (high level)
- Added: .github/workflows/wikimedia-kill.yml
- Added: scripts/wikimedia_kill.py
- Modified: .github/workflows/wikimedia-launch.yml (input description)
- Modified: lambda/wikimedia-slack-dispatch/handler.py
- Modified: scripts/wikimedia_launch.py
- Modified: tools/get_ids_es.py
- Modified: ingest_wikimedia/partners.py
- Modified: ingest_wikimedia/ssm.py
- Documentation: README.md, docs/operations.md

## Infrastructure & Deployment Notes (explicit)
- Lambda redeploy required: The wikimedia-slack-dispatch Lambda handler changed (command parsing, kill dispatch, QID handling). Redeploy the updated Lambda for Slack to pick up new behavior.
- Manual triggers: Launch and kill are initiated via Slack (Lambda → workflow_dispatch) or by manually triggering the GitHub Actions workflows; no scheduled jobs were added.
- New GitHub Actions workflow: wikimedia-kill.yml added and is usable once merged. No runner configuration changes were introduced.
- Shared infra/config: No changes to ECS task definitions, CodePipeline, CodeBuild, IAM policies, or other shared infra files are included in this PR.

## Secrets / Environment Variables / Permissions (explicit)
- No new repository secrets or AWS Secrets Manager keys are added/renamed/removed by this PR.
- Workflows and scripts consume existing secrets:
  - WIKIMEDIA_AWS_ACCESS_KEY_ID / WIKIMEDIA_AWS_SECRET_ACCESS_KEY (used by Actions to call SSM)
  - DPLA_SLACK_BOT_TOKEN (optional Slack posting from scripts)
  - GH_TOKEN (Lambda uses to dispatch workflows)
- Workflow-level settings added:
  - env.FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 set in the new workflow.
  - permissions.contents: read present on the new workflow.
- The PR assumes existing IAM roles/credentials already permit SSM usage; it does not modify IAM policies.

## Data / Migrations / Public APIs (explicit)
- No database migrations.
- No public HTTP API shape changes; Slack slash command semantics are extended (handled by Lambda).
- New workflow inputs: partner (shlex-encoded list) and response_url (optional).

## Security Considerations (explicit)
- Slack signature validation in Lambda is unchanged; SLACK_SIGNING_SECRET remains required.
- Inputs validated:
  - Wikidata QIDs validated with a QID regex and resolved via institutions_v2.json fetched from the repo.
  - `response_url` is accepted but only used when it matches Slack hooks prefix ("https://hooks.slack.com/commands/"); otherwise ignored and logged.
  - Unknown hubs or ineligible institutions are rejected with ephemeral errors in Lambda (kill targets are dispatched verbatim; kill script reports "no sessions found" when appropriate).
- Credentials handling unchanged: AWS credentials, Slack token, and GH_TOKEN remain repository secrets and are not embedded in code.
- Workflows install pinned boto3/requests versions and run with minimal declared permissions (contents: read).

## Review / Testing Notes
- Verify QID resolution and deduplication behavior across Lambda, scripts, and launch logic.
- Validate tools/get_ids_es.py `--institution` enforces exact name matches against institutions_v2.json.
- Test multi-target chained runs (successful and failing target mid-chain) to confirm && semantics and session naming (wikimedia-...+...).
- Validate conflict detection, `--force` behavior, and kill workflow: SSM tmux listing, session component matching, and correct session termination.
- Confirm Slack ephemeral responses, kill dispatch messaging, and handling of invalid `response_url` values.
- Confirm workflows run with the declared permissions and secrets available.

## Actions Required After Merge
- Redeploy the updated wikimedia-slack-dispatch Lambda.
- Ensure repository secrets referenced by workflows exist and are valid: WIKIMEDIA_AWS_ACCESS_KEY_ID, WIKIMEDIA_AWS_SECRET_ACCESS_KEY, DPLA_SLACK_BOT_TOKEN (optional), GH_TOKEN. No new secrets need adding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/156)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->