### PR TITLE
Fix is_institution_upload_eligible to respect hub-level eligibility

### DIFF
--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -134,11 +134,18 @@ def is_upload_eligible(canonical_slug: str, timeout: int = 5) -> bool:
 def is_institution_upload_eligible(
     canonical_slug: str, institution_name: str, timeout: int = 5
 ) -> bool:
-    """Return True if a specific institution has upload=True in institutions_v2.json."""
+    """Return True if a specific institution is upload-eligible.
+
+    An institution is eligible if its parent hub has upload=True (hub-level
+    eligibility cascades to all child institutions), or if the institution
+    itself has upload=True.
+    """
     hub_name = PARTNER_HUBS.get(canonical_slug)
     if not hub_name:
         return False
     hub = _get_institutions(timeout).get(hub_name, {})
+    if hub.get("upload", False):
+        return True
     inst_data = hub.get("institutions", {}).get(institution_name, {})
     return inst_data.get("upload", False)
 


### PR DESCRIPTION
## Summary

`is_institution_upload_eligible` was only checking the institution-level `upload` flag, ignoring the hub-level one. But eligibility has two paths:

1. The institution itself has `upload: true`, or
2. The parent hub has `upload: true` — which makes **all** child institutions eligible regardless of their individual `upload` value

The previous implementation rejected any institution whose hub has `upload: true` but whose own `upload` is `false` (or absent) — e.g. all NARA institutions, which inherit eligibility from the hub.

The fix adds a hub-level check first: if the hub has `upload: true`, return `True` immediately without consulting the institution entry.

This corrects a regression introduced by PR #165, which started calling `is_institution_upload_eligible` for all institution-level targets. Since the function was broken for hub-inherited eligibility, it blocked all NARA institution-level launches.

Note: `wikimedia_launch.py` is unchanged — the logic there (applying the check to all institution-level targets, with the existing NARA hub-level exception via `elif canonical != "nara"`) was correct in PR #165.

## Test plan

- [ ] Trigger a NARA institution-level upload (e.g. John F. Kennedy Library) — should launch without eligibility error
- [ ] Trigger an institution-level upload for a hub where `upload: true` is on the hub (not individual institutions) — should launch
- [ ] Trigger an institution-level upload with a genuinely ineligible institution (hub `upload: false`, institution `upload: false`) — should still be rejected early

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes is_institution_upload_eligible() in ingest_wikimedia/partners.py to respect hub-level upload eligibility flags. The function now checks the parent hub's upload flag first and returns True immediately if the hub has upload: true; otherwise it falls back to the institution's upload flag. This restores the intended rule that hub-level upload:true cascades to all child institutions and fixes a regression from PR #165 that caused some institution-level launches (e.g., NARA institutions) to be incorrectly rejected.

Implementation: add an early hub-level check in is_institution_upload_eligible; update the function docstring to document hub-level cascading eligibility. No public API or function signature changes.

Tests / manual checks (from PR):
- Trigger a NARA institution-level upload (e.g., John F. Kennedy Library) — should launch without eligibility error.
- Trigger an institution-level upload where upload: true is set on the hub (not the institution) — should launch.
- Trigger an institution-level upload with both hub and institution upload: false — should be rejected early.

Other notes required by reviewers:
- Deployment: No manual pipeline trigger or ECS redeployment required.
- Environment / secrets: No additions, removals, or renames of environment variables or AWS Secrets Manager keys.
- Database migrations: None.
- Shared infra (CodePipeline/CodeBuild/ECS/IAM): No changes.
- Public-facing API surface: No changes.
- Security implications: None introduced (no auth, credential, or new external data handling changes).
- Related behavior: scripts/wikimedia_launch.py remains unchanged; PR #165's change to call the eligibility check for institution-level targets (with the existing NARA exception) is still in place, but the eligibility logic now correctly honors hub-level upload:true.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/168)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->