### PR TITLE
Fix fileexists-shared-forbidden by resolving title-drift redirects

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -70,7 +70,9 @@ def get_page_title(
         .replace("/", "-")
         .replace(":", "-")
         .replace("#", "-")
-        .replace("|", "-")  # wikitext table/link syntax; breaks Commons extension detection
+        .replace(
+            "|", "-"
+        )  # wikitext table/link syntax; breaks Commons extension detection
         .replace(
             "\ufffd", "\u2019"
         )  # Unicode replacement char → right single quote (corrupted metadata)
@@ -226,6 +228,33 @@ def get_wikidata_site() -> BaseSite:
     site = pywikibot.Site("wikidata", "wikidata")
     site.login()
     return site
+
+
+COMMONSDELINKER_PAGE = "User:CommonsDelinker/commands/filemovers"
+_COMMONSDELINKER_REASON = (
+    "[[COM:FR|File renamed]]: [[COM:FR#FR1|Criterion 1]] (original uploader's request)"
+)
+
+
+def post_commonsdelinker_request(
+    site: BaseSite, old_filename: str, new_filename: str
+) -> None:
+    """Append a universal-replace request to CommonsDelinker's filemovers page.
+
+    Both filenames should be bare (without the 'File:' namespace prefix).
+    Each call makes one edit, matching the one-request-per-edit convention
+    used by other editors on that page.
+    """
+    page = pywikibot.Page(site, COMMONSDELINKER_PAGE)
+    template = (
+        f"{{{{universal replace"
+        f"|{old_filename}"
+        f"|{new_filename}"
+        f"|reason={_COMMONSDELINKER_REASON}}}}}"
+    )
+    summary = f"universal replace: [[File:{old_filename}]] → [[File:{new_filename}]]"
+    page.text = page.text.rstrip("\n") + "\n" + template
+    page.save(summary=summary, minor=False)
 
 
 def wiki_file_exists(site: BaseSite, sha1: str) -> bool:

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -5,7 +5,10 @@ import random
 import time
 from collections import Counter
 
+from botocore.exceptions import ClientError
+
 import click
+import pywikibot
 from pywikibot.site import BaseSite
 
 from tqdm import tqdm
@@ -55,6 +58,7 @@ from ingest_wikimedia.wikimedia import (
     ERROR_BACKEND_FAIL,
     get_site,
     get_wikidata_site,
+    post_commonsdelinker_request,
 )
 
 MAX_UPLOAD_RETRIES = 3
@@ -211,6 +215,25 @@ class Uploader:
 
                 wiki_file_page = get_page(self.site, page_title)
 
+                # If the intended title is a redirect caused by title drift,
+                # move the file there first so the upload lands at the right name.
+                if wiki_file_page.isRedirectPage():
+                    resolved = self._resolve_redirect_move(wiki_file_page, dpla_id)
+                    if resolved:
+                        wiki_file_page = resolved
+
+                # Use direct upload (chunk_size=0) + ignore_warnings=True when the
+                # file page already exists. The stash-commit path raises
+                # fileexists-shared-forbidden even on valid overwrites; the direct
+                # path with ignorewarnings=1 bypasses it. True (vs IGNORE_WIKIMEDIA_WARNINGS)
+                # is intentional — for an overwrite we want to suppress all warnings,
+                # including 'exists' variants that would fire on the direct path.
+                file_exists = (
+                    wiki_file_page.exists() and not wiki_file_page.isRedirectPage()
+                )
+                chunk_size = 0 if file_exists else WMC_UPLOAD_CHUNK_SIZE
+                upload_warnings = True if file_exists else IGNORE_WIKIMEDIA_WARNINGS
+
                 result = None
                 for attempt in range(1, MAX_UPLOAD_RETRIES + 1):
                     try:
@@ -219,9 +242,9 @@ class Uploader:
                             source_filename=temp_file.name,
                             comment=upload_comment,
                             text=wiki_markup,
-                            ignore_warnings=IGNORE_WIKIMEDIA_WARNINGS,
+                            ignore_warnings=upload_warnings,
                             asynchronous=True,
-                            chunk_size=WMC_UPLOAD_CHUNK_SIZE,
+                            chunk_size=chunk_size,
                         )
                         break
                     except Exception as ex:
@@ -261,6 +284,48 @@ class Uploader:
         finally:
             self.local_fs.clean_up_tmp_file(temp_file)
 
