### PR TITLE
downloader: post download-complete summary to Slack after refresh runs

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -82,50 +82,32 @@ def _format_bytes(num_bytes: int) -> str:
     return f"{value:,.1f} PB"
 
 
-def notify_upload_complete(
-    tracker: Tracker,
-    partner_label: str,
-    elapsed_seconds: float,
-    dry_run: bool = False,
-) -> None:
-    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
-    if not token:
-        logging.warning("DPLA_SLACK_BOT_TOKEN not set — skipping Slack notification")
-        return
-
-    session_label = os.environ.get("WIKIMEDIA_SESSION_LABEL")
-    effective_label = f"wikimedia-{session_label}" if session_label else partner_label
-
+def _format_runtime(elapsed_seconds: float) -> str:
     hours, remainder = divmod(int(elapsed_seconds), 3600)
     minutes, seconds = divmod(remainder, 60)
     if hours:
-        runtime = f"{hours}h {minutes}m {seconds}s"
-    elif minutes:
-        runtime = f"{minutes}m {seconds}s"
-    else:
-        runtime = f"{seconds}s"
+        return f"{hours}h {minutes}m {seconds}s"
+    if minutes:
+        return f"{minutes}m {seconds}s"
+    return f"{seconds}s"
 
-    dry_run_note = " _(dry run)_" if dry_run else ""
-    header = f"*Wikimedia Upload Complete: {effective_label}*{dry_run_note}"
 
-    lines = [
-        f"UPLOADED: {tracker.count(Result.UPLOADED):,}",
-        f"SKIPPED:  {tracker.count(Result.SKIPPED):,}",
-        f"FAILED:   {tracker.count(Result.FAILED):,}",
-        f"BYTES:    {_format_bytes(tracker.count(Result.BYTES))}",
-        f"Runtime:  {runtime}",
-    ]
-    body = "```" + "\n".join(lines) + "```"
-
+def _post_completion_notice(
+    token: str,
+    header: str,
+    plain_text: str,
+    stats_lines: list[str],
+) -> None:
+    """Post a completion summary block to #tech-alerts. Logs warnings on failure."""
+    body = "```" + "\n".join(stats_lines) + "```"
     payload = {
         "channel": SLACK_CHANNEL,
-        "text": f"Wikimedia upload complete: {effective_label}",
+        "text": plain_text,
         "blocks": [
             {"type": "section", "text": {"type": "mrkdwn", "text": header}},
             {"type": "section", "text": {"type": "mrkdwn", "text": body}},
         ],
     }
