### PR TITLE
Fix concurrency group name overflow in wikimedia-launch workflow

### DIFF
--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: string
         default: ""
+      concurrency_key:
+        description: "Short SHA256 prefix of the partner string, used as the concurrency group key (set by dispatcher to avoid the 400-char GitHub limit)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -24,7 +29,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
-  group: wikimedia-launch-${{ github.event.inputs.partner }}
+  group: wikimedia-launch-${{ github.event.inputs.concurrency_key || github.run_id }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -29,7 +29,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
-  group: "wikimedia-launch-${{ github.event.inputs.concurrency_key != '' ? github.event.inputs.concurrency_key : github.run_id }}"
+  group: "wikimedia-launch-${{ github.event.inputs.concurrency_key != '' && github.event.inputs.concurrency_key || github.run_id }}"
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -29,7 +29,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
-  group: wikimedia-launch-${{ github.event.inputs.concurrency_key != '' ? github.event.inputs.concurrency_key : github.run_id }}
+  group: "wikimedia-launch-${{ github.event.inputs.concurrency_key != '' ? github.event.inputs.concurrency_key : github.run_id }}"
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -29,7 +29,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
-  group: wikimedia-launch-${{ github.event.inputs.concurrency_key || github.run_id }}
+  group: wikimedia-launch-${{ github.event.inputs.concurrency_key != '' ? github.event.inputs.concurrency_key : github.run_id }}
   cancel-in-progress: false
 
 jobs:

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -276,13 +276,20 @@ def handler(event, context):
 
         partner_input = shlex.join(launch_targets)
         targets_display = ", ".join(f"`{t}`" for t in launch_targets)
+        # Keep the concurrency group name well under GitHub's 400-char limit by
+        # hashing the full partner string down to a 16-char hex prefix.
+        concurrency_key = hashlib.sha256(partner_input.encode()).hexdigest()[:16]
 
         try:
             status = _dispatch_workflow(
                 gh_token,
                 repo,
                 "wikimedia-launch.yml",
-                {"partner": partner_input, "response_url": response_url},
+                {
+                    "partner": partner_input,
+                    "response_url": response_url,
+                    "concurrency_key": concurrency_key,
+                },
             )
         except urllib.error.HTTPError as e:
             logging.error("GitHub API error: HTTP %s", e.code)


### PR DESCRIPTION
## Summary

- The concurrency group `wikimedia-launch-${{ github.event.inputs.partner }}` exceeded GitHub's 400-character limit when the partner input contained many DPLA item IDs or long target lists, causing the workflow to fail with 0 jobs and no Slack notification
- The Lambda dispatcher now computes a 16-char SHA256 prefix of the partner string and passes it as a separate `concurrency_key` input
- The workflow uses `concurrency_key || github.run_id` in its concurrency group, keeping the name to ~33 characters regardless of target list length
- Manual GitHub UI dispatches fall back to `github.run_id`, giving each run a unique group (no concurrency limiting, which is safe — the EC2 launch script handles session deduplication via tmux)

## Test plan

- [ ] Trigger `/wikimedia-upload` from Slack with a large number of DPLA item ID targets — verify the workflow starts and the concurrency group name does not trigger the 400-char error
- [ ] Trigger the workflow manually from the GitHub UI — verify it starts without `concurrency_key` and falls back to `run_id`
- [ ] Verify that two dispatches with the same partner string share the same concurrency group (same hash → same key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix concurrency group name overflow in wikimedia-launch workflow

This PR prevents GitHub Actions from failing when the concurrency group name would exceed GitHub’s 400-character limit by removing the long partner string from the group name and using a short deterministic key instead.

### Problem
The workflow previously used the full partner input in the concurrency group name (wikimedia-launch-${{ github.event.inputs.partner }}). Very long partner inputs (e.g., many DPLA item IDs or long target lists) could push the group name past GitHub’s 400-character limit, causing the workflow to fail to start (0 jobs) and no Slack notification.

### Solution
- The Lambda Slack dispatcher computes a deterministic 16-character SHA256 hex prefix of the normalized partner string and includes it as a new workflow_dispatch input concurrency_key.
- The workflow adds an optional workflow_dispatch input concurrency_key (type: string, default "") and updates concurrency.group to:
  "wikimedia-launch-${{ github.event.inputs.concurrency_key != '' && github.event.inputs.concurrency_key || github.run_id }}"
  (uses &&/|| short-circuiting because GitHub Actions expressions do not support the ?: operator). When concurrency_key is non-empty the group uses that key; otherwise it falls back to github.run_id.
- This keeps the concurrency group name short (~33 characters). Manual GitHub UI dispatches (which don’t provide concurrency_key) fall back to github.run_id, producing a unique group per run (no concurrency limiting). EC2 launch script continues to handle session deduplication via tmux.

### Changes
- .github/workflows/wikimedia-launch.yml
  - Added optional input: concurrency_key (type: string, default "").
  - Updated concurrency.group to use the new concurrency_key with &&/|| fallback to github.run_id instead of partner.
  - Launch step still passes the original partner input to the launch script.
- lambda/wikimedia-slack-dispatch/handler.py
  - Computes a 16-character SHA256 prefix from the normalized partner string and includes it as inputs["concurrency_key"] when dispatching wikimedia-launch.yml.
- Commit: replaced unsupported ternary with &&/|| short-circuit; co-authored-by metadata present.

### Test plan
- Trigger /wikimedia-upload from Slack with a large number of targets; verify the workflow starts without hitting the 400-character limit.
- Trigger the workflow manually from the GitHub UI; verify it starts and falls back to github.run_id.
- Dispatch twice from Slack with the same partner string; verify both runs share the same concurrency group (same hash → same key).

### Infrastructure / Impact Notes
- Deployment: the updated Lambda dispatcher must be deployed (redeploy the Lambda function or update its code) for Slack-initiated dispatches to supply concurrency_key; otherwise Slack dispatches will continue to work but will not set concurrency_key (manual dispatches already fall back to run_id).
- No changes to environment variables or AWS Secrets Manager keys.
- No database migrations.
- No changes to shared infra (CodePipeline/CodeBuild/ECS task definitions/IAM).
- No changes to public API response shapes or endpoints.
- Security: no new secrets introduced; dispatcher only adds a deterministic hash (concurrency_key) to the existing dispatch payload and does not alter credential handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->