### PR TITLE
Per-target CSV isolation + graceful skip of invalid/conflicting launch targets

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -289,9 +289,9 @@ def main() -> None:
     for canonical, institution, session_label in targets:
         pdir = PARTNER_DIR.get(canonical, canonical)
         base = f"/home/ec2-user/ingest-wikimedia/{pdir}"
-        # Use a per-target CSV filename so concurrent sessions sharing the same
-        # partner directory (e.g. multiple NARA institution runs) don't clobber
-        # each other's ID lists between the get-ids and downloader/uploader steps.
+        # Use a per-target CSV filename so concurrent institution-level sessions
+        # for the same hub don't clobber each other's ID lists between the
+        # get-ids and downloader/uploader steps.
         csv_file = f"{session_label}.csv"
         if canonical == "nara" and institution is None:
             get_ids_cmd = f"get-ids-nara > {csv_file}"

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -136,6 +136,11 @@ def main() -> None:
                 f"Target '{canonical}|{institution}' normalizes to an empty institution slug.",
             )
         label = f"{canonical}+{inst_label}" if inst_label is not None else canonical
+        if label in seen_session_labels:
+            _slack_fail(
+                response_url,
+                f"Target '{target_str}' normalizes to a duplicate session label '{label}'.",
+            )
         seen_session_labels[label] = None
         targets.append((canonical, institution, label))
 

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -289,13 +289,17 @@ def main() -> None:
     for canonical, institution, session_label in targets:
         pdir = PARTNER_DIR.get(canonical, canonical)
         base = f"/home/ec2-user/ingest-wikimedia/{pdir}"
+        # Use a per-target CSV filename so concurrent sessions sharing the same
+        # partner directory (e.g. multiple NARA institution runs) don't clobber
+        # each other's ID lists between the get-ids and downloader/uploader steps.
+        csv_file = f"{session_label}.csv"
         if canonical == "nara" and institution is None:
-            get_ids_cmd = f"get-ids-nara > {canonical}.csv"
+            get_ids_cmd = f"get-ids-nara > {csv_file}"
         else:
             get_ids_cmd = f"get-ids-es {canonical}"
             if institution is not None:
                 get_ids_cmd += f" --institution {shlex.quote(institution)}"
-            get_ids_cmd += f" > {canonical}.csv"
+            get_ids_cmd += f" > {csv_file}"
         # Export the session label before the group so the failure handler has the
         # correct label even when cd itself fails.
         label_export = f"export WIKIMEDIA_SESSION_LABEL={shlex.quote(session_label)}"
@@ -303,8 +307,8 @@ def main() -> None:
             [
                 f"cd {base}",
                 get_ids_cmd,
-                f"downloader {canonical}.csv {canonical}",
-                f"uploader {canonical}.csv {canonical}",
+                f"downloader {csv_file} {canonical}",
+                f"uploader {csv_file} {canonical}",
             ]
         )
         target_blocks.append(

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -88,15 +88,17 @@ def main() -> None:
         str, None
     ] = {}  # insertion-ordered; drives session naming
     targets: list[tuple[str, str | None, str]] = []
+    # Per-target validation warnings; populated by _add_target and the conflict
+    # check. If some targets are skipped but others remain valid, a summary is
+    # posted to the caller before launch rather than aborting the whole run.
+    skipped_warnings: list[str] = []
 
     def _add_target(canonical: str, institution: str | None) -> None:
         if institution is not None:
             institution = institution.strip()
             if not institution:
-                _slack_fail(
-                    response_url,
-                    f"Target '{canonical}|' has an empty institution name.",
-                )
+                skipped_warnings.append(f"'{canonical}|': empty institution name.")
+                return
         if canonical != "nara" and institution is None:
             # Hub-level target: check that any institution in the hub is eligible.
             # Institution-level eligibility is not checked here — get-ids-es enforces
@@ -106,23 +108,21 @@ def main() -> None:
             try:
                 eligible = is_upload_eligible(canonical)
             except Exception as e:
