### PR TITLE
uploader: fix false-positive {{Duplicate}} tagging on same-item sha1 coincidences

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -287,12 +287,23 @@ def find_file_by_hash(
 
 
 _DPLA_ID_RE = re.compile(r"- DPLA - ([0-9a-f]{32})")
+_PAGE_ORDINAL_RE = re.compile(r"\(page (\d+)\)")
 
 
 def extract_dpla_id_from_commons_title(title: str) -> str | None:
     """Extract the DPLA ID from a Commons filename, or None if not present."""
     m = _DPLA_ID_RE.search(title)
     return m.group(1) if m else None
+
+
+def extract_page_ordinal_from_commons_title(title: str) -> int | None:
+    """Extract the `(page N)` ordinal from a Commons filename.
+
+    Returns None for single-page items (no page suffix) and for any title
+    that doesn't follow the DPLA `... (page N)<ext>` format.
+    """
+    m = _PAGE_ORDINAL_RE.search(title)
+    return int(m.group(1)) if m else None
 
 
 # Patterns for metadata we preserve from the original page wikitext when

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -295,6 +295,46 @@ def extract_dpla_id_from_commons_title(title: str) -> str | None:
     return m.group(1) if m else None
 
 
+# Patterns for metadata we preserve from the original page wikitext when
+# rewriting a file description after a title-drift move.
+#
+# - PD-USGov family: {{PD-USGov}}, {{PD-USGov-Military-Army}}, {{PD-USGov-NARA}},
+#   with optional |params. Allowed name chars match Commons template-name rules.
+# - Image extracted: {{Image extracted|<params>}} — links the file back to the
+#   parent page it was extracted from. Anchored anywhere in the text (including
+#   inside |other versions= of an {{Information}} template).
+# - Category links: [[Category:Name]] or [[Category:Name|sort key]].
+_PD_USGOV_RE = re.compile(r"\{\{PD-USGov(?:-[A-Za-z0-9_-]+)?(?:\|[^{}]*)?\}\}")
+_IMAGE_EXTRACTED_RE = re.compile(r"\{\{Image extracted\|[^{}]*\}\}", re.IGNORECASE)
+_CATEGORY_RE = re.compile(r"\[\[Category:[^\]\n]+\]\]")
+
+
+def merge_preserved_wikitext(existing_text: str, new_artwork: str) -> str:
+    """Append preserved metadata from existing_text to new_artwork.
+
+    Used when the uploader rewrites a file description after a title-drift
+    move or redirect-overwrite. The new {{Artwork}} wikitext is authoritative
+    for the file's description, but page-level metadata that pre-existed —
+    PD-USGov license tags, Image-extracted parent links, and category
+    membership — must survive the rewrite.
+
+    Result order:
+        1. new_artwork (the freshly generated {{Artwork}} block)
+        2. preserved {{PD-USGov...}} templates (license, above categories)
+        3. preserved {{Image extracted|...}} templates (above categories)
+        4. preserved [[Category:...]] links
+
+    Duplicates within each preserved group are collapsed.
+    """
+    parts: list[str] = [new_artwork.rstrip()]
+    for pattern in (_PD_USGOV_RE, _IMAGE_EXTRACTED_RE, _CATEGORY_RE):
+        group = list(dict.fromkeys(pattern.findall(existing_text)))
+        if group:
+            parts.append("")
+            parts.extend(group)
+    return "\n".join(parts) + "\n"
+
+
 def tag_as_duplicate(
     site: BaseSite,
     file_page: FilePage,

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -287,7 +287,10 @@ def find_file_by_hash(
 
 
 _DPLA_ID_RE = re.compile(r"- DPLA - ([0-9a-f]{32})")
-_PAGE_ORDINAL_RE = re.compile(r"\(page (\d+)\)")
+# Anchored to the DPLA filename suffix: "... - DPLA - <id> (page N)<.ext>$".
+# Prevents false matches when "(page N)" appears in the descriptive title text
+# (e.g. titles where source brackets were normalised to parens by get_page_title).
+_PAGE_ORDINAL_RE = re.compile(r"- DPLA - [0-9a-f]{32} \(page (\d+)\)(?=\.[^.]+$)")
 
 
 def extract_dpla_id_from_commons_title(title: str) -> str | None:

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -254,3 +254,19 @@ def test_extract_page_ordinal_no_dpla_format():
 def test_extract_page_ordinal_high_page_number():
     title = "Pennsylvania Company Volume - DPLA - 148712806694602ddddfdec4a84e0229 (page 700).jpg"
     assert extract_page_ordinal_from_commons_title(title) == 700
+
+
+def test_extract_page_ordinal_ignores_non_suffix_page_token():
+    # "(page 12)" embedded in the descriptive title text — not the DPLA
+    # filename suffix — must not be parsed as the ordinal.
+    title = "Diary notes (page 12) - DPLA - 002b0f7ad761858506721b83e3370c5f.jpg"
+    assert extract_page_ordinal_from_commons_title(title) is None
+
+
+def test_extract_page_ordinal_ignores_non_suffix_with_multipage():
+    # Same as above but the file IS multi-page; ordinal must come from the
+    # tail, not from the spurious "(page 12)" in the title text.
+    title = (
+        "Diary notes (page 12) - DPLA - 002b0f7ad761858506721b83e3370c5f (page 5).jpg"
+    )
+    assert extract_page_ordinal_from_commons_title(title) == 5

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -7,6 +7,7 @@ from ingest_wikimedia.wikimedia import (
     get_permissions,
     escape_wiki_strings,
     join,
+    extract_page_ordinal_from_commons_title,
     extract_strings,
     extract_strings_dict,
     merge_preserved_wikitext,
@@ -231,3 +232,25 @@ def test_merge_preserved_wikitext_no_metadata_returns_artwork_unchanged():
     )
     result = merge_preserved_wikitext(existing, ARTWORK)
     assert result == ARTWORK + "\n"
+
+
+def test_extract_page_ordinal_multipage():
+    title = "Plant Life - DPLA - 002b0f7ad761858506721b83e3370c5f (page 17).jpg"
+    assert extract_page_ordinal_from_commons_title(title) == 17
+
+
+def test_extract_page_ordinal_single_page():
+    # Single-page DPLA items have no (page N) suffix
+    title = "President Ronald Reagan - DPLA - b3fb229b867046ddd9418c00289245ce.jpg"
+    assert extract_page_ordinal_from_commons_title(title) is None
+
+
+def test_extract_page_ordinal_no_dpla_format():
+    # Non-DPLA titles also return None
+    title = "President Ronald Reagan talking aboard Air Force One.jpg"
+    assert extract_page_ordinal_from_commons_title(title) is None
+
+
+def test_extract_page_ordinal_high_page_number():
+    title = "Pennsylvania Company Volume - DPLA - 148712806694602ddddfdec4a84e0229 (page 700).jpg"
+    assert extract_page_ordinal_from_commons_title(title) == 700

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -9,6 +9,7 @@ from ingest_wikimedia.wikimedia import (
     join,
     extract_strings,
     extract_strings_dict,
+    merge_preserved_wikitext,
     wiki_file_exists,
     check_content_type,
 )
@@ -114,3 +115,119 @@ def test_wiki_file_exists():
     exists = wiki_file_exists(mock_site, "fakehash")
     assert exists
     mock_site.allimages.assert_called_once()
+
+
+ARTWORK = "== {{int:filedesc}} ==\n{{Artwork|title=Example}}"
+
+
+def test_merge_preserved_wikitext_empty_existing():
+    result = merge_preserved_wikitext("", ARTWORK)
+    assert result == ARTWORK + "\n"
+
+
+def test_merge_preserved_wikitext_preserves_pd_usgov():
+    existing = "== {{int:license-header}} ==\n{{PD-USGov}}\n"
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert result == ARTWORK + "\n\n{{PD-USGov}}\n"
+
+
+def test_merge_preserved_wikitext_preserves_pd_usgov_variants():
+    existing = "{{PD-USGov-Military-Army}} and {{PD-USGov-NARA}}"
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert "{{PD-USGov-Military-Army}}" in result
+    assert "{{PD-USGov-NARA}}" in result
+
+
+def test_merge_preserved_wikitext_preserves_pd_usgov_with_params():
+    existing = "{{PD-USGov|date=1986}}"
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert "{{PD-USGov|date=1986}}" in result
+
+
+def test_merge_preserved_wikitext_preserves_image_extracted():
+    existing = "|other versions={{Image extracted|1=Parent Image.jpg}}"
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert "{{Image extracted|1=Parent Image.jpg}}" in result
+
+
+def test_merge_preserved_wikitext_preserves_categories():
+    existing = (
+        "[[Category:Ronald Reagan in 1986]]\n"
+        "[[Category:Nancy and Ronald Reagan]]\n"
+        "[[Category:Files uploaded by RandomUserGuy1738]]\n"
+    )
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert "[[Category:Ronald Reagan in 1986]]" in result
+    assert "[[Category:Nancy and Ronald Reagan]]" in result
+    assert "[[Category:Files uploaded by RandomUserGuy1738]]" in result
+
+
+def test_merge_preserved_wikitext_preserves_category_with_sort_key():
+    existing = "[[Category:Foo|Bar]]"
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert "[[Category:Foo|Bar]]" in result
+
+
+def test_merge_preserved_wikitext_full_screenshot_case():
+    # Mirrors the structure shown in the user-reported screenshot:
+    # Information template with Image extracted in |other versions=,
+    # PD-USGov license, then several categories.
+    existing = (
+        "== {{int:filedesc}} ==\n"
+        "{{Information\n"
+        "|description={{en|1=President Ronald Reagan ...}}\n"
+        "|date={{Taken on|1986-07-04|location=United States}}\n"
+        "|source=https://catalog.archives.gov/id/75854917\n"
+        "|author=Series: Reagan White House Photographs\n"
+        "|permission=\n"
+        "|other versions={{Image extracted|1=Nancy Reagan during a trip.jpg}}\n"
+        "}}\n"
+        "\n"
+        "== {{int:license-header}} ==\n"
+        "{{PD-USGov}}\n"
+        "\n"
+        "[[Category:Ronald Reagan in 1986]]\n"
+        "[[Category:Nancy and Ronald Reagan]]\n"
+        "[[Category:Files uploaded by RandomUserGuy1738]]\n"
+        "[[Category:1986 International Naval Review in New York]]\n"
+    )
+    result = merge_preserved_wikitext(existing, ARTWORK)
+
+    # Artwork comes first
+    assert result.startswith(ARTWORK)
+    # PD-USGov appears before any category
+    pd_idx = result.index("{{PD-USGov}}")
+    img_idx = result.index("{{Image extracted|1=Nancy Reagan during a trip.jpg}}")
+    first_cat_idx = result.index("[[Category:Ronald Reagan in 1986]]")
+    assert pd_idx < first_cat_idx
+    assert img_idx < first_cat_idx
+    # PD-USGov above Image extracted (license, then parent link)
+    assert pd_idx < img_idx
+    # All four categories preserved
+    for cat in (
+        "[[Category:Ronald Reagan in 1986]]",
+        "[[Category:Nancy and Ronald Reagan]]",
+        "[[Category:Files uploaded by RandomUserGuy1738]]",
+        "[[Category:1986 International Naval Review in New York]]",
+    ):
+        assert cat in result
+
+
+def test_merge_preserved_wikitext_dedupes():
+    existing = (
+        "[[Category:Foo]] [[Category:Foo]] "
+        "{{PD-USGov}} {{PD-USGov}} "
+        "{{Image extracted|1=A.jpg}} {{Image extracted|1=A.jpg}}"
+    )
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert result.count("[[Category:Foo]]") == 1
+    assert result.count("{{PD-USGov}}") == 1
+    assert result.count("{{Image extracted|1=A.jpg}}") == 1
+
+
+def test_merge_preserved_wikitext_no_metadata_returns_artwork_unchanged():
+    existing = (
+        "Some unrelated wikitext with no license, image-extracted, or categories."
+    )
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert result == ARTWORK + "\n"

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -547,6 +547,16 @@ class Uploader:
         # our hash to the correct title and leave their file alone. This prevents
         # ping-pong renaming between two valid items that happen to share a hash.
         existing_dpla_id = extract_dpla_id_from_commons_title(actual_filename)
+        if existing_dpla_id == dpla_id:
+            # Same-item hash coincidence: the hash lives at a different page of
+            # this item. Don't tag it as a duplicate — it belongs to this item
+            # and will be overwritten by its own ordinal in the current run.
+            logging.info(
+                f"Hash drift for {dpla_id} {ordinal}: SHA1 found at same-item "
+                f"title [[File:{actual_filename}]]; uploading to correct title only."
+            )
+            return "upload_only"
+
         if existing_dpla_id and existing_dpla_id != dpla_id:
             try:
                 other_item = self.dpla.get_item_metadata(existing_dpla_id)
@@ -591,7 +601,10 @@ class Uploader:
             )
             return "upload_only"
 
-        # Case 2: intended title has real content with a different hash.
+        # Case 2: intended title has real content with a different hash, and the
+        # file found at the wrong title belongs to a different item (or has no
+        # recognisable DPLA ID). Upload the correct hash and tag the orphaned
+        # old title as a duplicate so it can be cleaned up.
         logging.info(
             f"Title drift (Case 2): [[File:{intended_page.title(with_ns=False)}]] "
             f"has a different hash; will upload correct hash and tag "

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -569,7 +569,12 @@ class Uploader:
             #       changed across runs (a legitimate rename). Fall through so
             #       Case 1/3 can move the existing file to the new title.
             actual_page = extract_page_ordinal_from_commons_title(actual_filename)
-            if actual_page is not None and actual_page != ordinal:
+            intended_page = extract_page_ordinal_from_commons_title(page_title)
+            # Compare the two parsed ordinals so the decision is based on logical
+            # Commons page numbering rather than the S3 iteration index (which
+            # can diverge from intended_page in edge cases). None==None for a
+            # single-page item title-text rename falls through to Case 1/3.
+            if actual_page != intended_page:
                 logging.info(
                     f"Hash drift for {dpla_id} {ordinal}: SHA1 found at "
                     f"same-item page {actual_page} [[File:{actual_filename}]]; "

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -49,6 +49,7 @@ from ingest_wikimedia.wikimedia import (
     wikimedia_url,
     find_file_by_hash,
     extract_dpla_id_from_commons_title,
+    merge_preserved_wikitext,
     tag_as_duplicate,
     check_content_type,
     is_download_only,
@@ -464,7 +465,12 @@ class Uploader:
             f"— replacing with wikitext so upload can proceed "
             f"(will tag [[File:{old_filename}]] as duplicate)"
         )
-        wiki_file_page.text = wiki_markup
+        # Preserve license, Image-extracted, and category metadata from the
+        # redirect target (which holds the original file's wikitext and will
+        # be tagged as a duplicate after the upload).
+        wiki_file_page.text = merge_preserved_wikitext(
+            redirect_target.text or "", wiki_markup
+        )
         wiki_file_page.save(
             summary=(
                 f"Replacing redirect with DPLA metadata for title drift "
@@ -509,7 +515,12 @@ class Uploader:
         if wiki_markup:
             moved_page = get_page(self.site, intended_page.title())
             if moved_page.exists() and not moved_page.isRedirectPage():
-                moved_page.text = wiki_markup
+                # After the move, moved_page carries the original page's
+                # wikitext. Preserve license, Image-extracted, and category
+                # metadata from it before replacing with the DPLA Artwork block.
+                moved_page.text = merge_preserved_wikitext(
+                    moved_page.text or "", wiki_markup
+                )
                 moved_page.save(
                     summary=(
                         f"Update description after title drift correction "

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -49,6 +49,7 @@ from ingest_wikimedia.wikimedia import (
     wikimedia_url,
     find_file_by_hash,
     extract_dpla_id_from_commons_title,
+    extract_page_ordinal_from_commons_title,
     merge_preserved_wikitext,
     tag_as_duplicate,
     check_content_type,
@@ -559,14 +560,22 @@ class Uploader:
         # ping-pong renaming between two valid items that happen to share a hash.
         existing_dpla_id = extract_dpla_id_from_commons_title(actual_filename)
         if existing_dpla_id == dpla_id:
-            # Same-item hash coincidence: the hash lives at a different page of
-            # this item. Don't tag it as a duplicate — it belongs to this item
-            # and will be overwritten by its own ordinal in the current run.
-            logging.info(
-                f"Hash drift for {dpla_id} {ordinal}: SHA1 found at same-item "
-                f"title [[File:{actual_filename}]]; uploading to correct title only."
-            )
-            return "upload_only"
+            # Same DPLA item — distinguish two cases:
+            #   (a) different page of a multi-page item carrying a coincident
+            #       sha1 (e.g. source-institution re-scan whose new page-N hash
+            #       matches what was uploaded as page-M last run). Don't move
+            #       or tag — the right ordinal will be uploaded directly.
+            #   (b) same logical page but the free-text portion of the title
+            #       changed across runs (a legitimate rename). Fall through so
+            #       Case 1/3 can move the existing file to the new title.
+            actual_page = extract_page_ordinal_from_commons_title(actual_filename)
+            if actual_page is not None and actual_page != ordinal:
+                logging.info(
+                    f"Hash drift for {dpla_id} {ordinal}: SHA1 found at "
+                    f"same-item page {actual_page} [[File:{actual_filename}]]; "
+                    f"uploading to correct title only."
+                )
+                return "upload_only"
 
         if existing_dpla_id and existing_dpla_id != dpla_id:
             try:

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -415,7 +415,7 @@ class Uploader:
         new_filename = wiki_file_page.title(with_ns=False)
         reason = (
             f"Title drift correction: updating to current DPLA title "
-            f"(DPLA ID {dpla_id})"
+            f"(DPLA ID [[dpla:{dpla_id}|{dpla_id}]])"
         )
         logging.info(
             f"Title drift redirect detected — moving "
@@ -468,7 +468,7 @@ class Uploader:
         wiki_file_page.save(
             summary=(
                 f"Replacing redirect with DPLA metadata for title drift "
-                f"correction (DPLA ID {dpla_id})"
+                f"correction (DPLA ID [[dpla:{dpla_id}|{dpla_id}]])"
             ),
             minor=False,
         )
@@ -492,7 +492,7 @@ class Uploader:
         intended_filename = intended_page.title(with_ns=False)
         reason = (
             f"Title drift correction: updating to current DPLA title "
-            f"(DPLA ID {dpla_id})"
+            f"(DPLA ID [[dpla:{dpla_id}|{dpla_id}]])"
         )
         logging.info(
             f"Title drift ({case_label}): moving "
@@ -513,7 +513,7 @@ class Uploader:
                 moved_page.save(
                     summary=(
                         f"Update description after title drift correction "
-                        f"(DPLA ID {dpla_id})"
+                        f"(DPLA ID [[dpla:{dpla_id}|{dpla_id}]])"
                     ),
                     minor=False,
                 )


### PR DESCRIPTION
## Summary

- **Critical bug fix**: `_resolve_hash_drift` Case 2 was applying `{{Duplicate}}` to pages of multi-page items when a new sha1 coincidentally matched a *different page* of the same item from a prior upload run. This happened because `find_file_by_hash` searches all of Commons — it would find the sha1 at "page 17", see "page 1" had different content, and tag "page 17" as a duplicate. Added a guard: if the DPLA ID extracted from the wrong-title file matches the current item's DPLA ID, return `"upload_only"` instead of `"upload_and_tag"`.

## Root cause

PR #194 introduced `find_file_by_hash` which queries `allimages(sha1=…)` across all of Commons. When a source institution updates images between upload runs, the new sha1 for page N can coincidentally match what an older run uploaded as page M of the same item. The old code treated this as a cross-item title-drift collision and applied `{{Duplicate}}` to page M.

The fix: before checking whether the wrong-title file belongs to a *different* item, check whether it belongs to *this* item. If `existing_dpla_id == dpla_id`, the sha1 is just an intra-item coincidence — upload to the correct title without tagging.

**Impact**: The PA upload on 2026-05-20 produced ~3,133 false-positive `{{Duplicate}}` tags on multi-page Science History Institute items. An emergency script (`fix_duplicate_tags.py`) is removing those tags on EC2.

## Test plan

- [ ] Re-run a PA upload after merge to confirm no Case 2 false positives in the log
- [ ] Verify `find_file_by_hash` cross-item detection (different DPLA IDs) still triggers Case 2 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a false-positive duplicate-tagging bug in uploader._resolve_hash_drift (Case 2) and preserves selected page-level metadata when rewriting Commons file description/redirect pages.

High-level summary
- Fixes same-item SHA1 coincidence false positives: when find_file_by_hash returns a Commons file whose extracted DPLA ID equals the current item's DPLA ID but whose page-ordinal differs, _resolve_hash_drift now short-circuits to "upload_only" (so the correct file is uploaded and no {{Duplicate}} tag or move is applied). Cross-item SHA1 matches (different DPLA IDs) still trigger the existing Case 2 move/tag behavior.
- Preserves page-level metadata during redirect/description rewrites: adds merge_preserved_wikitext(existing_text, new_artwork) which makes the generated Artwork block authoritative and appends deduplicated preserved metadata groups (PD-USGov license templates and variants, Image extracted templates, and category links) in a fixed order with a trailing newline instead of overwriting them.
- Adds extract_page_ordinal_from_commons_title() to parse “(page N)” ordinals from Commons titles and uses it to distinguish intra-item different-page collisions from cross-item duplicates.
- Title-drift reason/save-summary messages updated to format DPLA IDs as linked [[dpla:...|...]] tokens.
- Tests: new unit tests in tests/test_wikimedia.py cover merge_preserved_wikitext ordering, preservation, deduplication, and ordinal extraction.

Files changed (high level)
- tools/uploader.py
  - Adds same-item hash-coincidence guard in _resolve_hash_drift to return "upload_only" when matched file’s DPLA ID == current DPLA ID and page-ordinal differs.
  - Uses merge_preserved_wikitext when updating redirect/moved page/text to preserve PD-USGov license templates, Image-extracted parent links, and categories.
  - Updates title-drift messages to include linked DPLA IDs.
- ingest_wikimedia/wikimedia.py
  - Adds extract_page_ordinal_from_commons_title(title: str) -> int | None and merge_preserved_wikitext(existing_text: str, new_artwork: str) -> str plus regexes for PD-USGov variants, Image extracted, and category extraction/ordering.
- tests/test_wikimedia.py
  - Adds tests validating merge_preserved_wikitext behavior, ordering, deduplication, and extract_page_ordinal_from_commons_title.

Root cause
- find_file_by_hash queries all of Commons. When source institutions refresh images between upload runs, a new sha1 for page N can coincidentally match a prior upload of page M of the same multi-page item. The previous logic treated such same-item, different-page matches as cross-item title-drift and applied {{Duplicate}} to the matched page.

Impact
- Prevents large-scale false-positive {{Duplicate}} tagging on multi-page items caused by intra-item SHA1 collisions while preserving correct cross-item duplicate detection.
- Incident referenced: a PA upload on 2026-05-20 produced ~3,133 false-positive {{Duplicate}} tags on multi-page Science History Institute items; an emergency script is removing those tags on EC2.

Testing / Plan
- Re-run a PA upload after merge to confirm no Case 2 false positives for same-item collisions and verify that cross-item detection (different DPLA IDs) still triggers Case 2 behavior.
- New unit tests exercise merge_preserved_wikitext and ordinal extraction; these should run in CI.

Deployment / infra / security notes
- Verified in the repo: no changes requiring a manual pipeline trigger or ECS redeployment.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No changes to shared infra (CodePipeline/CodeBuild/ECS task definitions/IAM).
- No changes to public API shapes or endpoints.
- No new credential/secret handling; no security-sensitive surface area changes beyond normal uploader behavior.

Developer notes / review focus
- Reviewers should focus on _resolve_hash_drift Case 2 logic and the narrow same-item guard (ensure it only short-circuits for true intra-item different-page sha1 collisions), page-ordinal extraction edge cases (including anchoring to the DPLA filename suffix), and merge_preserved_wikitext ordering/deduplication semantics for PD-USGov variants, Image extracted templates, and category formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->