### PR TITLE
uploader: replace redirect-move with redirect-overwrite for title drift

### DIFF
--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -256,9 +256,27 @@ class Uploader:
                 # Skip when drift resolution returned "upload_only" — in that case
                 # we've decided not to touch any other file; just upload directly.
                 if wiki_file_page.isRedirectPage() and drift_action != "upload_only":
-                    resolved = self._resolve_redirect_move(wiki_file_page, dpla_id)
-                    if resolved:
-                        wiki_file_page = resolved
+                    try:
+                        resolved = self._resolve_redirect_move(wiki_file_page, dpla_id)
+                        if resolved:
+                            wiki_file_page = resolved
+                    except pywikibot.exceptions.ArticleExistsConflictError:
+                        # Move is blocked because the redirect page itself has
+                        # page history or structured data that Commons won't let
+                        # us overwrite via a move. Fall back to replacing the
+                        # redirect text in-place and uploading directly.
+                        logging.info(
+                            f"Move blocked (ArticleExistsConflictError) for "
+                            f"{dpla_id}; falling back to redirect-overwrite"
+                        )
+                        resolved = self._resolve_redirect_overwrite(
+                            wiki_file_page, dpla_id, wiki_markup
+                        )
+                        if resolved:
+                            wiki_file_page, redirect_old_filename = resolved
+                            force_ignore_warnings = True
+                            if not drift_old_filename:
+                                drift_old_filename = redirect_old_filename
 
                 # Use direct upload (chunk_size=0) + ignore_warnings=True when the
                 # file page already exists, or when the hash already lives elsewhere
@@ -343,6 +361,10 @@ class Uploader:
         this is a title-drift case: move the file to the intended title and post
         a CommonsDelinker request. Returns a fresh FilePage for the intended title
         on success, or None if the redirect is not a title-drift case.
