### PR TITLE
Treat empty/unretrievable IIIF manifests as FAILED

### DIFF
--- a/ingest_wikimedia/iiif.py
+++ b/ingest_wikimedia/iiif.py
@@ -206,7 +206,7 @@ class IIIF:
             return request.json()
 
         except (requests.RequestException, json.JSONDecodeError):
-            logging.info(f"Unable to read IIIF manifest at {url}")
+            logging.warning(f"Unable to read IIIF manifest at {url}")
             return None
 
     @staticmethod

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -265,12 +265,21 @@ class Downloader:
                     manifest_url = get_str(item_metadata, IIIF_MANIFEST_FIELD_NAME)
                     manifest = self.iiif.get_iiif_manifest(manifest_url)
                     if not manifest:
-                        self.tracker.increment(Result.SKIPPED)
+                        logging.warning(
+                            f"Could not retrieve IIIF manifest for {dpla_id}: {manifest_url}"
+                        )
+                        self.tracker.increment(Result.FAILED)
                         return
                     self.s3_client.write_iiif_manifest(
                         partner, dpla_id, json.dumps(manifest)
                     )
                     media_urls = self.iiif.get_iiif_urls(manifest)
+                    if not media_urls:
+                        logging.warning(
+                            f"No image URLs extracted from IIIF manifest for {dpla_id}: {manifest_url}"
+                        )
+                        self.tracker.increment(Result.FAILED)
+                        return
                     self.s3_client.write_file_list(partner, dpla_id, media_urls)
 
             else:


### PR DESCRIPTION
## Summary

- **Manifest fetch failure**: was counted as `SKIPPED`; now `FAILED` with a warning log that includes the manifest URL
- **Zero URLs extracted from a valid manifest**: was completely silent (UPLOADED: 0, SKIPPED: 0, FAILED: 0); now `FAILED` with a warning log including the manifest URL. The empty file-list is no longer written back to S3.
- **`get_iiif_manifest()` network/parse error**: log level `INFO` → `WARNING` so failures surface in logs

## Background

Items with unparseable IIIF canvases were previously reporting all-zero counters after the PR #180 fix, making them invisible in the pipeline summary. This change ensures any IIIF item that can't produce image URLs shows up as `FAILED` so it can be tracked down via logs.

## Test plan

- [ ] Item with an unreachable/invalid IIIF manifest URL → `FAILED: 1`, warning logged with URL
- [ ] Item with a reachable manifest but no extractable image URLs (all canvases fail `maximize_iiif_url`) → `FAILED: 1`, warning logged with URL; no empty file-list written to S3
- [ ] Item with a valid manifest and extractable URLs → behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

`[[Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves error visibility and handling for IIIF manifest processing failures by:

1. **Elevated log severity**: Changed the log level for IIIF manifest fetch/parse errors in `get_iiif_manifest()` from `INFO` to `WARNING` to make failures more prominent in logs.

2. **Failed item tracking**: Modified `process_item()` to mark items as `FAILED` (instead of silently continuing) in two scenarios:
   - When a IIIF manifest cannot be retrieved, a warning is logged with the manifest URL and the item is immediately marked as failed
   - When a valid IIIF manifest yields zero extractable image URLs, a warning is logged with the manifest URL, the item is marked as failed, and no empty file-list is written to S3

These changes surface previously invisible IIIF processing failures in pipeline summaries, improving traceability and making it easier to identify problematic manifests.

**No deployment requirements**: This PR requires no manual pipeline trigger, ECS redeployment, database migrations, environment variable changes, infrastructure configuration updates, or API modifications. The changes take effect on the next pipeline execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->