### PR TITLE
Fix pipe in Commons titles; extend Slack handler for DPLA IDs and collection uploads

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -65,6 +65,7 @@ def get_page_title(
         .replace("/", "-")
         .replace(":", "-")
         .replace("#", "-")
+        .replace("|", "-")  # wikitext table/link syntax; breaks Commons extension detection
         .replace(
             "\ufffd", "\u2019"
         )  # Unicode replacement char → right single quote (corrupted metadata)

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -6,8 +6,12 @@ Handles:
                        #tech-alerts once the workflow completes (~2 minutes).
   /wikimedia-upload <target> [<target> ...]
                      — dispatches wikimedia-launch.yml; one tmux session runs all
-                       targets sequentially. Each target is a hub slug ("bpl") or
-                       a hub|institution pair ("indiana|Indiana State Library").
+                       targets sequentially. Each target is one of:
+                         hub slug            e.g. "bpl"
+                         hub|institution     e.g. "indiana|Indiana State Library"
+                         hub|institution|collection
+                         DPLA item ID        e.g. "087a554ba5d8feb82b1d9c26380d7d0f"
+                         Wikidata QID        e.g. "Q12345"
   /wikimedia-upload kill <hub> [<hub> ...]
                      — dispatches wikimedia-kill.yml to stop running sessions.
 
@@ -33,7 +37,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-from ingest_wikimedia.partners import resolve_slug
+from ingest_wikimedia.partners import is_dpla_id, resolve_slug
 
 _QID_RE = re.compile(r"^Q\d+$")
 
@@ -170,9 +174,10 @@ def handler(event, context):
         raw = fields.get("text", "").strip()
         if not raw:
             return _slack_reply(
-                "Usage: `/wikimedia-upload <hub> [<hub> ...]` or"
-                " `/wikimedia-upload <hub>|<institution>` or"
-                " `/wikimedia-upload kill <hub> [<hub> ...]`",
+                "Usage: `/wikimedia-upload <target> [<target> ...]`\n"
+                "Targets: hub slug, `hub|institution`, `hub|institution|collection`,"
+                " DPLA item ID, or Wikidata QID.\n"
+                "To stop a session: `/wikimedia-upload kill <label> [<label> ...]`",
                 ephemeral=True,
             )
 
@@ -205,13 +210,13 @@ def handler(event, context):
             )
 
         # Launch subcommand: /wikimedia-upload <target> [<target> ...]
-        # QIDs are passed through; the launch script resolves them.
-        # Dict preserves insertion order for stable session naming.
+        # QIDs and DPLA IDs are passed through; the launch script resolves them.
+        # Hub-based targets are validated here for fast Slack feedback.
         seen_tokens: set[str] = set()
         launch_targets: list[str] = []
         for token in tokens:
             if _QID_RE.match(token):
-                # Wikidata QID — validate format, pass through unchanged.
+                # Wikidata QID — pass through unchanged.
                 if token in seen_tokens:
                     return _slack_reply(
                         f"Target `{token}` appears more than once.",
@@ -219,29 +224,46 @@ def handler(event, context):
                     )
                 seen_tokens.add(token)
                 launch_targets.append(token)
+            elif is_dpla_id(token):
+                # DPLA item ID — normalise to lowercase and pass through for
+                # resolution by the launch script on EC2.
+                normalised = token.lower()
+                if normalised in seen_tokens:
+                    return _slack_reply(
+                        f"Target `{normalised}` appears more than once.",
+                        ephemeral=True,
+                    )
+                seen_tokens.add(normalised)
+                launch_targets.append(normalised)
             else:
-                if "|" in token:
-                    if token.count("|") != 1:
-                        return _slack_reply(
-                            f"Invalid target: `{token}`. Use `<hub>|<institution>`.",
-                            ephemeral=True,
-                        )
-                    hub_part, institution = token.split("|", 1)
-                    institution = institution.strip()
-                    if not institution:
-                        return _slack_reply(
-                            "Institution cannot be empty in `<hub>|<institution>`.",
-                            ephemeral=True,
-                        )
-                else:
-                    hub_part, institution = token, None
+                pipe_count = token.count("|")
+                if pipe_count > 2:
+                    return _slack_reply(
+                        f"Invalid target: `{token}`."
+                        " Use `<hub>`, `<hub>|<institution>`,"
+                        " or `<hub>|<institution>|<collection>`.",
+                        ephemeral=True,
+                    )
+                parts = token.split("|", 2)
+                hub_part = parts[0]
+                institution = parts[1].strip() if pipe_count >= 1 else None
+                collection = parts[2].strip() if pipe_count >= 2 else None
+                if institution is not None and not institution:
+                    return _slack_reply("Institution cannot be empty.", ephemeral=True)
+                if collection is not None and not collection:
+                    return _slack_reply("Collection cannot be empty.", ephemeral=True)
                 canonical = resolve_slug(hub_part)
                 if canonical is None:
                     return _slack_reply(
                         f"Unknown hub: `{hub_part}`. Check the hub slug and try again.",
                         ephemeral=True,
                     )
