### PR TITLE
wikimedia_upload_status: show real phase for retry sessions

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -13,7 +13,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import boto3
 import requests
 
-from ingest_wikimedia.partners import PARTNER_DIR, parse_session_labels
+from ingest_wikimedia.partners import PARTNER_DIR, parse_session_labels, resolve_slug
 from ingest_wikimedia.ssm import REGION, ssm_run
 
 SLACK_CHANNEL = "C02HEU2L3"
@@ -186,7 +186,50 @@ def main() -> None:
     results: dict[str, str] = {}
 
     def fetch(session: str) -> tuple[str, str]:
-        labels = parse_session_labels(session.removeprefix("wikimedia-"))
+        suffix = session.removeprefix("wikimedia-")
+
+        # Retry sessions are named wikimedia-retry-<days>d[-<partner>].
+        # parse_session_labels doesn't recognise the retry- prefix, so resolve
+        # the active hub by finding the most recently modified retry-* log.
+        if suffix.startswith("retry-"):
+            try:
+                find_out = ssm_run(
+                    ssm,
+                    "find /home/ec2-user/ingest-wikimedia"
+                    " -mindepth 3 -maxdepth 3 -path '*/logs/retry-*'"
+                    r" -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1",
+                )
+            except Exception:
+                logging.exception("Failed to find retry logs for %s", session)
+                return session, "Unknown (error)"
+            line = find_out.strip()
+            if not line:
+                return session, "Starting..."
+            # Output format: "<epoch.ns> <absolute-path>"
+            # e.g. "1747601234.0000000000 /home/ec2-user/ingest-wikimedia/indiana/logs/retry-indiana-upload.log"
+            _, _, log_path = line.partition(" ")
+            log_filename = log_path.rsplit("/", 1)[-1]
+            if log_filename.endswith("-download.log"):
+                label = log_filename[: -len("-download.log")]
+            elif log_filename.endswith("-upload.log"):
+                label = log_filename[: -len("-upload.log")]
+            else:
+                return session, f"Unknown (unrecognised log: {log_filename!r})"
+            raw_hub = label.removeprefix("retry-")
+            hub = resolve_slug(raw_hub) or raw_hub
+            try:
+                phase = get_phase_and_progress(ssm, session, hub, label)
+            except Exception:
+                logging.exception(
+                    "Failed to get retry status for %s (%s)", session, label
+                )
+                return session, "Unknown (error)"
+            return (
+                session,
+                f"[{label}] {phase}" if phase is not None else f"[{label}] Starting...",
+            )
+
+        labels = parse_session_labels(suffix)
         if not labels:
             return session, "Unknown (unrecognised session name)"
         multi = len(labels) > 1

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -190,33 +190,46 @@ def main() -> None:
 
         # Retry sessions are named wikimedia-retry-<days>d[-<partner>].
         # parse_session_labels doesn't recognise the retry- prefix, so resolve
-        # the active hub by finding the most recently modified retry-* log.
+        # the active hub directly from the session name when a partner is encoded
+        # there, or by finding the most recently modified retry-* log otherwise.
         if suffix.startswith("retry-"):
-            try:
-                find_out = ssm_run(
-                    ssm,
-                    "find /home/ec2-user/ingest-wikimedia"
-                    " -mindepth 3 -maxdepth 3 -path '*/logs/retry-*'"
-                    r" -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1",
-                )
-            except Exception:
-                logging.exception("Failed to find retry logs for %s", session)
-                return session, "Unknown (error)"
-            line = find_out.strip()
-            if not line:
-                return session, "Starting..."
-            # Output format: "<epoch.ns> <absolute-path>"
-            # e.g. "1747601234.0000000000 /home/ec2-user/ingest-wikimedia/indiana/logs/retry-indiana-upload.log"
-            _, _, log_path = line.partition(" ")
-            log_filename = log_path.rsplit("/", 1)[-1]
-            if log_filename.endswith("-download.log"):
-                label = log_filename[: -len("-download.log")]
-            elif log_filename.endswith("-upload.log"):
-                label = log_filename[: -len("-upload.log")]
+            # suffix format: "retry-<days>d" or "retry-<days>d-<partner>"
+            _, _, explicit_partner = suffix.removeprefix("retry-").partition("-")
+
+            if explicit_partner:
+                # Partner encoded in session name — use it directly to avoid
+                # picking up a stale log from a different partner's prior run.
+                hub = resolve_slug(explicit_partner) or explicit_partner
+                label = f"retry-{hub}"
             else:
