### PR TITLE
Update GitHub Actions to node24-compatible versions

### DIFF
--- a/.github/workflows/cim-pageviews.yml
+++ b/.github/workflows/cim-pageviews.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/cim-pageviews.yml
+++ b/.github/workflows/cim-pageviews.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@60cc2b45855283f89ec62f1aba5ee88bf9ec7fc7 # v6.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.5.3"
 
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@60cc2b45855283f89ec62f1aba5ee88bf9ec7fc7 # v6.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.5.3"
 

--- a/.github/workflows/cim-pageviews.yml
+++ b/.github/workflows/cim-pageviews.yml
@@ -29,10 +29,10 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a
+        uses: astral-sh/setup-uv@60cc2b45855283f89ec62f1aba5ee88bf9ec7fc7 # v6.2.0
         with:
           version: "0.5.3"
 
@@ -70,10 +70,10 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a
+        uses: astral-sh/setup-uv@60cc2b45855283f89ec62f1aba5ee88bf9ec7fc7 # v6.2.0
         with:
           version: "0.5.3"
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@60cc2b45855283f89ec62f1aba5ee88bf9ec7fc7 # v6.2.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.5.3"
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a
+        uses: astral-sh/setup-uv@60cc2b45855283f89ec62f1aba5ee88bf9ec7fc7 # v6.2.0
         with:
           version: "0.5.3"
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -10,5 +10,5 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -10,5 +10,5 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@f2e32211077f40bfeab40e16285216924ebea4cb
+      - uses: actions/checkout@v6
+      - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0

--- a/.github/workflows/wikimedia-kill.yml
+++ b/.github/workflows/wikimedia-kill.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/wikimedia-kill.yml
+++ b/.github/workflows/wikimedia-kill.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -32,9 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -32,9 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/wikimedia-upload-status.yml
+++ b/.github/workflows/wikimedia-upload-status.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/wikimedia-upload-status.yml
+++ b/.github/workflows/wikimedia-upload-status.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary

Silences the `Node.js 20 is deprecated` warning on all workflows by upgrading to action versions that natively target Node.js 24.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` (node20) | `@v6` (node24) |
| `actions/setup-python` | `@v5` (node20) | `@v6` (node24) |
| `astral-sh/setup-uv` | SHA pinned at old release (node20) | `v6.2.0` SHA (node24) |
| `astral-sh/ruff-action` | SHA pinned at old release | `v4.0.0` SHA (node24) |

GitHub was already forcing these to run on Node.js 24 anyway, so no functional change — this just aligns the declared runtime with what the runner actually uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
Updates six GitHub workflow files to use action versions that declare Node.js 24 as their runtime, silencing "Node.js 20 is deprecated" warnings and aligning declared action runtimes with the Node.js 24 environment already used by GitHub runners. These are declaration-only changes and do not change workflow behavior.

This PR does not require manual pipeline triggers or ECS redeployments to take effect, does not add/remove/rename environment variables or AWS Secrets Manager keys, includes no database migrations, does not change shared infrastructure configuration (CodePipeline/CodeBuild/ECS/IAM), does not modify any public-facing API shapes or endpoints, and has no security-sensitive credential-handling changes beyond updating action references. The commit also pins some actions to full commit SHAs to reduce supply-chain risk and includes co-author metadata.

## Changes
Applied across: .github/workflows/cim-pageviews.yml, pytest.yml, ruff.yml, wikimedia-kill.yml, wikimedia-launch.yml, wikimedia-upload-status.yml

- actions/checkout: @v4 → @v6 (pinned to full commit SHA in some workflows)
- actions/setup-python: @v5 → @v6 (pinned to full commit SHA where applicable)
- astral-sh/setup-uv: repinned to a Node.js 24-compatible release (v6.2.0 SHA)
- astral-sh/ruff-action: repinned to v4.0.0 (SHA) for Node.js 24 compatibility

All workflow logic, schedules, job conditions, environment variables, secret usages, Python versions, dependency installs, and script invocations remain unchanged.

Co-author metadata was added in the commit messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/169)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->