### PR TITLE
Post Slack launch notification before session verification poll

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -256,6 +256,17 @@ def main() -> None:
     )
     ssm_run(ssm, tmux_cmd)
 
+    if slack_token:
+        target_labels = [f"`{c}|{inst}`" if inst else f"`{c}`" for c, inst in targets]
+        try:
+            post_message(
+                slack_token,
+                f"▶ Started `{session_name}` pipeline: {', '.join(target_labels)}"
+                " (ID generation → download → upload).",
+            )
+        except Exception as e:
+            logging.warning("Slack notification failed: %s", e)
+
     print("Verifying session started...")
     result = ssm_run(
         ssm,
@@ -268,17 +279,6 @@ def main() -> None:
             " Check the GitHub Actions run for details.",
         )
     print(f"Session {session_name} confirmed running.")
-
-    if slack_token:
-        target_labels = [f"`{c}|{inst}`" if inst else f"`{c}`" for c, inst in targets]
-        try:
-            post_message(
-                slack_token,
-                f"▶ Started `{session_name}` pipeline: {', '.join(target_labels)}"
-                " (ID generation → download → upload).",
-            )
-        except Exception as e:
-            logging.warning("Slack notification failed: %s", e)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Moves the "▶ Started `wikimedia-*` pipeline" Slack notification to immediately after the tmux launch, before the verification poll
- The verification SSM command takes 5–15s to complete; during that time the pipeline was already running and posting its own messages (e.g. "starting id-generation"), so the "Started" message arrived late
- Verification still runs as a safety check — if it fails, a `_slack_fail` error is posted

## Test plan
- [ ] Trigger `/wikimedia-upload` and confirm "▶ Started" arrives in #tech-alerts before any pipeline progress messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR reorders the Slack notification in the wikimedia launch pipeline, moving the "▶ Started `wikimedia-*` pipeline" message to post immediately after the tmux session launch and before the SSM session verification poll.

**Rationale:** The session verification command takes 5–15 seconds to complete. While the verification was running, the pipeline began posting its own progress messages (e.g., "starting id-generation"), causing the "Started" notification to arrive late in the Slack thread. By posting the notification first, it now appears immediately in #tech-alerts, giving users timely confirmation that the pipeline has launched.

**Safety maintained:** The session verification remains in place as a safety check after the notification. If verification fails, an `_slack_fail` error is posted.

**Testing:** No redeployment is required. The GitHub Actions workflow (`wikimedia-launch.yml`) checks out the code fresh on each run, so the change takes effect immediately on the next manual trigger via `/wikimedia-upload` Slack command or GitHub Actions workflow dispatch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/157)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->