-                return session, f"Unknown (unrecognised log: {log_filename!r})"
-            raw_hub = label.removeprefix("retry-")
-            hub = resolve_slug(raw_hub) or raw_hub
+                # No explicit partner — discover the active hub from the most
+                # recently modified retry-* log across all partner directories.
+                try:
+                    find_out = ssm_run(
+                        ssm,
+                        "find /home/ec2-user/ingest-wikimedia"
+                        " -mindepth 3 -maxdepth 3 -path '*/logs/retry-*'"
+                        r" -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1",
+                    )
+                except Exception:
+                    logging.exception("Failed to find retry logs for %s", session)
+                    return session, "Unknown (error)"
+                line = find_out.strip()
+                if not line:
+                    return session, "Starting..."
+                # Output format: "<epoch.ns> <absolute-path>"
+                # e.g. "1747601234.0000000000 /home/ec2-user/ingest-wikimedia/indiana/logs/retry-indiana-upload.log"
+                _, _, log_path = line.partition(" ")
+                log_filename = log_path.rsplit("/", 1)[-1]
+                if log_filename.endswith("-download.log"):
+                    label = log_filename[: -len("-download.log")]
+                elif log_filename.endswith("-upload.log"):
+                    label = log_filename[: -len("-upload.log")]
+                else:
+                    return session, f"Unknown (unrecognised log: {log_filename!r})"
+                raw_hub = label.removeprefix("retry-")
+                hub = resolve_slug(raw_hub) or raw_hub
+
             try:
                 phase = get_phase_and_progress(ssm, session, hub, label)
             except Exception:


### PR DESCRIPTION
## Summary

- `wikimedia-retry-<days>d` sessions were showing `Unknown (unrecognised session name)` in `/wikimedia-status` because `parse_session_labels` doesn't recognise the `retry-` prefix
- Detect `wikimedia-retry-*` sessions before calling `parse_session_labels`; run `find` across partner `logs/` directories (depth-bounded with `-mindepth 3 -maxdepth 3`) to find the most recently modified `retry-*` log
- Parse the log filename to recover the hub slug and label (e.g. `retry-indiana`), then delegate to the existing `get_phase_and_progress` for full phase detail
- Falls back to `"Starting..."` if no retry log exists yet

## Test plan

- [ ] Trigger `/wikimedia-upload retry 1` with a known partner that has recent failures
- [ ] Run `/wikimedia-status` while the retry session is active — should show `wikimedia-retry-1d … [retry-<slug>] Uploading (…)` instead of "Unknown"
- [ ] Run `/wikimedia-status` after the retry session completes — session should be absent from output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes session status display for Wikimedia retry sessions in the /wikimedia-status endpoint. Sessions named wikimedia-retry-<days>d (and wikimedia-retry-<days>d-<partner>) are now recognized and the endpoint shows a real phase (e.g., "[retry-indiana] Uploading (...)") instead of "Unknown (unrecognised session name)".

## Changes

scripts/wikimedia_upload_status.py
- Added resolve_slug to imports.
- Extended fetch(session) to detect wikimedia-retry-* sessions before falling back to parse_session_labels:
  - If the retry session name encodes a partner (wikimedia-retry-<days>d-<partner>), resolve that partner directly and set label to retry-<hub> (avoids surfacing stale logs from other partners).
  - If no partner is encoded, find the most recently modified retry-* log across partner logs using a depth-bounded find (-mindepth 3 -maxdepth 3), parse the retry log filename (…-download.log / …-upload.log) to recover label and hub, and delegate to get_phase_and_progress() for phase/progress.
  - Returns "Starting..." when no retry log exists yet; returns "Unknown (error)" on lookup failures; returns "Unknown (unrecognised log: …)" for unexpected log filenames.
- Existing non-retry session handling via parse_session_labels and get_phase_and_progress is unchanged.

## Public API Impact

- Changes the /wikimedia-status Slack output: retry sessions now show resolved retry labels and phase/progress instead of an "Unknown" message. This is a user-visible change to the Slack status text returned by the slash command.

## Deployment / Infra / Config changes

- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No new or renamed environment variables or AWS Secrets Manager keys.
- No manual pipeline trigger or ECS redeployment required beyond the normal deployment of the repository (the script is used by the scheduled GitHub Action / Lambda integration); the change takes effect once the updated code is deployed through the repository's normal process.

## Security

- No authentication/credential handling changes. The change only refines how retry sessions are detected and how logs are located; no new external inputs or secret handling are introduced.

## Testing / Behavior notes

- Test plan: trigger /wikimedia-upload retry 1 with a partner that has recent failures; while retry session is active, /wikimedia-status should show "[retry-<hub>] <phase>" instead of "Unknown"; once retry completes the session should no longer appear in status output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->