### PR TITLE
Fix false-positive conflict detection for same-hub institution-level sessions

### DIFF
--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -157,9 +157,15 @@ def parse_session_labels(suffix: str) -> list[str]:
     while i < len(parts):
         part = parts[i]
         if part in PARTNER_HUBS:
-            if i + 1 < len(parts) and parts[i + 1] not in PARTNER_HUBS:
-                labels.append(f"{part}+{parts[i + 1]}")
-                i += 2
+            # Consume all consecutive non-hub tokens as the institution suffix.
+            # Institution names can contain '+' (e.g. "LGBTQ+ Archives"), producing
+            # multiple tokens here. Greedily take everything up to the next hub slug.
+            j = i + 1
+            while j < len(parts) and parts[j] not in PARTNER_HUBS:
+                j += 1
+            if j > i + 1:
+                labels.append("+".join(parts[i:j]))
+                i = j
             else:
                 labels.append(part)
                 i += 1

--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -136,6 +136,38 @@ def is_wikidata_id(s: str) -> bool:
     return bool(_QID_RE.match(s))
 
 
+def parse_session_labels(suffix: str) -> list[str]:
+    """Parse the part of a tmux session name after 'wikimedia-' into target labels.
+
+    Session names concatenate target labels with '+' as separator, but institution-level
+    labels themselves contain '+' (e.g. 'nara+herbert-hoover-library'). This function
+    uses PARTNER_HUBS keys as hub boundaries to unambiguously reconstruct labels:
+    a token that immediately follows a known hub slug and is not itself a known hub slug
+    is treated as that hub's institution slug.
+
+    Examples:
+        'bpl'                              → ['bpl']
+        'nara+herbert-hoover-library'      → ['nara+herbert-hoover-library']
+        'bpl+nara+herbert-hoover-library'  → ['bpl', 'nara+herbert-hoover-library']
+        'bpl+nara'                         → ['bpl', 'nara']
+    """
+    parts = suffix.split("+")
+    labels: list[str] = []
+    i = 0
+    while i < len(parts):
+        part = parts[i]
+        if part in PARTNER_HUBS:
+            if i + 1 < len(parts) and parts[i + 1] not in PARTNER_HUBS:
+                labels.append(f"{part}+{parts[i + 1]}")
+                i += 2
+            else:
+                labels.append(part)
+                i += 1
+        else:
+            i += 1  # orphaned token (malformed session name); skip
+    return labels
+
+
 def canonical_matches_session_component(
     canonical: str, component: str, timeout: int = 5
 ) -> bool:

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -120,7 +120,9 @@ def main() -> None:
         seen_target_strs.add(target_str)
         seen_canonicals[canonical] = None
         inst_label = (
-            institution.lower().replace(" ", "-") if institution is not None else None
+            re.sub(r"[^a-z0-9-]", "", institution.lower().replace(" ", "-"))
+            if institution is not None
+            else None
         )
         label = f"{canonical}+{inst_label}" if inst_label is not None else canonical
         seen_session_labels[label] = None

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -124,6 +124,11 @@ def main() -> None:
             if institution is not None
             else None
         )
+        if institution is not None and not inst_label:
+            _slack_fail(
+                response_url,
+                f"Target '{canonical}|{institution}' normalizes to an empty institution slug.",
+            )
         label = f"{canonical}+{inst_label}" if inst_label is not None else canonical
         seen_session_labels[label] = None
         targets.append((canonical, institution, label))

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -216,7 +216,12 @@ def main() -> None:
         if force:
             for existing_name, _ in conflicts:
                 print(f"Existing session found: {existing_name}; killing it (--force).")
-                ssm_run(ssm, f"tmux kill-session -t {shlex.quote(existing_name)}")
+                try:
+                    ssm_run(ssm, f"tmux kill-session -t {shlex.quote(existing_name)}")
+                except Exception as e:
+                    _slack_fail(
+                        response_url, f"⚠️ Failed to kill session `{existing_name}`: {e}"
+                    )
         else:
             conflict_names = ", ".join(f"`{n}`" for n, _ in conflicts)
             _slack_fail(
@@ -235,10 +240,16 @@ def main() -> None:
         "cp ingest-wikimedia-update/uv.lock /home/ec2-user/ingest-wikimedia/uv.lock && "
         "/home/ec2-user/.local/bin/uv sync --project /home/ec2-user/ingest-wikimedia && echo UPDATE_DONE"
     )
