### PR TITLE
Fix NARA institution eligibility check and launch verification race condition

### DIFF
--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -131,6 +131,18 @@ def is_upload_eligible(canonical_slug: str, timeout: int = 5) -> bool:
     )
 
 
+def is_institution_upload_eligible(
+    canonical_slug: str, institution_name: str, timeout: int = 5
+) -> bool:
+    """Return True if a specific institution has upload=True in institutions_v2.json."""
+    hub_name = PARTNER_HUBS.get(canonical_slug)
+    if not hub_name:
+        return False
+    hub = _get_institutions(timeout).get(hub_name, {})
+    inst_data = hub.get("institutions", {}).get(institution_name, {})
+    return inst_data.get("upload", False)
+
+
 def is_wikidata_id(s: str) -> bool:
     """Return True if s is a Wikidata QID (e.g. 'Q12345')."""
     return bool(_QID_RE.match(s))

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -21,12 +21,14 @@ import os
 import re
 import shlex
 import sys
+from typing import NoReturn
 
 import boto3
 import requests
 
 from ingest_wikimedia.partners import (
     PARTNER_DIR,
+    is_institution_upload_eligible,
     is_upload_eligible,
     is_wikidata_id,
     parse_session_labels,
@@ -40,7 +42,7 @@ from ingest_wikimedia.ssm import REGION, ssm_run
 MEMORY_HEADROOM_PCT = 30
 
 
-def _slack_fail(response_url: str, msg: str) -> None:
+def _slack_fail(response_url: str, msg: str) -> NoReturn:
     """Print msg to stderr, post ephemeral reply to response_url if set, then exit 1."""
     print(msg, file=sys.stderr)
     if response_url:
@@ -96,7 +98,27 @@ def main() -> None:
                     response_url,
                     f"Target '{canonical}|' has an empty institution name.",
                 )
-        if canonical != "nara":
+        if institution is not None:
+            # Institution-level target: check that specific institution's eligibility.
+            # This applies to all hubs including NARA, where individual institutions
+            # vary in eligibility. get-ids-es enforces the same check, so catching it
+            # here gives a clear error before the pipeline launches.
+            try:
+                inst_eligible = is_institution_upload_eligible(canonical, institution)
+            except Exception as e:
+                _slack_fail(
+                    response_url,
+                    f"Failed to check upload eligibility for '{canonical}|{institution}': {e}",
+                )
+            if not inst_eligible:
+                _slack_fail(
+                    response_url,
+                    f"Institution '{institution}' is not upload-eligible for hub"
+                    f" '{canonical}' per institutions_v2.json.",
+                )
+        elif canonical != "nara":
+            # Hub-level target: check that any institution in the hub is eligible.
+            # NARA hub-level runs use get-ids-nara which filters eligibility itself.
             try:
                 eligible = is_upload_eligible(canonical)
             except Exception as e:
@@ -299,33 +321,25 @@ def main() -> None:
             logging.warning("Slack notification failed: %s", e)
 
     print(f"Launching {session_name} pipeline...")
-    # Use double quotes around the pipeline so single-quoted institution names inside are preserved.
+    # Use double quotes around the pipeline so single-quoted institution names inside are
+    # preserved when the outer shell (bash -c) processes the tmux command. The sentinel
+    # echo runs immediately after tmux creates the detached session — before any pipeline
+    # commands execute — so it is not subject to a race with fast-completing pipelines.
     tmux_cmd = (
         f"tmux new-session -d -s {shlex.quote(session_name)} -c /home/ec2-user/ingest-wikimedia/"
-        f' "{pipeline_cmd}"'
+        f' "{pipeline_cmd}" && echo SESSION_STARTED'
     )
+    out = ""
     try:
-        ssm_run(ssm, tmux_cmd)
+        out = ssm_run(ssm, tmux_cmd)
     except Exception as e:
         _slack_fail(
             response_url, f"⚠️ Failed to launch tmux session `{session_name}`: {e}"
         )
