### PR TITLE
uploader: fix false-positive {{Duplicate}} tagging on same-item sha1 coincidences

### DIFF
--- a/scripts/wikimedia_kill.py
+++ b/scripts/wikimedia_kill.py
@@ -22,7 +22,7 @@ import sys
 import boto3
 import requests
 
-from ingest_wikimedia.partners import is_wikidata_id, resolve_wikidata_id
+from ingest_wikimedia.partners import is_wikidata_id, resolve_slug, resolve_wikidata_id
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run
 
@@ -83,9 +83,10 @@ def main() -> None:
                     seen.add(component)
                     kill_components.append(component)
         else:
-            if token not in seen:
-                seen.add(token)
-                kill_components.append(token)
+            component = resolve_slug(token) or token
+            if component not in seen:
+                seen.add(component)
+                kill_components.append(component)
 
     if not kill_components:
         _slack_fail(response_url, "No targets specified.")

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -19,6 +19,7 @@ from ingest_wikimedia.ssm import REGION, ssm_run
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
 _UPLOAD_COMPLETE_PREFIX = "Upload complete"
+_DOWNLOAD_COMPLETE_PREFIX = "Download complete"
 
 
 def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | None:
@@ -102,7 +103,12 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
     if log_file.endswith("-download.log"):
         if "Downloading" in tail or "Key already in S3" in tail:
             return f"Downloading ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%)"
-        return "Generating IDs"
+        if counts_marker > 0:
+            return f"{_DOWNLOAD_COMPLETE_PREFIX} ({dpla_id_count:,} / {total:,} items)"
+        # Log exists for this session but no active download indicators and no COUNTS
+        # marker — downloader likely crashed. Report item count without implying
+        # get-ids-es is running (the old "Generating IDs" fallback was wrong here).
+        return f"Stalled ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%)"
 
     if log_file.endswith("-upload.log"):
         if dpla_id_count == 0:

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -20,6 +20,9 @@ SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
 _UPLOAD_COMPLETE_PREFIX = "Upload complete"
 _DOWNLOAD_COMPLETE_PREFIX = "Download complete"
+# A session that hasn't written a log line in this many seconds is considered hung.
+# Uploads normally complete items in seconds; downloads in seconds to low minutes.
+_STALE_SECONDS = 1800  # 30 minutes
 
 
 def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | None:
@@ -70,6 +73,7 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
     sep = "__WM_SEP__"
     out = ssm_run(
         client,
+        f"date +%s; "
         f"stat -c %Y {log_path} 2>/dev/null || echo 0; "
         f"echo {sep}; "
         f"tail -5 {log_path}; "
@@ -82,7 +86,9 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
     )
 
     sections = out.split(f"{sep}\n", 2)
-    log_mtime = _safe_int(sections[0].strip()) if sections else 0
+    pre_sep = sections[0].strip().splitlines() if sections else []
+    now = _safe_int(pre_sep[0]) if pre_sep else 0
+    log_mtime = _safe_int(pre_sep[1]) if len(pre_sep) > 1 else 0
 
     # Log predates this session — no new log yet, treat same as no log.
     if session_created > 0 and log_mtime < session_created:
@@ -100,25 +106,41 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
     def pct(n: int) -> str:
         return f"{n / total * 100:.1f}" if total > 0 else "?"
 
+    # Append a staleness warning to any active (non-complete) phase whose log
+    # hasn't been updated in _STALE_SECONDS. Completed phases never get this.
+    stale_suffix = ""
+    if counts_marker == 0 and now > 0 and log_mtime > 0:
+        idle = now - log_mtime
+        if idle > _STALE_SECONDS:
+            idle_min = idle // 60
+            idle_str = (
+                f"{idle_min // 60}h{idle_min % 60:02d}m"
+                if idle_min >= 60
+                else f"{idle_min}m"
+            )
+            stale_suffix = f" ⚠ idle {idle_str}"
+
     if log_file.endswith("-download.log"):
         if "Downloading" in tail or "Key already in S3" in tail:
-            return f"Downloading ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%)"
+            return f"Downloading ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}"
         if counts_marker > 0:
             return f"{_DOWNLOAD_COMPLETE_PREFIX} ({dpla_id_count:,} / {total:,} items)"
         # Log exists for this session but no active download indicators and no COUNTS
         # marker — downloader likely crashed. Report item count without implying
         # get-ids-es is running (the old "Generating IDs" fallback was wrong here).
-        return f"Stalled ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%)"
+        return f"Stalled ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}"
 
     if log_file.endswith("-upload.log"):
         if dpla_id_count == 0:
+            # dpla_id_count == 0 means no items logged yet — uploader just started.
+            # Staleness here would be a false positive from the normal start-up lag.
             return "Uploading (starting...)"
         # Use the COUNTS: terminal marker as the definitive completion signal.
         # dpla_id_count is logged at the start of each item, not after all its
         # files finish, so count arithmetic alone can fire too early.
         if counts_marker > 0:
             return f"{_UPLOAD_COMPLETE_PREFIX} ({uploaded_count:,} uploaded, {skipped_count:,} already on Commons)"
-        return f"Uploading ({dpla_id_count:,} / {total:,}, ~{pct(dpla_id_count)}%)"
+        return f"Uploading ({dpla_id_count:,} / {total:,}, ~{pct(dpla_id_count)}%){stale_suffix}"
 
     return "Unknown"
 

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -121,10 +121,12 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
             stale_suffix = f" ⚠ idle {idle_str}"
 
     if log_file.endswith("-download.log"):
-        if "Downloading" in tail or "Key already in S3" in tail:
-            return f"Downloading ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}"
+        # Use the COUNTS: terminal marker as the definitive completion signal —
+        # "Downloading" may still appear in the tail even after the run finishes.
         if counts_marker > 0:
             return f"{_DOWNLOAD_COMPLETE_PREFIX} ({dpla_id_count:,} / {total:,} items)"
+        if "Downloading" in tail or "Key already in S3" in tail:
+            return f"Downloading ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}"
         # Log exists for this session but no active download indicators and no COUNTS
         # marker — downloader likely crashed. Report item count without implying
         # get-ids-es is running (the old "Generating IDs" fallback was wrong here).

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -304,8 +304,11 @@ def main() -> None:
             # This label has a log. Any earlier no-log labels were skipped.
             first_pending = None
 
-            if not phase.startswith(_UPLOAD_COMPLETE_PREFIX):
-                # Active label — this is the one to report.
+            if not (
+                phase.startswith(_UPLOAD_COMPLETE_PREFIX)
+                or phase.startswith(_DOWNLOAD_COMPLETE_PREFIX)
+            ):
+                # Active or stalled label — this is the one to report.
                 return session, f"[{label}] {phase}" if multi else phase
 
             last_complete_label = label

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -307,47 +307,49 @@ class Uploader:
                 # Avoid the `with executor:` context manager — its __exit__ calls
                 # shutdown(wait=True), which would block until pywikibot's stuck
                 # polling thread exits on its own, defeating the timeout entirely.
+                # Use try/finally to guarantee shutdown(wait=False) on all paths.
                 executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-                for attempt in range(1, MAX_UPLOAD_RETRIES + 1):
-                    try:
-                        future = executor.submit(
-                            self.site.upload,
-                            filepage=wiki_file_page,
-                            source_filename=temp_file.name,
-                            comment=upload_comment,
-                            text=wiki_markup,
-                            ignore_warnings=upload_warnings,
-                            asynchronous=True,
-                            chunk_size=chunk_size,
-                        )
+                try:
+                    for attempt in range(1, MAX_UPLOAD_RETRIES + 1):
                         try:
-                            result = future.result(timeout=UPLOAD_TIMEOUT_SECS)
-                        except concurrent.futures.TimeoutError:
-                            self.tracker.increment(Result.FAILED)
-                            executor.shutdown(wait=False)
-                            raise RuntimeError(
-                                f"Upload timed out after {UPLOAD_TIMEOUT_SECS // 3600}h "
-                                f"— Commons job queue likely stuck"
+                            future = executor.submit(
+                                self.site.upload,
+                                filepage=wiki_file_page,
+                                source_filename=temp_file.name,
+                                comment=upload_comment,
+                                text=wiki_markup,
+                                ignore_warnings=upload_warnings,
+                                asynchronous=True,
+                                chunk_size=chunk_size,
                             )
-                        break
-                    except Exception as ex:
-                        is_backend_fail = ERROR_BACKEND_FAIL in str(ex)
-                        if is_backend_fail and attempt < MAX_UPLOAD_RETRIES:
-                            delay = min(
-                                UPLOAD_RETRY_BASE_DELAY_SECS * (2 ** (attempt - 1)),
-                                UPLOAD_RETRY_MAX_DELAY_SECS,
-                            ) + random.uniform(0, 1.0)
-                            logging.warning(
-                                f"Transient upload error on attempt {attempt}/"
-                                f"{MAX_UPLOAD_RETRIES}, retrying in "
-                                f"{delay:.1f}s: {ex}"
-                            )
-                            time.sleep(delay)
-                        else:
-                            if is_backend_fail:
+                            try:
+                                result = future.result(timeout=UPLOAD_TIMEOUT_SECS)
+                            except concurrent.futures.TimeoutError:
                                 self.tracker.increment(Result.FAILED)
-                            raise
-                executor.shutdown(wait=False)
+                                raise RuntimeError(
+                                    f"Upload timed out after {UPLOAD_TIMEOUT_SECS // 3600}h "
+                                    f"— Commons job queue likely stuck"
+                                )
+                            break
+                        except Exception as ex:
+                            is_backend_fail = ERROR_BACKEND_FAIL in str(ex)
+                            if is_backend_fail and attempt < MAX_UPLOAD_RETRIES:
+                                delay = min(
+                                    UPLOAD_RETRY_BASE_DELAY_SECS * (2 ** (attempt - 1)),
+                                    UPLOAD_RETRY_MAX_DELAY_SECS,
+                                ) + random.uniform(0, 1.0)
+                                logging.warning(
+                                    f"Transient upload error on attempt {attempt}/"
+                                    f"{MAX_UPLOAD_RETRIES}, retrying in "
+                                    f"{delay:.1f}s: {ex}"
+                                )
+                                time.sleep(delay)
+                            else:
+                                if is_backend_fail:
+                                    self.tracker.increment(Result.FAILED)
+                                raise
+                finally:
+                    executor.shutdown(wait=False)
 
                 if not result:
                     # upload() returned None — file exists under a different page

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -547,6 +547,16 @@ class Uploader:
         # our hash to the correct title and leave their file alone. This prevents
         # ping-pong renaming between two valid items that happen to share a hash.
         existing_dpla_id = extract_dpla_id_from_commons_title(actual_filename)
+        if existing_dpla_id == dpla_id:
+            # Same-item hash coincidence: the hash lives at a different page of
+            # this item. Don't tag it as a duplicate — it belongs to this item
+            # and will be overwritten by its own ordinal in the current run.
+            logging.info(
+                f"Hash drift for {dpla_id} {ordinal}: SHA1 found at same-item "
+                f"title [[File:{actual_filename}]]; uploading to correct title only."
+            )
+            return "upload_only"
+
         if existing_dpla_id and existing_dpla_id != dpla_id:
             try:
                 other_item = self.dpla.get_item_metadata(existing_dpla_id)
@@ -591,7 +601,10 @@ class Uploader:
             )
             return "upload_only"
 