-    out = ssm_run(ssm, update_cmd)
+    out = ""
+    try:
+        out = ssm_run(ssm, update_cmd)
+    except Exception as e:
+        _slack_fail(response_url, f"⚠️ Failed to update EC2 code: {e}")
     if "UPDATE_DONE" not in out:
-        print(f"EC2 update did not confirm completion. Output: {out}", file=sys.stderr)
-        sys.exit(1)
+        _slack_fail(
+            response_url,
+            "⚠️ EC2 code update did not confirm completion. Check the GitHub Actions run for details.",
+        )
     print("EC2 code updated.")
 
     # Build a chained pipeline command for all targets.
@@ -286,13 +297,24 @@ def main() -> None:
         f"tmux new-session -d -s {shlex.quote(session_name)} -c /home/ec2-user/ingest-wikimedia/"
         f' "{pipeline_cmd}"'
     )
-    ssm_run(ssm, tmux_cmd)
+    try:
+        ssm_run(ssm, tmux_cmd)
+    except Exception as e:
+        _slack_fail(
+            response_url, f"⚠️ Failed to launch tmux session `{session_name}`: {e}"
+        )
 
     print("Verifying session started...")
-    result = ssm_run(
-        ssm,
-        f"tmux ls 2>/dev/null | grep -E '^{re.escape(session_name)}(:|$)' || echo NONE",
-    )
+    result = ""
+    try:
+        result = ssm_run(
+            ssm,
+            f"tmux ls 2>/dev/null | grep -E '^{re.escape(session_name)}(:|$)' || echo NONE",
+        )
+    except Exception as e:
+        _slack_fail(
+            response_url, f"⚠️ Failed to verify session `{session_name}` started: {e}"
+        )
     if session_name not in result:
         _slack_fail(
             response_url,

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -27,9 +27,9 @@ import requests
 
 from ingest_wikimedia.partners import (
     PARTNER_DIR,
-    canonical_matches_session_component,
     is_upload_eligible,
     is_wikidata_id,
+    parse_session_labels,
     resolve_slug,
     resolve_wikidata_id,
 )
@@ -191,14 +191,25 @@ def main() -> None:
         existing_name = line.split(":")[0].strip()
         if not existing_name.startswith("wikimedia-"):
             continue
-        existing_hubs = set(existing_name[len("wikimedia-") :].split("+"))
-        overlap = {
-            c
-            for c in seen_canonicals
-            if any(
-                canonical_matches_session_component(c, comp) for comp in existing_hubs
-            )
-        }
+        existing_labels = set(parse_session_labels(existing_name[len("wikimedia-") :]))
+        overlap: set[str] = set()
+        for canonical, institution, label in targets:
+            if institution is None:
+                # Hub-level request conflicts with any existing session touching this hub
+                # (hub-level or any institution-level for the same hub).
+                if any(
+                    lbl == canonical or lbl.startswith(f"{canonical}+")
+                    for lbl in existing_labels
+                ):
+                    overlap.add(canonical)
+            else:
+                # Institution-level request conflicts only with:
+                #   1. An existing hub-level session for the same hub (would run all institutions)
+                #   2. An existing session for the exact same hub+institution
+                # Two institution-level sessions for the same hub but different institutions
+                # do NOT conflict.
+                if canonical in existing_labels or label in existing_labels:
+                    overlap.add(canonical)
         if overlap:
             conflicts.append((existing_name, overlap))
     if conflicts:


### PR DESCRIPTION
## Summary

- Adds `parse_session_labels()` to `partners.py` — uses `PARTNER_HUBS` keys as hub boundaries to correctly reconstruct target labels from tmux session names, resolving the ambiguity of `+` being used both as the inter-target separator and within institution-level labels (`hub+inst-slug`)
- Rewrites conflict detection in `wikimedia_launch.py` to use proper label-level comparison instead of naive `split("+")` component matching

## Root Cause

Session names like `wikimedia-nara+herbert-hoover-library` represent a single institution-level target. The old code split on `+` to get `{"nara", "herbert-hoover-library"}`, then `canonical_matches_session_component("nara", "nara")` returned `True` — incorrectly blocking a second NARA institution launch.

## New Conflict Rules

| New request | Existing session | Conflict? |
|---|---|---|
| `nara` (hub-level) | `wikimedia-nara` | ✅ yes |
| `nara` (hub-level) | `wikimedia-nara+herbert-hoover-library` | ✅ yes |
| `nara\|Herbert Hoover Library` | `wikimedia-nara` | ✅ yes |
| `nara\|Herbert Hoover Library` | `wikimedia-nara+herbert-hoover-library` | ✅ yes (same institution) |
| `nara\|Some Other Library` | `wikimedia-nara+herbert-hoover-library` | ❌ no (different institution) |

## Test plan

- [ ] Launch `nara|Herbert Hoover Library` — succeeds
- [ ] Launch `nara|Some Other Library` while first is running — succeeds (no false conflict)
- [ ] Launch `nara` while an institution session is running — blocked (correct)
- [ ] Launch same institution twice — blocked (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Summary
- Fixes false-positive conflict detection when tmux session names include institution-level labels that themselves contain '+' by adding parse_session_labels(suffix: str) and reworking conflict detection to compare whole labels (hub or hub+institution) instead of naïvely splitting on '+' and matching components.
- Adds sanitization and validation for institution-derived session tokens: lowercases, replaces spaces with dashes, removes characters outside [a-z0-9-], and fails fast via _slack_fail if sanitization yields an empty slug (prevents creating labels like "nara+").
- Improves error handling in scripts/wikimedia_launch.py by wrapping ssm_run, EC2 update, tmux launch/kill, and verification calls in try/except and routing failures through _slack_fail(response_url, msg) so callers receive clear feedback (Slack ephemeral reply when response_url is valid) before exiting.

Files changed (high level)
- Added: ingest_wikimedia/partners.py: parse_session_labels(suffix: str) — parses tmux session suffixes into label tokens using PARTNER_HUBS keys as hub boundaries; skips orphaned tokens.
- Modified: scripts/wikimedia_launch.py — uses parse_session_labels() to build existing-label sets and enforce explicit hub-level vs institution-level conflict rules; sanitizes institution slugs used in session labels and validates they are non-empty; wraps previously unguarded ssm/tmux/update operations in try/except and reports failures via _slack_fail; preserves --force kill behavior but now reports kill failures.

Behavioral changes / Conflict rules
- Previous behavior: split session suffix on '+' and compared components, which could erroneously match a hub token inside an institution slug (false positives).
- New rules (implemented using parse_session_labels):
  - Hub-level request conflicts with any existing session label for that hub (either the exact hub label or any hub+institution label beginning with hub+).
  - Institution-level request conflicts only with:
    1) an existing hub-level session for the same hub, or
    2) the identical hub+institution session.
  - Two different institution-level sessions on the same hub (different institutions) do NOT conflict.
