### PR TITLE
wikimedia_retry: mkdir -p retry dir before running get-ids-retry

### DIFF
--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -107,6 +107,7 @@ def main() -> None:
         f"Scanning logs for retryable failures in the last {days} day(s){partner_desc}..."
     )
     scan_cmd = (
+        f"mkdir -p {shlex.quote(RETRY_DIR)} && "
         "source /home/ec2-user/ingest-wikimedia/.venv/bin/activate && "
         "cd /home/ec2-user/ingest-wikimedia && "
         f"get-ids-retry {days}"


### PR DESCRIPTION
## Summary

The `retry/` directory on EC2 can be owned by root if it was previously created by a direct SSM command (which runs as the SSM default user, root, rather than ec2-user). When `wikimedia_retry.py` then runs `get-ids-retry` via `ssm_run` (which executes as ec2-user), writing the output CSV fails with `PermissionError` even though the directory exists.

Fix: prepend `mkdir -p <RETRY_DIR>` to the scan command so that ec2-user always owns the directory before `get-ids-retry` tries to write into it.

## Root cause

First `/wikimedia-upload retry` run failed with:
```
PermissionError: [Errno 13] Permission denied: '/home/ec2-user/ingest-wikimedia/retry/nara-upload-retry.csv'
```
`ls -la` showed `retry/` and all its files owned by `root` — the directory was created by a prior manual `get-ids-retry` run sent via raw SSM (not `sudo -u ec2-user`).

The existing EC2 directory was fixed with `chown -R ec2-user:ec2-user`; this change prevents recurrence.

## Test plan

- [ ] Re-run `/wikimedia-upload retry 1` from Slack and confirm it completes past the scan step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes a permission issue in the automated wikimedia retry pipeline where the `retry/` directory on EC2 becomes owned by `root` when initially created via SSM commands (which run as root). When `wikimedia_retry.py` subsequently attempts to write retry CSV files to this directory as the `ec2-user`, it fails with a `PermissionError`.

## Changes

**scripts/wikimedia_retry.py**: Prepends `mkdir -p {RETRY_DIR} &&` to the scan command string (line 110), ensuring the directory is created with proper ownership by `ec2-user` before the SSM command executes and writes output files.

## Details

- **Lines changed**: +1/-0
- **No impact on**: Environment variables, AWS Secrets Manager keys, database migrations, infrastructure configuration, public APIs, or authentication mechanisms
- **Test plan**: Re-run `/wikimedia-upload` retry from Slack to confirm completion past the scan step

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->