### PR TITLE
Fix hash-drift: stop silently skipping files stranded at wrong Commons title

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -266,12 +266,24 @@ def wiki_file_exists(site: BaseSite, sha1: str) -> bool:
     return False
 
 
-def find_file_by_hash(site: BaseSite, sha1: str) -> FilePage | None:
-    """Return the first Commons FilePage with the given SHA1, or None."""
+def find_file_by_hash(
+    site: BaseSite, sha1: str, preferred_title: str | None = None
+) -> FilePage | None:
+    """Return the Commons FilePage with the given SHA1, or None.
+
+    If preferred_title is given and a file with that title (without namespace)
+    shares the hash, it is returned immediately. Otherwise the first result
+    returned by the API (alphabetical) is returned. This handles the rare case
+    where multiple files share a SHA1 and we want the one at the correct title.
+    """
     api_site = typing.cast(APISite, site)
+    first: FilePage | None = None
     for img in api_site.allimages(sha1=sha1):
-        return img
-    return None
+        if preferred_title and img.title(with_ns=False) == preferred_title:
+            return img
+        if first is None:
+            first = img
+    return first
 
 
 _DPLA_ID_RE = re.compile(r"- DPLA - ([0-9a-f]{32})")

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -266,6 +266,40 @@ def wiki_file_exists(site: BaseSite, sha1: str) -> bool:
     return False
 
 
