### PR TITLE
downloader: rolling 365-day S3 refresh and /wikimedia-upload refresh subcommand

### DIFF
--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -21,6 +21,15 @@ on:
         required: false
         type: string
         default: ""
+      max_age_days:
+        description: "For refresh runs: re-download files already in S3 if older than N days"
+        required: false
+        type: string
+        default: ""
+      refresh_only:
+        description: "Download-only refresh run — skip upload phase"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -56,4 +65,6 @@ jobs:
           python scripts/wikimedia_launch.py \
             --partner "${{ github.event.inputs.partner }}" \
             --force "${{ github.event.inputs.force }}" \
-            --response-url "${{ github.event.inputs.response_url }}"
+            --response-url "${{ github.event.inputs.response_url }}" \
+            --max-age-days "${{ github.event.inputs.max_age_days }}" \
+            --refresh-only "${{ github.event.inputs.refresh_only }}"

--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -61,10 +61,15 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           DPLA_SLACK_BOT_TOKEN: ${{ secrets.DPLA_SLACK_BOT_TOKEN }}
           PYTHONPATH: .
+          INPUT_PARTNER: ${{ github.event.inputs.partner }}
+          INPUT_FORCE: ${{ github.event.inputs.force }}
+          INPUT_RESPONSE_URL: ${{ github.event.inputs.response_url }}
+          INPUT_MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days }}
+          INPUT_REFRESH_ONLY: ${{ github.event.inputs.refresh_only }}
         run: |
           python scripts/wikimedia_launch.py \
-            --partner "${{ github.event.inputs.partner }}" \
-            --force "${{ github.event.inputs.force }}" \
-            --response-url "${{ github.event.inputs.response_url }}" \
-            --max-age-days "${{ github.event.inputs.max_age_days }}" \
-            --refresh-only "${{ github.event.inputs.refresh_only }}"
+            --partner "$INPUT_PARTNER" \
+            --force "$INPUT_FORCE" \
+            --response-url "$INPUT_RESPONSE_URL" \
+            --max-age-days "$INPUT_MAX_AGE_DAYS" \
+            --refresh-only "$INPUT_REFRESH_ONLY"

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -30,16 +30,13 @@ import hmac
 import json
 import logging
 import os
-import re
 import shlex
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
 
