### PR TITLE
Only paginate filenames within same-extension groups

### DIFF
--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -3,6 +3,7 @@ import logging
 import mimetypes
 import random
 import time
+from collections import Counter
 
 import click
 from pywikibot.site import BaseSite
@@ -295,16 +296,39 @@ class Uploader:
 
             title = titles[0] if titles else ""
 
-            ordinal = 0
             files = self.s3_client.get_file_list(partner, dpla_id)
 
-            for _ in tqdm(
-                files, desc="Uploading Files", leave=False, unit="File", ncols=100
+            # Pre-scan to resolve each file's extension from S3 content-type metadata.
+            # Files with distinct extensions represent the same content in different
+            # formats, not separate pages — page numbers are only assigned within
+            # groups that share the same extension and contain more than one file.
+            # Single-file items never need pagination so we skip the pre-scan for them.
+            ordinal_exts: dict[int, str] = {}
+            if len(files) > 1:
+                for i in range(1, len(files) + 1):
+                    s3_path = self.s3_client.get_media_s3_path(dpla_id, i, partner)
+                    if self.s3_client.s3_file_exists(s3_path):
+                        s3_obj = self.s3_client.get_s3().Object(S3_BUCKET, s3_path)
+                        ordinal_exts[i] = (
+                            mimetypes.guess_extension(s3_obj.content_type) or ""
+                        )
+
+            ext_counts: Counter[str] = Counter(ordinal_exts.values())
+            ext_seen: Counter[str] = Counter()
+
+            for ordinal, _ in enumerate(
+                tqdm(
+                    files, desc="Uploading Files", leave=False, unit="File", ncols=100
+                ),
+                start=1,
             ):
-                ordinal += 1
                 logging.info(f"Page {ordinal}")
-                # one-pagers don't have page numbers in their titles
-                page_label = "" if len(files) == 1 else str(ordinal)
+                ext = ordinal_exts.get(ordinal, "")
+                if ext_counts[ext] > 1:
+                    ext_seen[ext] += 1
+                    page_label = str(ext_seen[ext])
+                else:
+                    page_label = ""
                 self.process_file(
                     dpla_id,
                     title,

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -309,9 +309,17 @@ class Uploader:
                     s3_path = self.s3_client.get_media_s3_path(dpla_id, i, partner)
                     if self.s3_client.s3_file_exists(s3_path):
                         s3_obj = self.s3_client.get_s3().Object(S3_BUCKET, s3_path)
-                        ordinal_exts[i] = (
-                            mimetypes.guess_extension(s3_obj.content_type) or ""
-                        )
+                        mime = s3_obj.content_type
+                        # Skip generic MIME types — process_file re-detects these
+                        # via libmagic, so the real extension isn't known yet.
+                        # Excluding them avoids grouping files whose true types differ.
+                        if mime not in (
+                            "application/octet-stream",
+                            "binary/octet-stream",
+                        ):
+                            ext = mimetypes.guess_extension(mime)
+                            if ext:
+                                ordinal_exts[i] = ext
 
             ext_counts: Counter[str] = Counter(ordinal_exts.values())
             ext_seen: Counter[str] = Counter()


### PR DESCRIPTION
## Summary

- Items where the source provides multiple file formats (e.g. a `.jpg` and a `.pdf` of the same photograph) were getting `(page 1)` / `(page 2)` suffixes added to both filenames. Files with different extensions are the same content in different formats — not separate pages — and don't need pagination to de-conflict their names.
- The fix pre-scans all ordinals for their S3 content-type before the upload loop, groups them by extension, and only assigns page numbers within groups that contain more than one file with the same extension.
- Single-file items skip the pre-scan entirely (they can never need pagination).
- Multi-file items where all files share the same extension (e.g. a genuine multi-page PDF scanned to multiple JPEGs) continue to be paginated exactly as before.

## Examples

| Files staged | Before | After |
|---|---|---|
| `1_abc` (image/jpeg), `2_abc` (application/pdf) | `Title - DPLA - abc (page 1).jpg`, `Title - DPLA - abc (page 2).pdf` | `Title - DPLA - abc.jpg`, `Title - DPLA - abc.pdf` |
| `1_abc` (image/jpeg), `2_abc` (image/jpeg) | `Title - DPLA - abc (page 1).jpg`, `Title - DPLA - abc (page 2).jpg` | *(unchanged)* |
| `1_abc` (image/jpeg) | `Title - DPLA - abc.jpg` | *(unchanged)* |

## Test plan

- [ ] Upload an item with a `.jpg` + `.pdf` pair — verify neither gets a page suffix
- [ ] Upload a genuine multi-page item (multiple `.jpg` files) — verify page numbers are still applied
- [ ] Upload a single-file item — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates filename pagination in tools/uploader.py so page suffixes (e.g., "(page 1)") are applied only within same-extension groups rather than across all files in a multi-file item.

What changed
- Single-file items skip the pre-scan entirely (no pagination change).
- For multi-file items, the uploader pre-scans S3 content-type metadata to infer each ordinal’s extension (skipping generic/ambiguous MIME types like application/octet-stream and binary/octet-stream, and any MIME types where mimetypes.guess_extension returns None).
- Files are grouped by inferred extension; page numbers are assigned only inside groups that contain more than one file of the same extension.
- Files that are the same content in different formats (e.g., image/jpeg + application/pdf) will no longer get page suffixes; genuine multi-page items with multiple files sharing the same extension (e.g., multiple .jpg) keep pagination.
- Files whose pre-scan yields no concrete extension fall through to no pagination (page_label=""), allowing later per-file detection (e.g., via libmagic) to avoid suppressing pagination incorrectly.

Implementation notes
- Adds collections.Counter usage and extends process_item() to build an ordinal -> extension mapping and track per-extension seen counts while uploading.
- Code changes limited to tools/uploader.py (net +/− lines as noted in commit message).

Testing / test plan
- Upload .jpg + .pdf pair — verify no page suffixes.
- Upload multiple .jpg files — verify page numbers applied.
- Upload single-file item — verify unchanged behavior.

Impact checklist (explicit)
- Manual pipeline trigger / ECS redeploy required: No
- Adds/removes/renames env vars or AWS Secrets Manager keys: No
- Database migrations: None
- Changes to shared infra (CodePipeline/CodeBuild/ECS task defs/IAM): No
- Public API response shape or endpoints modified: No
- Security implications: No credential or auth changes; change affects filename labeling only.

If further review is desired, focus review on the pre-scan MIME-to-extension heuristics (handling of octet-stream and mimetypes.guess_extension fall-through) to ensure it matches expected behavior across the corpus.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/173)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->