### PR TITLE
Add /wikimedia-upload retry Slack subcommand

### DIFF
--- a/.github/workflows/wikimedia-retry.yml
+++ b/.github/workflows/wikimedia-retry.yml
@@ -1,0 +1,55 @@
+name: Wikimedia Upload Retry
+
+on:
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Number of days of logs to scan for retryable failures"
+        required: true
+        type: string
+      partner:
+        description: "Limit to a single partner hub slug (optional; omit for all partners)"
+        required: false
+        type: string
+        default: ""
+      response_url:
+        description: "Slack response_url for ephemeral user feedback on failure"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: "wikimedia-retry-${{ github.event.inputs.partner != '' && github.event.inputs.partner || 'all' }}"
+  cancel-in-progress: false
+
+jobs:
+  retry:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - run: pip install boto3==1.42.87 requests==2.32.5
+
+      - name: Run retry pipeline
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.WIKIMEDIA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.WIKIMEDIA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+          DPLA_SLACK_BOT_TOKEN: ${{ secrets.DPLA_SLACK_BOT_TOKEN }}
+          PYTHONPATH: .
+        run: |
+          python scripts/wikimedia_retry.py \
+            --days "${{ github.event.inputs.days }}" \
+            --partner "${{ github.event.inputs.partner }}" \
+            --response-url "${{ github.event.inputs.response_url }}"

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -95,22 +95,32 @@ def _slack_reply(text: str, ephemeral: bool = False) -> dict:
 
 
 def _dispatch_and_reply(
-    token: str, repo: str, workflow: str, inputs: dict, success_text: str
+    token: str,
+    repo: str,
+    workflow: str,
+    inputs: dict,
+    success_text: str,
+    *,
+    ephemeral: bool = False,
 ) -> dict:
     try:
         status = _dispatch_workflow(token, repo, workflow, inputs)
     except urllib.error.HTTPError as e:
         logging.error("GitHub API error: HTTP %s", e.code)
-        return _slack_reply(f"Failed to trigger workflow (HTTP {e.code}).")
+        return _slack_reply(
+            f"Failed to trigger workflow (HTTP {e.code}).", ephemeral=ephemeral
+        )
     except Exception:
         logging.exception("Unexpected error dispatching workflow")
-        return _slack_reply("Failed to trigger workflow due to an internal error.")
+        return _slack_reply(
+            "Failed to trigger workflow due to an internal error.", ephemeral=ephemeral
+        )
     text = (
         success_text
         if status == 204
         else f"Unexpected response from GitHub (HTTP {status})"
     )
-    return _slack_reply(text)
+    return _slack_reply(text, ephemeral=ephemeral)
 
 
 def handler(event, context):
@@ -234,6 +244,11 @@ def handler(event, context):
                     f"`{days_str}` is not a valid number of days. Provide a positive integer.",
                     ephemeral=True,
                 )
+            if len(retry_tokens) > 2:
+                return _slack_reply(
+                    "Too many arguments. Usage: `/wikimedia-upload retry <days> [<partner>]`",
+                    ephemeral=True,
+                )
             retry_partner = ""
             if len(retry_tokens) > 1:
                 hub = retry_tokens[1]
@@ -256,6 +271,7 @@ def handler(event, context):
                 f"Scanning the last {days} day{'s' if days != 1 else ''} of logs"
                 f" for retryable failures{f' for `{retry_partner}`' if retry_partner else ''}"
                 " — results will post to #tech-alerts shortly.",
+                ephemeral=True,
             )
 
         # Launch subcommand: /wikimedia-upload <target> [<target> ...]

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -179,7 +179,8 @@ def handler(event, context):
                 " DPLA item ID, or Wikidata QID.\n"
                 "Wrap targets containing spaces in quotes:"
                 ' `/wikimedia-upload "indiana|Indiana State Library"`\n'
-                "To stop a session: `/wikimedia-upload kill <label> [<label> ...]`",
+                "To stop a session: `/wikimedia-upload kill <label> [<label> ...]`\n"
+                "To retry transient failures: `/wikimedia-upload retry <days> [<partner>]`",
                 ephemeral=True,
             )
 
@@ -209,6 +210,52 @@ def handler(event, context):
                 "wikimedia-kill.yml",
                 {"partner": partner_input, "response_url": response_url},
                 f"Kill signal sent for {label} — result will post to #tech-alerts shortly.",