-from ingest_wikimedia.partners import is_dpla_id, resolve_slug
-
-_QID_RE = re.compile(r"^Q\d+$")
+from ingest_wikimedia.partners import is_dpla_id, is_wikidata_id, resolve_slug
 
 
 def _verify_slack_signature(
@@ -123,6 +120,84 @@ def _dispatch_and_reply(
     return _slack_reply(text, ephemeral=ephemeral)
 
 
+def _parse_positive_int(value: str) -> tuple[int, dict | None]:
+    """Parse a positive integer. Returns (n, None) on success or (0, error_reply)."""
+    try:
+        n = int(value)
+        if n <= 0:
+            raise ValueError
+    except ValueError:
+        return 0, _slack_reply(
+            f"`{value}` is not a valid number of days. Provide a positive integer.",
+            ephemeral=True,
+        )
+    return n, None
+
+
+def _validate_launch_targets(
+    tokens: list[str],
+) -> tuple[list[str], dict | None]:
+    """
+    Validate a list of target tokens (hub slugs, DPLA IDs, QIDs, pipe-separated).
+    Returns (launch_targets, None) on success, or ([], error_reply) on the first
+    invalid token.
+    """
+    seen_tokens: set[str] = set()
+    launch_targets: list[str] = []
+    for token in tokens:
+        if is_wikidata_id(token):
+            if token in seen_tokens:
+                return [], _slack_reply(
+                    f"Target `{token}` appears more than once.", ephemeral=True
+                )
+            seen_tokens.add(token)
+            launch_targets.append(token)
+        elif is_dpla_id(token):
+            normalised = token.lower()
+            if normalised in seen_tokens:
+                return [], _slack_reply(
+                    f"Target `{normalised}` appears more than once.", ephemeral=True
+                )
+            seen_tokens.add(normalised)
+            launch_targets.append(normalised)
+        else:
+            pipe_count = token.count("|")
+            if pipe_count > 2:
+                return [], _slack_reply(
+                    f"Invalid target: `{token}`."
+                    " Use `<hub>`, `<hub>|<institution>`,"
+                    " or `<hub>|<institution>|<collection>`.",
+                    ephemeral=True,
+                )
+            parts = token.split("|", 2)
+            hub_part = parts[0].strip()
+            institution = parts[1].strip() if pipe_count >= 1 else None
+            collection = parts[2].strip() if pipe_count >= 2 else None
+            if institution is not None and not institution:
+                return [], _slack_reply("Institution cannot be empty.", ephemeral=True)
+            if collection is not None and not collection:
+                return [], _slack_reply("Collection cannot be empty.", ephemeral=True)
+            canonical = resolve_slug(hub_part)
+            if canonical is None:
+                return [], _slack_reply(
+                    f"Unknown hub: `{hub_part}`. Check the hub slug and try again.",
+                    ephemeral=True,
+                )
+            if collection is not None:
+                target_str = f"{canonical}|{institution}|{collection}"
+            elif institution is not None:
+                target_str = f"{canonical}|{institution}"
+            else:
+                target_str = canonical
+            if target_str in seen_tokens:
+                return [], _slack_reply(
+                    f"Target `{target_str}` appears more than once.", ephemeral=True
+                )
+            seen_tokens.add(target_str)
+            launch_targets.append(target_str)
+    return launch_targets, None
+
+
 def handler(event, context):
     headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
     body = event.get("body") or ""
@@ -190,7 +265,8 @@ def handler(event, context):
                 "Wrap targets containing spaces in quotes:"
                 ' `/wikimedia-upload "indiana|Indiana State Library"`\n'
                 "To stop a session: `/wikimedia-upload kill <label> [<label> ...]`\n"
-                "To retry transient failures: `/wikimedia-upload retry <days> [<partner>]`",
+                "To retry transient failures: `/wikimedia-upload retry <days> [<partner>]`\n"
+                "To refresh S3 files: `/wikimedia-upload refresh <target> <days>`",
                 ephemeral=True,
             )
 
@@ -234,16 +310,9 @@ def handler(event, context):
                     "Example: `/wikimedia-upload retry 7` or `/wikimedia-upload retry 14 nara`",
                     ephemeral=True,
                 )
-            days_str = retry_tokens[0]
-            try:
-                days = int(days_str)
-                if days <= 0:
-                    raise ValueError
-            except ValueError:
-                return _slack_reply(
-                    f"`{days_str}` is not a valid number of days. Provide a positive integer.",
-                    ephemeral=True,
-                )
+            days, err = _parse_positive_int(retry_tokens[0])
+            if err is not None:
+                return err
             if len(retry_tokens) > 2:
                 return _slack_reply(
                     "Too many arguments. Usage: `/wikimedia-upload retry <days> [<partner>]`",
@@ -274,68 +343,52 @@ def handler(event, context):
                 ephemeral=True,
             )
 
