### PR TITLE
Post Slack launch notification before starting tmux session

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -248,14 +248,6 @@ def main() -> None:
         ]
     pipeline_cmd = " && ".join(steps)
 
-    print(f"Launching {session_name} pipeline...")
-    # Use double quotes around the pipeline so single-quoted institution names inside are preserved.
-    tmux_cmd = (
-        f"tmux new-session -d -s {shlex.quote(session_name)} -c /home/ec2-user/ingest-wikimedia/"
-        f' "{pipeline_cmd}"'
-    )
-    ssm_run(ssm, tmux_cmd)
-
     if slack_token:
         target_labels = [f"`{c}|{inst}`" if inst else f"`{c}`" for c, inst in targets]
         try:
@@ -266,6 +258,14 @@ def main() -> None:
             )
         except Exception as e:
             logging.warning("Slack notification failed: %s", e)
+
+    print(f"Launching {session_name} pipeline...")
+    # Use double quotes around the pipeline so single-quoted institution names inside are preserved.
+    tmux_cmd = (
+        f"tmux new-session -d -s {shlex.quote(session_name)} -c /home/ec2-user/ingest-wikimedia/"
+        f' "{pipeline_cmd}"'
+    )
+    ssm_run(ssm, tmux_cmd)
 
     print("Verifying session started...")
     result = ssm_run(


### PR DESCRIPTION
## Summary

- Moves the "▶ Launching" Slack notification to fire **before** `ssm_run` starts the tmux session, rather than after
- All pre-checks (memory headroom, conflict detection, eligibility, EC2 code update) have already passed at this point, so the message is accurate
- Fixes ordering: previously `ssm_run` took ~5s to confirm command invocation, so fast pipelines (e.g. 2-item institution runs) would emit their own "starting download" notifications before "Launching" arrived

## Test plan

- [ ] Trigger a launch and verify "▶ Launching" arrives in #tech-alerts before any pipeline phase notifications
- [ ] Verify the session-not-found failure path still works (notification fires, then verification fails, then `_slack_fail` is called)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR reorders the Slack notification in the Wikimedia pipeline launch script to fire **before** the tmux session starts, rather than after.

## Changes

**File modified:** `scripts/wikimedia_launch.py` (+8/-8)

The "▶ Launching" Slack notification (lines 251–260) is now sent after all pre-launch validation checks have passed (memory headroom verification, conflicting session detection, upload eligibility, and EC2 code update), but **before** the tmux session is created (line 268). Session verification still occurs after the tmux launch.

This fixes a race condition where on fast pipelines (e.g., 2-item institution runs), downstream pipeline phase notifications could arrive in Slack before the "Launching" message, since `ssm_run` takes ~5 seconds to confirm command invocation.

## Impact Assessment

- **No manual pipeline trigger or redeployment required** — this is a script change that takes effect on next execution
- **No environment variables or AWS Secrets Manager keys added/removed**
- **No database migrations**
- **No changes to shared infrastructure** (CodePipeline, CodeBuild, ECS, IAM policies)
- **No API changes or new endpoints**
- **No security implications** — notification timing change only

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/159)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->