### PR TITLE
Fix institution-level session labels in Slack notifications and status

### DIFF
--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -67,6 +67,11 @@ PARTNER_HUBS: dict[str, str] = {
     "wisconsin": "Recollection Wisconsin",
 }
 
+# Partners whose EC2 directory name differs from their canonical slug.
+PARTNER_DIR: dict[str, str] = {
+    "si": "smithsonian",
+}
+
 # Alternate slugs that map to a canonical slug in PARTNER_HUBS
 _SLUG_ALIASES: dict[str, str] = {
     "nwdh": "northwest-heritage",

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -36,9 +36,10 @@ def notify_phase_start(partner: str, phase: Phase) -> None:
     if not token:
         logging.warning("DPLA_SLACK_BOT_TOKEN not set — skipping Slack notification")
         return
+    session_label = os.environ.get("WIKIMEDIA_SESSION_LABEL") or partner
     emoji = _PHASE_EMOJI.get(phase, "▶")
     try:
-        post_message(token, f"{emoji} `wikimedia-{partner}`: starting {phase}")
+        post_message(token, f"{emoji} `wikimedia-{session_label}`: starting {phase}")
     except Exception:
         logging.warning("Slack phase notification failed", exc_info=True)
 
@@ -63,6 +64,9 @@ def notify_upload_complete(
         logging.warning("DPLA_SLACK_BOT_TOKEN not set — skipping Slack notification")
         return
 
+    session_label = os.environ.get("WIKIMEDIA_SESSION_LABEL")
+    effective_label = f"wikimedia-{session_label}" if session_label else partner_label
+
     hours, remainder = divmod(int(elapsed_seconds), 3600)
     minutes, seconds = divmod(remainder, 60)
     if hours:
@@ -73,7 +77,7 @@ def notify_upload_complete(
         runtime = f"{seconds}s"
 
     dry_run_note = " _(dry run)_" if dry_run else ""
-    header = f"*Wikimedia Upload Complete: {partner_label}*{dry_run_note}"
+    header = f"*Wikimedia Upload Complete: {effective_label}*{dry_run_note}"
 
     lines = [
         f"UPLOADED: {tracker.count(Result.UPLOADED):,}",
@@ -86,7 +90,7 @@ def notify_upload_complete(
 
     payload = {
         "channel": SLACK_CHANNEL,
-        "text": f"Wikimedia upload complete: {partner_label}",
+        "text": f"Wikimedia upload complete: {effective_label}",
         "blocks": [
             {"type": "section", "text": {"type": "mrkdwn", "text": header}},
             {"type": "section", "text": {"type": "mrkdwn", "text": body}},

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -26,6 +26,7 @@ import boto3
 import requests
 
 from ingest_wikimedia.partners import (
+    PARTNER_DIR,
     canonical_matches_session_component,
     is_upload_eligible,
     is_wikidata_id,
@@ -37,11 +38,6 @@ from ingest_wikimedia.ssm import REGION, ssm_run
 
 # Each ingest session peaks at ~300–500 MB; 30% of 7.6 GB leaves headroom for 4–5 concurrent sessions.
 MEMORY_HEADROOM_PCT = 30
-
-# Partners whose EC2 directory name differs from their partner key
-PARTNER_DIR = {
-    "si": "smithsonian",
-}
 
 
 def _slack_fail(response_url: str, msg: str) -> None:
@@ -90,7 +86,7 @@ def main() -> None:
     seen_session_labels: dict[
         str, None
     ] = {}  # insertion-ordered; drives session naming
-    targets: list[tuple[str, str | None]] = []
+    targets: list[tuple[str, str | None, str]] = []
 
     def _add_target(canonical: str, institution: str | None) -> None:
         if canonical == "nara":
@@ -118,9 +114,10 @@ def main() -> None:
             )
         seen_target_strs.add(target_str)
         seen_canonicals[canonical] = None
-        label = institution.lower().replace(" ", "-") if institution else canonical
+        inst_label = institution.lower().replace(" ", "-") if institution else None
+        label = f"{canonical}+{inst_label}" if inst_label else canonical
         seen_session_labels[label] = None
-        targets.append((canonical, institution))
+        targets.append((canonical, institution, label))
 
     for token in target_tokens:
         if is_wikidata_id(token):
@@ -148,8 +145,8 @@ def main() -> None:
         _slack_fail(response_url, "No targets specified.")
 
     # Session name uses + as separator (unambiguous since slugs/institution names use -).
-    # Institution-level targets use the institution name (hyphenated) rather than the
-    # hub slug, so "indiana|Indiana State Library" → wikimedia-indiana-state-library.
+    # Institution-level targets include the hub slug as a prefix so the status script
+    # can derive the EC2 directory: "indiana|Indiana State Library" → wikimedia-indiana+indiana-state-library.
     session_name = "wikimedia-" + "+".join(seen_session_labels)
 
     slack_token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
@@ -233,7 +230,7 @@ def main() -> None:
         "source ~/.bashrc",
         "source /home/ec2-user/ingest-wikimedia/.venv/bin/activate",
     ]
-    for canonical, institution in targets:
+    for canonical, institution, session_label in targets:
         pdir = PARTNER_DIR.get(canonical, canonical)
         base = f"/home/ec2-user/ingest-wikimedia/{pdir}"
         get_ids_cmd = f"get-ids-es {canonical}"
@@ -242,6 +239,7 @@ def main() -> None:
         get_ids_cmd += f" > {canonical}.csv"
         steps += [
             f"cd {base}",
+            f"export WIKIMEDIA_SESSION_LABEL={shlex.quote(session_label)}",
             get_ids_cmd,
             f"downloader {canonical}.csv {canonical}",
             f"uploader {canonical}.csv {canonical}",
@@ -249,7 +247,9 @@ def main() -> None:
     pipeline_cmd = " && ".join(steps)
 
     if slack_token:
-        target_labels = [f"`{c}|{inst}`" if inst else f"`{c}`" for c, inst in targets]
+        target_labels = [
+            f"`{c}|{inst}`" if inst else f"`{c}`" for c, inst, _ in targets
+        ]
         try:
             post_message(
                 slack_token,

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -89,6 +89,13 @@ def main() -> None:
     targets: list[tuple[str, str | None, str]] = []
 
     def _add_target(canonical: str, institution: str | None) -> None:
+        if institution is not None:
+            institution = institution.strip()
+            if not institution:
+                _slack_fail(
+                    response_url,
+                    f"Target '{canonical}|' has an empty institution name.",
+                )
         if canonical == "nara":
             _slack_fail(
                 response_url,
@@ -106,7 +113,9 @@ def main() -> None:
                 response_url,
                 f"Hub '{canonical}' is not upload-eligible per institutions_v2.json.",
             )
-        target_str = f"{canonical}|{institution}" if institution else canonical
+        target_str = (
+            f"{canonical}|{institution}" if institution is not None else canonical
+        )
         if target_str in seen_target_strs:
             _slack_fail(
                 response_url,
@@ -114,8 +123,10 @@ def main() -> None:
             )
         seen_target_strs.add(target_str)
         seen_canonicals[canonical] = None
-        inst_label = institution.lower().replace(" ", "-") if institution else None
-        label = f"{canonical}+{inst_label}" if inst_label else canonical
+        inst_label = (
+            institution.lower().replace(" ", "-") if institution is not None else None
+        )
+        label = f"{canonical}+{inst_label}" if inst_label is not None else canonical
         seen_session_labels[label] = None
         targets.append((canonical, institution, label))
 

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -13,22 +13,24 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import boto3
 import requests
 
+from ingest_wikimedia.partners import PARTNER_DIR
 from ingest_wikimedia.ssm import REGION, ssm_run
 
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
 
 
-def get_phase_and_progress(client, partner: str) -> str:
+def get_phase_and_progress(client, session: str, hub: str) -> str:
     def _safe_int(s: str) -> int:
         try:
             return int(s)
         except ValueError:
             return 0
 
-    base = f"/home/ec2-user/ingest-wikimedia/{partner}"
+    pdir = PARTNER_DIR.get(hub, hub)
+    base = f"/home/ec2-user/ingest-wikimedia/{pdir}"
     log_dir = shlex.quote(f"{base}/logs")
-    session_name = shlex.quote(f"wikimedia-{partner}")
+    session_name = shlex.quote(session)
 
     # Get session creation time and most recent log filename — no shell variables
     # needed, avoiding outer-bash expansion of $f inside the bash -c double-quote.
@@ -45,7 +47,7 @@ def get_phase_and_progress(client, partner: str) -> str:
         return "Generating IDs"
 
     log_path = shlex.quote(f"{base}/logs/{log_file}")
-    csv_path = shlex.quote(f"{base}/{partner}.csv")
+    csv_path = shlex.quote(f"{base}/{hub}.csv")
 
     sep = "__WM_SEP__"
     out = ssm_run(
@@ -167,9 +169,9 @@ def main() -> None:
     results: dict[str, str] = {}
 
     def fetch(session: str) -> tuple[str, str]:
-        partner = session.removeprefix("wikimedia-")
+        hub = session.removeprefix("wikimedia-").split("+")[0]
         try:
-            phase = get_phase_and_progress(ssm, partner)
+            phase = get_phase_and_progress(ssm, session, hub)
         except Exception:
             logging.exception("Failed to get status for %s", session)
             phase = "Unknown (error)"


### PR DESCRIPTION
## Summary

- **Wrong session label in notifications**: Phase and upload-complete notifications showed `wikimedia-indiana` instead of `wikimedia-indiana+benjamin-harrison-presidential-site` for institution-level runs. Fixed by exporting `WIKIMEDIA_SESSION_LABEL` per target block in the pipeline; `notify_phase_start` and `notify_upload_complete` in `slack.py` now read it (consistent with each other, no changes needed in callers).

- **Status showing stale "Generating IDs"**: The status script derived the EC2 directory from `session.removeprefix("wikimedia-")`, so `wikimedia-benjamin-harrison-presidential-site` tried to look in a non-existent directory. Fixed by changing institution-level session labels to `{canonical}+{institution_label}` format (`indiana+benjamin-harrison-presidential-site`), so `split("+")[0]` reliably extracts the hub slug. Also fixes a pre-existing bug for `si` → `smithsonian` directory mapping, which was missing from the status script.

- **`PARTNER_DIR` moved** from `wikimedia_launch.py` to `partners.py` so both scripts share a single definition.

- **Label computed once** in `_add_target` and stored in the `targets` list (third element) to avoid duplicating the `institution.lower().replace(" ", "-")` expression in the pipeline-building loop.

## Session naming examples

| Command | Old session name | New session name |
|---------|-----------------|-----------------|
| `/wikimedia-upload indiana` | `wikimedia-indiana` | `wikimedia-indiana` (unchanged) |
| `/wikimedia-upload indiana\|"Benjamin Harrison Presidential Site"` | `wikimedia-benjamin-harrison-presidential-site` | `wikimedia-indiana+benjamin-harrison-presidential-site` |
| `/wikimedia-upload bpl pa` | `wikimedia-bpl+pa` | `wikimedia-bpl+pa` (unchanged) |

## Test plan

- [ ] Launch an institution-level run; verify "▶ Launching" and "starting id-generation/download/upload" notifications all show `wikimedia-{hub}+{institution-label}`
- [ ] Run `/wikimedia-status` mid-run; verify it shows the correct phase and progress
- [ ] Launch a hub-level run; verify session name and notifications are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes incorrect session labeling for institution-level runs, corrects a status-script directory-mapping bug, and contains small refactors to centralize partner directory mapping and avoid recomputing session labels.

High-level changes
- Slack notifications: notify_phase_start and notify_upload_complete now read a per-target WIKIMEDIA_SESSION_LABEL (exported by the launch script) so Slack messages show the full session label for institution-level runs (e.g., wikimedia-indiana+benjamin-harrison-presidential-site) instead of the hub-only label.
- Launch script: scripts/wikimedia_launch.py computes a per-target session_label in _add_target (stored as the third element of each target tuple) and exports WIKIMEDIA_SESSION_LABEL for each target block in the chained pipeline. Session naming uses "+" as a separator; institution-level labels are canonical+token (canonical + hyphenated, lowercased institution token).
- Status script: scripts/wikimedia_upload_status.py now accepts (client, session, hub) in get_phase_and_progress, derives hub by splitting the tmux session name on "+" (after removing "wikimedia-"), and maps hub → on-disk partner directory via PARTNER_DIR.get(hub, hub). This fixes looking in the wrong directory for institution-level sessions and adds the missing "si" → "smithsonian" mapping.
- Shared constant: PARTNER_DIR was moved into ingest_wikimedia/partners.py and imported by both scripts; PARTNER_DIR currently contains the "si" -> "smithsonian" mapping.
- Input validation: _add_target rejects empty institution names (prevents malformed targets that would collapse to hub-only labels while passing empty --institution to get-ids-es).
- API/CLI surface: get_phase_and_progress signature changed from (client, partner) → (client, session, hub).

Environment variables / infra impact
- Adds a per-target environment variable exported inside EC2 pipeline runs: WIKIMEDIA_SESSION_LABEL (value = hub slug or hub+institution-token). Slack code reads this variable; no other callers need changes.
- No new AWS Secrets Manager keys. DPLA_SLACK_BOT_TOKEN usage unchanged and still required for status posting.
- No database migrations.
- No changes to CodePipeline/CodeBuild/ECS task definitions, IAM policies, or other shared infra.
- Deployment: these changes take effect when the launch pipeline is next triggered (the launch script updates EC2 code on each run). No ECS redeployment is required.

Security implications
- No changes to credential handling or authentication flows; no new external credentials introduced.

Files changed (high level)
- ingest_wikimedia/partners.py: added exported PARTNER_DIR and mapping "si" → "smithsonian"; utilities for slug resolution and upload eligibility unchanged otherwise.
- ingest_wikimedia/slack.py: notify_phase_start() and notify_upload_complete() now read WIKIMEDIA_SESSION_LABEL and use it in Slack messages.
- scripts/wikimedia_launch.py: import PARTNER_DIR; compute and store per-target session labels in _add_target; export WIKIMEDIA_SESSION_LABEL per target in the tmux pipeline; reject empty institution names.
- scripts/wikimedia_upload_status.py: get_phase_and_progress signature updated to (client, session, hub); maps hub → partner dir with PARTNER_DIR; reads CSV/log paths using hub-derived names; derives hub by splitting the session on "+".

Tests / Validation (from PR)
1. Launch an institution-level run and confirm Slack phase-start and upload-complete messages include the full institution-level session label.
2. Run the status check while an institution-level session is active and confirm it reports progress rather than "Generating IDs".
3. Run a hub-level (no institution) run to verify hub-only behavior remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/160)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->