+        # Refresh subcommand: /wikimedia-upload refresh <target> [<target> ...] <days>
+        # Re-downloads files older than DAYS days without running the uploader.
+        if tokens[0] == "refresh":
+            refresh_tokens = tokens[1:]
+            if len(refresh_tokens) < 2:
+                return _slack_reply(
+                    "Usage: `/wikimedia-upload refresh <target> <days>`\n"
+                    "Re-downloads files already in S3 that are older than DAYS days,"
+                    " without re-uploading to Commons.\n"
+                    "Example: `/wikimedia-upload refresh ohio 90`\n"
+                    'Example: `/wikimedia-upload refresh "indiana|Indiana State Library" 30`',
+                    ephemeral=True,
+                )
+            days, err = _parse_positive_int(refresh_tokens[-1])
+            if err is not None:
+                return err
+            refresh_targets, err = _validate_launch_targets(refresh_tokens[:-1])
+            if err is not None:
+                return err
+            if not refresh_targets:
+                return _slack_reply("No valid targets provided.", ephemeral=True)
+            partner_input = shlex.join(refresh_targets)
+            targets_display = ", ".join(f"`{t}`" for t in refresh_targets)
+            concurrency_key = hashlib.sha256(partner_input.encode()).hexdigest()[:16]
+            return _dispatch_and_reply(
+                gh_token,
+                repo,
+                "wikimedia-launch.yml",
+                {
+                    "partner": partner_input,
+                    "response_url": response_url,
+                    "concurrency_key": concurrency_key,
+                    "max_age_days": str(days),
+                    "refresh_only": "true",
+                },
+                f"Launching download refresh for {targets_display}"
+                f" — re-downloading files older than {days} day{'s' if days != 1 else ''}"
+                ", no upload. Confirmation will post to #tech-alerts shortly.",
+            )
+
         # Launch subcommand: /wikimedia-upload <target> [<target> ...]
         # QIDs and DPLA IDs are passed through; the launch script resolves them.
         # Hub-based targets are validated here for fast Slack feedback.
-        seen_tokens: set[str] = set()
-        launch_targets: list[str] = []
-        for token in tokens:
-            if _QID_RE.match(token):
-                # Wikidata QID — pass through unchanged.
-                if token in seen_tokens:
-                    return _slack_reply(
-                        f"Target `{token}` appears more than once.",
-                        ephemeral=True,
-                    )
-                seen_tokens.add(token)
-                launch_targets.append(token)
-            elif is_dpla_id(token):
-                # DPLA item ID — normalise to lowercase and pass through for
-                # resolution by the launch script on EC2.
-                normalised = token.lower()
-                if normalised in seen_tokens:
-                    return _slack_reply(
-                        f"Target `{normalised}` appears more than once.",
-                        ephemeral=True,
-                    )
-                seen_tokens.add(normalised)
-                launch_targets.append(normalised)
-            else:
-                pipe_count = token.count("|")
-                if pipe_count > 2:
-                    return _slack_reply(
-                        f"Invalid target: `{token}`."
-                        " Use `<hub>`, `<hub>|<institution>`,"
-                        " or `<hub>|<institution>|<collection>`.",
-                        ephemeral=True,
-                    )
-                parts = token.split("|", 2)
-                hub_part = parts[0].strip()
-                institution = parts[1].strip() if pipe_count >= 1 else None
-                collection = parts[2].strip() if pipe_count >= 2 else None
-                if institution is not None and not institution:
-                    return _slack_reply("Institution cannot be empty.", ephemeral=True)
-                if collection is not None and not collection:
-                    return _slack_reply("Collection cannot be empty.", ephemeral=True)
-                canonical = resolve_slug(hub_part)
-                if canonical is None:
-                    return _slack_reply(
-                        f"Unknown hub: `{hub_part}`. Check the hub slug and try again.",
-                        ephemeral=True,
-                    )
-                if collection is not None:
-                    target_str = f"{canonical}|{institution}|{collection}"
-                elif institution is not None:
-                    target_str = f"{canonical}|{institution}"
-                else:
-                    target_str = canonical
-                if target_str in seen_tokens:
-                    return _slack_reply(
-                        f"Target `{target_str}` appears more than once.",
-                        ephemeral=True,
-                    )
-                seen_tokens.add(target_str)
-                launch_targets.append(target_str)
+        launch_targets, err = _validate_launch_targets(tokens)
+        if err is not None:
+            return err
 
         partner_input = shlex.join(launch_targets)
         targets_display = ", ".join(f"`{t}`" for t in launch_targets)

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -79,9 +79,13 @@ def main() -> None:
     parser.add_argument("--partner", required=True)
     parser.add_argument("--force", default="false")
     parser.add_argument("--response-url", default="")