-
-    print("Verifying session started...")
-    result = ""
-    try:
-        result = ssm_run(
-            ssm,
-            f"tmux ls 2>/dev/null | grep -E '^{re.escape(session_name)}(:|$)' || echo NONE",
-        )
-    except Exception as e:
-        _slack_fail(
-            response_url, f"⚠️ Failed to verify session `{session_name}` started: {e}"
-        )
-    if session_name not in result:
+    if "SESSION_STARTED" not in out:
         _slack_fail(
             response_url,
-            f"⚠️ `{session_name}` failed to start — tmux session not found after launch."
+            f"⚠️ `{session_name}` failed to start — tmux could not create session."
             " Check the GitHub Actions run for details.",
         )
     print(f"Session {session_name} confirmed running.")


### PR DESCRIPTION
## Summary

- **Institution eligibility for NARA**: `_add_target` previously skipped ALL eligibility checks for NARA targets due to `if canonical != "nara":`. Institution-level NARA targets now get a per-institution eligibility check via the new `is_institution_upload_eligible` helper; hub-level NARA still skips (get-ids-nara filters eligibility itself).
- **Adds `is_institution_upload_eligible`** to `partners.py`: looks up a specific institution name in `institutions_v2.json` and returns `upload` flag. Used by `wikimedia_launch.py` to validate institution-level targets before launching the pipeline.
- **Eliminates launch verification race condition**: Previously, launch and verification were separate SSM calls. A fast-completing pipeline (all items already cached) could exit between the two calls, making verification incorrectly report "session not found." Now a single SSM call runs `tmux new-session ... && echo SESSION_STARTED` — the sentinel fires the moment tmux creates the detached session, before any pipeline commands execute.
- **`_slack_fail` typed as `-> NoReturn`**: Ensures type checkers can prove variables bound only in the happy path are always set.

## Test plan

- [ ] Trigger a NARA institution-level upload with a known-ineligible institution (e.g. "Archival Operations Division") — expect an early eligibility error, not a "session not found" error
- [ ] Trigger a multi-institution NARA chain with all eligible institutions — expect the full chain to run
- [ ] Trigger a single-partner upload where all items are already cached — expect SESSION_STARTED to appear in the SSM output without a race-condition false failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes two bugs in the Wikimedia upload pipeline launch process:

1. **Institution eligibility for NARA targets**: Previously, `_add_target` skipped all eligibility checks for NARA targets (due to `if canonical != "nara"`), causing NARA institution-level targets like `nara|Archival Operations Division` to bypass validation. If an institution was ineligible, the pipeline would fail mid-execution when `get-ids-es` ran, silently stopping the chain in multi-institution uploads. The fix adds a per-institution eligibility check via new helper `is_institution_upload_eligible` in `partners.py`. This validates institution-level targets for all hubs (including NARA) before pipeline launch, reporting ineligibility via `_slack_fail`. Hub-level NARA runs continue to skip the check since `get-ids-nara` performs its own filtering.

2. **Launch verification race condition**: Separate SSM calls for launch and verification created a race where fast-completing pipelines could exit before the verification step ran, causing false "session not found" errors. The fix combines launch and verification into a single SSM command by appending `&& echo SESSION_STARTED` immediately after tmux creates the detached session (before any pipeline commands execute), making the sentinel immune to pipeline completion races.

### Code Changes

**`ingest_wikimedia/partners.py`** (+12/-0):
- Added `is_institution_upload_eligible(canonical_slug: str, institution_name: str, timeout: int = 5) -> bool`: looks up institution in `institutions_v2.json` and returns its `upload` flag.

**`scripts/wikimedia_launch.py`** (+33/-19):
- Updated `_slack_fail` return type to `-> NoReturn` for proper type checking.
- Added institution-level eligibility enforcement in `_add_target` for all hubs via `is_institution_upload_eligible`.
- Modified tmux launch command to append `&& echo SESSION_STARTED` sentinel and check for it in SSM output, replacing the prior post-launch `tmux ls` verification.

### Deployment Notes

- No manual pipeline trigger or ECS redeployment required; the changes apply immediately to the next workflow run.
- No environment variables, AWS Secrets Manager keys, or infrastructure configuration changes.
- No database migrations or public API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/165)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->