-        # Case 2: intended title has real content with a different hash.
+        # Case 2: intended title has real content with a different hash, and the
+        # file found at the wrong title belongs to a different item (or has no
+        # recognisable DPLA ID). Upload the correct hash and tag the orphaned
+        # old title as a duplicate so it can be cleaned up.
         logging.info(
             f"Title drift (Case 2): [[File:{intended_page.title(with_ns=False)}]] "
             f"has a different hash; will upload correct hash and tag "

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -323,6 +323,7 @@ class Uploader:
                         try:
                             result = future.result(timeout=UPLOAD_TIMEOUT_SECS)
                         except concurrent.futures.TimeoutError:
+                            self.tracker.increment(Result.FAILED)
                             executor.shutdown(wait=False)
                             raise RuntimeError(
                                 f"Upload timed out after {UPLOAD_TIMEOUT_SECS // 3600}h "

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -71,6 +71,15 @@ UPLOAD_RETRY_MAX_DELAY_SECS = 60
 UPLOAD_TIMEOUT_SECS = 3600  # 1 hour
 
 
+class UploadTimeoutError(RuntimeError):
+    """Raised when a single file upload exceeds UPLOAD_TIMEOUT_SECS.
+
+    Distinct from RuntimeError so it can escape process_file()'s catch-all
+    and break the remaining-files loop in process_item() — no point attempting
+    further pages when Commons' job queue is stuck.
+    """
+
+
 class Uploader:
     def __init__(
         self,
@@ -326,7 +335,12 @@ class Uploader:
                                 result = future.result(timeout=UPLOAD_TIMEOUT_SECS)
                             except concurrent.futures.TimeoutError:
                                 self.tracker.increment(Result.FAILED)
-                                raise RuntimeError(
+                                # Note: the worker thread keeps running until
+                                # pywikibot's own socket timeout fires (~11 min
+                                # max). This is acceptable — UploadTimeoutError
+                                # skips the remaining files for this item, so
+                                # at most one orphaned thread exists per item.
+                                raise UploadTimeoutError(
                                     f"Upload timed out after {UPLOAD_TIMEOUT_SECS // 3600}h "
                                     f"— Commons job queue likely stuck"
                                 )
@@ -365,6 +379,8 @@ class Uploader:
                 self.tracker.increment(Result.UPLOADED)
                 self.tracker.increment(Result.BYTES, file_size)
 
+        except UploadTimeoutError:
+            raise
         except Exception as ex:
             self.handle_upload_exception(ex)
 
@@ -707,18 +723,22 @@ class Uploader:
                     page_label = str(ext_seen[ext])
                 else:
                     page_label = ""
-                self.process_file(
-                    dpla_id,
-                    title,
-                    item_metadata,
-                    provider,
-                    data_provider,
-                    ordinal,
-                    partner,
-                    page_label,
-                    verbose,
-                    dry_run,
-                )
+                try:
+                    self.process_file(
+                        dpla_id,
+                        title,
+                        item_metadata,
+                        provider,
+                        data_provider,
+                        ordinal,
+                        partner,
+                        page_label,
+                        verbose,
+                        dry_run,
+                    )
+                except UploadTimeoutError as ex:
+                    self.handle_upload_exception(ex)
+                    break
 
         except Exception as ex:
             logging.warning(

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import json
 import logging
 import mimetypes
@@ -65,6 +66,9 @@ from ingest_wikimedia.wikimedia import (
 MAX_UPLOAD_RETRIES = 3
 UPLOAD_RETRY_BASE_DELAY_SECS = 5
 UPLOAD_RETRY_MAX_DELAY_SECS = 60
+# pywikibot's async upload polls Commons indefinitely when the job queue is stuck.
+# This cap ensures a single hung upload never freezes the whole session.
+UPLOAD_TIMEOUT_SECS = 3600  # 1 hour
 
 
 class Uploader:
@@ -300,9 +304,14 @@ class Uploader:
                 )
 
                 result = None
+                # Avoid the `with executor:` context manager — its __exit__ calls
+                # shutdown(wait=True), which would block until pywikibot's stuck
+                # polling thread exits on its own, defeating the timeout entirely.
+                executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                 for attempt in range(1, MAX_UPLOAD_RETRIES + 1):
                     try:
-                        result = self.site.upload(
+                        future = executor.submit(
+                            self.site.upload,
                             filepage=wiki_file_page,
                             source_filename=temp_file.name,
                             comment=upload_comment,
@@ -311,6 +320,14 @@ class Uploader:
                             asynchronous=True,
                             chunk_size=chunk_size,
                         )
+                        try:
+                            result = future.result(timeout=UPLOAD_TIMEOUT_SECS)
+                        except concurrent.futures.TimeoutError:
+                            executor.shutdown(wait=False)
+                            raise RuntimeError(
+                                f"Upload timed out after {UPLOAD_TIMEOUT_SECS // 3600}h "
+                                f"— Commons job queue likely stuck"
+                            )
                         break
                     except Exception as ex:
                         is_backend_fail = ERROR_BACKEND_FAIL in str(ex)
@@ -329,11 +346,11 @@ class Uploader:
                             if is_backend_fail:
                                 self.tracker.increment(Result.FAILED)
                             raise
+                executor.shutdown(wait=False)
 
                 if not result:
-                    # These error message accounts for Page does not exist,
-                    # but File does exist and is linked to another Page
-                    # (ex. DPLA ID drift)
+                    # upload() returned None — file exists under a different page
+                    # title, likely due to DPLA ID drift between runs.
                     self.tracker.increment(Result.FAILED)
                     raise RuntimeError(
                         "File linked to another page (possible ID drift)"


### PR DESCRIPTION
## Summary

- **Critical bug fix**: `_resolve_hash_drift` Case 2 was applying `{{Duplicate}}` to pages of multi-page items when a new sha1 coincidentally matched a *different page* of the same item from a prior upload run. This happened because `find_file_by_hash` searches all of Commons — it would find the sha1 at \"page 17\", see \"page 1\" had different content, and tag \"page 17\" as a duplicate. Added a guard: if the DPLA ID extracted from the wrong-title file matches the current item's DPLA ID, return `"upload_only"` instead of `"upload_and_tag"`.
- Adds download-complete Slack notification and runtime reporting
- `uploader`: `UploadTimeoutError` now skips remaining files in the timed-out item rather than retrying indefinitely
- `uploader`: cap per-item async upload at 1 hour to prevent hung sessions
- `status`: detect hung sessions via log mtime; fix misleading "Generating IDs" message when a download log already exists
- `kill`: resolve partner slug aliases (e.g. `si` → `smithsonian`) before matching tmux sessions

## Root cause (critical fix)

PR #194 introduced `find_file_by_hash` which queries `allimages(sha1=…)` across all of Commons. When a source institution updates images between upload runs, the new sha1 for page N can coincidentally match what an older run uploaded as page M of the same item. The old code treated this as a cross-item title-drift collision and applied `{{Duplicate}}` to page M.

The fix: before checking whether the wrong-title file belongs to a *different* item, check whether it belongs to *this* item. If `existing_dpla_id == dpla_id`, the sha1 is just an intra-item coincidence — upload to the correct title without tagging.

**Impact**: The PA upload on 2026-05-20 produced ~3,133 false-positive `{{Duplicate}}` tags on multi-page Science History Institute items. An emergency script (`fix_duplicate_tags.py`) is removing those tags on EC2.

## Test plan

- [ ] Re-run a PA upload after merge to confirm no Case 2 false positives in the log
- [ ] Verify `find_file_by_hash` cross-item detection (different DPLA IDs) still triggers Case 2 correctly
- [ ] Confirm Slack download-complete notification fires at end of downloader run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->