### PR TITLE
Add backward-compat fallback for pre-fix log filenames in status script

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -45,6 +45,17 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str:
     session_created = _safe_int(precheck_lines[0]) if precheck_lines else 0
     log_file = precheck_lines[1].strip() if len(precheck_lines) > 1 else ""
 
+    # Backward compat: sessions launched before the session-label log naming change
+    # use hub-slug-only filenames (e.g. nara-download.log). If no label-prefixed log
+    # is found, fall back to the most recent hub-slug log, excluding new-format files
+    # (which contain '+' in the name and belong to a different institution).
+    if not log_file:
+        hub_prefix = shlex.quote(hub + "-")
+        log_file = ssm_run(
+            client,
+            f"ls -t {log_dir}/ 2>/dev/null | grep -F {hub_prefix} | grep -vF '+' | head -1 || true",
+        ).strip()
+
     if not log_file:
         return "Generating IDs"
 


### PR DESCRIPTION
## Summary

Sessions launched before PR #171 (which introduced session-label log naming) write logs using only the hub slug — e.g. `nara-download.log`. The new `grep -F 'nara+center-for-legislative-archives-'` filter finds nothing for these sessions, causing a false **Generating IDs** status for all of them.

This adds a fallback: if no label-prefixed log is found, retry with a hub-slug-only filter (`grep -F 'nara-'`) while excluding new-format files (those containing `+` in the name, which belong to a different institution). This recovers correct status for in-flight sessions from before the naming change.

The fallback is intentionally short-lived — once all pre-fix sessions complete and new ones are launched, the label-filtered path is always hit and the fallback is never reached.

## Test plan

- [ ] Verify sessions running before the naming change now show correct phase/progress
- [ ] Verify sessions launched after the naming change still show per-institution status (no conflation)
- [ ] Verify sessions with no logs at all still return "Generating IDs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds a backward-compatibility fallback in the status reporting script to handle log files created before PR #171's log naming change. Previously, sessions created before PR #171 wrote log files using only the hub slug (e.g., `nara-download.log`). PR #171 introduced session-label-prefixed naming (e.g., `nara+center-for-legislative-archives-download.log`), but the status script's grep filter couldn't find pre-change sessions, causing them to display as stuck at "Generating IDs".

The fix adds a secondary search: if no label-prefixed log is found, the script now searches for hub-slug-only logs while excluding new-format files containing `+` to prevent conflating logs from different institutions. This fallback is intended as a temporary measure and will become unnecessary once all pre-change sessions complete.

## Changes

**scripts/wikimedia_upload_status.py** (+11 lines)
- In `get_phase_and_progress()`: Added backward-compatibility fallback logic that searches for the most recent hub-slug-only log file when a label-prefixed log is not found, while filtering out new-format files containing `+`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/172)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->