### PR TITLE
get_ids_retry: exclude already-uploaded IDs from retry sets

### DIFF
--- a/tools/get_ids_retry.py
+++ b/tools/get_ids_retry.py
@@ -95,31 +95,41 @@ def parse_download_log(path: Path) -> set[str]:
 def collect_partner_ids(partner: str, cutoff: datetime) -> tuple[set[str], set[str]]:
     """Scan logs for *partner* and return (upload_failures, download_failures).
 
-    Only IDs with zero transient upload errors AND at least one successful upload
-    are excluded — they are confirmed fully on Commons.  An ID whose log shows
-    both a success and a transient failure (partial run, or failure then success
-    in the same window) is kept: at least one file may still be missing.
+    Upload logs are processed oldest-first so each run's outcome can supersede
+    the previous one.  For each run an ID is classified as:
+
+      "retry" — had any transient error (even alongside per-file successes);
+                at least one file may be missing from Commons.
+      "done"  — clean upload (no transient errors, at least one success);
+                confirmed fully on Commons for this run.
+
+    An ID that fails in an early run but uploads cleanly in a later run ends up
+    as "done" and is excluded.  An ID with partial success in a single run
+    (some files fail, some succeed) stays "retry".
     """
     log_dir = BASE_DIR / partner / "logs"
-    upload_failures: set[str] = set()
-    upload_successes: set[str] = set()
+    # id → "retry" | "done"; later log files (by mtime) overwrite earlier ones.
+    outcomes: dict[str, str] = {}
     download_failures: set[str] = set()
 
-    for log_file in sorted(log_dir.glob("*-upload.log")):
+    for log_file in sorted(
+        log_dir.glob("*-upload.log"), key=lambda f: f.stat().st_mtime
+    ):
         if datetime.fromtimestamp(log_file.stat().st_mtime, tz=timezone.utc) < cutoff:
             continue
-        failures, successes = parse_upload_log(log_file)
-        upload_failures.update(failures)
-        upload_successes.update(successes)
+        file_failures, file_successes = parse_upload_log(log_file)
+        for dpla_id in file_failures:
+            outcomes[dpla_id] = "retry"
+        for dpla_id in file_successes - file_failures:
+            outcomes[dpla_id] = "done"
 
     for log_file in sorted(log_dir.glob("*-download.log")):
         if datetime.fromtimestamp(log_file.stat().st_mtime, tz=timezone.utc) < cutoff:
             continue
         download_failures.update(parse_download_log(log_file))
 
-    # IDs confirmed fully on Commons: succeeded with no transient errors anywhere in
-    # the window.  IDs in both sets had mixed results — keep them for retry.
-    fully_uploaded = upload_successes - upload_failures
+    upload_failures = {dpla_id for dpla_id, o in outcomes.items() if o == "retry"}
+    fully_uploaded = {dpla_id for dpla_id, o in outcomes.items() if o == "done"}
     download_failures -= fully_uploaded
     # Avoid scheduling the same ID for both retry types.
     upload_failures -= download_failures

--- a/tools/get_ids_retry.py
+++ b/tools/get_ids_retry.py
@@ -53,18 +53,27 @@ DOWNLOAD_FAILED_RE = re.compile(r"Failed: ([0-9a-f]{32})")
 EMPTY_URL_FAILURE = "Failed downloading  to"
 
 
-def parse_upload_log(path: Path) -> set[str]:
-    """Return DPLA IDs that hit transient Wikimedia errors."""
-    failed: set[str] = set()
+def parse_upload_log(path: Path) -> tuple[set[str], set[str]]:
+    """Return (transient_failure_ids, successfully_uploaded_ids) from an upload log.
+
+    transient_failure_ids  — IDs that hit lock-contention or backend-storage errors;
+                             the S3 asset is present but the upload didn't land on Commons.
+    successfully_uploaded_ids — IDs for which at least one file reached Commons ("Uploaded to").
+    """
+    failures: set[str] = set()
+    successes: set[str] = set()
     current_id: str | None = None
     with open(path, errors="replace") as f:
         for line in f:
             m = DPLA_ID_RE.search(line)
             if m:
                 current_id = m.group(1)
-            elif current_id and UPLOAD_TRANSIENT_RE.search(line):
-                failed.add(current_id)
-    return failed
+            elif current_id:
+                if UPLOAD_TRANSIENT_RE.search(line):
+                    failures.add(current_id)
+                elif "Uploaded to" in line:
+                    successes.add(current_id)
+    return failures, successes
 
 
 def parse_download_log(path: Path) -> set[str]:
@@ -84,23 +93,30 @@ def parse_download_log(path: Path) -> set[str]:
 
 
 def collect_partner_ids(partner: str, cutoff: datetime) -> tuple[set[str], set[str]]:
-    """Scan logs for *partner* and return (upload_failures, download_failures)."""
+    """Scan logs for *partner* and return (upload_failures, download_failures).
+
+    IDs that were successfully uploaded within the window are excluded from both
+    sets — they are already on Commons and retrying them would only produce skips.
+    """
     log_dir = BASE_DIR / partner / "logs"
     upload_failures: set[str] = set()
+    upload_successes: set[str] = set()
     download_failures: set[str] = set()
 
-    for pattern, parser, target in (
-        ("*-upload.log", parse_upload_log, upload_failures),
-        ("*-download.log", parse_download_log, download_failures),
-    ):
-        for log_file in sorted(log_dir.glob(pattern)):
-            if (
-                datetime.fromtimestamp(log_file.stat().st_mtime, tz=timezone.utc)
-                < cutoff
-            ):
-                continue
-            target.update(parser(log_file))
+    for log_file in sorted(log_dir.glob("*-upload.log")):
+        if datetime.fromtimestamp(log_file.stat().st_mtime, tz=timezone.utc) < cutoff:
+            continue
+        failures, successes = parse_upload_log(log_file)
+        upload_failures.update(failures)
+        upload_successes.update(successes)
 
