### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/tools/get_ids_retry.py
+++ b/tools/get_ids_retry.py
@@ -23,7 +23,7 @@ import logging
 import os
 import re
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import click
@@ -137,7 +137,7 @@ def main(days: int, partner: str | None, output_dir: str) -> None:
       <partner>-upload-retry.csv   — run uploader only
       <partner>-download-retry.csv — run downloader then uploader
     """
-    cutoff = datetime.now() - timedelta(days=days)
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(days=days)
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 

--- a/tools/get_ids_retry.py
+++ b/tools/get_ids_retry.py
@@ -29,7 +29,9 @@ from pathlib import Path
 import click
 
 
-BASE_DIR = Path(os.environ.get("INGEST_WIKIMEDIA_DIR", "/home/ec2-user/ingest-wikimedia"))
+BASE_DIR = Path(
+    os.environ.get("INGEST_WIKIMEDIA_DIR", "/home/ec2-user/ingest-wikimedia")
+)
 
 UPLOAD_TRANSIENT_ERRORS = (
     "lockmanager-fail-conflict",
@@ -92,7 +94,10 @@ def collect_partner_ids(partner: str, cutoff: datetime) -> tuple[set[str], set[s
         ("*-download.log", parse_download_log, download_failures),
     ):
         for log_file in sorted(log_dir.glob(pattern)):
-            if datetime.fromtimestamp(log_file.stat().st_mtime) < cutoff:
+            if (
+                datetime.fromtimestamp(log_file.stat().st_mtime, tz=timezone.utc)
+                < cutoff
+            ):
                 continue
             target.update(parser(log_file))
 
@@ -172,4 +177,3 @@ def main(days: int, partner: str | None, output_dir: str) -> None:
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
_This PR applies 1/2 suggestions from code quality [AI findings](https://github.com/dpla/ingest-wikimedia/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix for datetime timezone mismatch in ID collection script

This PR addresses a code quality finding by fixing a timezone-aware/naive datetime comparison bug in `tools/get_ids_retry.py`. The script collects partner IDs from log files and compares their modification times against a cutoff timestamp.

**Changes:**
- Updated imports to include `timezone` from the `datetime` module
- Modified the cutoff timestamp calculation to be timezone-aware (UTC)
- Changed `datetime.fromtimestamp()` calls to use `datetime.fromtimestamp(..., tz=timezone.utc)` to ensure consistent UTC-aware datetime comparisons

This fixes a `TypeError` that would occur at runtime when comparing a timezone-aware datetime (cutoff) with a naive datetime (log file modification time).

**Scope:** Bug fix to Python utility script; no deployment, environment, database, infrastructure, or API changes required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->