- parse_session_labels treats PARTNER_HUBS keys as hub boundaries and greedily consumes following non-hub tokens so institution labels that include '+' are reconstructed as a single hub+institution label, avoiding false positives. Orphan/malformed tokens are skipped.

Error-handling changes
- ssm_run, EC2 update, tmux launch, tmux kill, and verification steps are now wrapped in try/except; failures call _slack_fail(response_url, msg) which prints to stderr, attempts an ephemeral Slack reply to response_url (if it looks like a valid Slack response_url), and exits with code 1. tmux kill failures during --force are reported via _slack_fail instead of failing silently.

Testing
- PR includes a four-case manual test plan covering:
  1) hub vs hub (conflict),
  2) hub vs hub+institution (conflict),
  3) identical hub+institution (conflict),
  4) different hub+institution on same hub (no conflict).
- Reviewers should exercise institution names containing '+' and other punctuation in session suffixes and mixed multi-target session names to verify parsing, sanitization, and conflict behavior.

Impact checklist (explicit)
- Manual pipeline / ECS redeploy required: No — changes are in repository scripts and library; running the updated workflow or invoking the updated script picks them up. No ECS/task redeploy required.
- Environment variables / AWS Secrets Manager keys added/removed/renamed: No changes.
- Database migration: None.
- Shared infra (CodePipeline, CodeBuild, ECS task defs, IAM): No changes.
- Public API response shape or endpoints: No changes.
- Security implications: No changes to authentication, credential handling, or new external data inputs. The change reduces the risk of incorrect session killing by fixing false positives and improves error reporting.

