### PR TITLE
Retry S3 upload on transient CredentialRetrievalError

### DIFF
--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -111,6 +111,8 @@ class Downloader:
                     )
                 self.tracker.increment(Result.DOWNLOADED)
 
+        except CredentialRetrievalError:
+            raise  # let the caller's retry loop handle transient credential blips
         except Exception as e:
             raise RuntimeError(
                 f"Error uploading to s3://{S3_BUCKET}/{destination_path}"

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -13,7 +13,7 @@ from ingest_wikimedia.s3 import S3_BUCKET, S3_KEY_METADATA, S3Client
 from typing import IO
 
 import click
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, CredentialRetrievalError
 from tqdm import tqdm
 
 from ingest_wikimedia.common import (
@@ -31,6 +31,8 @@ from ingest_wikimedia.web import Web
 from ingest_wikimedia.wikimedia import check_content_type
 
 DOWNLOAD_BUFFER_SIZE = 4 * 1024 * 1024  # 4 MB
+CREDENTIAL_RETRY_MAX = 3
+CREDENTIAL_RETRY_BASE_DELAY_SECS = 5
 
 
 class Downloader:
@@ -152,6 +154,11 @@ class Downloader:
         """
         For a given capture for a given item, downloads it if we don't have it or are
         overwriting, gets the mime and sha1, and sticks it in S3.
+
+        upload_file_to_s3() is retried on CredentialRetrievalError: EC2 instance profile
+        credentials occasionally fail to refresh from IMDS, causing a brief blip that
+        resolves within seconds. Only the S3 upload is retried — the HTTP download is
+        not repeated, since the file is already on disk when the upload step fails.
         """
         temp_file = self.local_fs.get_temp_file()
         temp_file_name = temp_file.name
@@ -176,8 +183,27 @@ class Downloader:
                 return
 
             sha1 = self.local_fs.get_file_hash(temp_file_name)
-            self.upload_file_to_s3(temp_file_name, destination_path, content_type, sha1)
-            self.tracker.increment(Result.BYTES, os.stat(temp_file_name).st_size)
+
+            for attempt in range(1, CREDENTIAL_RETRY_MAX + 1):
+                try:
+                    self.upload_file_to_s3(
+                        temp_file_name, destination_path, content_type, sha1
+                    )
+                    self.tracker.increment(
+                        Result.BYTES, os.stat(temp_file_name).st_size
+                    )
+                    return
+                except CredentialRetrievalError as e:
+                    if attempt < CREDENTIAL_RETRY_MAX:
+                        delay = CREDENTIAL_RETRY_BASE_DELAY_SECS * (2 ** (attempt - 1))
+                        logging.warning(
+                            f"IAM credential refresh failed for {dpla_id} {ordinal} "
+                            f"(attempt {attempt}/{CREDENTIAL_RETRY_MAX}), "
+                            f"retrying in {delay}s: {e}"
+                        )
+                        time.sleep(delay)
+                    else:
+                        raise
 
         except Exception as e:
             self.tracker.increment(Result.FAILED)

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -62,9 +62,10 @@ class Downloader:
         destination_path: str,
         content_type: str,
         sha1: str,
-    ):
+    ) -> bool:
         """
-        Once we have a valid file to store in S3, this puts it there.
+        Uploads the file to S3. Returns True if the file was uploaded, False if it
+        already existed with a matching checksum and was skipped.
         """
         try:
             with open(file, "rb") as f:
@@ -87,7 +88,7 @@ class Downloader:
                         if int(obj.content_length) > 0:
                             logging.info("Already exists.")
                             self.tracker.increment(Result.SKIPPED)
-                            return
+                            return False
                     except (TypeError, ValueError):
                         pass  # zero-byte stub or unreadable length — fall through to upload
 
@@ -110,6 +111,7 @@ class Downloader:
                         Callback=lambda bytes_xfer: t.update(bytes_xfer),
                     )
                 self.tracker.increment(Result.DOWNLOADED)
+                return True
 
         except CredentialRetrievalError:
             raise  # let the caller's retry loop handle transient credential blips
@@ -188,12 +190,12 @@ class Downloader:
 
             for attempt in range(1, CREDENTIAL_RETRY_MAX + 1):
                 try:
