### PR TITLE
Add get-ids-retry: extract failed DPLA IDs from logs for retry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,5 @@ nara-ids = "tools.nara_ids:main"
 get-ids-nara = "tools.get_ids_nara:main"
 resolve-dpla-ids = "tools.resolve_dpla_ids:main"
 fix-unknown-categories = "tools.fix_unknown_categories:main"
+get-ids-retry = "tools.get_ids_retry:main"
+

--- a/tools/get_ids_retry.py
+++ b/tools/get_ids_retry.py
@@ -1,0 +1,174 @@
+"""
+Extract DPLA IDs from recent upload/download logs for items that failed due to
+transient issues and should be retried.
+
+Two failure types are identified:
+
+  upload   — Wikimedia-side transient errors (lock contention, backend storage
+              failures).  S3 assets are already present; only the uploader
+              needs to run.
+
+  download — Media-server HTTP failures after all retries are exhausted.  Both
+              the downloader and uploader need to run.
+
+Output: one CSV per partner per failure type, written to --output-dir.
+A summary table is printed to stdout.
+
+Usage:
+    get-ids-retry <days> [--partner PARTNER] [--output-dir DIR]
+"""
+
+import csv
+import logging
+import re
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import click
+
+
+BASE_DIR = Path("/home/ec2-user/ingest-wikimedia")
+
+UPLOAD_TRANSIENT_ERRORS = (
+    "lockmanager-fail-conflict",
+    "lockmanager-fail-svr-acquire",
+    "stashfailed: Could not acquire lock",
+    "stashfailed: Server failed to publish temporary file",
+    "backend-fail-internal",
+    "uploadstash-exception",
+)
+
+UPLOAD_TRANSIENT_RE = re.compile(
+    "|".join(re.escape(e) for e in UPLOAD_TRANSIENT_ERRORS)
+)
+
+DPLA_ID_RE = re.compile(r"DPLA ID: ([0-9a-f]{32})")
+DOWNLOAD_FAILED_RE = re.compile(r"Failed: ([0-9a-f]{32})")
+
+# The double space indicates an empty URL — produced by the IIIF parsing bug fixed in PR #180.
+EMPTY_URL_FAILURE = "Failed downloading  to"
+
+
+def parse_upload_log(path: Path) -> set[str]:
+    """Return DPLA IDs that hit transient Wikimedia errors."""
+    failed: set[str] = set()
+    current_id: str | None = None
+    with open(path, errors="replace") as f:
+        for line in f:
+            m = DPLA_ID_RE.search(line)
+            if m:
+                current_id = m.group(1)
+            elif current_id and UPLOAD_TRANSIENT_RE.search(line):
+                failed.add(current_id)
+    return failed
+
+
+def parse_download_log(path: Path) -> set[str]:
+    """Return DPLA IDs that hit media-server download failures (non-empty URL)."""
+    failed: set[str] = set()
+    current_id: str | None = None
+    with open(path, errors="replace") as f:
+        for line in f:
+            m = DOWNLOAD_FAILED_RE.search(line)
+            if m:
+                current_id = m.group(1)
+            elif current_id and "Failed downloading" in line:
+                if EMPTY_URL_FAILURE not in line:
+                    failed.add(current_id)
+                current_id = None
+    return failed
+
+
+def collect_partner_ids(partner: str, cutoff: datetime) -> tuple[set[str], set[str]]:
+    """Scan logs for *partner* and return (upload_failures, download_failures)."""
+    log_dir = BASE_DIR / partner / "logs"
+    upload_failures: set[str] = set()
+    download_failures: set[str] = set()
+
+    for pattern, parser, target in (
+        ("*-upload.log", parse_upload_log, upload_failures),
+        ("*-download.log", parse_download_log, download_failures),
+    ):
+        for log_file in sorted(log_dir.glob(pattern)):
+            if datetime.fromtimestamp(log_file.stat().st_mtime) < cutoff:
+                continue
+            target.update(parser(log_file))
+
+    # Avoid scheduling the same ID for both retry types.
+    upload_failures -= download_failures
+    return upload_failures, download_failures
+
+
+def write_ids(path: Path, ids: set[str]) -> None:
+    # Write-side counterpart to ingest_wikimedia.common.load_ids.
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        for dpla_id in sorted(ids):
+            writer.writerow([dpla_id])
+
+
+def _discover_partners() -> list[str]:
+    return sorted(
+        d.name
+        for d in BASE_DIR.iterdir()
+        if d.is_dir() and (d / "logs").is_dir() and not d.name.startswith(".")
+    )
+
+
+@click.command()
+@click.argument("days", type=int)
+@click.option(
+    "--partner",
+    default=None,
+    help="Limit to a single partner hub. Defaults to all partners.",
+)
+@click.option(
+    "--output-dir",
+    default=str(BASE_DIR / "retry"),
+    show_default=True,
+    help="Directory to write retry CSV files.",
+)
+def main(days: int, partner: str | None, output_dir: str) -> None:
+    """Extract failed DPLA IDs from the last DAYS days of logs for retry.
+
+    Writes one CSV per partner per failure type to OUTPUT_DIR:
+      <partner>-upload-retry.csv   — run uploader only
+      <partner>-download-retry.csv — run downloader then uploader
+    """
+    cutoff = datetime.now() - timedelta(days=days)
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    partners = [partner] if partner else _discover_partners()
+
+    rows: list[tuple[str, str, int, Path]] = []
+
+    for p in partners:
+        log_dir = BASE_DIR / p / "logs"
+        if not log_dir.is_dir():
+            logging.warning("No logs directory for partner '%s', skipping.", p)
+            continue
+
+        upload_ids, download_ids = collect_partner_ids(p, cutoff)
+        for suffix, ids in (("upload", upload_ids), ("download", download_ids)):
+            if ids:
+                csv_path = out / f"{p}-{suffix}-retry.csv"
+                write_ids(csv_path, ids)
+                rows.append((p, suffix, len(ids), csv_path))
+
+    if not rows:
+        print(f"No retryable failures found in the last {days} days.")
+        sys.exit(0)
+
+    col_w = max(len(r[0]) for r in rows)
+    print(f"\n{'Partner':<{col_w}}  {'Type':<8}  {'IDs':>6}  File")
+    print("-" * (col_w + 2 + 8 + 2 + 6 + 2 + 40))
+    for partner_name, failure_type, count, csv_file in rows:
+        print(f"{partner_name:<{col_w}}  {failure_type:<8}  {count:>6}  {csv_file}")
+    print()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/get_ids_retry.py
+++ b/tools/get_ids_retry.py
@@ -20,6 +20,7 @@ Usage:
 
 import csv
 import logging
