### PR TITLE
Exclude NARA from institution-level upload eligibility check

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -98,11 +98,11 @@ def main() -> None:
                     response_url,
                     f"Target '{canonical}|' has an empty institution name.",
                 )
-        if institution is not None:
+        if institution is not None and canonical != "nara":
             # Institution-level target: check that specific institution's eligibility.
-            # This applies to all hubs including NARA, where individual institutions
-            # vary in eligibility. get-ids-es enforces the same check, so catching it
-            # here gives a clear error before the pipeline launches.
+            # NARA is excluded — all its institutions have upload=false in the JSON
+            # but the hub itself is eligible; get-ids-es handles per-institution
+            # filtering for NARA (based on Wikidata ID presence, not the upload flag).
             try:
                 inst_eligible = is_institution_upload_eligible(canonical, institution)
             except Exception as e:
@@ -116,7 +116,7 @@ def main() -> None:
                     f"Institution '{institution}' is not upload-eligible for hub"
                     f" '{canonical}' per institutions_v2.json.",
                 )
-        elif canonical != "nara":
+        elif institution is None and canonical != "nara":
             # Hub-level target: check that any institution in the hub is eligible.
             # NARA hub-level runs use get-ids-nara which filters eligibility itself.
             try:


### PR DESCRIPTION
## Summary

PR #165 added a per-institution eligibility check for institution-level targets. The intent was to catch ineligible institutions early rather than letting the pipeline fail mid-chain. However, NARA is a special case: all 41 NARA institutions have `upload: false` in `institutions_v2.json`, while the NARA hub itself has `upload: true`. The institution-level `upload` flag doesn't govern NARA eligibility — `get-ids-es` handles per-institution filtering internally based on Wikidata ID presence.

This caused every NARA institution-level launch attempt to fail immediately after PR #165 deployed.

The fix: extend the existing NARA exception (already applied to hub-level targets) to institution-level targets as well. NARA institution targets skip the `is_institution_upload_eligible` check and let `get-ids-es` enforce eligibility on EC2.

## Test plan

- [ ] Trigger a NARA institution-level upload with a valid institution (e.g. John F. Kennedy Library) — expect launch to succeed
- [ ] Trigger a non-NARA institution-level upload with an ineligible institution — expect the early eligibility error to fire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR extends an existing NARA exception from hub-level to institution-level upload eligibility checks in the GitHub Actions wikimedia upload launch workflow.

## Changes

Modified `scripts/wikimedia_launch.py` to exclude NARA institution-level targets from the `is_institution_upload_eligible` check (introduced in PR #165). The code now skips eligibility validation for any target where `canonical == "nara"`, whether institution-level or hub-level. This defers eligibility enforcement to `get-ids-es` on EC2, which performs per-institution filtering based on Wikidata ID presence rather than the institution-level `upload` flag in `institutions_v2.json`.

The fix addresses a regression where PR #165 broke all NARA institution-level launches because all 41 NARA institutions have `upload: false` in the configuration, despite the NARA hub itself having `upload: true`.

## Deployment

No manual pipeline trigger, ECS redeployment, environment variable changes, database migrations, infrastructure configuration changes, API modifications, or security implications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/167)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->