### PR TITLE
Temporarily disable collection phase in get-ids-nara

### DIFF
--- a/tools/get_ids_nara.py
+++ b/tools/get_ids_nara.py
@@ -285,9 +285,11 @@ def main() -> None:
     format_batches = build_format_queries()
     print(f"  {len(format_batches)} format batches", file=sys.stderr)
 
-    print("Fetching eligible collections...", file=sys.stderr)
-    collection_titles = build_collection_queries()
-    print(f"  {len(collection_titles)} collections", file=sys.stderr)
+    # Collection phase temporarily disabled — re-enable after the first upload run
+    # completes with phases 1–4 (format, mediaMaster, identifier, language) fully uploaded.
+    # print("Fetching eligible collections...", file=sys.stderr)
+    # collection_titles = build_collection_queries()
+    # print(f"  {len(collection_titles)} collections", file=sys.stderr)
 
     print("Fetching language query batches...", file=sys.stderr)
     lang_batches = build_language_queries()
@@ -317,27 +319,29 @@ def main() -> None:
         )
     )
 
-    for i in range(0, len(collection_titles), COLLECTIONS_PER_QUERY):
-        batch = collection_titles[i : i + COLLECTIONS_PER_QUERY]
-        queries.append(
-            (
-                f"collections: {batch[0][:50]}{'...' if len(batch[0]) > 50 else ''}",
-                {
-                    "bool": {
-                        "filter": [
-                            {
-                                "terms": {
-                                    "sourceResource.collection.title.not_analyzed": batch
-                                }
-                            }
-                        ],
-                        "must_not": _COLLECTION_MUST_NOT,
-                    }
-                },
-            )
-        )
+    # Collection phase temporarily disabled — re-enable after the first upload run
+    # completes with phases 1–4 (format, mediaMaster, identifier, language) fully uploaded.
+    # for i in range(0, len(collection_titles), COLLECTIONS_PER_QUERY):
+    #     batch = collection_titles[i : i + COLLECTIONS_PER_QUERY]
+    #     queries.append(
+    #         (
+    #             f"collections: {batch[0][:50]}{'...' if len(batch[0]) > 50 else ''}",
+    #             {
+    #                 "bool": {
+    #                     "filter": [
+    #                         {
+    #                             "terms": {
+    #                                 "sourceResource.collection.title.not_analyzed": batch
+    #                             }
+    #                         }
+    #                     ],
+    #                     "must_not": _COLLECTION_MUST_NOT,
+    #                 }
+    #             },
+    #         )
+    #     )
 
-    # Phase 5: language — non-English languages, smallest first
+    # Phase 5 (active as phase 4 until collections re-enabled): language — non-English languages, smallest first
     for batch in lang_batches:
         queries.append(
             (


### PR DESCRIPTION
Comments out phase 4 (collection queries) to keep the first production NARA run to a manageable size. The format, mediaMaster extension, identifier, and language phases together produced ~160K IDs in testing — a solid first batch.

Re-enable by uncommenting the two blocks when the initial upload run has completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request temporarily disables the collection phase (phase 4) in the `get-ids-nara` script by commenting out the query logic that fetches and processes eligible NARA collections. The change limits the initial production NARA ingestion run to four active phases: format, mediaMaster extension, identifier, and language queries, which generated approximately 160,000 IDs during testing.

## Changes

- **tools/get_ids_nara.py**: 
  - Commented out the `build_collection_queries()` call and its associated print statement (lines 290-292)
  - Commented out the loop that constructs collection-based ES queries and appends them to the query list (lines 324-342)
  - Updated the phase comment to note that the language phase operates as phase 4 until collections are re-enabled (line 344)

The commented code blocks are marked with clear re-enablement instructions for when the first production upload run completes.

## Impact Assessment

- **Pipeline Deployment**: No manual pipeline trigger or ECS redeployment required; the script change takes effect with the next execution
- **Environment Variables/Secrets**: No changes
- **Database Migrations**: Not applicable
- **Infrastructure Configuration**: No changes to shared infrastructure (CodePipeline, CodeBuild, ECS, IAM)
- **Public-Facing APIs**: Not applicable (internal ingestion tool)
- **Security**: No security implications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/163)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->