+    def _resolve_redirect_move(
+        self,
+        wiki_file_page: pywikibot.FilePage,
+        dpla_id: str,
+    ) -> pywikibot.FilePage | None:
+        """
+        If wiki_file_page is a redirect whose target filename contains dpla_id,
+        this is a title-drift case: move the file to the intended title and post
+        a CommonsDelinker request. Returns a fresh FilePage for the intended title
+        on success, or None if the redirect is not a title-drift case.
+        """
+        redirect_target = wiki_file_page.getRedirectTarget()
+        if dpla_id not in redirect_target.title():
+            logging.warning(
+                f"Redirect at intended title {wiki_file_page.title()} points to "
+                f"{redirect_target.title()} which does not share DPLA ID {dpla_id} "
+                f"— cannot auto-resolve; upload will fail"
+            )
+            return None
+
+        old_filename = redirect_target.title(with_ns=False)
+        new_filename = wiki_file_page.title(with_ns=False)
+        reason = (
+            f"Title drift correction: updating to current DPLA title "
+            f"(DPLA ID {dpla_id})"
+        )
+
+        logging.info(
+            f"Title drift redirect detected — moving "
+            f"[[File:{old_filename}]] → [[File:{new_filename}]]"
+        )
+        redirect_target.move(
+            wiki_file_page.title(),
+            reason=reason,
+            movetalk=False,
+            noredirect=False,  # leave a redirect at the old title
+        )
+        post_commonsdelinker_request(self.site, old_filename, new_filename)
+
+        # Fresh FilePage for the now-real file page at the intended title
+        return get_page(self.site, wiki_file_page.title())
+
     def process_item(
         self,
         dpla_id: str,
@@ -282,6 +347,13 @@ class Uploader:
             provider, data_provider = self.dpla.get_provider_and_data_provider(
                 item_metadata, providers_json
             )
+
+            if not self.dpla.is_wiki_eligible(
+                dpla_id, item_metadata, provider, data_provider
+            ):
+                logging.info(f"Skipping {dpla_id}: Not eligible.")
+                self.tracker.increment(Result.SKIPPED)
+                return
 
             if self.category_ensurer:
                 institution_name = get_str(
@@ -320,21 +392,24 @@ class Uploader:
             if len(files) > 1:
                 for i in range(1, len(files) + 1):
                     s3_path = self.s3_client.get_media_s3_path(dpla_id, i, partner)
-                    if self.s3_client.s3_file_exists(s3_path):
+                    try:
                         s3_obj = self.s3_client.get_s3().Object(S3_BUCKET, s3_path)
                         mime = s3_obj.content_type
-                        # Skip generic MIME types — process_file re-detects these
-                        # via libmagic, so the real extension isn't known yet.
-                        # Excluding them avoids grouping files whose true types differ.
-                        # Also skip download-only types (e.g. video) — they are never
-                        # uploaded so they should not influence page numbering.
-                        if mime not in (
-                            "application/octet-stream",
-                            "binary/octet-stream",
-                        ) and not is_download_only(mime):
-                            ext = mimetypes.guess_extension(mime)
-                            if ext and ext != MIME_UNKNOWN_EXT:
-                                ordinal_exts[i] = ext
+                    except ClientError:
+                        continue
+                    # Download-only types (e.g. video) are never uploaded, so they
+                    # should not influence page numbering.
+                    if is_download_only(mime):
+                        continue
+                    # Generic MIME types are re-detected by libmagic in process_file;
+                    # use "" as a placeholder so they still get unique page labels.
+                    if mime in ("application/octet-stream", "binary/octet-stream"):
+                        ordinal_exts[i] = ""
+                        continue
+                    ext = mimetypes.guess_extension(mime)
+                    # Use "" for unresolvable extensions — process_file will skip
+                    # them, but the placeholder prevents page-title collisions.
+                    ordinal_exts[i] = ext if ext and ext != MIME_UNKNOWN_EXT else ""
 
             ext_counts: Counter[str] = Counter(ordinal_exts.values())
             ext_seen: Counter[str] = Counter()

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -396,6 +396,7 @@ class Uploader:
                         s3_obj = self.s3_client.get_s3().Object(S3_BUCKET, s3_path)
                         mime = s3_obj.content_type
                     except ClientError:
+                        ordinal_exts[i] = ""
                         continue
                     # Download-only types (e.g. video) are never uploaded, so they
                     # should not influence page numbering.


### PR DESCRIPTION
## Problem

When DPLA item titles change over time (title drift), the intended Commons filename differs from the originally uploaded filename. Both share the same DPLA ID. After title drift, the intended title may be a redirect pointing to the old title. The uploader followed that redirect and hit `fileexists-shared-forbidden` from the stash-commit path, then counted the item as SKIPPED — leaving the wrong image at the wrong title on Commons.

## Solution

Before uploading, detect if the intended title is a redirect whose target filename contains the same DPLA ID. If so:

1. **Move** the existing file from the old title to the intended title (overwriting the redirect)
2. **Post a CommonsDelinker `{{universal replace}}` request** so other wiki transclusions are updated
3. **Upload** using the direct path (`chunk_size=0` + `ignore_warnings=True`) to overwrite the now-real file page, bypassing `fileexists-shared-forbidden`

If the redirect target does NOT share the DPLA ID, the upload proceeds unchanged (and will still fail with the original error, logged as a warning).

When the intended title is an existing real file page (not a redirect), the same direct-path overwrite is used.

## Other changes

- Restores `is_wiki_eligible()` check in `process_item` that was missing
- Pre-scan ordinal logic: replaces `s3_file_exists()` + `Object()` two-call pattern with `try/except ClientError`; adds `""` placeholder entries for octet-stream/unresolvable files to prevent page-title collisions on multi-file items

## Test plan

- [x] Manual move tested via `tools/test_move_over_redirect.py` — DPLA bot confirmed able to move a file over a redirect on Commons
- [x] CommonsDelinker request format tested via `tools/test_commonsdelinker_request.py` — entries appended correctly
- [ ] Run Ohio upload session that includes items `05e72b3901e433c5878231d9ade05a7c` and `bb1689e59809702ce0c10bc99b948251` to verify the full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Pull Request Summary: Fix fileexists-shared-forbidden by resolving title-drift redirects

## Overview
This PR fixes an upload failure caused by DPLA title drift where the intended Commons filename may be a redirect to an old filename that contains the same DPLA ID. Previously, following such redirects could hit `fileexists-shared-forbidden`, mark the item SKIPPED, and leave the wrong image at the wrong title on Commons. The PR detects and resolves those title-drift redirects so the intended title is used and transclusions are updated.

## Key Changes

### Problem-resolution workflow
- Detect when the intended Commons title is a redirect whose redirect target filename contains the same DPLA ID.
- If so:
  1. Move the existing file from the redirect/old title to the intended title (overwriting the redirect).
  2. Post a CommonsDelinker `{{universal replace ...}}` request to update transclusions.
  3. Upload via the direct path (chunk_size=0, ignore_warnings=True) to overwrite the now-real file page and bypass `fileexists-shared-forbidden`.
- If the redirect target does not include the DPLA ID, behavior is unchanged (upload will fail and be logged as a warning).
- If the intended title already exists as a real file page (not a redirect), use the direct-path overwrite flow.

### Code changes
- ingest_wikimedia/wikimedia.py
  - Added constants:
    - COMMONSDELINKER_PAGE = "User:CommonsDelinker/commands/filemovers"
    - _COMMONSDELINKER_REASON (standardized rename reason)
  - Added helper: post_commonsdelinker_request(site, old_filename, new_filename)
  - Minor refactor to get_page_title() escaping logic

- tools/uploader.py
  - Added Uploader._resolve_redirect_move(wiki_file_page, dpla_id) to handle redirect resolution and file moves
  - Restored is_wiki_eligible() check in process_item() to gate uploads early for ineligible items
  - S3 pre-scan robustness:
    - Replace s3_file_exists() + Object() pattern with try/except ClientError per-object
    - Insert "" placeholder extensions for octet-stream/unresolvable files to preserve ordinal slots and avoid page-title collisions on multi-file items
  - Improved upload-path selection: detect existing file pages and select chunk_size=0 / ignore_warnings appropriately for overwrites
  - Various small refactors and improved error handling

## Testing
- Manual move-over-redirect tested via tools/test_move_over_redirect.py
- CommonsDelinker request format tested via tools/test_commonsdelinker_request.py
- End-to-end verification pending: planned Ohio upload session including two specified items

## Infrastructure, deployment, and security notes (explicit)
- Deployment: Requires normal code redeployment/CI; no special manual pipeline trigger beyond standard CI/CD. The uploader code must be redeployed before running upload sessions.
- Environment / Secrets: No environment variables or AWS Secrets Manager keys added, removed, or renamed.
- Database migrations: None.
- Shared infrastructure: No changes to CodePipeline, CodeBuild, ECS task definitions, or IAM policies.
- Public API: No changes to API endpoints or response shapes.
- Dependencies: No new external package dependencies introduced.
- Security: No changes to authentication, credential handling, or external data inputs beyond existing pywikibot/boto3 usage.

## Miscellaneous
- Commit-level note: when S3 pre-scan raises ClientError for an object, the code preserves the ordinal slot by inserting "" to avoid page-label collisions for multi-file items.
- Estimated review effort: Medium (ingest_wikimedia/wikimedia.py) / High (tools/uploader.py).

## Outstanding
- Run the Ohio upload session for full end-to-end verification (pending).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->