### PR TITLE
Fix status reporting for chained multi-hub upload sessions

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -13,11 +13,12 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import boto3
 import requests
 
-from ingest_wikimedia.partners import PARTNER_DIR
+from ingest_wikimedia.partners import PARTNER_DIR, parse_session_labels
 from ingest_wikimedia.ssm import REGION, ssm_run
 
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
+_UPLOAD_COMPLETE_PREFIX = "Upload complete"
 
 
 def get_phase_and_progress(client, session: str, hub: str) -> str:
@@ -94,7 +95,7 @@ def get_phase_and_progress(client, session: str, hub: str) -> str:
         # dpla_id_count is logged at the start of each item, not after all its
         # files finish, so count arithmetic alone can fire too early.
         if counts_marker > 0:
-            return f"Upload complete ({uploaded_count:,} uploaded, {skipped_count:,} already on Commons)"
+            return f"{_UPLOAD_COMPLETE_PREFIX} ({uploaded_count:,} uploaded, {skipped_count:,} already on Commons)"
         return f"Uploading ({dpla_id_count:,} / {total:,}, ~{pct(dpla_id_count)}%)"
 
     return "Unknown"
@@ -169,13 +170,26 @@ def main() -> None:
     results: dict[str, str] = {}
 
     def fetch(session: str) -> tuple[str, str]:
-        hub = session.removeprefix("wikimedia-").split("+")[0]
-        try:
-            phase = get_phase_and_progress(ssm, session, hub)
-        except Exception:
-            logging.exception("Failed to get status for %s", session)
-            phase = "Unknown (error)"
-        return session, phase
+        labels = parse_session_labels(session.removeprefix("wikimedia-"))
+        if not labels:
+            return session, "Unknown (unrecognised session name)"
+        multi = len(labels) > 1
+        hub_cache: dict[str, str] = {}
+        label, phase = labels[0], "Unknown"
+        for label in labels:
+            hub = label.split("+")[0]
+            if hub not in hub_cache:
+                try:
+                    hub_cache[hub] = get_phase_and_progress(ssm, session, hub)
+                except Exception:
+                    logging.exception(
+                        "Failed to get status for %s (%s)", session, label
+                    )
+                    hub_cache[hub] = "Unknown (error)"
+            phase = hub_cache[hub]
+            if not phase.startswith(_UPLOAD_COMPLETE_PREFIX):
+                break
+        return session, f"[{label}] {phase}" if multi else phase
 
     with ThreadPoolExecutor(max_workers=min(len(sessions), 8)) as executor:
         futures = {executor.submit(fetch, s): s for s in sessions}

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -176,7 +176,7 @@ def main() -> None:
         multi = len(labels) > 1
         hub_cache: dict[str, str] = {}
         label, phase = labels[0], "Unknown"
-        for label in labels:
+        for i, label in enumerate(labels):
             hub = label.split("+")[0]
             if hub not in hub_cache:
                 try:
@@ -188,6 +188,15 @@ def main() -> None:
                     hub_cache[hub] = "Unknown (error)"
             phase = hub_cache[hub]
             if not phase.startswith(_UPLOAD_COMPLETE_PREFIX):
+                # get_phase_and_progress reads the most recent log for this hub,
+                # which reflects the last institution currently running. When the
+                # same hub appears multiple times (e.g. chained NARA institutions),
+                # attribute the phase to the last label for this hub rather than
+                # the first one we encounter.
+                for j in range(len(labels) - 1, i, -1):
+                    if labels[j].split("+")[0] == hub:
+                        label = labels[j]
+                        break
                 break
         return session, f"[{label}] {phase}" if multi else phase
 


### PR DESCRIPTION
## Summary

- **Root cause**: `fetch()` was doing `session.removeprefix("wikimedia-").split("+")[0]` to get the hub, which always returned the *first* hub in the session name. For `wikimedia-indiana+p2p`, this permanently read Indiana's logs even after Indiana completed — reporting "Upload complete (0 uploaded, 180,971 already on Commons)" while p2p was actively downloading.
- **Fix**: Use `parse_session_labels` to enumerate all targets in the chain. Iterate them in order, stopping at the first non-complete one. The active target's phase (prefixed with `[label]` for multi-target sessions) is returned.
- **Hub cache**: When the same hub appears multiple times (e.g. two chained NARA institution sessions), the second call would hit the same directory and return the same result. A `hub_cache` dict skips the duplicate SSM round-trips.
- **Empty labels guard**: `parse_session_labels` can return `[]` for a malformed session name (all tokens unrecognized). Previously `labels[0]` would crash; now returns `"Unknown (unrecognised session name)"`.
- **`_UPLOAD_COMPLETE_PREFIX` constant**: `get_phase_and_progress` produces `"Upload complete (...)"` and `fetch` checks `phase.startswith(...)` against the same string. Extracting the constant makes the coupling explicit and prevents silent breakage if the prefix ever changes.

## Test plan

- [ ] Trigger `/wikimedia-status` while `wikimedia-indiana+p2p` is running with Indiana complete and p2p downloading — expect `[p2p] Downloading (X / Y items, ~Z%)` instead of Indiana's completed status
- [ ] Trigger `/wikimedia-status` while a single-hub session is running — expect unchanged format (no `[label]` prefix)
- [ ] Trigger `/wikimedia-status` while a chained NARA institution session is running — expect `[nara+<active-institution>] <phase>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/166)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->