-                    self.upload_file_to_s3(
+                    if self.upload_file_to_s3(
                         temp_file_name, destination_path, content_type, sha1
-                    )
-                    self.tracker.increment(
-                        Result.BYTES, os.stat(temp_file_name).st_size
-                    )
+                    ):
+                        self.tracker.increment(
+                            Result.BYTES, os.stat(temp_file_name).st_size
+                        )
                     return
                 except CredentialRetrievalError as e:
                     if attempt < CREDENTIAL_RETRY_MAX:


### PR DESCRIPTION
## Summary

- Wraps `upload_file_to_s3()` in a retry loop (up to 3 attempts) that catches `CredentialRetrievalError` and sleeps with exponential backoff (5s, 10s) before retrying
- The HTTP download is hoisted **outside** the retry loop — only the S3 upload step is retried, so a credential blip doesn't cause the file to be re-fetched from the source
- Backoff matches the uploader's convention (`base * 2^(attempt-1)`, starting at 5s)

**Background**: All `CredentialRetrievalError` hits in the Indiana download log were concentrated in a 4-second window — a transient IMDS credential refresh blip. Without retry, every concurrent `process_media()` call in that window marked its file as `FAILED`. A short sleep is enough to outlast the blip.

## Test plan

- [ ] Review retry loop control flow: `CredentialRetrievalError` on attempts 1–2 sleeps and continues; on attempt 3 raises, caught by the outer `except Exception`, increments `FAILED`
- [ ] Verify temp file lifecycle: created once before the retry loop, cleaned up in the single outer `finally` — no file handle leaks or double-cleanup on retry
- [ ] Confirm non-credential exceptions still fail immediately (no retry)
- [ ] Confirm `download_file_to_temp_path` is not called on retry (download hoisted above loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Retry S3 upload on transient CredentialRetrievalError

This PR adds bounded retry logic to the S3 upload step in tools/downloader.py so transient EC2 instance profile credential refresh failures (CredentialRetrievalError) do not cause files to be marked FAILED.

### Changes

- Imported CredentialRetrievalError from botocore.exceptions.
- Added module-level retry constants:
  - CREDENTIAL_RETRY_MAX = 3
  - CREDENTIAL_RETRY_BASE_DELAY_SECS = 5
- Hoisted HTTP download (download_file_to_temp_path) so the file is fetched once before any S3 retry attempts.
- upload_file_to_s3(...) now returns bool: True when an actual upload occurs, False when skipped due to matching checksum.
  - The S3 upload path still raises CredentialRetrievalError unchanged so callers can retry.
  - Other exceptions are wrapped and re-raised as RuntimeError.
- process_media() wraps the upload step in a bounded exponential-backoff retry loop:
  - Retries only on CredentialRetrievalError up to CREDENTIAL_RETRY_MAX attempts.
  - Backoff delay = CREDENTIAL_RETRY_BASE_DELAY_SECS * 2^(attempt-1) (delays: 5s, 10s).
  - Logs a warning for each retry attempt and sleeps before retrying.
  - Re-raises the credential exception after exhausting retries so the outer handler increments FAILED.
  - Increments the BYTES tracker only when upload_file_to_s3() returns True (prevents double-counting skipped objects).
- Ensured temp file lifecycle: temp file created once and cleaned up once in the final finally block.

### Tests / Verification

- Retry control flow: CredentialRetrievalError on attempts 1–2 sleeps and retries; attempt 3 re-raises and is handled by the outer except to mark FAILED.
- Temp file lifecycle: created once before retries and cleaned up once (no leaks or double-cleanup).
- Non-credential exceptions fail immediately (no retry).
- download_file_to_temp_path is not called on retry (download hoisted above loop).
- BYTES counter only increments on actual uploads (upload_file_to_s3() returning True).

### Security & Impact Notes

- Security: Improves robustness against transient credential refresh blips; does not introduce new credential exposures or change how credentials are acquired/stored.
- Deployment / Infra: No manual pipeline trigger or ECS redeploy required. No changes to environment variables, AWS Secrets Manager keys, IAM policies, shared infra (CodePipeline/CodeBuild/ECS task defs), database migrations, or public APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->