+    parser.add_argument("--max-age-days", default="")
+    parser.add_argument("--refresh-only", default="false")
     args = parser.parse_args()
 
     force = args.force.lower() == "true"
+    # GitHub Actions passes boolean inputs as the strings "true"/"false" — same as --force.
+    refresh_only = args.refresh_only.lower() == "true"
     raw_url = args.response_url.strip()
     # Only accept genuine Slack response_url values — reject arbitrary POST targets.
     response_url = (
@@ -89,6 +93,17 @@ def main() -> None:
     )
     if raw_url and not response_url:
         print(f"Ignoring invalid response_url: {raw_url!r}", file=sys.stderr)
+    max_age_days: int | None = None
+    if args.max_age_days.strip():
+        try:
+            max_age_days = int(args.max_age_days)
+            if max_age_days <= 0:
+                raise ValueError
+        except ValueError:
+            _slack_fail(
+                response_url,
+                f"Invalid --max-age-days value: {args.max_age_days!r} (must be a positive integer).",
+            )
 
     # --partner may be a shlex-encoded list: 'bpl "indiana|Indiana State Library"'
     try:
@@ -511,14 +526,17 @@ def main() -> None:
             f"export WIKIMEDIA_SESSION_LABEL={shlex.quote(session_label)}; "
             f"{single_item_env}"
         )