-                _slack_fail(
-                    response_url,
-                    f"Failed to check upload eligibility for '{canonical}': {e}",
+                skipped_warnings.append(
+                    f"'{canonical}': failed to check upload eligibility: {e}"
                 )
+                return
             if not eligible:
-                _slack_fail(
-                    response_url,
-                    f"Hub '{canonical}' is not upload-eligible per institutions_v2.json.",
+                skipped_warnings.append(
+                    f"'{canonical}': not upload-eligible per institutions_v2.json."
                 )
+                return
         target_str = (
             f"{canonical}|{institution}" if institution is not None else canonical
         )
         if target_str in seen_target_strs:
-            _slack_fail(
-                response_url,
-                f"Target '{target_str}' appears more than once in the target list.",
-            )
+            skipped_warnings.append(f"'{target_str}': duplicate target.")
+            return
         seen_target_strs.add(target_str)
         seen_canonicals[canonical] = None
         inst_label = (
@@ -131,16 +131,16 @@ def main() -> None:
             else None
         )
         if institution is not None and not inst_label:
-            _slack_fail(
-                response_url,
-                f"Target '{canonical}|{institution}' normalizes to an empty institution slug.",
+            skipped_warnings.append(
+                f"'{canonical}|{institution}': institution name normalizes to an empty slug."
             )
+            return
         label = f"{canonical}+{inst_label}" if inst_label is not None else canonical
         if label in seen_session_labels:
-            _slack_fail(
-                response_url,
-                f"Target '{target_str}' normalizes to a duplicate session label '{label}'.",
+            skipped_warnings.append(
+                f"'{target_str}': normalizes to the same session label ('{label}') as a previous target."
             )
+            return
         seen_session_labels[label] = None
         targets.append((canonical, institution, label))
 
@@ -148,26 +148,29 @@ def main() -> None:
         if is_wikidata_id(token):
             resolved = resolve_wikidata_id(token)
             if not resolved:
-                _slack_fail(
-                    response_url,
-                    f"No hub or institution found for Wikidata ID {token!r} in institutions_v2.json.",
+                skipped_warnings.append(
+                    f"Wikidata ID {token!r}: not found in institutions_v2.json."
                 )
+                continue
             for canonical, institution in resolved:
                 _add_target(canonical, institution)
         elif "|" in token:
             hub_part, institution = token.split("|", 1)
             canonical = resolve_slug(hub_part)
             if canonical is None:
-                _slack_fail(response_url, f"Unknown hub: {token!r}")
+                skipped_warnings.append(f"'{token}': unknown hub '{hub_part}'.")
+                continue
             _add_target(canonical, institution)
         else:
             canonical = resolve_slug(token)
             if canonical is None:
-                _slack_fail(response_url, f"Unknown hub: {token!r}")
+                skipped_warnings.append(f"'{token}': unknown hub slug.")
+                continue
             _add_target(canonical, None)
 
     if not targets:
-        _slack_fail(response_url, "No targets specified.")
+        detail = ("\n• " + "\n• ".join(skipped_warnings)) if skipped_warnings else ""
+        _slack_fail(response_url, f"No valid targets to launch.{detail}")
 
     # Session name uses + as separator (unambiguous since slugs/institution names use -).
     # Institution-level targets include the hub slug as a prefix so the status script
@@ -198,41 +201,44 @@ def main() -> None:
             f" ({available_mb} MB of {total_mb} MB). Threshold is {MEMORY_HEADROOM_PCT}%.",
         )
 
-    # Check for any existing session that includes one of the requested hubs.
+    # Check for any existing session that includes one of the requested targets.
+    # Maps each requested label to the existing session name(s) it conflicts with.
     print(f"Checking for existing sessions that overlap with {session_name}...")
     try:
         tmux_list = ssm_run(ssm, "tmux ls 2>/dev/null || true")
     except Exception as e:
         _slack_fail(response_url, f"⚠️ Failed to list tmux sessions: {e}")
-    conflicts = []
+    label_conflicts: dict[str, list[str]] = {}
     for line in tmux_list.splitlines():
         existing_name = line.split(":")[0].strip()
         if not existing_name.startswith("wikimedia-"):
             continue
         existing_labels = set(parse_session_labels(existing_name[len("wikimedia-") :]))
-        overlap: set[str] = set()
         for canonical, institution, label in targets:
             if institution is None:
                 # Hub-level request conflicts with any existing session touching this hub
                 # (hub-level or any institution-level for the same hub).
-                if any(
+                conflicts_this = any(
                     lbl == canonical or lbl.startswith(f"{canonical}+")
                     for lbl in existing_labels
-                ):
-                    overlap.add(canonical)
+                )
             else:
                 # Institution-level request conflicts only with:
                 #   1. An existing hub-level session for the same hub (would run all institutions)
                 #   2. An existing session for the exact same hub+institution
                 # Two institution-level sessions for the same hub but different institutions
                 # do NOT conflict.
-                if canonical in existing_labels or label in existing_labels:
-                    overlap.add(canonical)
-        if overlap:
-            conflicts.append((existing_name, overlap))
-    if conflicts:
+                conflicts_this = (
+                    canonical in existing_labels or label in existing_labels
+                )
+            if conflicts_this:
+                label_conflicts.setdefault(label, []).append(existing_name)
+    if label_conflicts:
         if force:
-            for existing_name, _ in conflicts:
+            sessions_to_kill = {
+                name for names in label_conflicts.values() for name in names
+            }
+            for existing_name in sessions_to_kill:
                 print(f"Existing session found: {existing_name}; killing it (--force).")
                 try:
                     ssm_run(ssm, f"tmux kill-session -t {shlex.quote(existing_name)}")
@@ -241,12 +247,41 @@ def main() -> None:
                         response_url, f"⚠️ Failed to kill session `{existing_name}`: {e}"
                     )
         else:
-            conflict_names = ", ".join(f"`{n}`" for n, _ in conflicts)
-            _slack_fail(
-                response_url,
-                f"⚠️ Session(s) already running with overlapping hubs: {conflict_names}."
-                " To restart, trigger the launch workflow from GitHub Actions with force=true.",
-            )
+            for label, existing_names in label_conflicts.items():
+                existing_str = ", ".join(f"`{n}`" for n in existing_names)
+                skipped_warnings.append(
+                    f"`{label}`: conflicts with already-running session(s) {existing_str}."
+                    " Use force=true to restart."
+                )
+            conflicting_labels = set(label_conflicts)
+            targets[:] = [
+                (c, i, lbl) for c, i, lbl in targets if lbl not in conflicting_labels
+            ]
+            for lbl in conflicting_labels:
+                seen_session_labels.pop(lbl, None)
+            if not targets:
+                detail = "\n• " + "\n• ".join(skipped_warnings)
+                _slack_fail(
+                    response_url,
+                    f"No valid targets remain — all conflict with running sessions.{detail}",
+                )
+
+    if skipped_warnings:
+        warning_text = "⚠️ Skipped targets:\n• " + "\n• ".join(skipped_warnings)
+        print(warning_text, file=sys.stderr)
+        if response_url:
+            try:
+                requests.post(
+                    response_url,
+                    json={"response_type": "ephemeral", "text": warning_text},
+                    timeout=5,
+                ).raise_for_status()
+            except Exception as e:
+                logging.warning("Failed to post skip warnings to Slack: %s", e)
+
+    # Recompute after conflict filtering — derive from targets to guarantee
+    # the label order in the session name matches the surviving target list.
+    session_name = "wikimedia-" + "+".join(lbl for _, _, lbl in targets)
 
     print("Updating EC2 code...")
     update_cmd = (

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -60,7 +60,7 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str:
         return "Generating IDs"
 
     log_path = shlex.quote(f"{base}/logs/{log_file}")
-    csv_path = shlex.quote(f"{base}/{hub}.csv")
+    csv_path = shlex.quote(f"{base}/{label}.csv")
 
     sep = "__WM_SEP__"
     out = ssm_run(


### PR DESCRIPTION
## Summary

**CSV race condition fix**: When two or more institution-level sessions share the same hub (e.g. two concurrent NARA institutions), they run in the same partner directory and previously all wrote to the same `{hub}.csv`. A race between one session's `get-ids` and another session's uploader start could cause the uploader to process the wrong institution's ID list — misdirected uploads and a premature "upload complete" Slack notification. Fix: name the CSV after the session label (e.g. `nara+national-personnel-records-center---military-personnel-records.csv`) so each target has its own file. Also updates `wikimedia_upload_status.py` to look up `{label}.csv` for progress totals.

**Graceful skip of invalid/conflicting targets**: Previously, any per-target validation error (unknown hub slug, ineligible hub, already-running session conflict, duplicate label) called `_slack_fail` and killed the entire launch — preventing valid co-listed targets from starting. Now only true whole-launch failures hard-abort: a malformed `--partner` string (shlex parse error) and insufficient EC2 memory. Everything else warns and skips:

- Unknown hub slug
- Hub not upload-eligible
- Duplicate or malformed target
- Session label collision after normalization
- Already-running session conflict (was the reported UX issue)

Skipped targets are collected and posted as an ephemeral Slack warning before the remaining valid targets launch. If all targets are skipped, the run aborts with a message listing all reasons.

## Test plan

- [ ] Launch two concurrent institution-level sessions for the same hub and verify each writes to its own `.csv` file
- [ ] Verify the status script reports a non-zero total count for institution-level sessions
- [ ] Launch a chain with one already-running target and one new one — verify the new one launches and the conflicting one is reported as skipped (not a full abort)
- [ ] Launch a chain with an unknown hub slug mixed with valid targets — verify valid ones launch
- [ ] `force=true` still kills all conflicting sessions and launches everything as before
- [ ] All-invalid input still aborts with a useful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR prevents CSV clobbering between concurrent sessions by switching from a hub-scoped CSV to per-target CSV filenames derived from the session label (e.g. `{session_label}.csv`) and updates launch validation to skip invalid/conflicting targets (with ephemeral Slack warnings) instead of aborting the whole run for per-target issues.

### Changes

**scripts/wikimedia_launch.py**
- Per-target CSV filenames: pipeline steps (get-ids, downloader, uploader) now use CSV files named from the normalized session label (`{session_label}.csv`) in the partner directory rather than a single `{hub}.csv`. NARA hub-level runs still use `get-ids-nara`; institution runs use `get-ids-es {hub} --institution {name}` but write/read the per-target `{session_label}.csv`.
- Launch validation behavior:
  - Per-target validation errors (unknown/invalid hub slug, ineligible hub, duplicate/malformed target string, empty-normalized label, normalized session-label collisions, already-running session conflicts) are now accumulated as skipped targets with reasons and skipped (not hard-failed). If a Slack response URL is available, an ephemeral Slack warning lists skipped targets and reasons.
  - Conflicting existing tmux sessions: with `force=true`, existing conflicting sessions are killed as before; without `force`, conflicting targets are removed and warned. `session_name` is recomputed from surviving targets.
  - Whole-launch aborts still occur for shlex parse errors or insufficient EC2 memory. If all targets are skipped, the launcher aborts with a consolidated message.
- CSV filename usage updated across pipeline command generation so each target consistently reads/writes its `{session_label}.csv`.

**scripts/wikimedia_upload_status.py**
- Progress/status lookup now derives the CSV path from the specific session label (`{base}/{label}.csv`) when computing total counts (wc -l), matching the new per-target CSV naming.

### Impact / Compatibility

- Fixes the race where an institution session's get-ids output could be overwritten by another concurrent session for the same hub; applies to all hubs.
- Hub-level sessions remain unchanged in behavior because their `session_label` equals the hub slug.
- Prevents ambiguous launches by skipping targets whose normalized labels would collide (previous behavior that could have aborted the run is replaced by per-target skipping and warnings).

### Deployment / Infra / Security Notes

- No infrastructure changes required: no manual pipeline trigger or ECS redeploy necessary.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No changes to shared infra (CodePipeline/CodeBuild/ECS task definitions/IAM).
- No public API response or endpoint changes.
- No auth/credential handling/security-sensitive changes introduced.

### Tests / Validation (as described in PR)
- Launch two concurrent institution-level sessions for the same hub and confirm each writes its own `{session_label}.csv`.
- Run the status script and confirm it reports a non-zero total for institution-level sessions.
- Confirm hub-level sessions (where `session_label == hub slug`) continue to use the hub-derived filename and behave as before.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->