+            )
+
+        # Retry subcommand: /wikimedia-upload retry <days> [<partner>]
+        # Scans the last DAYS days of upload/download logs for transient failures
+        # and re-runs the affected items.
+        if tokens[0] == "retry":
+            retry_tokens = tokens[1:]
+            if not retry_tokens:
+                return _slack_reply(
+                    "Usage: `/wikimedia-upload retry <days> [<partner>]`\n"
+                    "Scans the last DAYS days of logs and re-runs transiently failed items.\n"
+                    "Example: `/wikimedia-upload retry 7` or `/wikimedia-upload retry 14 nara`",
+                    ephemeral=True,
+                )
+            days_str = retry_tokens[0]
+            try:
+                days = int(days_str)
+                if days <= 0:
+                    raise ValueError
+            except ValueError:
+                return _slack_reply(
+                    f"`{days_str}` is not a valid number of days. Provide a positive integer.",
+                    ephemeral=True,
+                )
+            retry_partner = ""
+            if len(retry_tokens) > 1:
+                hub = retry_tokens[1]
+                canonical = resolve_slug(hub)
+                if canonical is None:
+                    return _slack_reply(
+                        f"Unknown hub: `{hub}`. Check the hub slug and try again.",
+                        ephemeral=True,
+                    )
+                retry_partner = canonical
+            return _dispatch_and_reply(
+                gh_token,
+                repo,
+                "wikimedia-retry.yml",
+                {
+                    "days": str(days),
+                    "partner": retry_partner,
+                    "response_url": response_url,
+                },
+                f"Scanning the last {days} day{'s' if days != 1 else ''} of logs"
+                f" for retryable failures{f' for `{retry_partner}`' if retry_partner else ''}"
+                " — results will post to #tech-alerts shortly.",
             )
 
         # Launch subcommand: /wikimedia-upload <target> [<target> ...]

--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -51,6 +51,9 @@ def main() -> None:
     args = parser.parse_args()
 
     days = args.days
+    if days <= 0:
+        print("--days must be a positive integer.", file=sys.stderr)
+        sys.exit(1)
     partner = args.partner.strip()
     raw_url = args.response_url.strip()
     # Only accept genuine Slack response_url values — reject arbitrary POST targets.
@@ -58,7 +61,7 @@ def main() -> None:
         raw_url if raw_url.startswith("https://hooks.slack.com/commands/") else ""
     )
     if raw_url and not response_url:
-        print(f"Ignoring invalid response_url: {raw_url!r}", file=sys.stderr)
+        print("Ignoring invalid response_url (not a Slack hooks URL).", file=sys.stderr)
 
     slack_token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
     ssm = boto3.client("ssm", region_name=REGION)