+    for log_file in sorted(log_dir.glob("*-download.log")):
+        if datetime.fromtimestamp(log_file.stat().st_mtime, tz=timezone.utc) < cutoff:
+            continue
+        download_failures.update(parse_download_log(log_file))
+
+    upload_failures -= upload_successes
+    download_failures -= upload_successes
     # Avoid scheduling the same ID for both retry types.
     upload_failures -= download_failures
     return upload_failures, download_failures

--- a/tools/get_ids_retry.py
+++ b/tools/get_ids_retry.py
@@ -95,8 +95,10 @@ def parse_download_log(path: Path) -> set[str]:
 def collect_partner_ids(partner: str, cutoff: datetime) -> tuple[set[str], set[str]]:
     """Scan logs for *partner* and return (upload_failures, download_failures).
 
-    IDs that were successfully uploaded within the window are excluded from both
-    sets — they are already on Commons and retrying them would only produce skips.
+    Only IDs with zero transient upload errors AND at least one successful upload
+    are excluded — they are confirmed fully on Commons.  An ID whose log shows
+    both a success and a transient failure (partial run, or failure then success
+    in the same window) is kept: at least one file may still be missing.
     """
     log_dir = BASE_DIR / partner / "logs"
     upload_failures: set[str] = set()
@@ -115,8 +117,10 @@ def collect_partner_ids(partner: str, cutoff: datetime) -> tuple[set[str], set[s
             continue
         download_failures.update(parse_download_log(log_file))
 
-    upload_failures -= upload_successes
-    download_failures -= upload_successes
+    # IDs confirmed fully on Commons: succeeded with no transient errors anywhere in
+    # the window.  IDs in both sets had mixed results — keep them for retry.
+    fully_uploaded = upload_successes - upload_failures
+    download_failures -= fully_uploaded
     # Avoid scheduling the same ID for both retry types.
     upload_failures -= download_failures
     return upload_failures, download_failures


### PR DESCRIPTION
## Summary

- `parse_upload_log` now returns `(failures, successes)` instead of just `failures`, tracking both transient-error IDs and successfully-uploaded IDs in a single log pass
- `collect_partner_ids` subtracts all successfully-uploaded IDs from both `upload_failures` and `download_failures` before returning — items already confirmed on Commons are never scheduled for retry
- Previously, IDs that had failed transiently but were later successfully uploaded (e.g. by a subsequent full run) were still included in retry CSVs, causing retry runs to produce 100% SKIPs with nothing actually repaired

## Root cause

The original `get-ids-retry` scanned for failure log entries without checking whether those items had since been successfully uploaded. A retry run therefore re-queued items that were already on Commons, and the uploader correctly skipped all of them.

## Test plan

- [ ] Run `get-ids-retry <days>` and verify the CSV counts decrease relative to the old version when recent logs contain both failures and subsequent successes for the same IDs
- [ ] Verify items with only transient failures (no subsequent "Uploaded to") still appear in retry CSVs
- [ ] Verify `download_failures` no longer includes IDs that appear as "Uploaded to" in any upload log within the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a bug in the get-ids-retry tool so items that were later confirmed uploaded to Commons are not re-queued for retry.

Summary of changes
- tools/get_ids_retry.py
  - parse_upload_log(path: Path) → tuple[set[str], set[str]]: now returns (transient_failure_ids, successfully_uploaded_ids). It records both transient upload errors (lockmanager/backend patterns) and "Uploaded to" successes in a single pass through each upload log.
  - collect_partner_ids(partner, cutoff) rewritten to:
    - process upload logs oldest-first and track each ID’s most recent outcome (either "retry" if any transient upload error was seen, or "done" if a success was seen and no transient upload errors remain).
    - aggregate upload transient failures and upload successes across upload logs within the cutoff window, letting later logs supersede earlier ones.
    - aggregate download failures across download logs within the cutoff window.
    - compute fully_uploaded = upload_successes - upload_failures and exclude those IDs from download_failures (IDs with at least one successful "Uploaded to" and zero transient upload errors in the window are removed).
    - preserve IDs that have both a success and a transient failure within the window (they remain candidates for retry).
    - continue to prevent scheduling the same ID for both retry types by subtracting download_failures from upload_failures.
  - write_ids, parse_download_log, and CLI behavior unchanged aside from the new exclusion logic.
  - Behavior within a single run: if an ID has both transient error and success, the failure takes precedence (successes are computed as successes - failures).

Behavioral intent / root cause
- get-ids-retry previously scanned failure log entries without checking for later successful uploads; that caused re-queuing of items already present on Commons and retry runs producing SKIPs. Now IDs confirmed fully on Commons (success with zero transient upload errors in the window) are removed from retry sets, while IDs with mixed results remain for retry.

Public API / infrastructure / security impact
- No changes to public APIs, environment variables, AWS Secrets Manager keys, database migrations, IAM policies, CodePipeline/CodeBuild/ECS task definitions, or other shared infra.
- No manual pipeline trigger, redeployment, or ECS action required — this is a standalone CLI script change.
- No security-sensitive changes.

Developer notes / testing
- Test plan: run get-ids-retry <days> and confirm CSV counts drop when logs contain both failures and later successes for the same IDs; confirm pure transient-failure-only IDs still appear; confirm download_failures excludes IDs that are fully uploaded.
- Commit message/logic highlights: upload logs handled oldest-first; ID outcomes tracked by latest-seen result; an ID is excluded only if it has zero transient upload errors and at least one successful upload within the window.
- Function signature change: parse_upload_log now returns a tuple; callers in this module were updated accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->