Notes for reviewers
- Verify parse_session_labels’ greedy logic with PARTNER_HUBS keys reconstructs multi-token institution labels correctly (e.g., tokens produced by "LGBTQ+ Archives") and that malformed/orphan tokens are safely ignored.
- Confirm institution slug sanitization matches expected regex (lowercase, spaces→hyphens, strip [^a-z0-9-]) and that the new empty-slug guard produces a clear _slack_fail message.
- Confirm conflict-detection branches in scripts/wikimedia_launch.py implement the hub-vs-institution rules above and that --force still attempts kills while surfacing any kill failures via _slack_fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/164)

<!-- review_stack_entry_end -->

Summary
- Fixes false-positive conflict detection when tmux session names include institution-level labels that themselves contain '+'.
- Adds parse_session_labels(suffix: str) to ingest_wikimedia/partners.py and rewrites conflict-detection in scripts/wikimedia_launch.py to compare whole labels (hub or hub+institution) rather than naïvely splitting on '+' and matching components.
- Sanitizes institution-derived session tokens (lowercase, spaces→hyphens, strip chars outside [a-z0-9-]) so tmux session names and tmux target quoting are safe when institution names contain punctuation like '.'.
- Adjusts error handling in scripts/wikimedia_launch.py: ssm_run, EC2 update, tmux launch/kill/verification calls are wrapped in try/except and route failures through _slack_fail() (posts to Slack response_url when present) instead of leaving callers without feedback or using bare sys.exit(1).

Files changed (high level)
- Added: ingest_wikimedia/partners.py: parse_session_labels(suffix: str) — parses tmux session suffixes into label tokens using PARTNER_HUBS keys as hub boundaries and rejoining institution parts as needed.
- Modified: scripts/wikimedia_launch.py — uses parse_session_labels() and explicit label-level conflict rules for existing-session checks; sanitizes institution slugs used in session labels; wraps previously unguarded ssm_run/update/tmux calls (including tmux kill-session) in try/except and reports failures via _slack_fail; preserves --force kill behavior but now reports kill failures.

Behavioral changes / Conflict rules
- Previous behavior: split session suffix on '+' and compared components, which could erroneously match a hub token inside an institution slug.
- New rules (implemented using parse_session_labels):
  - Hub-level request conflicts with any existing session label for that hub (exact hub label or any hub+institution label starting with hub+).
  - Institution-level request conflicts only with:
    1) an existing hub-level session for the same hub, or
    2) the identical hub+institution session.
  - Two different institution-level requests on the same hub (different institutions) do NOT conflict.
- parse_session_labels treats PARTNER_HUBS keys as hub boundaries and greedily consumes following non-hub tokens so institution slugs that include '+' are reconstructed as a single label (hub+institution-slug), avoiding false positives.

Error-handling changes
- ssm_run, EC2 update, tmux launch, tmux kill, and verification steps are wrapped in try/except; failures call _slack_fail(response_url, msg) which prints to stderr and posts an ephemeral Slack response if a valid response_url is provided, then exits. This ensures transient RuntimeError/SSM failures report back to the caller and that tmux kill failures report via Slack instead of failing silently.

Testing
- PR includes a four-case manual test plan covering:
  1) hub vs hub (conflict),
  2) hub vs hub+institution (conflict),
  3) identical hub+institution (conflict),
  4) different hub+institution on same hub (no conflict).
- Reviewers should exercise institution names containing '+' and other punctuation in session suffixes and mixed multi-target session names to verify parsing, sanitization, and conflict behavior.

Impact checklist (explicit)
- Manual pipeline / ECS redeploy required: No — changes are in repository scripts and library; running the updated workflow will pick them up. No ECS/task redeploy required.
- Environment variables / AWS Secrets Manager keys added/removed/renamed: No changes.
- Database migration: None.
- Shared infra (CodePipeline, CodeBuild, ECS task defs, IAM): No changes.
- Public API response shape or endpoints: No changes.
- Security implications: No changes to authentication, credential handling, or new external data inputs. The change reduces risk of incorrect session killing by fixing false positives and improves error reporting.

Notes for reviewers
- Confirm parse_session_labels’ greedy logic and reliance on PARTNER_HUBS keys as hub boundaries correctly reconstructs multi-token institution labels (e.g., "LGBTQ+ Archives") and skips malformed tokens.
- Verify sanitization of institution slugs used in session labels avoids tmux/ssm quoting issues and that tmux kill-session errors are surfaced via _slack_fail().
- Check the conflict-detection branches in scripts/wikimedia_launch.py correctly treat hub-level vs institution-level targets per the new rules and that --force still allows killing conflicting sessions while reporting failures.
<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/164)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->