+
+        Raises ArticleExistsConflictError if the move is blocked (e.g. the
+        redirect page has history/structured data). Caller should fall back to
+        _resolve_redirect_overwrite in that case.
         """
         redirect_target = wiki_file_page.getRedirectTarget()
         if dpla_id not in redirect_target.title():
@@ -359,7 +381,6 @@ class Uploader:
             f"Title drift correction: updating to current DPLA title "
             f"(DPLA ID {dpla_id})"
         )
-
         logging.info(
             f"Title drift redirect detected — moving "
             f"[[File:{old_filename}]] → [[File:{new_filename}]]"
@@ -374,6 +395,49 @@ class Uploader:
 
         # Fresh FilePage for the now-real file page at the intended title
         return get_page(self.site, wiki_file_page.title())
+
+    def _resolve_redirect_overwrite(
+        self,
+        wiki_file_page: pywikibot.FilePage,
+        dpla_id: str,
+        wiki_markup: str,
+    ) -> tuple[pywikibot.FilePage, str] | None:
+        """
+        Fallback for when _resolve_redirect_move raises ArticleExistsConflictError.
+
+        Replaces the redirect page text with the correct DPLA Artwork wikitext
+        so the upload API no longer sees a file conflict, then uploads directly.
+        The redirect target (wrong-title file) is returned as old_filename for
+        later duplicate-tagging.
+
+        Returns (updated_file_page, old_filename) on success, or None if the
+        redirect does not share the DPLA ID (cannot auto-resolve).
+        """
+        redirect_target = wiki_file_page.getRedirectTarget()
+        if dpla_id not in redirect_target.title():
+            logging.warning(
+                f"Redirect at intended title {wiki_file_page.title()} points to "
+                f"{redirect_target.title()} which does not share DPLA ID {dpla_id} "
+                f"— cannot auto-resolve; upload will fail"
+            )
+            return None
+
+        old_filename = redirect_target.title(with_ns=False)
+        logging.info(
+            f"Title drift redirect at [[File:{wiki_file_page.title(with_ns=False)}]] "
+            f"— replacing with wikitext so upload can proceed "
+            f"(will tag [[File:{old_filename}]] as duplicate)"
+        )
+        wiki_file_page.text = wiki_markup
+        wiki_file_page.save(
+            summary=(
+                f"Replacing redirect with DPLA metadata for title drift "
+                f"correction (DPLA ID {dpla_id})"
+            ),
+            minor=False,
+        )
+        wiki_file_page.clear_cache()
+        return wiki_file_page, old_filename
 
     def _move_to_correct_title(
         self,


### PR DESCRIPTION
## Summary

- When the intended Commons title is a redirect, the uploader's primary path moves the file there (works in most cases, e.g. item 15771bd38d9423e6eb18af4dd53e066e).
- In some cases (e.g. the redirect page has page history or structured data), that move raises `ArticleExistsConflictError`. This PR adds a fallback for that edge case, confirmed working on item `0e23f89d45d35e91094968e6f86eef7b`:
  1. Replace the redirect page text with the correct DPLA Artwork wikitext
  2. Upload the S3 file directly to the now-non-redirect page
  3. Tag the former redirect target (wrong-title file) as `{{Duplicate}}`

## Test plan

- [ ] Verify move path still works for the common case (redirect with no blocking history)
- [ ] Verify fallback triggers on `ArticleExistsConflictError` and resolves the item correctly
- [ ] Verify the wrong-title file is tagged `{{Duplicate}}` in the fallback path
- [ ] Verify upload sha1 on Commons matches S3 after fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes title-drift handling in the Wikimedia Commons file upload process by adding a fallback "overwrite" flow when an intended Commons title is a redirect and the DPLA bot lacks `move-overredirect` rights. Previously attempting to move over a redirect could raise `ArticleExistsConflictError`; the new logic avoids that failure by overwriting the redirect page text and then uploading directly.

### Changes

**File: `tools/uploader.py`**
- Added method: `_resolve_redirect_overwrite(self, wiki_file_page: pywikibot.FilePage, dpla_id: str, wiki_markup: str) -> tuple[pywikibot.FilePage, str] | None`
  - Validates the redirect target contains the DPLA ID, replaces the redirect page `.text` with the provided Artwork wikitext, saves with a "Replacing redirect…" summary, clears cache, and returns the updated file page plus the former redirect-target filename.
- Updated `Uploader.process_file` redirect handling to:
  - Attempt the existing `_resolve_redirect_move(...)` first.
  - If that raises `pywikibot.exceptions.ArticleExistsConflictError`, fall back to `_resolve_redirect_overwrite(...)`.
  - On successful overwrite fallback, populate `drift_old_filename` (if unset) with the returned redirect-target filename and enable `force_ignore_warnings` so the subsequent direct upload proceeds.
- `_resolve_redirect_move(...)` remains; its docstring now documents that it may raise `ArticleExistsConflictError` and callers should fall back to the overwrite path.

### Behavior (confirmed on item 0e23f89d45d35e91094968e6f86eef7b)
1. Replace the redirect page text with correct DPLA Artwork wikitext.
2. Upload the S3 file directly to the now-non-redirect page (avoids `fileexists-shared-forbidden`).
3. Tag the former redirect target (wrong-title file) as `{{Duplicate}}` via existing `_tag_drift_duplicate` flow.

### Test Plan
- Verify `ArticleExistsConflictError` no longer appears in upload logs when the intended Commons title is a redirect.
- Verify the redirect page is replaced with the correct Artwork wikitext after the run.
- Verify the wrong-title file is tagged `{{Duplicate}}`.
- Verify upload succeeds and SHA1 on Commons matches S3.

### Impact Assessment
- Requires no manual pipeline trigger or ECS redeployment to take effect (code change only).
- No environment variables, AWS Secrets Manager keys, or infrastructure/IAM changes.
- No database migrations.
- No public-facing API changes.
- No new security-sensitive credential handling or external-integration changes beyond the existing uploader behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->