### PR TITLE
Fix status conflation when multiple sessions share the same hub directory

### DIFF
--- a/ingest_wikimedia/logs.py
+++ b/ingest_wikimedia/logs.py
@@ -31,7 +31,8 @@ def setup_logging(partner: str, event_type: str, level: int = logging.INFO) -> N
     """
     os.makedirs(LOGS_DIR_BASE, exist_ok=True)
     time_str = datetime.now().strftime("%Y%m%d-%H%M%S")
-    log_file_name = f"{time_str}-{partner}-{event_type}.log"
+    session_label = os.environ.get("WIKIMEDIA_SESSION_LABEL") or partner
+    log_file_name = f"{time_str}-{session_label}-{event_type}.log"
     filename = f"{LOGS_DIR_BASE}/{log_file_name}"
     logging.basicConfig(
         level=level,

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -21,7 +21,7 @@ SLACK_API_URL = "https://slack.com/api/chat.postMessage"
 _UPLOAD_COMPLETE_PREFIX = "Upload complete"
 
 
-def get_phase_and_progress(client, session: str, hub: str) -> str:
+def get_phase_and_progress(client, session: str, hub: str, label: str) -> str:
     def _safe_int(s: str) -> int:
         try:
             return int(s)
@@ -33,12 +33,13 @@ def get_phase_and_progress(client, session: str, hub: str) -> str:
     log_dir = shlex.quote(f"{base}/logs")
     session_name = shlex.quote(session)
 
-    # Get session creation time and most recent log filename — no shell variables
-    # needed, avoiding outer-bash expansion of $f inside the bash -c double-quote.
+    # Get session creation time and most recent log for this label — no shell
+    # variables needed, avoiding outer-bash expansion of $f inside bash -c.
+    label_prefix = shlex.quote(label + "-")
     precheck = ssm_run(
         client,
         f"tmux display-message -t {session_name} -p '#{{session_created}}' 2>/dev/null || echo 0; "
-        f"ls -t {log_dir}/ 2>/dev/null | head -1",
+        f"ls -t {log_dir}/ 2>/dev/null | grep -F {label_prefix} | head -1",
     )
     precheck_lines = precheck.splitlines()
     session_created = _safe_int(precheck_lines[0]) if precheck_lines else 0
@@ -174,29 +175,15 @@ def main() -> None:
         if not labels:
             return session, "Unknown (unrecognised session name)"
         multi = len(labels) > 1
-        hub_cache: dict[str, str] = {}
-        label, phase = labels[0], "Unknown"
-        for i, label in enumerate(labels):
+        label, phase = labels[-1], "Unknown"
+        for label in labels:
             hub = label.split("+")[0]
-            if hub not in hub_cache:
-                try:
-                    hub_cache[hub] = get_phase_and_progress(ssm, session, hub)
-                except Exception:
-                    logging.exception(
-                        "Failed to get status for %s (%s)", session, label
-                    )
-                    hub_cache[hub] = "Unknown (error)"
-            phase = hub_cache[hub]
+            try:
+                phase = get_phase_and_progress(ssm, session, hub, label)
+            except Exception:
+                logging.exception("Failed to get status for %s (%s)", session, label)
+                phase = "Unknown (error)"
             if not phase.startswith(_UPLOAD_COMPLETE_PREFIX):
-                # get_phase_and_progress reads the most recent log for this hub,
-                # which reflects the last institution currently running. When the
-                # same hub appears multiple times (e.g. chained NARA institutions),
-                # attribute the phase to the last label for this hub rather than
-                # the first one we encounter.
-                for j in range(len(labels) - 1, i, -1):
-                    if labels[j].split("+")[0] == hub:
-                        label = labels[j]
-                        break
                 break
         return session, f"[{label}] {phase}" if multi else phase
 


### PR DESCRIPTION
## Summary

- **`ingest_wikimedia/logs.py`**: Log filenames now include `WIKIMEDIA_SESSION_LABEL` instead of just the hub slug. For example, a NARA session for the Center for Legislative Archives produces `20260514-143022-nara+center-for-legislative-archives-download.log` rather than `20260514-143022-nara-download.log`. Falls back to the hub slug if the env var is not set (non-session runs are unaffected).
- **`scripts/wikimedia_upload_status.py`**: `get_phase_and_progress` now accepts a `label` parameter and filters the log directory with `grep -F {label}-` so it only finds logs belonging to that specific label. The `fetch()` function drops the `hub_cache` deduplication (which was the source of conflation) and queries each label independently, stopping at the first incomplete one.

## Root cause

All concurrent NARA sessions shared `/home/ec2-user/ingest-wikimedia/nara/logs/`. The status script used `ls -t | head -1` with no label filter, so every session reported the status of whichever log file was most recently modified — producing identical (and wrong) status for all sessions.

## Test plan

- [ ] Trigger multiple concurrent NARA institution sessions
- [ ] Verify each session in the Slack status report shows its own phase and item count
- [ ] Verify single-hub sessions (non-NARA) are unaffected
- [ ] Verify `setup_logging` without `WIKIMEDIA_SESSION_LABEL` set still uses the partner slug as the log filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix status conflation when multiple sessions share the same hub directory

This PR resolves an issue where concurrent NARA sessions sharing the same hub log directory would all report identical, incorrect status because the status script indiscriminately selected the most recently modified log file rather than filtering by session.

### Changes

**ingest_wikimedia/logs.py**
- The `setup_logging` function now incorporates the optional `WIKIMEDIA_SESSION_LABEL` environment variable (already set by `scripts/wikimedia_launch.py`) into log filenames, with fallback to the hub slug for backwards compatibility
- Example new format: `20260514-143022-nara+center-for-legislative-archives-download.log` (versus `20260514-143022-nara-download.log`)

**scripts/wikimedia_upload_status.py**
- `get_phase_and_progress()` now accepts a `label` parameter and filters log files using `grep -F {label}-` to identify logs for a specific session label
- The `fetch()` worker function was refactored to remove hub-level caching and instead query status per label independently, calling `get_phase_and_progress()` for each label and stopping at the first incomplete one
- Phase selection logic simplified to use the last parsed label and default to `"Unknown"`

### Deployment notes

No manual pipeline trigger or ECS redeployment required. Code changes take effect immediately upon merge since the status check runs via GitHub Actions scheduled workflow (every 6 hours) and API-driven dispatch.

### Testing considerations

- Verify concurrent NARA institution sessions each report their own correct phase and item count in Slack
- Confirm single-hub (non-NARA) sessions remain unaffected
- Validate that `setup_logging` without `WIKIMEDIA_SESSION_LABEL` still uses the partner slug as the log filename

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/171)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->