-
     try:
         response = requests.post(
             SLACK_API_URL,
@@ -141,3 +123,65 @@ def notify_upload_complete(
         logging.warning(f"Slack API returned HTTP {ex.response.status_code}")
     except Exception as ex:
         logging.warning("Failed to send Slack notification", exc_info=ex)
+
+
+def notify_download_complete(
+    tracker: Tracker,
+    partner_label: str,
+    elapsed_seconds: float,
+    dry_run: bool = False,
+) -> None:
+    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
+    if not token:
+        logging.warning("DPLA_SLACK_BOT_TOKEN not set — skipping Slack notification")
+        return
+
+    effective_label = (
+        f"wikimedia-{os.environ.get('WIKIMEDIA_SESSION_LABEL') or partner_label}"
+    )
+    runtime = _format_runtime(elapsed_seconds)
+    dry_run_note = " _(dry run)_" if dry_run else ""
+
+    _post_completion_notice(
+        token=token,
+        header=f"*Wikimedia Download Refresh Complete: {effective_label}*{dry_run_note}",
+        plain_text=f"Wikimedia download refresh complete: {effective_label}",
+        stats_lines=[
+            f"REFRESHED: {tracker.count(Result.DOWNLOADED):,}",
+            f"SKIPPED:   {tracker.count(Result.SKIPPED):,}",
+            f"FAILED:    {tracker.count(Result.FAILED):,}",
+            f"BYTES:     {_format_bytes(tracker.count(Result.BYTES))}",
+            f"Runtime:   {runtime}",
+        ],
+    )
+
+
+def notify_upload_complete(
+    tracker: Tracker,
+    partner_label: str,
+    elapsed_seconds: float,
+    dry_run: bool = False,
+) -> None:
+    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
+    if not token:
+        logging.warning("DPLA_SLACK_BOT_TOKEN not set — skipping Slack notification")
+        return
+
+    effective_label = (
+        f"wikimedia-{os.environ.get('WIKIMEDIA_SESSION_LABEL') or partner_label}"
+    )
+    runtime = _format_runtime(elapsed_seconds)
+    dry_run_note = " _(dry run)_" if dry_run else ""
+
+    _post_completion_notice(
+        token=token,
+        header=f"*Wikimedia Upload Complete: {effective_label}*{dry_run_note}",
+        plain_text=f"Wikimedia upload complete: {effective_label}",
+        stats_lines=[
+            f"UPLOADED: {tracker.count(Result.UPLOADED):,}",
+            f"SKIPPED:  {tracker.count(Result.SKIPPED):,}",
+            f"FAILED:   {tracker.count(Result.FAILED):,}",
+            f"BYTES:    {_format_bytes(tracker.count(Result.BYTES))}",
+            f"Runtime:  {runtime}",
+        ],
+    )

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -529,10 +529,11 @@ def main() -> None:
         dl_age_opt = (
             f"--max-age-days {max_age_days} " if max_age_days is not None else ""
         )
+        dl_notify_opt = "--notify-complete " if refresh_only else ""
         pipeline_steps = [
             f"cd {base}",
             get_ids_cmd,
-            f"downloader {dl_age_opt}{csv_file} {canonical}",
+            f"downloader {dl_age_opt}{dl_notify_opt}{csv_file} {canonical}",
         ]
         if not refresh_only:
             pipeline_steps.append(f"uploader {csv_file} {canonical}")

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -25,7 +25,7 @@ from ingest_wikimedia.common import (
     CONTENT_TYPE,
 )
 from ingest_wikimedia.logs import setup_logging
-from ingest_wikimedia.slack import notify_phase_start
+from ingest_wikimedia.slack import notify_download_complete, notify_phase_start
 from ingest_wikimedia.tools_context import ToolsContext
 from ingest_wikimedia.tracker import Result, Tracker
 from ingest_wikimedia.web import Web
@@ -392,6 +392,11 @@ class Downloader:
     type=click.IntRange(min=0),
     help="Re-download files already in S3 if older than N days (default: 365).",
 )
+@click.option(
+    "--notify-complete",
+    is_flag=True,
+    help="Post a download-complete summary to Slack when finished (used for refresh runs).",
+)
 def main(
     ids_file: IO,
     partner: str,
@@ -400,6 +405,7 @@ def main(
     overwrite: bool,
     sleep: float,
     max_age_days: int | None,
+    notify_complete: bool,
 ):
     setup_logging(partner, "download", logging.INFO)
     start_time = time.time()
@@ -441,9 +447,17 @@ def main(
             )
 
     finally:
+        elapsed = time.time() - start_time
         logging.info("\n" + str(tracker))
-        logging.info(f"{time.time() - start_time} seconds.")
+        logging.info(f"{elapsed} seconds.")
         local_fs.cleanup_temp_dir()
+        if notify_complete:
+            notify_download_complete(
+                tracker=tracker,
+                partner_label=partner,
+                elapsed_seconds=elapsed,
+                dry_run=dry_run,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `notify_download_complete` to `slack.py`, called from the downloader when `--notify-complete` is set
- `wikimedia_launch.py` passes `--notify-complete` to the downloader for refresh-only runs (where download is the final phase), so `#tech-alerts` receives a completion summary matching the upload notification format
- Refactors `slack.py` to extract `_format_runtime` and `_post_completion_notice` helpers, eliminating duplicated logic between `notify_download_complete` and `notify_upload_complete`
- Fixes session-label fallback in both completion functions to always prefix `wikimedia-`, consistent with `notify_phase_start`

## Slack message format

```
Wikimedia Download Refresh Complete: wikimedia-ohio
REFRESHED: 142
SKIPPED:   48,203
FAILED:    3
BYTES:     2.1 GB
Runtime:   1h 12m 44s
```

## Test plan

- [ ] Trigger `/wikimedia-upload refresh <partner> <days>` and confirm completion summary posts to `#tech-alerts`
- [ ] Confirm normal upload runs are unaffected (no completion message from downloader phase)
- [ ] Confirm dry-run flag appends `(dry run)` note to header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Slack Completion Notification for Downloader Refresh Runs

This PR adds a Slack notification feature to post download completion summaries to `#tech-alerts` when the downloader finishes during refresh-only runs. It introduces shared Slack helper functions and wires the notification through the downloader CLI and orchestration script.

### Changes Summary

**ingest_wikimedia/slack.py** (+76 lines, -32 lines)
- Extracted internal helpers `_format_runtime()` and `_post_completion_notice()` to standardize completion message formatting and delivery across completion notifications
- Added new public function `notify_download_complete()` that posts download/refresh-specific completion summaries with the same block-based message format as upload completions
- Refactored `notify_upload_complete()` to use the shared helpers, eliminating duplicated logic
- Fixed session-label fallback in both completion functions to consistently prefix with "wikimedia-"

**tools/downloader.py** (+16 lines, -2 lines)
- Added `--notify-complete` CLI flag that triggers Slack notification after download finishes
- Integrated `notify_download_complete()` call in the finally block to post completion summary with runtime, partner label, and dry-run status
- Imported `notify_download_complete` from slack module

**scripts/wikimedia_launch.py** (+2 lines, -1 line)
- Modified per-target downloader command to conditionally pass `--notify-complete` only during refresh-only runs (when download is the final pipeline phase)
- This ensures `#tech-alerts` receives completion summaries for refresh operations without spurious notifications from full pipeline runs

### Deployment Notes

**EC2 Code Update Required**: The changes take effect on the next EC2 code update via `git pull` in the workflow. No ECS redeployment or infrastructure changes needed. The code update already occurs automatically at the start of each `wikimedia_launch.py` execution.

**No New Environment Variables or Secrets**: The PR reuses existing `DPLA_SLACK_BOT_TOKEN` and `WIKIMEDIA_SESSION_LABEL` environment variables; no new configuration is required.

**Behavioral Change**: The `--notify-complete` flag is only passed to downloader when `refresh_only=true` in `wikimedia_launch.py`, ensuring notifications only post for refresh-only operations and not for standard full pipeline runs.

### Message Format

Slack messages follow the existing completion notice template (header + fenced code block with runtime and stats):
```
Wikimedia Download Refresh Complete: wikimedia-<label>
REFRESHED: <count>
SKIPPED: <count>
FAILED: <count>
BYTES: <size>
Runtime: <duration>
```

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->