-        target_steps = " && ".join(
-            [
-                f"cd {base}",
-                get_ids_cmd,
-                f"downloader {csv_file} {canonical}",
-                f"uploader {csv_file} {canonical}",
-            ]
+        dl_age_opt = (
+            f"--max-age-days {max_age_days} " if max_age_days is not None else ""
         )
+        pipeline_steps = [
+            f"cd {base}",
+            get_ids_cmd,
+            f"downloader {dl_age_opt}{csv_file} {canonical}",
+        ]
+        if not refresh_only:
+            pipeline_steps.append(f"uploader {csv_file} {canonical}")
+        target_steps = " && ".join(pipeline_steps)
         target_blocks.append(
             f"{label_export}; {{ {target_steps}; }}"
             f" || {{ {notify_fail_cmd} >/dev/null 2>&1 || true; }}"
@@ -541,17 +559,27 @@ def main() -> None:
         batch_targets = [
             (c, i, lbl, col) for c, i, lbl, did, col in targets if did is None
         ]
+        refresh_suffix = ""
+        if refresh_only:
+            age_note = f">{max_age_days}d" if max_age_days is not None else ">365d"
+            refresh_suffix = f" (ID generation → download, refreshing files {age_note})"
         if single_item_targets and not batch_targets:
             # All single-item targets: use the eligibility-confirmed format.
             item_descs = [f"`{did}` ({c})" for c, _, did in single_item_targets]
-            msg = f"✅ {', '.join(item_descs)} — eligible, download + upload starting."
+            if refresh_only:
+                msg = f"✅ {', '.join(item_descs)} — eligible, download refresh starting{refresh_suffix}."
+            else:
+                msg = f"✅ {', '.join(item_descs)} — eligible, download + upload starting."
         elif batch_targets and not single_item_targets:
             # All batch targets (hub, institution, or collection).
             batch_labels = [_target_label(c, i, col) for c, i, _, col in batch_targets]
-            msg = (
-                f"▶ Launching `{session_name}` pipeline: {', '.join(batch_labels)}"
-                " (ID generation → download → upload)."
-            )
+            if refresh_only:
+                msg = f"▶ Launching `{session_name}` refresh: {', '.join(batch_labels)}{refresh_suffix}."
+            else:
+                msg = (
+                    f"▶ Launching `{session_name}` pipeline: {', '.join(batch_labels)}"
+                    " (ID generation → download → upload)."
+                )
         else:
             # Mixed: list all targets with a note distinguishing items from batches.
             all_descs = []
@@ -560,7 +588,10 @@ def main() -> None:
                     all_descs.append(f"`{did[:8]}…` ({c}, item)")
                 else:
                     all_descs.append(_target_label(c, i, col))
-            msg = f"▶ Launching `{session_name}` pipeline: {', '.join(all_descs)}."
+            if refresh_only:
+                msg = f"▶ Launching `{session_name}` refresh: {', '.join(all_descs)}{refresh_suffix}."
+            else:
+                msg = f"▶ Launching `{session_name}` pipeline: {', '.join(all_descs)}."
         try:
             post_message(slack_token, msg)
         except Exception as e:

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -86,7 +86,14 @@ class Downloader:
 
                 # Don't overwrite a valid existing S3 file with a 0-byte download
                 # (e.g. a transient empty HTTP response from the source server).
-                if obj_metadata and os.stat(file).st_size == 0:
+                # Use `is not None` rather than truthiness — empty metadata dicts ({})
+                # are falsy but still indicate the object exists.
+                existing_size = int(obj.content_length or 0)
+                if (
+                    obj_metadata is not None
+                    and existing_size > 0
+                    and os.stat(file).st_size == 0
+                ):
                     logging.warning(
                         f"New download is 0 bytes; keeping existing file at "
                         f"s3://{S3_BUCKET}/{destination_path}"
@@ -373,7 +380,7 @@ class Downloader:
 @click.option(
     "--max-age-days",
     default=365,
-    type=int,
+    type=click.IntRange(min=0),
     help="Re-download files already in S3 if older than N days (default: 365).",
 )
 def main(

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import time
+from datetime import datetime, timezone
 
 from ingest_wikimedia.dpla import (
     MEDIA_MASTER_FIELD_NAME,
@@ -83,6 +84,16 @@ class Downloader:
                         # Just in case (dunno why this would happen)
                         raise e
 
+                # Don't overwrite a valid existing S3 file with a 0-byte download
+                # (e.g. a transient empty HTTP response from the source server).
+                if obj_metadata and os.stat(file).st_size == 0:
+                    logging.warning(
+                        f"New download is 0 bytes; keeping existing file at "
+                        f"s3://{S3_BUCKET}/{destination_path}"
+                    )
+                    self.tracker.increment(Result.SKIPPED)
+                    return False
+
                 if obj_metadata and obj_metadata.get(CHECKSUM) == sha1:
                     try:
                         if int(obj.content_length) > 0:
@@ -146,6 +157,17 @@ class Downloader:
         except Exception as e:
             raise RuntimeError(f"Failed downloading {media_url} to local") from e
 
+    def _s3_key_age_days(self, s3_path: str) -> float | None:
+        """Return the age in days of an S3 object, or None if it does not exist."""
+        try:
+            obj = self.s3_client.get_s3().Object(S3_BUCKET, s3_path)
+            age = datetime.now(tz=timezone.utc) - obj.last_modified
+            return age.total_seconds() / 86400
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") == "404":
+                return None
+            raise
+
     def process_media(
         self,
         partner: str,
@@ -153,11 +175,16 @@ class Downloader:
         ordinal: int,
         media_url: str,
         overwrite: bool,
+        max_age_days: int | None,
         sleep_secs: float,
     ) -> None:
         """
         For a given capture for a given item, downloads it if we don't have it or are
         overwriting, gets the mime and sha1, and sticks it in S3.
+
+        If max_age_days is set, files already in S3 are re-downloaded once they are
+        older than that threshold. The existing S3 file is kept if the new download
+        is 0 bytes (see upload_file_to_s3).
 
         upload_file_to_s3() is retried on CredentialRetrievalError: EC2 instance profile
         credentials occasionally fail to refresh from IMDS, causing a brief blip that
@@ -171,10 +198,17 @@ class Downloader:
             destination_path = self.s3_client.get_media_s3_path(
                 dpla_id, ordinal, partner
             )
-            if not overwrite and self.s3_client.s3_file_exists(destination_path):
-                logging.info("Key already in S3.")
-                self.tracker.increment(Result.SKIPPED)
-                return
+            if not overwrite:
+                age_days = self._s3_key_age_days(destination_path)
+                if age_days is not None:
+                    if max_age_days is None or age_days < max_age_days:
+                        logging.info("Key already in S3.")
+                        self.tracker.increment(Result.SKIPPED)
+                        return
+                    logging.info(
+                        f"Refreshing {dpla_id} {ordinal}: S3 file is "
+                        f"{age_days:.0f} days old (threshold: {max_age_days})."
+                    )
 
             if sleep_secs != 0:
                 time.sleep(sleep_secs)
@@ -224,6 +258,7 @@ class Downloader:
         partner: str,
         dpla_id: str,
         sleep_secs: float,
+        max_age_days: int | None = None,
     ) -> None:
         """
         For every item, tries to get a list of files for it and stores the
@@ -319,6 +354,7 @@ class Downloader:
                     count,
                     media_url,
                     overwrite,
+                    max_age_days,
                     sleep_secs,
                 )
 
@@ -334,6 +370,12 @@ class Downloader:
     default=0.0,
     help="Interval to wait in between http requests in float seconds.",
 )
+@click.option(
+    "--max-age-days",
+    default=None,
+    type=int,
+    help="Re-download files already in S3 if older than N days (default: always skip existing files).",
+)
 def main(
     ids_file: IO,
     partner: str,
@@ -341,6 +383,7 @@ def main(
     verbose: bool,
     overwrite: bool,
     sleep: float,
+    max_age_days: int | None,
 ):
     setup_logging(partner, "download", logging.INFO)
     start_time = time.time()
@@ -378,6 +421,7 @@ def main(
                 partner,
                 dpla_id,
                 sleep,
+                max_age_days,
             )
 
     finally:

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -10,7 +10,7 @@ from ingest_wikimedia.dpla import (
 )
 from ingest_wikimedia.iiif import IIIF
 from ingest_wikimedia.localfs import LocalFS
-from ingest_wikimedia.s3 import S3_BUCKET, S3_KEY_METADATA, S3Client
+from ingest_wikimedia.s3 import S3_BUCKET, S3_KEY_METADATA, S3Client, FILE_LIST_TXT
 from typing import IO
 
 import click
@@ -88,18 +88,17 @@ class Downloader:
                 # (e.g. a transient empty HTTP response from the source server).
                 # Use `is not None` rather than truthiness — empty metadata dicts ({})
                 # are falsy but still indicate the object exists.
-                existing_size = int(obj.content_length or 0)
-                if (
-                    obj_metadata is not None
-                    and existing_size > 0
-                    and os.stat(file).st_size == 0
-                ):
-                    logging.warning(
-                        f"New download is 0 bytes; keeping existing file at "
-                        f"s3://{S3_BUCKET}/{destination_path}"
-                    )
-                    self.tracker.increment(Result.SKIPPED)
-                    return False
+                # Only access obj.content_length when obj_metadata is not None: accessing
+                # it on a non-existent object triggers a second HEAD request (another 404).
+                if obj_metadata is not None and os.stat(file).st_size == 0:
+                    existing_size = int(obj.content_length or 0)
+                    if existing_size > 0:
+                        logging.warning(
+                            f"New download is 0 bytes; keeping existing file at "
+                            f"s3://{S3_BUCKET}/{destination_path}"
+                        )
+                        self.tracker.increment(Result.SKIPPED)
+                        return False
 
                 if obj_metadata and obj_metadata.get(CHECKSUM) == sha1:
                     try:
@@ -301,7 +300,17 @@ class Downloader:
 
             elif IIIF_MANIFEST_FIELD_NAME in item_metadata:
                 cached_urls = self.s3_client.get_file_list(partner, dpla_id)
-                if not overwrite and cached_urls:
+                use_cache = not overwrite and bool(cached_urls)
+                if use_cache and max_age_days is not None:
+                    file_list_path = self.s3_client.get_item_s3_path(
+                        dpla_id, FILE_LIST_TXT, partner
+                    )
+                    cache_age = self._s3_key_age_days(file_list_path)
+                    # cache_age is None means the key vanished since get_file_list
+                    # read it (TOCTOU); treat as stale so the manifest is re-fetched.
+                    if cache_age is None or cache_age >= max_age_days:
+                        use_cache = False
+                if use_cache:
                     media_urls = cached_urls
                 else:
                     manifest_url = get_str(item_metadata, IIIF_MANIFEST_FIELD_NAME)

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -258,7 +258,7 @@ class Downloader:
         partner: str,
         dpla_id: str,
         sleep_secs: float,
-        max_age_days: int | None = None,
+        max_age_days: int | None = 365,
     ) -> None:
         """
         For every item, tries to get a list of files for it and stores the
@@ -372,9 +372,9 @@ class Downloader:
 )
 @click.option(
     "--max-age-days",
-    default=None,
+    default=365,
     type=int,
-    help="Re-download files already in S3 if older than N days (default: always skip existing files).",
+    help="Re-download files already in S3 if older than N days (default: 365).",
 )
 def main(
     ids_file: IO,


### PR DESCRIPTION
## Summary

- **Default 365-day rolling refresh**: `--max-age-days` now defaults to `365` in the downloader — every normal pipeline run re-downloads files that have been in S3 for over a year, creating a rolling refresh cycle that detects provider-side content changes without manual intervention
- **`/wikimedia-upload refresh <target> <days>`**: New Slack subcommand that runs get-ids + download-only with a custom age threshold (no upload). Accepts the same target syntax as a normal upload: hub slug, \`hub|institution\`, \`hub|institution|collection\`, DPLA item ID, or Wikidata QID
- **0-byte protection**: Preserves the existing S3 file if a new download comes back empty (transient HTTP response), preventing valid files from being silently overwritten with stubs
- **Narrow `ClientError` catch**: `_s3_key_age_days` now only swallows 404s — permission errors and throttling propagate instead of being misread as "file doesn't exist"
- **Handler cleanup**: Extracted `_parse_positive_int` and `_validate_launch_targets` helpers in the Lambda handler, removing duplicated validation between the `retry` and `refresh` subcommands; replaced local `_QID_RE` with `is_wikidata_id()` from the partners module

## Behaviour

### Normal pipeline runs (default)
| S3 file exists | Age | Action |
|---|---|---|
| No | — | Download |
| Yes | < 365 days | Skip |
| Yes | ≥ 365 days | Re-download |

### `/wikimedia-upload refresh <target> <days>`
Runs get-ids + download only (no uploader) with the specified threshold. Example:
- `/wikimedia-upload refresh ohio 90` — re-downloads Ohio files older than 90 days
- `/wikimedia-upload refresh "indiana|Indiana State Library" 180` — institution-scoped refresh

## Test plan

- [ ] Normal run on a partner with all-recent files — nothing re-downloaded
- [ ] Normal run on a partner with files > 365 days old — those files re-downloaded, log shows "Refreshing … S3 file is X days old"
- [ ] `/wikimedia-upload refresh ohio 30` — dispatches correctly, Slack confirmation shows refresh wording
- [ ] `/wikimedia-upload refresh ohio notanumber` — returns ephemeral error
- [ ] 0-byte download with existing S3 file — existing file preserved, warning logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Pull Request Summary

## Overview
Implements a 365-day rolling S3 refresh for the downloader and adds a Slack-driven on-demand refresh subcommand. Files in S3 older than the configured threshold are re-downloaded to detect provider-side changes; 0-byte downloads are protected against overwriting existing objects.

## Key Changes

### Downloader (tools/downloader.py)
- Adds S3 age-awareness via _s3_key_age_days(); default CLI flag --max-age-days now defaults to 365.
- Behavior: missing S3 objects → download; existing and age < threshold → skip; existing and age ≥ threshold → re-download.
- IIIF manifest cache file-list.txt is treated age-aware: caches older than threshold are re-fetched.
- Prevents overwriting S3 objects with newly downloaded 0-byte files: upload is skipped and tracked as skipped.
- Narrower S3 error handling: only 404s are swallowed; permission/throttling errors propagate.
- Public CLI signatures updated to accept max_age_days and pass it into process_item/process_media.

### Slack & Lambda (lambda/wikimedia-slack-dispatch/handler.py)
- Adds new Slack subcommand: /wikimedia-upload refresh <target> <days> — dispatches a refresh-only launch (download-only, no upload) via the workflow dispatch.
- Target parsing/validation refactored into helpers (_parse_positive_int, _validate_launch_targets); QID handling uses partners.is_wikidata_id().
- Acceptable targets: hub slug, hub|institution, hub|institution|collection, DPLA item ID, or Wikidata QID.
- Updated usage/help text and consolidated validation for retry/refresh days.

### Workflow & Launch Script
- .github/workflows/wikimedia-launch.yml: adds workflow_dispatch inputs max_age_days and refresh_only; wires them into environment variables (INPUT_MAX_AGE_DAYS, INPUT_REFRESH_ONLY) for the launch step.
- scripts/wikimedia_launch.py: adds CLI flags --max-age-days and --refresh-only; in refresh-only mode, uploader step is omitted and --max-age-days is forwarded to downloader for age-controlled refreshes. Slack notifications updated to reflect refresh semantics and include age note.

## Deployment & Infrastructure Notes (explicit)
- Manual pipeline trigger / redeployment:
  - The new default downloader behavior (365-day refresh) takes effect when the pipeline runs code that includes this change—no separate ECS redeployment or infra change is required for the default behavior.
  - The new Slack subcommand requires the Lambda handler code to be deployed via existing CI/CD; it is not available until that deployment completes.
  - The GitHub Actions workflow changes enable manual dispatch inputs; those inputs are available immediately once this code is merged (no external service reconfiguration required).
- Environment variables / secrets:
  - Adds GitHub Actions workflow environment variables INPUT_MAX_AGE_DAYS and INPUT_REFRESH_ONLY (derived from workflow_dispatch inputs). These are workflow-scoped and do not require changes to AWS Secrets Manager or other external secret stores.
  - No new AWS credentials or secret keys introduced or renamed.
- Shared infrastructure:
  - No changes to CodePipeline, CodeBuild, ECS task definitions, IAM policies, or other shared infra in this PR.
- Database migrations / public APIs:
  - No database migrations.
  - No public-facing API response shapes or endpoints are changed.
- Security implications:
  - S3 error handling tightened so permission/throttling errors no longer get swallowed silently.
  - Input validation for numeric days added/centralized (Click IntRange and handler validation).
  - No changes to credential handling; existing AWS S3 and Slack authentication remain in use.

## Tests / Behavior verification
- Tests / manual checks included/checked in PR:
  - Verify no re-downloads for recent files (< threshold).
  - Verify re-downloads and logging for files ≥ 365 days (or custom threshold).
  - Verify Slack /wikimedia-upload refresh dispatch, target validation, and numeric days parsing.
  - Verify 0-byte downloads do not overwrite existing non-zero S3 objects and emit warnings.

## Public API / Exported Signature Changes
- tools/downloader.py: updated function/method signatures to accept max_age_days (main, Downloader.process_item, Downloader.process_media).
- Lambda handler entrypoint signature unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->