### PR TITLE
categories: lazy-init Wikidata connection to avoid startup crash

### DIFF
--- a/ingest_wikimedia/categories.py
+++ b/ingest_wikimedia/categories.py
@@ -60,13 +60,6 @@ class CategoryEnsurer:
         if institution_qid in self._ensured:
             return
 
-        if self._institution_has_category(institution_qid):
-            logging.info(
-                f"Category already set up for {institution_name} ({institution_qid})"
-            )
-            self._ensured.add(institution_qid)
-            return
-
         institution_name = institution_name.strip()
         if not institution_name:
             raise ValueError(
@@ -74,6 +67,26 @@ class CategoryEnsurer:
             )
 
         category_name = COMMONS_CATEGORY_PREFIX + institution_name
+
+        # Fast path: Commons category already exists — no Wikidata connection needed.
+        # The Wikidata P8464 link was created when the category was, so skipping the
+        # check here is safe and keeps uploads working when Wikidata is lagged.
+        if self._commons_category_exists(category_name):
+            logging.info(
+                f"Category already set up for {institution_name} ({institution_qid})"
+            )
+            self._ensured.add(institution_qid)
+            return
+
+        # Commons category absent — check whether Wikidata already has P8464 set
+        # (e.g. category exists under a different name or was created out-of-band).
+        if self._institution_has_category(institution_qid):
+            logging.info(
+                f"Category already set up for {institution_name} ({institution_qid})"
+            )
+            self._ensured.add(institution_qid)
+            return
+
         hub_category_qid = self._get_hub_category_qid(hub_institution_qid)
 
         logging.info(

--- a/ingest_wikimedia/categories.py
+++ b/ingest_wikimedia/categories.py
@@ -3,6 +3,8 @@ import logging
 import pywikibot
 from pywikibot.site import BaseSite
 
+from ingest_wikimedia.wikimedia import get_wikidata_site
+
 # Stable Wikimedia ontology constants — these items will not change
 WD_WIKIMEDIA_CONTENT_PARTNERSHIP = "Q97580368"  # "Wikimedia content partnership"
 WD_WIKIMEDIA_CATEGORY = "Q4167836"  # "Wikimedia category"
@@ -24,15 +26,25 @@ class CategoryEnsurer:
     def __init__(
         self,
         commons_site: BaseSite,
-        wikidata_site: BaseSite,
         dry_run: bool = False,
     ):
         self.commons_site = commons_site
-        self.wikidata_site = wikidata_site
         self.dry_run = dry_run
         self._ensured: set[str] = set()
         self._hub_category_qids: dict[str, str] = {}
-        self._repo = wikidata_site.data_repository()
+        self._wikidata_repo: BaseSite | None = None
+
+    @property
+    def _repo(self) -> BaseSite:
+        """Connect to Wikidata on first use, not at construction time.
+
+        Deferring this avoids a MaxlagTimeoutError crash at uploader startup
+        when Wikimedia is under load — the connection is only attempted when a
+        category actually needs to be created or verified.
+        """
+        if self._wikidata_repo is None:
+            self._wikidata_repo = get_wikidata_site().data_repository()
+        return self._wikidata_repo
 
     def ensure(
         self,

--- a/tools/fix_unknown_categories.py
+++ b/tools/fix_unknown_categories.py
@@ -54,9 +54,7 @@ def main(verbose: bool) -> None:
     start_time = time.time()
 
     commons_site = get_site()
-    wikidata_site = get_wikidata_site()
     category_ensurer = CategoryEnsurer(commons_site)
-    repo = wikidata_site.data_repository()
 
     unknown_cat = pywikibot.Category(commons_site, UNKNOWN_INSTITUTION_CATEGORY)
 
@@ -64,6 +62,8 @@ def main(verbose: bool) -> None:
     files_touched = 0
     # Tracks files we cannot parse, so we don't loop on them forever
     cannot_process: set[str] = set()
+    # Lazily initialised on first use so a startup maxlag error doesn't abort the run.
+    repo = None
 
     while True:
         file_page = None
@@ -93,6 +93,8 @@ def main(verbose: bool) -> None:
             continue
 
         try:
+            if repo is None:
+                repo = get_wikidata_site().data_repository()
             institution_item = pywikibot.ItemPage(repo, institution_qid)
             institution_item.get()
             institution_name = institution_item.labels.get("en", institution_qid)

--- a/tools/fix_unknown_categories.py
+++ b/tools/fix_unknown_categories.py
@@ -55,7 +55,7 @@ def main(verbose: bool) -> None:
 
     commons_site = get_site()
     wikidata_site = get_wikidata_site()
-    category_ensurer = CategoryEnsurer(commons_site, wikidata_site)
+    category_ensurer = CategoryEnsurer(commons_site)
     repo = wikidata_site.data_repository()
 
     unknown_cat = pywikibot.Category(commons_site, UNKNOWN_INSTITUTION_CATEGORY)

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -59,7 +59,6 @@ from ingest_wikimedia.wikimedia import (
     ERROR_NOCHANGE,
     ERROR_BACKEND_FAIL,
     get_site,
-    get_wikidata_site,
     post_commonsdelinker_request,
 )
 
@@ -685,8 +684,7 @@ def main(ids_file, partner: str, dry_run: bool, verbose: bool) -> None:
     tools_context = ToolsContext.init(partner)
 
     commons_site = get_site()
-    wikidata_site = get_wikidata_site()
-    category_ensurer = CategoryEnsurer(commons_site, wikidata_site, dry_run=dry_run)
+    category_ensurer = CategoryEnsurer(commons_site, dry_run=dry_run)
 
     uploader = Uploader(
         tools_context.get_tracker(),


### PR DESCRIPTION
## Summary

- `CategoryEnsurer` previously called `get_wikidata_site()` at construction time (eager), which caused a `MaxlagTimeoutError` crash before any uploads began when Wikimedia was under heavy load
- `_repo` is now a lazy property that connects on first access — only when a category actually needs to be created or verified
- Uploads for items whose institution categories already exist (the common case) never touch Wikidata at all
- Also fixes `fix_unknown_categories.py` which was still passing the now-removed `wikidata_site` argument to the constructor

## Root cause

The crash sequence: `main()` → `CategoryEnsurer(commons_site, wikidata_site)` → `wikidata_site.data_repository()` — pywikibot attempted to authenticate against Wikidata immediately. After exhausting its own maxlag retries it raised `MaxlagTimeoutError`, killing the uploader before processing a single item.

## Test plan

- [ ] Run uploader normally — confirm no change in behaviour when Wikidata is reachable
- [ ] Simulate Wikidata unavailability at startup — confirm uploader now proceeds to upload items; category creation fails per-item rather than killing the process

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Refactors CategoryEnsurer to lazily initialize its Wikidata data-repository connection, deferring the connection from construction time to first access. This prevents MaxlagTimeoutError crashes during uploader startup when Wikimedia is under heavy load and ensures Wikidata unavailability at startup does not abort the whole run.

## Changes

ingest_wikimedia/categories.py
- Removed wikidata_site parameter from CategoryEnsurer.__init__().
- Added _wikidata_repo instance field (initially None) and a _repo property that calls get_wikidata_site().data_repository() on first access.
- Reordered ensure() logic to check Commons category existence first (fast path) and only access Wikidata when the Commons category is absent.
- All Wikidata operations (hub lookup, item checks/creation, adding P8464) now use self._repo and occur lazily.

tools/fix_unknown_categories.py
- Instantiate CategoryEnsurer with only the Commons site.
- Lazily initialize a local repo variable via get_wikidata_site().data_repository() on first use so a startup maxlag error is handled per-institution rather than aborting the run.

tools/uploader.py
- No longer imports get_wikidata_site; CategoryEnsurer is instantiated with commons_site and dry_run only (no wikidata_site argument).

## Impact

- Deployment: This is a code change and requires deploying the updated application (pipeline/ECS redeploy) for the fix to take effect.
- Infrastructure/Secrets: No changes to environment variables, AWS Secrets Manager keys, IAM policies, CodePipeline/CodeBuild/ECS task definitions, or other shared infra.
- Database migrations: None.
- Public APIs: No changes to public-facing API shapes or endpoints.
- Security: No change to credential handling or authentication behavior beyond deferring the existing Wikidata connection attempt until first needed; no new external inputs or credential storage changes.

## Behavior notes

- No behavioral change when Wikidata is reachable; common-case uploads for institutions with existing Commons categories avoid contacting Wikidata entirely.
- When Wikidata is unavailable at startup, uploads proceed; category creation/verification failures are handled per-item rather than aborting the uploader process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->