### PR TITLE
wikimedia_retry: one tmux block per hub, combine download+upload failures

### DIFF
--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -225,8 +225,9 @@ def main() -> None:
 
     # Build one tmux block per hub. Download and upload failures for the same hub
     # are combined: downloader runs on the download CSV, then uploader runs on each
-    # CSV in turn. The uploader is idempotent (skips already-uploaded files), so
-    # running it on the download CSV then the upload CSV is always safe.
+    # CSV in turn. Running the uploader on the download CSV then the upload CSV is
+    # safe: the uploader checks each file's SHA-1 against Commons before uploading
+    # and skips files already present, so re-running on overlapping IDs is harmless.
     target_blocks = []
     for slug, type_csvs in hub_csvs.items():
         pdir = PARTNER_DIR.get(slug, slug)

--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -155,10 +155,11 @@ def main() -> None:
         _slack_fail(response_url, "⚠️ Unexpected output from find + memory check.")
     find_part, _, mem_out = combined_out.partition("__MEM_CHECK__")
 
-    # Parse (canonical_slug, retry_type, csv_path) from filenames.
+    # Parse retry CSVs into a per-hub map: slug → {retry_type: csv_path}.
     # Filenames use EC2 directory names (e.g. "smithsonian-upload-retry.csv") which may
     # differ from canonical slugs (e.g. "si"); resolve via alias table.
-    retry_targets: list[tuple[str, str, str]] = []
+    # Insertion order is preserved (find | sort), so hubs run in a stable sequence.
+    hub_csvs: dict[str, dict[str, str]] = {}
     for line in find_part.splitlines():
         csv_path = line.strip()
         if not csv_path:
@@ -179,9 +180,9 @@ def main() -> None:
                 "Unknown partner in retry CSV filename: %s", csv_partner_dir
             )
             continue
-        retry_targets.append((slug, retry_type, csv_path))
+        hub_csvs.setdefault(slug, {})[retry_type] = csv_path
 
-    if not retry_targets:
+    if not hub_csvs:
         _slack_fail(
             response_url,
             "⚠️ Log scan found failures but no retry CSVs were created.",
@@ -222,27 +223,27 @@ def main() -> None:
         ]
     )
 
+    # Build one tmux block per hub. Download and upload failures for the same hub
+    # are combined: downloader runs on the download CSV, then uploader runs on each
+    # CSV in turn. The uploader is idempotent (skips already-uploaded files), so
+    # running it on the download CSV then the upload CSV is always safe.
     target_blocks = []
-    for slug, retry_type, csv_path in retry_targets:
+    for slug, type_csvs in hub_csvs.items():
         pdir = PARTNER_DIR.get(slug, slug)
         base = shlex.quote(f"/home/ec2-user/ingest-wikimedia/{pdir}")
-        session_label = f"retry-{slug}-{retry_type}"
+        session_label = f"retry-{slug}"
         label_export = (
             f"export WIKIMEDIA_SESSION_LABEL={shlex.quote(session_label)}; "
             "unset WIKIMEDIA_SINGLE_ITEM"
         )
-        quoted_csv = shlex.quote(csv_path)
-        if retry_type == "download":
-            steps = [
-                f"cd {base}",
-                f"downloader {quoted_csv} {slug}",
-                f"uploader {quoted_csv} {slug}",
-            ]
-        else:
-            steps = [
-                f"cd {base}",
-                f"uploader {quoted_csv} {slug}",
-            ]
+        download_csv = type_csvs.get("download")
+        upload_csv = type_csvs.get("upload")
+        steps = [f"cd {base}"]
+        if download_csv:
+            steps.append(f"downloader {shlex.quote(download_csv)} {slug}")
+            steps.append(f"uploader {shlex.quote(download_csv)} {slug}")
+        if upload_csv:
+            steps.append(f"uploader {shlex.quote(upload_csv)} {slug}")
         target_steps = " && ".join(steps)
         target_blocks.append(
             f"{label_export}; {{ {target_steps}; }}"
@@ -253,9 +254,7 @@ def main() -> None:
 
     # Post launch notification before starting the session.
     if slack_token:
-        target_summary = ", ".join(
-            f"`{slug}` ({rtype})" for slug, rtype, _ in retry_targets
-        )
+        target_summary = ", ".join(f"`{slug}`" for slug in hub_csvs)
         msg = (
             f"🔁 Launching `{session_name}`: {target_summary}"
             f" ({days} day{'s' if days != 1 else ''} of log history)."


### PR DESCRIPTION
## Summary

- Previously each `(hub, retry_type)` pair produced a separate tmux block with its own `WIKIMEDIA_SESSION_LABEL`, generating two Slack phase-start notifications per hub when both download and upload failures existed. The label suffix (`-download` / `-upload`) also confused the failure cause with the pipeline stage actually running.
- Now one block per hub handles both retry types: downloader runs on the download CSV (if any), then uploader runs on the download CSV, then uploader runs on the upload CSV (if any). The uploader is idempotent so running it on both CSVs is safe.
- Session labels drop the retry-type suffix (`retry-indiana` instead of `retry-indiana-download`), and the launch notification lists each hub once.

## Test plan

- [ ] Run `/wikimedia-upload retry 1` when at least one hub has both download and upload failures — confirm one Slack launch line per hub (not two) and one session label in the tmux output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## wikimedia_retry: group download and upload retries into one block per hub

Refactors the retry orchestration script to group retry work by hub rather than by (hub, retry_type) pair. Previously, each hub with both download and upload failures would generate two separate tmux blocks and two Slack phase-start notifications. Now a single tmux block per hub handles both failure types in sequence: downloader runs on the download CSV (if present), followed by uploader on the download CSV, then uploader on the upload CSV (if present).

Key changes:
- Session labels simplified from `retry-{slug}-{retry_type}` to `retry-{slug}`
- Internal data structure changed from a list of `(slug, retry_type, csv_path)` tuples to a per-hub dictionary mapping retry types to CSV paths (`hub_csvs`)
- tmux pipeline now creates one block per hub and conditionally chains: downloader → uploader(download CSV) → uploader(upload CSV)
- Slack launch notification now lists each hub once instead of once per retry type
- Uploader is treated as idempotent, so running it on both CSVs is safe
- No changes to exported/public function signatures in scripts/wikimedia_retry.py

Operational impacts and special notes:
- No infrastructure changes required (no CodePipeline/CodeBuild/ECS task definition/IAM changes)
- No environment variables or AWS Secrets Manager keys added/removed/renamed
- No database migrations
- No public API response or endpoint changes
- No authentication or credential handling changes beyond the existing script behavior

Deployment / runtime:
- No manual pipeline trigger or ECS redeployment is required for this script change to take effect if the updated code is already deployed. (If the change is only present in source and not yet deployed, deploy/push the new code through your normal release process.)
- Test plan: run `/wikimedia-upload retry 1` when at least one hub has both download and upload failures; confirm one Slack launch line per hub and a single `retry-{slug}` session label in tmux output.

Lines changed: +21 / -21
Estimated review effort: Medium

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->