+def find_file_by_hash(site: BaseSite, sha1: str) -> FilePage | None:
+    """Return the first Commons FilePage with the given SHA1, or None."""
+    api_site = typing.cast(APISite, site)
+    for img in api_site.allimages(sha1=sha1):
+        return img
+    return None
+
+
+_DPLA_ID_RE = re.compile(r"- DPLA - ([0-9a-f]{32})")
+
+
+def extract_dpla_id_from_commons_title(title: str) -> str | None:
+    """Extract the DPLA ID from a Commons filename, or None if not present."""
+    m = _DPLA_ID_RE.search(title)
+    return m.group(1) if m else None
+
+
+def tag_as_duplicate(
+    site: BaseSite,
+    file_page: FilePage,
+    correct_filename: str,
+    reason: str,
+) -> None:
+    """Prepend {{Duplicate}} to file_page, flagging it for speedy deletion.
+
+    correct_filename should be bare (no 'File:' prefix).
+    reason is the free-text reason shown in the template.
+    """
+    tag = f"{{{{Duplicate|{correct_filename}|{reason}}}}}"
+    summary = f"Tagging as duplicate: correct title is [[File:{correct_filename}]]"
+    file_page.text = tag + "\n" + file_page.text
+    file_page.save(summary=summary, minor=False)
+
+
 INVALID_CONTENT_TYPES = frozenset(
     [
         "text/html",

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -46,7 +46,9 @@ from ingest_wikimedia.wikimedia import (
     get_page_title,
     get_wiki_text,
     wikimedia_url,
-    wiki_file_exists,
+    find_file_by_hash,
+    extract_dpla_id_from_commons_title,
+    tag_as_duplicate,
     check_content_type,
     is_download_only,
     get_page,
@@ -190,14 +192,43 @@ class Uploader:
                 logging.info(f"Upload comment: {upload_comment}")
                 logging.info(f"Wikitext: \n {wiki_markup}")
 
-            if wiki_file_exists(self.site, sha1):
+            # Check whether this file's hash already exists on Commons.
+            # If it's at the correct title, skip. If it's at a different title,
+            # attempt drift correction before uploading.
+            existing_file = find_file_by_hash(self.site, sha1)
+            if existing_file is not None:
+                if existing_file.title(with_ns=False) == page_title:
+                    logging.info(
+                        f"Skipping {dpla_id} {ordinal}: Already exists on commons."
+                    )
+                    self.tracker.increment(Result.SKIPPED)
+                    return
                 logging.info(
-                    f"Skipping {dpla_id} {ordinal}: Already exists on commons."
+                    f"Hash drift detected for {dpla_id} {ordinal}: "
+                    f"SHA1 found at [[File:{existing_file.title(with_ns=False)}]]"
                 )
-                self.tracker.increment(Result.SKIPPED)
-                return
 
             if not dry_run and not file_downloaded:
+                # Resolve hash drift before downloading — Case 3 (simple move)
+                # needs no file download, so detecting it first avoids wasted I/O.
+                drift_old_filename: str | None = None
+                force_ignore_warnings = False
+                if existing_file is not None:
+                    drift_action = self._resolve_hash_drift(
+                        existing_file=existing_file,
+                        page_title=page_title,
+                        dpla_id=dpla_id,
+                        ordinal=ordinal,
+                    )
+                    if drift_action == "moved":
+                        self.tracker.increment(Result.UPLOADED)
+                        return
+                    elif drift_action == "upload_and_tag":
+                        drift_old_filename = existing_file.title(with_ns=False)
+                        force_ignore_warnings = True
+                    else:  # "upload_only"
+                        force_ignore_warnings = True
+
                 with tqdm(
                     total=s3_object.content_length,
                     leave=False,
@@ -217,13 +248,16 @@ class Uploader:
 
                 # If the intended title is a redirect caused by title drift,
                 # move the file there first so the upload lands at the right name.
+                # This path is reached when the hash is new (not yet on Commons)
+                # and the intended title is a redirect from a prior drift correction.
                 if wiki_file_page.isRedirectPage():
                     resolved = self._resolve_redirect_move(wiki_file_page, dpla_id)
                     if resolved:
                         wiki_file_page = resolved
 
                 # Use direct upload (chunk_size=0) + ignore_warnings=True when the
-                # file page already exists. The stash-commit path raises
+                # file page already exists, or when the hash already lives elsewhere
+                # on Commons (drift case). The stash-commit path raises
                 # fileexists-shared-forbidden even on valid overwrites; the direct
                 # path with ignorewarnings=1 bypasses it. True (vs IGNORE_WIKIMEDIA_WARNINGS)
                 # is intentional — for an overwrite we want to suppress all warnings,
@@ -231,8 +265,16 @@ class Uploader:
                 file_exists = (
                     wiki_file_page.exists() and not wiki_file_page.isRedirectPage()
                 )
-                chunk_size = 0 if file_exists else WMC_UPLOAD_CHUNK_SIZE
-                upload_warnings = True if file_exists else IGNORE_WIKIMEDIA_WARNINGS
+                chunk_size = (
+                    0
+                    if (file_exists or force_ignore_warnings)
+                    else WMC_UPLOAD_CHUNK_SIZE
+                )
+                upload_warnings = (
+                    True
+                    if (file_exists or force_ignore_warnings)
+                    else IGNORE_WIKIMEDIA_WARNINGS
+                )
 
                 result = None
                 for attempt in range(1, MAX_UPLOAD_RETRIES + 1):
@@ -275,6 +317,8 @@ class Uploader:
                     )
 
                 logging.info(f"Uploaded to {wikimedia_url(page_title)}")
+                if drift_old_filename:
+                    self._tag_drift_duplicate(drift_old_filename, page_title, dpla_id)
                 self.tracker.increment(Result.UPLOADED)
                 self.tracker.increment(Result.BYTES, file_size)
 
@@ -325,6 +369,127 @@ class Uploader:
 
         # Fresh FilePage for the now-real file page at the intended title
         return get_page(self.site, wiki_file_page.title())
+
+    def _move_to_correct_title(
+        self,
+        existing_file: pywikibot.FilePage,
+        intended_page: pywikibot.FilePage,
+        dpla_id: str,
+        case_label: str,
+    ) -> None:
+        """Move existing_file to intended_page and post a CommonsDelinker request."""
+        actual_filename = existing_file.title(with_ns=False)
+        intended_filename = intended_page.title(with_ns=False)
+        reason = (
+            f"Title drift correction: updating to current DPLA title "
+            f"(DPLA ID {dpla_id})"
+        )
+        logging.info(
+            f"Title drift ({case_label}): moving "
+            f"[[File:{actual_filename}]] → [[File:{intended_filename}]]"
+        )
+        existing_file.move(
+            intended_page.title(),
+            reason=reason,
+            movetalk=False,
+            noredirect=False,
+        )
+        post_commonsdelinker_request(self.site, actual_filename, intended_filename)
+
+    def _resolve_hash_drift(
+        self,
+        existing_file: pywikibot.FilePage,
+        page_title: str,
+        dpla_id: str,
+        ordinal: int,
+    ) -> str:
+        """
+        Determine and where possible resolve the case where our file's SHA1
+        already lives on Commons at a different title than intended.
+
+        Returns one of:
+          "moved"          — Case 1/3: file moved to correct title; caller should
+                             increment UPLOADED and return (no upload needed).
+          "upload_and_tag" — Case 2: correct title has a different file; caller
+                             should upload (ignore_warnings=True) then tag the
+                             orphaned old title as a duplicate.
+          "upload_only"    — Cross-item hash collision with a still-valid DPLA ID;
+                             upload to the correct title but leave the other file alone.
+        """
+        actual_filename = existing_file.title(with_ns=False)
+
+        # --- Hash collision safety check ---
+        # If the file at the wrong title was uploaded for a different DPLA ID
+        # and that ID is still a valid item, don't move or tag it — just upload
+        # our hash to the correct title and leave their file alone. This prevents
+        # ping-pong renaming between two valid items that happen to share a hash.
+        existing_dpla_id = extract_dpla_id_from_commons_title(actual_filename)
+        if existing_dpla_id and existing_dpla_id != dpla_id:
+            try:
+                other_item = self.dpla.get_item_metadata(existing_dpla_id)
+            except Exception:
+                other_item = {}
+            if other_item:
+                logging.info(
+                    f"Hash drift for {dpla_id} {ordinal}: "
+                    f"[[File:{actual_filename}]] belongs to valid DPLA item "
+                    f"{existing_dpla_id}; uploading to correct title only."
+                )
+                return "upload_only"
+
+        intended_page = get_page(self.site, page_title)
+
+        if not intended_page.exists():
+            # Case 3: nothing at the intended title — simple move.
+            self._move_to_correct_title(existing_file, intended_page, dpla_id, "Case 3")
+            return "moved"
+
+        if intended_page.isRedirectPage():
+            # Case 1 (via hash lookup): intended title is a redirect. If it
+            # redirects to our existing file (same DPLA ID), move over it.
+            redirect_target = intended_page.getRedirectTarget()
+            if dpla_id in redirect_target.title():
+                self._move_to_correct_title(
+                    existing_file, intended_page, dpla_id, "Case 1"
+                )
+                return "moved"
+            logging.warning(
+                f"Hash drift for {dpla_id} {ordinal}: intended title "
+                f"[[File:{intended_page.title(with_ns=False)}]] redirects to "
+                f"{redirect_target.title(with_ns=False)!r}, "
+                f"which does not share DPLA ID {dpla_id}; uploading anyway."
+            )
+            return "upload_only"
+
+        # Case 2: intended title has real content with a different hash.
+        logging.info(
+            f"Title drift (Case 2): [[File:{intended_page.title(with_ns=False)}]] "
+            f"has a different hash; will upload correct hash and tag "
+            f"[[File:{actual_filename}]] as duplicate."
+        )
+        return "upload_and_tag"
+
+    def _tag_drift_duplicate(
+        self,
+        old_filename: str,
+        new_filename: str,
+        dpla_id: str,
+    ) -> None:
+        """Tag a stranded file page as a duplicate after its hash was uploaded elsewhere."""
+        try:
+            old_page = get_page(self.site, f"File:{old_filename}")
+            tag_as_duplicate(
+                self.site,
+                old_page,
+                correct_filename=new_filename,
+                reason="Other file has the correct title.",
+            )
+            logging.info(
+                f"Tagged [[File:{old_filename}]] as duplicate of "
+                f"[[File:{new_filename}]] (DPLA ID {dpla_id})"
+            )
+        except Exception as ex:
+            logging.warning(f"Failed to tag [[File:{old_filename}]] as duplicate: {ex}")
 
     def process_item(
         self,

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -214,6 +214,7 @@ class Uploader:
                 # Resolve hash drift before downloading — Case 3 (simple move)
                 # needs no file download, so detecting it first avoids wasted I/O.
                 drift_old_filename: str | None = None
+                drift_action: str | None = None
                 force_ignore_warnings = False
                 if existing_file is not None:
                     drift_action = self._resolve_hash_drift(
@@ -221,6 +222,7 @@ class Uploader:
                         page_title=page_title,
                         dpla_id=dpla_id,
                         ordinal=ordinal,
+                        wiki_markup=wiki_markup,
                     )
                     if drift_action == "moved":
                         self.tracker.increment(Result.UPLOADED)
@@ -252,7 +254,9 @@ class Uploader:
                 # move the file there first so the upload lands at the right name.
                 # This path is reached when the hash is new (not yet on Commons)
                 # and the intended title is a redirect from a prior drift correction.
-                if wiki_file_page.isRedirectPage():
+                # Skip when drift resolution returned "upload_only" — in that case
+                # we've decided not to touch any other file; just upload directly.
+                if wiki_file_page.isRedirectPage() and drift_action != "upload_only":
                     resolved = self._resolve_redirect_move(wiki_file_page, dpla_id)
                     if resolved:
                         wiki_file_page = resolved
@@ -378,8 +382,13 @@ class Uploader:
         intended_page: pywikibot.FilePage,
         dpla_id: str,
         case_label: str,
+        wiki_markup: str | None = None,
     ) -> None:
-        """Move existing_file to intended_page and post a CommonsDelinker request."""
+        """Move existing_file to intended_page and post a CommonsDelinker request.
+
+        If wiki_markup is provided, the moved page's description is updated to
+        reflect current DPLA metadata after the move.
+        """
         actual_filename = existing_file.title(with_ns=False)
         intended_filename = intended_page.title(with_ns=False)
         reason = (
@@ -398,12 +407,25 @@ class Uploader:
         )
         post_commonsdelinker_request(self.site, actual_filename, intended_filename)
 
+        if wiki_markup:
+            moved_page = get_page(self.site, intended_page.title())
+            if moved_page.exists() and not moved_page.isRedirectPage():
+                moved_page.text = wiki_markup
+                moved_page.save(
+                    summary=(
+                        f"Update description after title drift correction "
+                        f"(DPLA ID {dpla_id})"
+                    ),
+                    minor=False,
+                )
+
     def _resolve_hash_drift(
         self,
         existing_file: pywikibot.FilePage,
         page_title: str,
         dpla_id: str,
         ordinal: int,
+        wiki_markup: str | None = None,
     ) -> str:
         """
         Determine and where possible resolve the case where our file's SHA1
@@ -448,7 +470,9 @@ class Uploader:
 
         if not intended_page.exists():
             # Case 3: nothing at the intended title — simple move.
-            self._move_to_correct_title(existing_file, intended_page, dpla_id, "Case 3")
+            self._move_to_correct_title(
+                existing_file, intended_page, dpla_id, "Case 3", wiki_markup
+            )
             return "moved"
 
         if intended_page.isRedirectPage():
@@ -457,7 +481,7 @@ class Uploader:
             redirect_target = intended_page.getRedirectTarget()
             if redirect_target.title(with_ns=False) == actual_filename:
                 self._move_to_correct_title(
-                    existing_file, intended_page, dpla_id, "Case 1"
+                    existing_file, intended_page, dpla_id, "Case 1", wiki_markup
                 )
                 return "moved"
             logging.warning(

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -195,7 +195,9 @@ class Uploader:
             # Check whether this file's hash already exists on Commons.
             # If it's at the correct title, skip. If it's at a different title,
             # attempt drift correction before uploading.
-            existing_file = find_file_by_hash(self.site, sha1)
+            existing_file = find_file_by_hash(
+                self.site, sha1, preferred_title=page_title
+            )
             if existing_file is not None:
                 if existing_file.title(with_ns=False) == page_title:
                     logging.info(
@@ -427,8 +429,13 @@ class Uploader:
         if existing_dpla_id and existing_dpla_id != dpla_id:
             try:
                 other_item = self.dpla.get_item_metadata(existing_dpla_id)
-            except Exception:
-                other_item = {}
+            except Exception as ex:
+                logging.warning(
+                    f"Hash drift for {dpla_id} {ordinal}: failed to verify "
+                    f"colliding DPLA item {existing_dpla_id}: {ex}; "
+                    f"falling back to upload_only."
+                )
+                return "upload_only"
             if other_item:
                 logging.info(
                     f"Hash drift for {dpla_id} {ordinal}: "
@@ -446,9 +453,9 @@ class Uploader:
 
         if intended_page.isRedirectPage():
             # Case 1 (via hash lookup): intended title is a redirect. If it
-            # redirects to our existing file (same DPLA ID), move over it.
+            # redirects to exactly our existing file (same filename), move over it.
             redirect_target = intended_page.getRedirectTarget()
-            if dpla_id in redirect_target.title():
+            if redirect_target.title(with_ns=False) == actual_filename:
                 self._move_to_correct_title(
                     existing_file, intended_page, dpla_id, "Case 1"
                 )


### PR DESCRIPTION
## Summary

- **Bug fixed**: When `wiki_file_exists()` returned True, the uploader blindly skipped the item even if the file lived at the wrong Commons title (e.g. from a typo correction or DPLA ID change after the original upload). The file remained permanently stranded with no mechanism to move it.

- **Solution**: Replace the boolean check with `find_file_by_hash()`, which returns the actual `FilePage` so the title can be compared. If the file is at the correct title: skip as before. If it's at the wrong title: `_resolve_hash_drift()` handles it:
  - **Case 1/3** (redirect at intended title, or nothing there): move the file to the correct title, post CommonsDelinker request — no download needed
  - **Case 2** (different file at intended title): upload correct hash with `ignore_warnings=True`, then tag orphaned old title with `{{Duplicate}}`
  - **Cross-item collision** (other DPLA ID is still a valid item): upload to correct title only; leave the other file untouched to prevent ping-pong renaming

- Drift resolution runs **before** the S3 download so Case 3 moves (simplest case) never incur unnecessary I/O.

## New helpers

- `wikimedia.py`: `find_file_by_hash()`, `tag_as_duplicate()`, `extract_dpla_id_from_commons_title()`
- `uploader.py`: `_resolve_hash_drift()`, `_move_to_correct_title()`, `_tag_drift_duplicate()`

## Test plan

- [ ] Dry-run against Ohio: confirm previously-skipped drifted files now log "Hash drift detected" instead of "Already exists on commons"
- [ ] Live run against Ohio: confirm Case 3 files (e.g. DPLA ID `07bc538cffbad348fa35f8428b6d7e16` — "Foreward"→"Foreword") are moved and count as UPLOADED
- [ ] Confirm CommonsDelinker request is posted for moved files
- [ ] Confirm `{{Duplicate}}` tag is applied to orphaned old titles after Case 2 uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix hash-drift: stop silently skipping files stranded at wrong Commons title

This PR fixes a bug where the uploader previously skipped items when a boolean SHA-1 existence check returned True even if the Commons file lived at the wrong title (e.g., after a typo correction or DPLA ID change). The boolean check is replaced with a SHA-1 lookup that returns the actual FilePage and the uploader now resolves “hash drift” cases before any S3 download so simple moves avoid unnecessary I/O.

### Changes Overview

- ingest_wikimedia/wikimedia.py
  - Added find_file_by_hash(site, sha1, preferred_title=None): queries Commons allimages by SHA1 and returns a FilePage (prefers an exact bare-filename match when preferred_title is provided).
  - Added extract_dpla_id_from_commons_title(title): extracts a 32-hex DPLA ID from Commons filenames containing " - DPLA - <id>".
  - Added tag_as_duplicate(site, file_page, correct_filename, reason): prepends a {{Duplicate|...|...}} template to a FilePage and saves it.
  - Minor net: +46 lines.

- tools/uploader.py
  - Replace wiki_file_exists() boolean check with find_file_by_hash() and introduce structured hash-drift resolution before downloading from S3.
  - New Uploader helpers:
    - _resolve_hash_drift(existing_file, page_title, dpla_id, ordinal, wiki_markup) -> "moved" | "upload_and_tag" | "upload_only": classifies drift and decides action with a collision safety check against the DPLA API.
    - _move_to_correct_title(existing_file, intended_page, dpla_id, case_label, wiki_markup): moves an existing Commons file to the intended title, posts a CommonsDelinker request, and (if wiki_markup provided) updates the moved page’s description to avoid stale metadata.
    - _tag_drift_duplicate(old_filename, new_filename, dpla_id): tags a stranded old filename as {{Duplicate}}.
  - Redirect handling: _resolve_redirect_move is called only when drift_action != "upload_only" so cross-item collisions are not moved.
  - Upload behavior: when drift resolution requires overwrite/tagging, uploader uses direct upload (chunk_size=0) with warnings suppressed (ignore_warnings=True); otherwise retains prior chunking/warning behavior.
  - Drift resolution runs before S3 download; simple moves avoid downloads.
  - Net: +~205/-9 lines.

### Drift resolution cases
1. Intended title is a redirect or absent (move): move the existing file to the intended title and post a CommonsDelinker request (no download/upload) — caller treats this as UPLOADED.
2. Intended title occupied by a different file (upload + tag): upload the correct hash to the intended title with ignore_warnings=True, then tag the orphaned old filename with {{Duplicate}}.
3. Cross-item collision (upload only): if another valid DPLA item appears to own the orphaned file, upload to the correct title only and leave the other file untouched to avoid ping-pong renames.

### Behavioral / robustness notes
- find_file_by_hash accepts preferred_title to prefer correct-title matches when multiple files share the same SHA1.
- _resolve_hash_drift is conservative: on DPLA API lookup failures it falls back to "upload_only" with a warning rather than performing moves/tags.
- wiki_markup (wikitext) is threaded through process_file → _resolve_hash_drift → _move_to_correct_title so moved pages can be updated to current metadata to avoid stale descriptions.
- Redirect handling is guarded to avoid touching other items in cross-item collisions.
- Drift detection and resolution are executed before S3 download to reduce unnecessary I/O.

### Tests / QA
- Test checklist in PR: dry-run to confirm logging change; live run to confirm Case 3 moves counted as UPLOADED, CommonsDelinker requests posted for moved files, and {{Duplicate}} tagging applied for Case 2.

### Impact on infrastructure, deployment, security, and APIs
- No manual pipeline trigger or ECS redeployment required.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No shared infrastructure changes (CodePipeline, CodeBuild, ECS task definitions, IAM).
- No public API shape changes or new endpoints.
- No new credential handling; security posture unchanged. The change reduces the risk of orphaned files and is conservative on remote lookup failures to avoid accidental destructive actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->