### PR TITLE
Fix mixed implicit/explicit returns in sdc-sync.py

### DIFF
--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -244,7 +244,7 @@ class Downloader:
                     if candidate.get("_staged_by_get_ids_es"):
                         item_metadata = candidate
                 except (json.JSONDecodeError, AttributeError):
-                    pass
+                    pass  # Malformed metadata — treated as absent; handled below.
 
             if item_metadata is None:
                 # Metadata missing or lacks the get-ids-es staging marker.

--- a/tools/sdc-sync.py
+++ b/tools/sdc-sync.py
@@ -963,7 +963,7 @@ def dpla_claims(
                                     }
                                 )
                             except Exception as _:
-                                pass
+                                pass  # P973 qualifier missing or malformed — skip this source statement.
                         elif type == "wikibase-entityid":
                             dpla_claims.append(
                                 {

--- a/tools/sdc-sync.py
+++ b/tools/sdc-sync.py
@@ -370,6 +370,9 @@ def check(mediaid, qid, prop):
         except KeyError:
             return True, ref
     # Unrecognized qid type — treat claim as absent; no existing ref to update.
+    print(
+        f" -- check() fallback: unrecognized qid type '{qid[0]}' for {mediaid}, {prop}"
+    )
     return True, ""
 
 

--- a/tools/sdc-sync.py
+++ b/tools/sdc-sync.py
@@ -369,6 +369,8 @@ def check(mediaid, qid, prop):
                 return True, ref
         except KeyError:
             return True, ref
+    # Unrecognized qid type — treat claim as absent; no existing ref to update.
+    return True, ""
 
 
 # The following functions define specific statements to add, and uses formattedclaim() to append them to the "claims" array. It first uses the check() to check if the statement is not yet in the item, and appends it the list of statements to add in the edit if not. For now, we are just hardcoding actual values which are the same for all edits. check() returns True, False, or the string value of a statement id.
@@ -422,7 +424,6 @@ def add_rs(mediaid, rs, dpla_id):
         if checkclaim[0] is True:
             pywikibot.output(summary)
             claims["claims"].append(claim)
-            return claim
 
 
 def add_collection(mediaid, hub, institution, dpla_id):
@@ -444,7 +445,6 @@ def add_collection(mediaid, hub, institution, dpla_id):
         if checkclaim[0] is True:
             pywikibot.output(summary)
             claims["claims"].append(claim)
-            return claim
 
 
 def add_access(mediaid, access, dpla_id):
@@ -464,7 +464,6 @@ def add_access(mediaid, access, dpla_id):
         if checkclaim[0] is True:
             pywikibot.output(summary)
             claims["claims"].append(claim)
-            return claim
 
 
 def add_level(mediaid, level, dpla_id):
@@ -484,7 +483,6 @@ def add_level(mediaid, level, dpla_id):
         if checkclaim[0] is True:
             pywikibot.output(summary)
             claims["claims"].append(claim)
-            return claim
 
 
 def add_parent(mediaid, parent, dpla_id):
@@ -504,7 +502,6 @@ def add_parent(mediaid, parent, dpla_id):
         if checkclaim[0] is True:
             pywikibot.output(summary)
             claims["claims"].append(claim)
-            return claim
 
 
 def add_id(mediaid, id):
@@ -517,7 +514,6 @@ def add_id(mediaid, id):
     if checkclaim[0] is True:
         pywikibot.output(summary)
         claims["claims"].append(claim)
-        return claim
 
 
 def add_naid(mediaid, naid, dpla_id):
@@ -530,7 +526,6 @@ def add_naid(mediaid, naid, dpla_id):
     if checkclaim[0] is True:
         pywikibot.output(summary)
         claims["claims"].append(claim)
-        return claim
 
 
 def add_subject(mediaid, subject, dpla_id):
@@ -543,7 +538,6 @@ def add_subject(mediaid, subject, dpla_id):
     if checkclaim[0] is True:
         pywikibot.output(summary)
         claims["claims"].append(claim)
-        return claim
 
 
 def add_subject_entity(mediaid, qid, dpla_id):
@@ -562,7 +556,6 @@ def add_subject_entity(mediaid, qid, dpla_id):
     if checkclaim[0] is True:
         pywikibot.output(summary)
         claims["claims"].append(claim)
-        return claim
 
 
 def add_title(mediaid, title, dpla_id):
@@ -582,7 +575,6 @@ def add_title(mediaid, title, dpla_id):
         if checkclaim[0] is True:
             pywikibot.output(summary)
             claims["claims"].append(claim)
-            return claim
 
 
 def add_desc(mediaid, desc, dpla_id):
@@ -602,7 +594,6 @@ def add_desc(mediaid, desc, dpla_id):
         if checkclaim[0] is True:
             pywikibot.output(summary)
             claims["claims"].append(claim)
-            return claim
 
 
 def add_creator(mediaid, creator, dpla_id):
@@ -623,7 +614,6 @@ def add_creator(mediaid, creator, dpla_id):
         if checkclaim[0] is True:
             pywikibot.output(summary)
             claims["claims"].append(claim)
-            return claim
 
 
 # This will catch when displayDate is a single year or a date.
@@ -641,7 +631,6 @@ def add_date(mediaid, date, dpla_id):
     if checkclaim[0] is True:
         pywikibot.output(summary)
         claims["claims"].append(claim)
-        return claim
 
 
 def add_contributed(mediaid, hub, institution, dpla_id):
@@ -790,7 +779,6 @@ def add_local_id(mediaid, id, institution, dpla_id):
         if checkclaim[0] is True:
             pywikibot.output(summary)
             claims["claims"].append(claim)
-            return claim
 
 
 def add_source(mediaid, hub, url, dpla_id):
@@ -830,7 +818,6 @@ def add_source(mediaid, hub, url, dpla_id):
     if checkclaim[0] is True:
         pywikibot.output(summary)
         claims["claims"].append(claim)
-        return claim
 
 
 def add_det(claimid):


### PR DESCRIPTION
## Summary

- Removes unused \`return claim\` from 15 \`add_*\` functions in \`tools/sdc-sync.py\` — callers never capture the return value, so the explicit returns mixed with implicit \`None\` returns served no purpose and triggered Copilot code quality findings
- Adds \`return True, ""\` at the end of \`check()\` to handle the unrecognized-\`qid[0]\` and edge-case \`somevalue\`/\`source\` fallthrough paths that previously returned \`None\` implicitly (callers unpack the result as a 2-tuple, so implicit \`None\` would cause \`TypeError\`)
- Adds a clarifying comment on the new fallthrough return to explain the empty-ref sentinel
- Adds explanatory comments to two bare-\`pass\` \`except\` clauses (one in \`tools/downloader.py\`, one in \`tools/sdc-sync.py\`) flagged by Copilot as having no explanation for the silent suppression
- Skips the \`iiif.py\` finding (\`get_iiif_urls\`) — it's a false positive: the match statement's wildcard \`case x:\` raises \`ValueError\`, so there is no path that returns \`None\` implicitly

## Test plan

- [ ] Confirm all 19 Copilot code quality findings are resolved after this PR lands
- [ ] \`ruff check\` and \`ruff format\` pass (verified locally — no changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR resolves 17 Copilot code-quality findings related to mixed implicit/explicit returns across tools/sdc-sync.py and tools/downloader.py.

## Changes

**tools/sdc-sync.py**
- Removed unused `return claim` statements from 15 helper functions (add_rights, add_collection, add_access, add_level, add_parent, add_id, add_naid, add_subject, add_subject_entity, add_title, add_desc, add_creator, add_date, add_contributed, add_local_id, add_source). These helpers remain side-effect-only (building qualifiers/references and appending to `claims["claims"]` / `refclaims["claims"]`).
- Ensured `check()` always returns a 2-tuple by adding `print()` warning + explicit `return True, ""` for unrecognized `qid[0]` and edge-case `somevalue`/`source` fallthroughs (prevents tuple-unpacking errors in callers).
- Added clarifying comment explaining the empty-ref sentinel used in the new fallthrough return.
- Added an explanatory inline comment to the bare `pass` in `dpla_claims()` (P973 qualifier missing/malformed) to document intentional silent suppression.
- Marked the iiif.py finding (get_iiif_urls) as a false positive: the match statement’s wildcard `case x:` raises ValueError so there is no implicit-None return path.

**tools/downloader.py**
- Added a clarifying comment to `Downloader.process_item` documenting that malformed staged item metadata (JSON decode failure or unexpected structure) is treated as absent and falls through to existing “missing/invalid staged metadata” skip logic. No functional behavior change.

## Tests / Quality
- Author ran `ruff check` and `ruff format` locally.
- Test plan: confirm Copilot findings are resolved after merge (17 findings), and existing test suite / linting pass.

## Impact / Risk
- Code-only cleanup: no changes to function signatures, public API shapes, environment variables, AWS Secrets Manager keys, database schemas/migrations, or shared infrastructure (CI/CD, ECS, IAM, CodePipeline, CodeBuild).
- No manual pipeline trigger or ECS redeployment required.
- No security-affecting changes (no credential handling or auth changes).
- Minimal behavioral risk: added explicit returns and comments; removed unused return values; one added warning print for a previously implicit fallback path to aid debugging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->