+import os
 import re
 import sys
 from datetime import datetime, timedelta
@@ -28,7 +29,7 @@ from pathlib import Path
 import click
 
 
-BASE_DIR = Path("/home/ec2-user/ingest-wikimedia")
+BASE_DIR = Path(os.environ.get("INGEST_WIKIMEDIA_DIR", "/home/ec2-user/ingest-wikimedia"))
 
 UPLOAD_TRANSIENT_ERRORS = (
     "lockmanager-fail-conflict",


### PR DESCRIPTION
## Summary

- Adds a new `get-ids-retry` CLI command (`tools/get_ids_retry.py`) that scans upload and download logs from the last N days and extracts DPLA IDs that failed due to transient issues
- Identifies two failure types: **upload** (Wikimedia lock/backend errors — S3 assets present, uploader only needed) and **download** (media server HTTP failures — downloader + uploader needed)
- Writes one CSV per partner per failure type to a `retry/` output directory, in the same format consumed by the existing `uploader` and `downloader` commands
- Registers the command as `get-ids-retry` in `pyproject.toml`

## Usage

```
get-ids-retry 7                        # all partners, last 7 days
get-ids-retry 14 --partner nara        # nara only, last 14 days
get-ids-retry 7 --output-dir /tmp/out  # custom output dir
```

Output:
```
Partner      Type         IDs  File
-----------------------------------------------------------------------
nara         upload      2261  retry/nara-upload-retry.csv
nara         download     610  retry/nara-download-retry.csv
texas        upload       596  retry/texas-upload-retry.csv
...
```

## Upload error types detected

- `lockmanager-fail-conflict`
- `lockmanager-fail-svr-acquire`
- `stashfailed: Could not acquire lock`
- `stashfailed: Server failed to publish temporary file`
- `backend-fail-internal`
- `uploadstash-exception`

## Test plan

- [ ] `get-ids-retry 7` produces expected output with no warnings
- [ ] `get-ids-retry 7 --partner nara` limits to nara only
- [ ] CSVs written to `retry/` are readable by `uploader` and `downloader`
- [ ] `get-ids-retry 0` (no logs in range) prints "No retryable failures found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## PR Summary: Add get-ids-retry CLI command

Adds a new CLI utility get-ids-retry that extracts DPLA IDs from upload and download logs for items that failed due to transient issues, enabling targeted retry operations.

### Changes

**pyproject.toml**
- Registers new CLI command: get-ids-retry = "tools.get_ids_retry:main"

**tools/get_ids_retry.py** (new file, ~175 lines)
- New Click-based CLI that scans partner log directories under BASE_DIR for the last N days to identify two failure types:
  - upload — Wikimedia transient errors (lock contention, backend storage failures). S3 assets are present; only the uploader needs to run.
  - download — Media-server HTTP failures (non-empty URL). Both downloader and uploader are needed.
- Parses upload logs for DPLA ID lines and a set of transient error patterns and parses download logs by linking "Failed: <id>" with subsequent "Failed downloading" messages (excluding a known empty-URL failure signature).
- For each partner (all discovered under BASE_DIR or a single partner via --partner), writes one CSV per partner per failure type to --output-dir (default: retry/ under BASE_DIR) with filenames like <partner>-upload-retry.csv and <partner>-download-retry.csv.
- Deduplicates so an ID is not scheduled for both upload and download retries.
- Prints a summary table listing partner, failure type, ID counts, and CSV paths. Exits with status 0 if no retryable failures are found.

### Behavior / Usage
- Example CLI usage:
  - get-ids-retry 7                          # all partners, last 7 days
  - get-ids-retry 14 --partner nara         # NARA only, last 14 days
  - get-ids-retry 7 --output-dir /tmp/out   # custom output dir
- Default BASE_DIR is Path(INGEST_WIKIMEDIA_DIR env var or /home/ec2-user/ingest-wikimedia).
  - The tool honors the INGEST_WIKIMEDIA_DIR environment variable to configure the base repository path.

### Deployment & Impact Notes
- No infrastructure/deployment config changes required (no CodePipeline/CodeBuild/ECS/IAM changes).
- No new secrets, AWS Secrets Manager keys, or environment variables added beyond supporting the existing INGEST_WIKIMEDIA_DIR override (made configurable in the new code).
- No database migrations.
- No public API changes.
- Security: low risk — the tool only reads local log files and writes local CSVs; it does not introduce credential handling or external network inputs.

### Test Plan (as implemented / intended)
- Verify CSVs are created in the output directory with expected filenames and contents.
- Verify filtering by --partner works.
- Verify CSVs are compatible with existing uploader/downloader commands.
- Verify get-ids-retry 0 prints "No retryable failures found in the last 0 days." when no logs fall in the range.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->