### PR TITLE
retry: add title/hash drift errors to retryable error set

### DIFF
--- a/tools/get_ids_retry.py
+++ b/tools/get_ids_retry.py
@@ -64,8 +64,10 @@ EMPTY_URL_FAILURE = "Failed downloading  to"
 def parse_upload_log(path: Path) -> tuple[set[str], set[str]]:
     """Return (transient_failure_ids, successfully_uploaded_ids) from an upload log.
 
-    transient_failure_ids  — IDs that hit lock-contention or backend-storage errors;
-                             the S3 asset is present but the upload didn't land on Commons.
+    transient_failure_ids  — IDs that hit lock-contention, backend-storage, or
+                             title/hash-drift errors; S3 assets are present but
+                             the upload didn't land on Commons (or landed at the
+                             wrong title).
     successfully_uploaded_ids — IDs for which at least one file reached Commons ("Uploaded to").
     """
     failures: set[str] = set()

--- a/tools/get_ids_retry.py
+++ b/tools/get_ids_retry.py
@@ -47,6 +47,7 @@ UPLOAD_TRANSIENT_ERRORS = (
     # "Failed: Unknown" warnings, where the line-by-line regex below matches them.
     "File linked to another page",  # RuntimeError: file exists on Commons at wrong title
     "ArticleExistsConflictError",  # pywikibot: move-over-redirect blocked by insufficient rights
+    "fileexists-shared-forbidden",  # Wikimedia API: different file already at intended title
 )
 
 UPLOAD_TRANSIENT_RE = re.compile(

--- a/tools/get_ids_retry.py
+++ b/tools/get_ids_retry.py
@@ -1,12 +1,13 @@
 """
 Extract DPLA IDs from recent upload/download logs for items that failed due to
-transient issues and should be retried.
+transient or now-resolvable issues and should be retried.
 
 Two failure types are identified:
 
   upload   — Wikimedia-side transient errors (lock contention, backend storage
-              failures).  S3 assets are already present; only the uploader
-              needs to run.
+              failures) and title/hash-drift errors that the uploader can now
+              correct.  S3 assets are already present; only the uploader needs
+              to run.
 
   download — Media-server HTTP failures after all retries are exhausted.  Both
               the downloader and uploader need to run.
@@ -34,12 +35,18 @@ BASE_DIR = Path(
 )
 
 UPLOAD_TRANSIENT_ERRORS = (
+    # Wikimedia API / storage transient errors
     "lockmanager-fail-conflict",
     "lockmanager-fail-svr-acquire",
     "stashfailed: Could not acquire lock",
     "stashfailed: Server failed to publish temporary file",
     "backend-fail-internal",
     "uploadstash-exception",
+    # Title / hash drift errors — the uploader's drift-correction logic resolves
+    # these on retry.  Both appear in log tracebacks (via exc_info=) attached to
+    # "Failed: Unknown" warnings, where the line-by-line regex below matches them.
+    "File linked to another page",  # RuntimeError: file exists on Commons at wrong title
+    "ArticleExistsConflictError",  # pywikibot: move-over-redirect blocked by insufficient rights
 )
 
 UPLOAD_TRANSIENT_RE = re.compile(


### PR DESCRIPTION
## Summary

- Adds `"File linked to another page"` and `"ArticleExistsConflictError"` to `UPLOAD_TRANSIENT_ERRORS` in `get_ids_retry.py`
- These two strings appear in log tracebacks attached to `Failed: Unknown` warnings for items that failed due to title/hash drift
- With the drift-correction logic from PR #194 now active, running `/wikimedia-upload retry` will re-queue these items and the uploader will resolve the drift instead of failing again

**`"File linked to another page"`** — `RuntimeError` raised when `site.upload()` returns falsy because the file already exists on Commons under a different title (the pre-PR-#194 ID drift failure path). Appeared as ~51k failures in the April Ohio log.

**`"ArticleExistsConflictError"`** — pywikibot exception thrown when `_resolve_redirect_move` tries to move a file to a title occupied by a redirect, but the bot lacks the `move-overredirect` right on Commons.

## Test plan

- [ ] Run `get-ids-retry` on a recent Ohio log and confirm IDs with these failure strings appear in the output CSV
- [ ] Verify a retry run picks up `0e23f89d45d35e91094968e6f86eef7b` (the known `ArticleExistsConflictError` case from today's test run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR expands the retryable upload-failure set in tools/get_ids_retry.py by adding title/hash-drift-related log markers so items that failed due to title/hash drift are included in upload-retry CSVs. Specifically, the UPLOAD_TRANSIENT_ERRORS tuple now includes:
- "File linked to another page" (RuntimeError when a file exists on Commons at a different title),
- "ArticleExistsConflictError" (pywikibot exception when move-over-redirect is blocked by insufficient rights),
- "fileexists-shared-forbidden" (Wikimedia API: a different file already at the intended title).

The module docstring and parse_upload_log documentation were updated to distinguish Wikimedia-side transient/storage/lock errors from uploader-resolvable title/hash-drift errors and to clarify that transient_failure_ids now includes drift cases (S3 assets present but upload either failed to land on Commons or landed at the wrong title).

Behavioral rationale: With the drift-correction logic from the recent PR, re-queued items that previously failed for these reasons will be retried and the uploader should resolve the drift (for example by using direct-upload/ignore_warnings) instead of leaving items stranded.

Files changed: tools/get_ids_retry.py (small, focused change; +11 / -3 lines).

Operational impact (explicit):
- No manual pipeline trigger or ECS redeployment required.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No shared infrastructure (CodePipeline/CodeBuild/ECS/IAM) configuration changes.
- No public API response or endpoint changes.
- No security-sensitive credential or auth surface changes.

Tests / verification:
- Run get-ids-retry on recent logs and confirm IDs with the new failure strings appear in the output CSVs.
- A retry run should pick up known ArticleExistsConflictError cases (example ID noted in the PR description).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->