### PR TITLE
uploader: stop redirect-move oscillation between same-item ordinals

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -322,8 +322,9 @@ def is_same_item_redirect_relic(
     same shuffle would be reversed when the iteration later reaches the
     other ordinal, producing an oscillation that destroys uploaded content.
     """
+    intended_dpla_id = extract_dpla_id_from_commons_title(intended_title)
     target_dpla_id = extract_dpla_id_from_commons_title(target_title)
-    if target_dpla_id != dpla_id:
+    if intended_dpla_id != dpla_id or target_dpla_id != dpla_id:
         return False
     intended_page = extract_page_ordinal_from_commons_title(intended_title)
     target_page = extract_page_ordinal_from_commons_title(target_title)

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -309,6 +309,31 @@ def extract_page_ordinal_from_commons_title(title: str) -> int | None:
     return int(m.group(1)) if m else None
 
 
+def is_same_item_redirect_relic(
+    intended_title: str, target_title: str, dpla_id: str
+) -> bool:
+    """True if a redirect from intended_title → target_title is a relic of a
+    prior bad move within the same multi-page DPLA item.
+
+    Both titles must carry the same DPLA ID matching the current item, and
+    both must have parseable but different page ordinals. When this is True
+    the uploader must NOT call _resolve_redirect_move — doing so would just
+    shuffle content between two valid ordinals of the same item, and the
+    same shuffle would be reversed when the iteration later reaches the
+    other ordinal, producing an oscillation that destroys uploaded content.
+    """
+    target_dpla_id = extract_dpla_id_from_commons_title(target_title)
+    if target_dpla_id != dpla_id:
+        return False
+    intended_page = extract_page_ordinal_from_commons_title(intended_title)
+    target_page = extract_page_ordinal_from_commons_title(target_title)
+    return (
+        intended_page is not None
+        and target_page is not None
+        and intended_page != target_page
+    )
+
+
 # Patterns for metadata we preserve from the original page wikitext when
 # rewriting a file description after a title-drift move.
 #

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -322,3 +322,13 @@ def test_relic_only_one_side_has_page_ordinal_is_false():
     intended = f"Foo - DPLA - {ITEM}.jpg"
     target = f"Foo - DPLA - {ITEM} (page 5).jpg"
     assert is_same_item_redirect_relic(intended, target, ITEM) is False
+
+
+def test_relic_intended_belongs_to_different_item_is_false():
+    # intended_title carries a parseable (page N) ordinal but its DPLA ID
+    # is a third item, not the one being processed. Must not be classified
+    # as a same-item relic.
+    other_id = "fe9a56003cde86d71a7f68bcc42c9216"
+    intended = f"Foo - DPLA - {other_id} (page 1).jpg"
+    target = f"Foo - DPLA - {ITEM} (page 3).jpg"
+    assert is_same_item_redirect_relic(intended, target, ITEM) is False

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -10,6 +10,7 @@ from ingest_wikimedia.wikimedia import (
     extract_page_ordinal_from_commons_title,
     extract_strings,
     extract_strings_dict,
+    is_same_item_redirect_relic,
     merge_preserved_wikitext,
     wiki_file_exists,
     check_content_type,
@@ -270,3 +271,54 @@ def test_extract_page_ordinal_ignores_non_suffix_with_multipage():
         "Diary notes (page 12) - DPLA - 002b0f7ad761858506721b83e3370c5f (page 5).jpg"
     )
     assert extract_page_ordinal_from_commons_title(title) == 5
+
+
+# is_same_item_redirect_relic — the oscillation guard for redirect handling
+ITEM = "190aa1b74ca34559e61c25e9dbb97a61"
+PHYS = "Physical Apparatus for Universities and Colleges Manufactured and Imported by Central Scientific Co."
+
+
+def test_relic_same_item_different_pages_is_true():
+    intended = f"{PHYS} - DPLA - {ITEM} (page 83).jpg"
+    target = f"{PHYS} - DPLA - {ITEM} (page 103).jpg"
+    assert is_same_item_redirect_relic(intended, target, ITEM) is True
+
+
+def test_relic_same_item_same_page_is_false():
+    # Same DPLA ID and same ordinal — legitimate title-text rename, let
+    # _resolve_redirect_move handle it.
+    intended = f"New text - DPLA - {ITEM} (page 5).jpg"
+    target = f"Old text - DPLA - {ITEM} (page 5).jpg"
+    assert is_same_item_redirect_relic(intended, target, ITEM) is False
+
+
+def test_relic_different_item_is_false():
+    # Different DPLA IDs — not a same-item case at all.
+    other_id = "fe9a56003cde86d71a7f68bcc42c9216"
+    intended = f"Foo - DPLA - {ITEM} (page 1).jpg"
+    target = f"Emblema XIII - DPLA - {other_id}.jpg"
+    assert is_same_item_redirect_relic(intended, target, ITEM) is False
+
+
+def test_relic_single_page_item_is_false():
+    # No (page N) suffix on either side — single-page item, title-text
+    # rename. Let _resolve_redirect_move handle it.
+    intended = f"New title - DPLA - {ITEM}.jpg"
+    target = f"Old title - DPLA - {ITEM}.jpg"
+    assert is_same_item_redirect_relic(intended, target, ITEM) is False
+
+
+def test_relic_target_lacks_dpla_id_is_false():
+    # Target was uploaded under an institutional title (no DPLA ID) — that
+    # IS the legitimate Case 1 title-drift scenario; allow the move.
+    intended = f"Reagan - DPLA - {ITEM}.jpg"
+    target = "President Ronald Reagan original NARA title.jpg"
+    assert is_same_item_redirect_relic(intended, target, ITEM) is False
+
+
+def test_relic_only_one_side_has_page_ordinal_is_false():
+    # Target has (page N) but intended doesn't (or vice versa). Treat as
+    # not-a-relic — let the existing move path handle it.
+    intended = f"Foo - DPLA - {ITEM}.jpg"
+    target = f"Foo - DPLA - {ITEM} (page 5).jpg"
+    assert is_same_item_redirect_relic(intended, target, ITEM) is False

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -50,6 +50,7 @@ from ingest_wikimedia.wikimedia import (
     find_file_by_hash,
     extract_dpla_id_from_commons_title,
     extract_page_ordinal_from_commons_title,
+    is_same_item_redirect_relic,
     merge_preserved_wikitext,
     tag_as_duplicate,
     check_content_type,
@@ -271,27 +272,54 @@ class Uploader:
                 # Skip when drift resolution returned "upload_only" — in that case
                 # we've decided not to touch any other file; just upload directly.
                 if wiki_file_page.isRedirectPage() and drift_action != "upload_only":
-                    try:
-                        resolved = self._resolve_redirect_move(wiki_file_page, dpla_id)
-                        if resolved:
-                            wiki_file_page = resolved
-                    except pywikibot.exceptions.ArticleExistsConflictError:
-                        # Move is blocked because the redirect page itself has
-                        # page history or structured data that Commons won't let
-                        # us overwrite via a move. Fall back to replacing the
-                        # redirect text in-place and uploading directly.
+                    target_title = wiki_file_page.getRedirectTarget().title(
+                        with_ns=False
+                    )
+                    if is_same_item_redirect_relic(
+                        wiki_file_page.title(with_ns=False), target_title, dpla_id
+                    ):
+                        # Same-item different-page redirect — relic of a prior
+                        # bad move. Don't move (would oscillate); overwrite the
+                        # redirect in place and let the upload land here.
                         logging.info(
-                            f"Move blocked (ArticleExistsConflictError) for "
-                            f"{dpla_id}; falling back to redirect-overwrite"
+                            f"Same-item redirect relic for {dpla_id}: "
+                            f"[[File:{wiki_file_page.title(with_ns=False)}]] → "
+                            f"[[File:{target_title}]]; overwriting redirect "
+                            f"without moving sibling page."
                         )
                         resolved = self._resolve_redirect_overwrite(
                             wiki_file_page, dpla_id, wiki_markup
                         )
                         if resolved:
-                            wiki_file_page, redirect_old_filename = resolved
+                            wiki_file_page, _ = resolved
                             force_ignore_warnings = True
-                            if not drift_old_filename:
-                                drift_old_filename = redirect_old_filename
+                            # Intentionally NOT setting drift_old_filename:
+                            # the sibling page is a valid file at its own
+                            # ordinal and must not be tagged as a duplicate.
+                    else:
+                        try:
+                            resolved = self._resolve_redirect_move(
+                                wiki_file_page, dpla_id
+                            )
+                            if resolved:
+                                wiki_file_page = resolved
+                        except pywikibot.exceptions.ArticleExistsConflictError:
+                            # Move is blocked because the redirect page itself has
+                            # page history or structured data that Commons won't let
+                            # us overwrite via a move. Fall back to replacing the
+                            # redirect text in-place and uploading directly.
+                            logging.info(
+                                f"Move blocked (ArticleExistsConflictError) for "
+                                f"{dpla_id}; falling back to redirect-overwrite"
+                            )
+                            resolved = self._resolve_redirect_overwrite(
+                                wiki_file_page, dpla_id, wiki_markup
+                            )
+                            if resolved:
+                                wiki_file_page, redirect_old_filename = resolved
+                                force_ignore_warnings = True
+                                if not drift_old_filename:
+                                    drift_old_filename = redirect_old_filename
 
                 # Use direct upload (chunk_size=0) + ignore_warnings=True when the
                 # file page already exists, or when the hash already lives elsewhere


### PR DESCRIPTION
## Summary

When a multi-page item carries a redirect at one ordinal pointing at another ordinal of itself, the previous logic in `_resolve_redirect_move` treated it as title drift and would move the file across the redirect — only for the iteration to reach the other ordinal a few seconds later, see its intended title was now the redirect, and move the file back. Net result: oscillation, obliterated uploads, and 4 wasted edits per ordinal pair.

## Observed damage

A re-run of \`/wikimedia-upload 190aa1b74ca34559e61c25e9dbb97a61\` (Physical Apparatus for Universities and Colleges) produced **14 edits in ~40s** — 4 moves forming 2 reciprocal pairs (83↔103, 87↔104), plus their CommonsDelinker requests and uploads. The Y83 / Y87 content uploaded at the lower ordinals was overwritten by the reverse move a few steps later.

## Fix

New \`is_same_item_redirect_relic(intended_title, target_title, dpla_id)\` helper in \`ingest_wikimedia/wikimedia.py\`. Returns True only when:

- the redirect target carries the **same DPLA ID** as the item being processed (not a cross-item case), and
- both intended and target titles have **parseable but different page ordinals** (not a single-page rename, not a same-ordinal text rename — both of those still legitimately need \`_resolve_redirect_move\`).

When True, the uploader skips \`_resolve_redirect_move\` and instead overwrites the redirect text in place via \`_resolve_redirect_overwrite\`, **without setting \`drift_old_filename\`** — the sibling page at the redirect target is a valid file at its own ordinal and must not be tagged as a duplicate. The subsequent upload lands at the now-real intended title without disturbing the sibling.

## Test plan

- [ ] After merge + deploy, re-run \`/wikimedia-upload 190aa1b74ca34559e61c25e9dbb97a61\` to restore correct content at the 4 affected ordinals (page 83, 87, 103, 104).
- [ ] Verify no new same-item moves appear in DPLA bot's log for that item.
- [ ] Apply the same re-run pattern to the other 34 PA items affected by the original 531 same-item moves from yesterday's bug (catalogued in earlier session forensics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a redirect oscillation bug in the Wikimedia Commons uploader that caused reciprocal moves and destructive overwrites for multi-page DPLA items when a redirect pointed from one page ordinal to a different ordinal of the same item.

Changes
- ingest_wikimedia/wikimedia.py
  - Added is_same_item_redirect_relic(intended_title: str, target_title: str, dpla_id: str) -> bool. Returns True only when both titles parse to the same DPLA ID equal to dpla_id and both include parseable but different page ordinals; otherwise False. This tightens the relic predicate to validate the DPLA ID on both titles (defense-in-depth against malformed callers).

- tools/uploader.py
  - Uses is_same_item_redirect_relic to distinguish a “same-item redirect relic” from other title-drift cases. When detected, the uploader skips the move logic and calls _resolve_redirect_overwrite to overwrite the redirect text in place and intentionally does not set drift_old_filename, so sibling pages are preserved and the upload lands at the intended title without disturbing the sibling.

- tests/test_wikimedia.py
  - Adds unit tests covering the relic classification and related scenarios (same-item different-page redirects → True; same-page renames, different DPLA IDs, missing ordinals, single-sided ordinals, targets lacking DPLA ID → False).

Observed behavior fixed
- Prevents reciprocal moves/overwrites previously observed (e.g., item 190aa1b74ca34559e61c25e9dbb97a61 which produced multiple reciprocal moves and overwrites).

Deployment
- Requires pipeline redeployment to take effect (redeploy the new application code). No environment variable or AWS Secrets Manager key changes; no database migrations; no shared infrastructure (CodePipeline/CodeBuild/ECS task definition/IAM) changes noted.

Impact assessment
- No public API response shape changes or new endpoints.
- No database migrations.
- No changes to environment variables or Secrets Manager.
- No shared infra config changes.
- No security-sensitive credential-handling or auth changes introduced; this is a targeted application-logic fix for upload/redirect handling.

Test plan
- After merge/deploy: re-run /wikimedia-upload for item 190aa1b74ca34559e61c25e9dbb97a61 and verify pages 83, 87, 103, 104 are restored without new same-item moves; apply the same re-run pattern to the other ~34 affected PA items and verify no further same-item moves occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->