--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Run retry passes for failed Wikimedia upload and download items.
+
+Triggered by the /wikimedia-upload retry <days> [<partner>] Slack command.
+Scans EC2 logs for transient failures, then launches downloader+uploader (for
+download failures) or uploader only (for upload failures) for each affected partner.
+
+Environment variables:
+  AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY  — IAM credentials with ssm:SendCommand
+  DPLA_SLACK_BOT_TOKEN                       — optional; skips Slack post if absent
+"""
+
+import argparse
+import logging
+import os
+import shlex
+import sys
+from typing import NoReturn
+
+import boto3
+import requests
+
+from ingest_wikimedia.partners import PARTNER_DIR, resolve_slug
+from ingest_wikimedia.slack import post_message
+from ingest_wikimedia.ssm import REGION, ssm_run
+
+RETRY_DIR = "/home/ec2-user/ingest-wikimedia/retry"
+MEMORY_HEADROOM_PCT = 30
+
+
+def _slack_fail(response_url: str, msg: str) -> NoReturn:
+    """Print msg to stderr, post ephemeral reply to response_url if set, then exit 1."""
+    print(msg, file=sys.stderr)
+    if response_url:
+        try:
+            requests.post(
+                response_url,
+                json={"response_type": "ephemeral", "text": msg},
+                timeout=5,
+            ).raise_for_status()
+        except Exception as e:
+            logging.warning("Failed to post to Slack response_url: %s", e)
+    sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--days", required=True, type=int)
+    parser.add_argument("--partner", default="")
+    parser.add_argument("--response-url", default="")
+    args = parser.parse_args()
+
+    days = args.days
+    partner = args.partner.strip()
+    raw_url = args.response_url.strip()
+    # Only accept genuine Slack response_url values — reject arbitrary POST targets.
+    response_url = (
+        raw_url if raw_url.startswith("https://hooks.slack.com/commands/") else ""
+    )
+    if raw_url and not response_url:
+        print(f"Ignoring invalid response_url: {raw_url!r}", file=sys.stderr)
+
+    slack_token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
+    ssm = boto3.client("ssm", region_name=REGION)
+
+    # Update EC2 code first so get-ids-retry and the pipeline run the latest version.
+    # Pin to GITHUB_SHA when available (always set in GitHub Actions).
+    print("Updating EC2 code...")
+    github_sha = (os.environ.get("GITHUB_SHA") or "").strip()
+    pin_step = (
+        f"cd /tmp/ingest-wikimedia-update && "
+        f"git fetch --depth 1 origin {shlex.quote(github_sha)} && "
+        f"git checkout --detach {shlex.quote(github_sha)} && "
+        "cd /tmp && "
+        if github_sha
+        else ""
+    )
+    update_cmd = (
+        "cd /tmp && rm -rf ingest-wikimedia-update && "
+        "git clone --depth 1 https://github.com/dpla/ingest-wikimedia.git ingest-wikimedia-update && "
+        + pin_step
+        + "cp -r ingest-wikimedia-update/ingest_wikimedia/* /home/ec2-user/ingest-wikimedia/ingest_wikimedia/ && "
+        "cp -r ingest-wikimedia-update/tools/* /home/ec2-user/ingest-wikimedia/tools/ && "
+        "cp ingest-wikimedia-update/pyproject.toml /home/ec2-user/ingest-wikimedia/pyproject.toml && "
+        "cp ingest-wikimedia-update/uv.lock /home/ec2-user/ingest-wikimedia/uv.lock && "
+        "/home/ec2-user/.local/bin/uv sync --project /home/ec2-user/ingest-wikimedia && echo UPDATE_DONE"
+    )
+    update_out = ""
+    try:
+        update_out = ssm_run(ssm, update_cmd)
+    except Exception as e:
+        _slack_fail(response_url, f"⚠️ Failed to update EC2 code: {e}")
+    if "UPDATE_DONE" not in update_out:
+        _slack_fail(
+            response_url,
+            "⚠️ EC2 code update did not confirm completion. Check the GitHub Actions run for details.",
+        )
+    print("EC2 code updated.")
+
+    # Scan logs for retryable failures. Pass the EC2 directory name rather than the
+    # canonical slug so get-ids-retry can find the logs dir (e.g. "smithsonian" for "si").
+    partner_desc = f" for `{partner}`" if partner else ""
+    print(
+        f"Scanning logs for retryable failures in the last {days} day(s){partner_desc}..."
+    )
+    scan_cmd = (
+        "source /home/ec2-user/ingest-wikimedia/.venv/bin/activate && "
+        "cd /home/ec2-user/ingest-wikimedia && "
+        f"get-ids-retry {days}"
+    )
+    if partner:
+        # PARTNER_DIR maps canonical slugs to EC2 directory names (e.g. si → smithsonian).
+        # get-ids-retry discovers partners by directory name, so we must pass the dir name.
+        dir_name = PARTNER_DIR.get(partner, partner)
+        scan_cmd += f" --partner {shlex.quote(dir_name)}"
+    scan_cmd += f" --output-dir {shlex.quote(RETRY_DIR)}"
+    scan_out = ""
+    try:
+        scan_out = ssm_run(ssm, scan_cmd)
+    except Exception as e:
+        _slack_fail(response_url, f"⚠️ Failed to scan logs for retryable failures: {e}")
+
+    print(f"Scan output:\n{scan_out}")
+
+    if "No retryable failures found" in scan_out:
+        msg = (
+            f"🔍 No retryable failures found in the last {days} day"
+            f"{'s' if days != 1 else ''}{partner_desc}."
+        )
+        if slack_token:
+            try:
+                post_message(slack_token, msg)
+            except Exception as e:
+                logging.warning("Slack notification failed: %s", e)
+        print(msg)
+        sys.exit(0)
+
+    # List retry CSVs and check memory in a single SSM round-trip.
+    print("Checking instance memory...")
+    combined_out = ""
+    try:
+        combined_out = ssm_run(
+            ssm,
+            f"find {shlex.quote(RETRY_DIR)} -name '*-retry.csv' | sort && "
+            "echo __MEM_CHECK__ && "
+            "free -m | awk 'NR==2{print $2, $7}'",
+        )
+    except Exception as e:
+        _slack_fail(response_url, f"⚠️ Failed to list retry CSVs and check memory: {e}")
+    if "__MEM_CHECK__" not in combined_out:
+        _slack_fail(response_url, "⚠️ Unexpected output from find + memory check.")
+    find_part, _, mem_out = combined_out.partition("__MEM_CHECK__")
+
+    # Parse (canonical_slug, retry_type, csv_path) from filenames.
+    # Filenames use EC2 directory names (e.g. "smithsonian-upload-retry.csv") which may
+    # differ from canonical slugs (e.g. "si"); resolve via alias table.
+    retry_targets: list[tuple[str, str, str]] = []
+    for line in find_part.splitlines():
+        csv_path = line.strip()
+        if not csv_path:
+            continue
+        filename = csv_path.rsplit("/", 1)[-1]
+        if filename.endswith("-download-retry.csv"):
+            csv_partner_dir = filename[: -len("-download-retry.csv")]
+            retry_type = "download"
+        elif filename.endswith("-upload-retry.csv"):
+            csv_partner_dir = filename[: -len("-upload-retry.csv")]
+            retry_type = "upload"
+        else:
+            logging.warning("Unexpected CSV filename: %s", filename)
+            continue
+        slug = resolve_slug(csv_partner_dir)
+        if slug is None:
+            logging.warning(
+                "Unknown partner in retry CSV filename: %s", csv_partner_dir
+            )
+            continue
+        retry_targets.append((slug, retry_type, csv_path))
+
+    if not retry_targets:
+        _slack_fail(
+            response_url,
+            "⚠️ Log scan found failures but no retry CSVs were created.",
+        )
+
+    mem_parts = mem_out.split()
+    if len(mem_parts) != 2:
+        _slack_fail(response_url, f"⚠️ Unexpected memory output: {mem_out!r}")
+    try:
+        total_mb, available_mb = int(mem_parts[0]), int(mem_parts[1])
+        pct_available = available_mb * 100 // total_mb
+    except (ValueError, ZeroDivisionError) as e:
+        _slack_fail(response_url, f"⚠️ Could not parse memory output ({mem_out!r}): {e}")
+    print(f"Memory: {pct_available}% available ({available_mb} MB of {total_mb} MB).")
+    if pct_available < MEMORY_HEADROOM_PCT:
+        _slack_fail(
+            response_url,
+            f"⚠️ Only {pct_available}% memory available"
+            f" ({available_mb} MB of {total_mb} MB)."
+            f" Threshold is {MEMORY_HEADROOM_PCT}%.",
+        )
+
+    # Build tmux pipeline command. Each target block exports WIKIMEDIA_SESSION_LABEL,
+    # runs the appropriate commands in the partner directory, and posts a failure
+    # notification if the block exits non-zero before continuing to the next target.
+    session_name = f"wikimedia-retry-{days}d"
+    if partner:
+        session_name += f"-{partner}"
+
+    notify_fail_cmd = (
+        "python3 -c "
+        "'from ingest_wikimedia.slack import notify_pipeline_fail; notify_pipeline_fail()'"
+    )
+    setup = " && ".join(
+        [
+            "source ~/.bashrc",
+            "source /home/ec2-user/ingest-wikimedia/.venv/bin/activate",
+        ]
+    )
+
+    target_blocks = []
+    for slug, retry_type, csv_path in retry_targets:
+        pdir = PARTNER_DIR.get(slug, slug)
+        base = shlex.quote(f"/home/ec2-user/ingest-wikimedia/{pdir}")
+        session_label = f"retry-{slug}-{retry_type}"
+        label_export = (
+            f"export WIKIMEDIA_SESSION_LABEL={shlex.quote(session_label)}; "
+            "unset WIKIMEDIA_SINGLE_ITEM"
+        )
+        quoted_csv = shlex.quote(csv_path)
+        if retry_type == "download":
+            steps = [
+                f"cd {base}",
+                f"downloader {quoted_csv} {slug}",
+                f"uploader {quoted_csv} {slug}",
+            ]
+        else:
+            steps = [
+                f"cd {base}",
+                f"uploader {quoted_csv} {slug}",
+            ]
+        target_steps = " && ".join(steps)
+        target_blocks.append(
+            f"{label_export}; {{ {target_steps}; }}"
+            f" || {{ {notify_fail_cmd} >/dev/null 2>&1 || true; }}"
+        )
+
+    pipeline_cmd = f"{setup} && {{ {'; '.join(target_blocks)}; }}"
+
+    # Post launch notification before starting the session.
+    if slack_token:
+        target_summary = ", ".join(
+            f"`{slug}` ({rtype})" for slug, rtype, _ in retry_targets
+        )
+        msg = (
+            f"🔁 Launching `{session_name}`: {target_summary}"
+            f" ({days} day{'s' if days != 1 else ''} of log history)."
+        )
+        try:
+            post_message(slack_token, msg)
+        except Exception as e:
+            logging.warning("Slack notification failed: %s", e)
+
+    # Kill any existing session with the same name (retries are idempotent) and launch.
+    print(f"Launching {session_name}...")
+    tmux_cmd = (
+        f"tmux kill-session -t {shlex.quote(session_name)} 2>/dev/null || true; "
+        f"tmux new-session -d -s {shlex.quote(session_name)}"
+        " -c /home/ec2-user/ingest-wikimedia/"
+        f' "{pipeline_cmd}" && echo SESSION_STARTED'
+    )
+    tmux_out = ""
+    try:
+        tmux_out = ssm_run(ssm, tmux_cmd)
+    except Exception as e:
+        _slack_fail(
+            response_url, f"⚠️ Failed to launch tmux session `{session_name}`: {e}"
+        )
+    if "SESSION_STARTED" not in tmux_out:
+        _slack_fail(
+            response_url,
+            f"⚠️ `{session_name}` failed to start — tmux could not create session."
+            " Check the GitHub Actions run for details.",
+        )
+    print(f"Session {session_name} confirmed running.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Lambda handler** (`lambda/wikimedia-slack-dispatch/handler.py`): adds a `retry` subcommand to `/wikimedia-upload`. Parses `retry <days> [<partner>]`, validates that `days` is a positive integer, resolves the optional partner to a canonical slug, and dispatches `wikimedia-retry.yml` with `days`, `partner`, and `response_url` inputs. Returns an immediate ephemeral ack; results post to #tech-alerts once the workflow completes.
- **New workflow** (`.github/workflows/wikimedia-retry.yml`): mirrors `wikimedia-launch.yml` structure. Pulls latest EC2 code, runs `get-ids-retry` to scan the last N days of logs for transient Wikimedia/download failures, checks available instance memory (≥30% required), then launches a named tmux session that chains `downloader + uploader` (for download failures) or `uploader` only (for upload failures) per affected partner.
- **New script** (`scripts/wikimedia_retry.py`): orchestrates the retry pipeline via SSM. Key details:
  - Converts canonical slugs to EC2 directory names before passing `--partner` to `get-ids-retry` (handles `si` → `smithsonian`)
  - Parses retry CSV filenames back to canonical slugs via `resolve_slug` for tmux command construction
  - Combines `find` + `free -m` into a single SSM round-trip using a `__MEM_CHECK__` delimiter
  - Posts 🔍 "no failures found" or 🔁 "launching session" Slack notifications
  - Validates the `response_url` is a genuine `https://hooks.slack.com/commands/` URL before using it for ephemeral replies

## Test plan

- [ ] Dispatch `wikimedia-retry.yml` manually via GitHub Actions UI with `days=1` and no partner — verify it runs `get-ids-retry --output-dir /home/ec2-user/ingest-wikimedia/retry` and either reports no failures or launches the appropriate tmux sessions
- [ ] Test `/wikimedia-upload retry 7` from Slack — confirm immediate ack, then results in #tech-alerts
- [ ] Test `/wikimedia-upload retry 14 nara` — confirm partner slug resolves and `--partner nara` is passed to `get-ids-retry`
- [ ] Test invalid days (`/wikimedia-upload retry abc`) — confirm ephemeral error reply
- [ ] Test unknown partner (`/wikimedia-upload retry 7 bogus`) — confirm ephemeral error reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a `/wikimedia-upload retry <days> [<partner>]` Slack subcommand and orchestration to locate and relaunch transient Wikimedia ingest failures from the last N days of logs. It includes three parts: a Lambda handler extension, a new GitHub Actions workflow, and a new EC2 orchestration script.

### Changes

- Lambda handler (lambda/wikimedia-slack-dispatch/handler.py)
  - Adds `retry <days> [<partner>]` parsing and validation (days must be a positive integer).
  - Resolves optional partner input to a canonical slug via resolve_slug.
  - Dispatches the new `wikimedia-retry.yml` workflow with inputs: `days`, `partner` (empty if omitted), and `response_url`.
  - Propagates an `ephemeral` flag so the retry subcommand sends an immediate ephemeral acknowledgement to the Slack caller; usage/validation errors are also returned ephemerally.
  - Forwards ephemeral reply capability and ensures `response_url` is accepted only when it looks like a Slack hooks command URL (SSRF mitigation).

- GitHub Actions workflow (.github/workflows/wikimedia-retry.yml)
  - New manual/workflow_dispatch workflow named "Wikimedia Upload Retry" with inputs `days` (required), `partner` (optional), and `response_url` (optional).
  - Runs on ubuntu-latest, installs pinned Python deps (boto3==1.42.87, requests==2.32.5), and executes `python scripts/wikimedia_retry.py` with environment secrets for AWS and Slack.
  - Concurrency keyed by partner to avoid overlapping retry runs for the same partner.

- Orchestration script (scripts/wikimedia_retry.py)
  - New executable script that:
    - Validates `--days > 0`, optional `--partner`, and only accepts `--response-url` values beginning with https://hooks.slack.com/commands/ for ephemeral replies.
    - Updates EC2 code checkout (optionally pinned to GITHUB_SHA) via SSM, runs `get-ids-retry <days>` (scoped to partner's EC2 directory name when provided) and writes retry CSVs under RETRY_DIR.
    - Combines `find` and `free -m` into a single SSM round-trip to list retry CSVs and check instance memory in one call.
    - Exits with an optional Slack notification when no retryable failures are found; otherwise parses retry CSV filenames back to canonical slugs, validates memory headroom (MEMORY_HEADROOM_PCT = 30), and constructs a tmux session to run downloader+uploader (for download failures) or uploader-only (for upload failures) per partner.
    - Kills existing tmux session with the same name, starts a detached session, verifies startup, and posts failure messages to Slack when appropriate.
  - Adds module-level constants RETRY_DIR and MEMORY_HEADROOM_PCT and helper function _slack_fail.

### Deployments, triggers & infra impact

- Manual triggers:
  - The GitHub Actions workflow is workflow_dispatch (can be manually triggered); the Lambda handler dispatches it programmatically.
  - Lambda code changes must be deployed (Lambda redeploy) for the new Slack subcommand to take effect.
- Secrets / environment variables:
  - No new AWS Secrets Manager keys or repository secrets are introduced by this PR.
  - The workflow and script use existing secrets/env vars:
    - WIKIMEDIA_AWS_ACCESS_KEY_ID / WIKIMEDIA_AWS_SECRET_ACCESS_KEY (workflow uses these for AWS access via env)
    - DPLA_SLACK_BOT_TOKEN (optional; used for posting notifications)
    - GH_TOKEN on the Lambda (used to dispatch workflows)
  - No ECS task definitions, CodePipeline/CodeBuild, or IAM policy changes are included in this PR.
- Infrastructure / permissions:
  - Workflow requires only repository contents:read permission; EC2 orchestration uses AWS SSM (SSM send-command via credentials supplied).
  - The new workflow and script interact with EC2 via SSM and rely on existing SSM IAM access configured for the provided AWS credentials.

### Public API / UX changes

- Adds a new public-facing Slack subcommand: `/wikimedia-upload retry <days> [<partner>]`. The Lambda handler returns an immediate ephemeral acknowledgement while the workflow performs the scan and run; results are posted to `#tech-alerts` upon workflow completion.

### Security considerations

- Validates Slack request signatures in the Lambda handler as before.
- Restricts `response_url` accepted by the orchestration script to Slack command hooks (prefix https://hooks.slack.com/commands/) to mitigate SSRF.
- The PR also ensures ephemeral replies are used for immediate ack/errors and redacts or avoids logging sensitive `response_url` tokens (commit-level changes note redaction of response_url in logs).
- Shell command construction in the script uses shlex.quote() or equivalent to reduce command-injection risk.

### Database / migrations

- None.

### Other notes / testing

- Test plan included in PR description: manual workflow dispatch, Slack command variants, validation of invalid days/unknown partners, and verification of ephemeral ack behavior.
- Estimated review effort: Medium for workflow and Lambda changes; High for the new orchestration script (larger surface area and SSM/tmux orchestration).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->