### PR TITLE
Update docs: institution-level session naming format

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -72,11 +72,12 @@ The immediate Slack reply confirms that the workflow was dispatched. A confirmat
 
 ### `/wikimedia-upload kill <label> [<label> ...]`
 
-Stops one or more running pipeline sessions. Use the session label suffix shown by `/wikimedia-status` — for example, `indiana-state-library` kills `wikimedia-indiana-state-library`. Wikidata QIDs are also accepted and resolved to their label.
+Stops one or more running pipeline sessions. Use any `+`-delimited component of the session name shown by `/wikimedia-status` — for example, both `indiana` and `indiana-state-library` match the session `wikimedia-indiana+indiana-state-library`. Wikidata QIDs are also accepted and resolved to their label components.
 
 ```text
 /wikimedia-upload kill bpl
 /wikimedia-upload kill bpl pa
+/wikimedia-upload kill indiana
 /wikimedia-upload kill indiana-state-library
 /wikimedia-upload kill Q72380652
 ```
@@ -258,13 +259,13 @@ When multiple targets are specified, they all run in a single tmux session. The 
 wikimedia-<label1>+<label2>+...
 ```
 
-The label for a full-hub target is its canonical slug. The label for an institution-level target is the institution name, lowercased with spaces replaced by hyphens. This is what `/wikimedia-status` reports and what `/wikimedia-upload kill` accepts.
+The label for a full-hub target is its canonical slug. The label for an institution-level target is `{canonical}+{institution}`, where the institution name is lowercased with spaces replaced by hyphens. The hub slug prefix lets the status script locate the correct EC2 directory and is also what `/wikimedia-upload kill` accepts.
 
 Examples:
 - `/wikimedia-upload bpl` → session `wikimedia-bpl`
 - `/wikimedia-upload bpl pa` → session `wikimedia-bpl+pa`
-- `/wikimedia-upload "indiana|Indiana State Library"` → session `wikimedia-indiana-state-library`
-- `/wikimedia-upload bpl "indiana|Indiana State Library"` → session `wikimedia-bpl+indiana-state-library`
+- `/wikimedia-upload "indiana|Indiana State Library"` → session `wikimedia-indiana+indiana-state-library`
+- `/wikimedia-upload bpl "indiana|Indiana State Library"` → session `wikimedia-bpl+indiana+indiana-state-library`
 
 The `+` separator is unambiguous because labels use `-` as their only separator character.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -259,7 +259,7 @@ When multiple targets are specified, they all run in a single tmux session. The 
 wikimedia-<label1>+<label2>+...
 ```
 
-The label for a full-hub target is its canonical slug. The label for an institution-level target is `{canonical}+{institution}`, where the institution name is lowercased with spaces replaced by hyphens. The hub slug prefix lets the status script locate the correct EC2 directory and is also what `/wikimedia-upload kill` accepts.
+The label for a full-hub target is its canonical slug. The label for an institution-level target is `{canonical}+{institution}`, where the institution name is lowercased with spaces replaced by hyphens. The hub slug prefix lets the status script locate the correct EC2 directory. `/wikimedia-upload kill` accepts any `+`-delimited component of the session name (see kill command section above).
 
 Examples:
 - `/wikimedia-upload bpl` → session `wikimedia-bpl`


### PR DESCRIPTION
## Summary

- Updates session naming examples in the **Session naming and chaining** section to reflect the new `{canonical}+{institution_label}` format introduced in #160 (e.g. `wikimedia-indiana+indiana-state-library` instead of `wikimedia-indiana-state-library`)
- Clarifies that `/wikimedia-upload kill` accepts any `+`-delimited component of the session name — both `indiana` and `indiana-state-library` match `wikimedia-indiana+indiana-state-library`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Pull Request Summary: Update docs: institution-level session naming format

### Overview
Documentation-only update to docs/operations.md reflecting the institution-level session naming format change introduced in PR #160 and clarifying `/wikimedia-upload kill` matching behavior.

### Changes Made
- Session naming and chaining:
  - Redefined institution-level session label format to `{canonical}+{institution}` (institution portion lowercased, spaces → hyphens).
  - Updated examples to the new format (e.g., `wikimedia-indiana+indiana-state-library`).
  - Clarified that the hub canonical slug prefix is used by the status script to locate the EC2 directory.
- Kill command behavior:
  - Clarified that `/wikimedia-upload kill` accepts any `+`-delimited component of the tmux session name shown by `/wikimedia-status` (this includes hub-label components and QID-resolved label components).
  - Example: both `indiana` and `indiana-state-library` will match `wikimedia-indiana+indiana-state-library`.
- Commit message clarifies separation of responsibilities: hub slug locates EC2 directory; kill accepts any `+` component.

### Operational Impact
- No runtime, deployment, or infrastructure changes required.
- Does not require a manual pipeline trigger or ECS redeployment.
- No environment variables, AWS Secrets Manager keys, database migrations, shared infra configurations, or public API changes.
- No security implications beyond documentation clarification.

Lines changed: +5/-4

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/161)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->