-                target_str = f"{canonical}|{institution}" if institution else canonical
+                if collection is not None:
+                    target_str = f"{canonical}|{institution}|{collection}"
+                elif institution is not None:
+                    target_str = f"{canonical}|{institution}"
+                else:
+                    target_str = canonical
                 if target_str in seen_tokens:
                     return _slack_reply(
                         f"Target `{target_str}` appears more than once.",

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -177,6 +177,8 @@ def handler(event, context):
                 "Usage: `/wikimedia-upload <target> [<target> ...]`\n"
                 "Targets: hub slug, `hub|institution`, `hub|institution|collection`,"
                 " DPLA item ID, or Wikidata QID.\n"
+                "Wrap targets containing spaces in quotes:"
+                ' `/wikimedia-upload "indiana|Indiana State Library"`\n'
                 "To stop a session: `/wikimedia-upload kill <label> [<label> ...]`",
                 ephemeral=True,
             )
@@ -245,7 +247,7 @@ def handler(event, context):
                         ephemeral=True,
                     )
                 parts = token.split("|", 2)
-                hub_part = parts[0]
+                hub_part = parts[0].strip()
                 institution = parts[1].strip() if pipe_count >= 1 else None
                 collection = parts[2].strip() if pipe_count >= 2 else None
                 if institution is not None and not institution:


### PR DESCRIPTION
## Summary

**Pipe character in Commons filenames** (`ingest_wikimedia/wikimedia.py`)
- `get_page_title()` was not escaping `|`, which is wikitext table/link syntax
- A BPL record with `||` in its title caused Wikimedia's extension parser to split on `||` before the `.jpg` extension, producing a \"does not have a valid extension\" error
- Fix: add `.replace("|", "-")` to the sanitization chain, consistent with `/`, `:`, `#`

**Slack handler gaps** (`lambda/wikimedia-slack-dispatch/handler.py`)
- `/wikimedia-upload <dpla-id>` was broken — 32-char hex tokens hit `resolve_slug()`, got \"Unknown hub\", and were rejected before reaching the launch script
- `/wikimedia-upload <hub>|<institution>|<collection>` was rejected with \"Invalid target\" because the handler only allowed exactly one `|`
- Fix: handler now recognises DPLA item IDs (normalised to lowercase, passed through for EC2 resolution) and `hub|institution|collection` triples (hub validated, forwarded to workflow)
- Updated usage message to list all supported target formats

Lambda deployment required after merge to rebundle `ingest_wikimedia/partners.py`.

## Test plan
- [ ] Confirm BPL item `33e466585b0858d907602585ddac0f5c` (H. Gleason, Pine Grove Cemetery) uploads successfully on next BPL run
- [ ] Confirm `/wikimedia-upload <32-char-hex-id>` from Slack dispatches the workflow instead of returning \"Unknown hub\"
- [ ] Confirm `/wikimedia-upload <hub>|<institution>|<collection>` from Slack dispatches correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes Commons filename sanitization by replacing pipe characters (`|`) with hyphens in get_page_title() (ingest_wikimedia/wikimedia.py), preventing Wikimedia's parser from misinterpreting `|`/`||` as wikitext table/link syntax and splitting the extension. It also updates the Slack Lambda handler for /wikimedia-upload (lambda/wikimedia-slack-dispatch/handler.py) to accept and validate additional target formats: DPLA item IDs (32-char hex, normalized to lowercase), hub|institution|collection triples (validated and canonicalized), plus improved support for Wikidata QIDs; usage/help text and duplicate-detection logic were updated accordingly.

## Context

Titles containing pipe characters (e.g., a BPL record with `||`) resulted in Commons uploads failing with "does not have a valid extension" because the extension parser split on `||` before the file extension. Replacing `|` with `-` aligns with existing handling for other structural punctuation (`/`, `:`, `#`). The Slack handler changes address Slack dispatch failures for DPLA IDs and multi-part hub targets.

## Changes

- ingest_wikimedia/wikimedia.py
  - get_page_title(): add .replace("|", "-") to the sanitization chain; comment noting wikitext table/link syntax.
- lambda/wikimedia-slack-dispatch/handler.py
  - Recognize and normalize DPLA item IDs (32-char hex, lowercased).
  - Recognize Wikidata QIDs (pass-through).
  - Parse hub-based targets with up to two pipes, validate non-empty institution/collection, canonicalize hub slugs via resolve_slug, and emit canonical target strings.
  - Accept hub|institution|collection triples (previously rejected).
  - Update usage/help text (note: targets with spaces must be quoted) and duplicate-detection/error messages.
  - Import is_dpla_id from ingest_wikimedia.partners.

## Tests & Verification

- Existing unit test test_get_page_title() covers title sanitization; change is small (+1 line).
- Manual verification planned:
  - Confirm BPL item 33e466585b0858d907602585ddac0f5c uploads successfully on next BPL run.
  - Confirm `/wikimedia-upload <32-char-hex-id>` dispatches the workflow.
  - Confirm `/wikimedia-upload <hub>|<institution>|<collection>` dispatches correctly.

## Deployment & Infrastructure

- The Slack Lambda must be redeployed after merging to rebundle ingest_wikimedia/partners.py (i.e., a Lambda redeploy/republish required). 
- No other pipeline triggers, ECS redeployments, environment variable or Secrets Manager key changes, database migrations, shared infrastructure changes, or public API response/endpoint changes are introduced.

## Security & Risk

- No credential or auth changes.
- Input validation for new Slack handler target formats was added; hub-based targets are validated/canonicalized locally before downstream processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->