### PR TITLE
uploader: overwrite cross-item redirects so S3 sha1 always lands at intended title

### DIFF
--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -275,51 +275,72 @@ class Uploader:
                     target_title = wiki_file_page.getRedirectTarget().title(
                         with_ns=False
                     )
-                    if is_same_item_redirect_relic(
+                    target_dpla_id = extract_dpla_id_from_commons_title(target_title)
+                    is_relic = is_same_item_redirect_relic(
                         wiki_file_page.title(with_ns=False), target_title, dpla_id
-                    ):
-                        # Same-item different-page redirect — relic of a prior
-                        # bad move. Don't move (would oscillate); overwrite the
-                        # redirect in place and let the upload land here.
-                        logging.info(
-                            f"Same-item redirect relic for {dpla_id}: "
-                            f"[[File:{wiki_file_page.title(with_ns=False)}]] → "
-                            f"[[File:{target_title}]]; overwriting redirect "
-                            f"without moving sibling page."
-                        )
-                        resolved = self._resolve_redirect_overwrite(
-                            wiki_file_page, dpla_id, wiki_markup
-                        )
-                        if resolved:
-                            wiki_file_page, _ = resolved
-                            force_ignore_warnings = True
-                            # Intentionally NOT setting drift_old_filename:
-                            # the sibling page is a valid file at its own
-                            # ordinal and must not be tagged as a duplicate.
-                    else:
+                    )
+                    # A move only makes sense when the redirect target carries
+                    # this item's DPLA ID at the same logical page (title-text
+                    # drift). For everything else — same-item different-page
+                    # relics, cross-item dedups, or no-DPLA-ID legacy redirects
+                    # — we overwrite the redirect in place so the upload lands
+                    # at our intended title without touching the target.
+                    if target_dpla_id == dpla_id and not is_relic:
                         try:
-                            resolved = self._resolve_redirect_move(
+                            wiki_file_page = self._resolve_redirect_move(
                                 wiki_file_page, dpla_id
                             )
-                            if resolved:
-                                wiki_file_page = resolved
                         except pywikibot.exceptions.ArticleExistsConflictError:
-                            # Move is blocked because the redirect page itself has
-                            # page history or structured data that Commons won't let
-                            # us overwrite via a move. Fall back to replacing the
-                            # redirect text in-place and uploading directly.
+                            # Move is blocked because the redirect page itself
+                            # has page history or structured data Commons won't
+                            # let us overwrite via a move. Fall back to
+                            # replacing the redirect text in-place.
                             logging.info(
                                 f"Move blocked (ArticleExistsConflictError) for "
                                 f"{dpla_id}; falling back to redirect-overwrite"
                             )
-                            resolved = self._resolve_redirect_overwrite(
-                                wiki_file_page, dpla_id, wiki_markup
+                            wiki_file_page, redirect_old_filename = (
+                                self._resolve_redirect_overwrite(
+                                    wiki_file_page, dpla_id, wiki_markup
+                                )
                             )
-                            if resolved:
-                                wiki_file_page, redirect_old_filename = resolved
-                                force_ignore_warnings = True
-                                if not drift_old_filename:
-                                    drift_old_filename = redirect_old_filename
+                            force_ignore_warnings = True
+                            if not drift_old_filename:
+                                drift_old_filename = redirect_old_filename
+                    else:
+                        # Same-item relic: target is a sibling page of this
+                        # item — preserve its metadata, since license tags
+                        # and categories carry meaning across pages of the
+                        # same multi-page item.
+                        # Cross-item / no-DPLA-ID: don't pull metadata from
+                        # a foreign page; we'd inherit its Image-extracted
+                        # link and unrelated categories.
+                        preserve = is_relic
+                        if is_relic:
+                            logging.info(
+                                f"Same-item redirect relic for {dpla_id}: "
+                                f"[[File:{wiki_file_page.title(with_ns=False)}]] → "
+                                f"[[File:{target_title}]]; overwriting without "
+                                f"moving sibling page."
+                            )
+                        else:
+                            logging.info(
+                                f"Cross-item or no-DPLA redirect for {dpla_id}: "
+                                f"[[File:{wiki_file_page.title(with_ns=False)}]] → "
+                                f"[[File:{target_title}]]; overwriting redirect "
+                                f"with fresh wikitext (no metadata preservation)."
+                            )
+                        wiki_file_page, _ = self._resolve_redirect_overwrite(
+                            wiki_file_page,
+                            dpla_id,
+                            wiki_markup,
+                            preserve_from_target=preserve,
+                        )
+                        force_ignore_warnings = True
+                        # Intentionally NOT setting drift_old_filename in
+                        # either of these paths: the target is either a
+                        # valid sibling (same-item relic) or a foreign file
+                        # (cross-item) and must not be tagged as a duplicate.
 
                 # Use direct upload (chunk_size=0) + ignore_warnings=True when the
                 # file page already exists, or when the hash already lives elsewhere
@@ -421,26 +442,21 @@ class Uploader:
         self,
         wiki_file_page: pywikibot.FilePage,
         dpla_id: str,
-    ) -> pywikibot.FilePage | None:
+    ) -> pywikibot.FilePage:
         """
-        If wiki_file_page is a redirect whose target filename contains dpla_id,
-        this is a title-drift case: move the file to the intended title and post
-        a CommonsDelinker request. Returns a fresh FilePage for the intended title
-        on success, or None if the redirect is not a title-drift case.
+        Title-text-drift correction: the redirect at our intended title points
+        to the same item's file under a slightly different title. Move the
+        target file to the intended title and post a CommonsDelinker request.
+
+        Caller must verify the redirect target carries the same DPLA ID and
+        same logical page (i.e. not a same-item different-page relic, where
+        moving would oscillate); see is_same_item_redirect_relic.
 
         Raises ArticleExistsConflictError if the move is blocked (e.g. the
-        redirect page has history/structured data). Caller should fall back to
+        redirect page has history/structured data). Caller falls back to
         _resolve_redirect_overwrite in that case.
         """
         redirect_target = wiki_file_page.getRedirectTarget()
-        if dpla_id not in redirect_target.title():
-            logging.warning(
-                f"Redirect at intended title {wiki_file_page.title()} points to "
-                f"{redirect_target.title()} which does not share DPLA ID {dpla_id} "
-                f"— cannot auto-resolve; upload will fail"
-            )
-            return None
-
         old_filename = redirect_target.title(with_ns=False)
         new_filename = wiki_file_page.title(with_ns=False)
         reason = (
@@ -467,39 +483,38 @@ class Uploader:
         wiki_file_page: pywikibot.FilePage,
         dpla_id: str,
         wiki_markup: str,
-    ) -> tuple[pywikibot.FilePage, str] | None:
+        preserve_from_target: bool = True,
+    ) -> tuple[pywikibot.FilePage, str]:
         """
-        Fallback for when _resolve_redirect_move raises ArticleExistsConflictError.
+        Replace a redirect at our intended title with wikitext so the
+        subsequent upload can land the new S3 file there.
 
-        Replaces the redirect page text with the correct DPLA Artwork wikitext
-        so the upload API no longer sees a file conflict, then uploads directly.
-        The redirect target (wrong-title file) is returned as old_filename for
-        later duplicate-tagging.
+        Works for *any* redirect target — same-item different-page relic,
+        cross-item dedup (e.g. a 2022 human "redirecting to duplicate file"
+        edit), or a no-DPLA-ID legacy title. The S3 sha1 must land at the
+        intended title regardless of where the redirect points.
 
-        Returns (updated_file_page, old_filename) on success, or None if the
-        redirect does not share the DPLA ID (cannot auto-resolve).
+        When `preserve_from_target` is True (default), license/Image-extracted/
+        category metadata from the redirect target is carried into the new
+        page. Callers should pass False when the target is a foreign DPLA
+        item, since its categories and Image-extracted parent link don't
+        apply to our page.
+
+        Returns (updated_file_page, old_filename).
         """
         redirect_target = wiki_file_page.getRedirectTarget()
-        if dpla_id not in redirect_target.title():
-            logging.warning(
-                f"Redirect at intended title {wiki_file_page.title()} points to "
-                f"{redirect_target.title()} which does not share DPLA ID {dpla_id} "
-                f"— cannot auto-resolve; upload will fail"
-            )
-            return None
-
         old_filename = redirect_target.title(with_ns=False)
         logging.info(
-            f"Title drift redirect at [[File:{wiki_file_page.title(with_ns=False)}]] "
-            f"— replacing with wikitext so upload can proceed "
-            f"(will tag [[File:{old_filename}]] as duplicate)"
+            f"Replacing redirect at "
+            f"[[File:{wiki_file_page.title(with_ns=False)}]] "
+            f"(target [[File:{old_filename}]], "
+            f"preserve_metadata={preserve_from_target})"
         )
-        # Preserve license, Image-extracted, and category metadata from the
-        # redirect target (which holds the original file's wikitext and will
-        # be tagged as a duplicate after the upload).
-        wiki_file_page.text = merge_preserved_wikitext(
-            redirect_target.text or "", wiki_markup
-        )
+        if preserve_from_target:
+            new_text = merge_preserved_wikitext(redirect_target.text or "", wiki_markup)
+        else:
+            new_text = wiki_markup
+        wiki_file_page.text = new_text
         wiki_file_page.save(
             summary=(
                 f"Replacing redirect with DPLA metadata for title drift "

--- a/tools/verify_item.py
+++ b/tools/verify_item.py
@@ -28,6 +28,8 @@ Output:
     /tmp/verify_<dpla_id>.json for follow-up.
 """
 
+import datetime
+import email.utils
 import json
 import logging
 import mimetypes
@@ -49,6 +51,23 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 COMMONS_API = "https://commons.wikimedia.org/w/api.php"
 BATCH = 50
 DC_TITLE_FIELD = "title"  # under sourceResource
+DEFAULT_RETRY_AFTER_SECS = 30
+
+
+def _parse_retry_after(value: str | None) -> int:
+    """Parse a Retry-After header (delay-seconds or HTTP-date, RFC 7231)."""
+    if not value:
+        return DEFAULT_RETRY_AFTER_SECS
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        when = email.utils.parsedate_to_datetime(value)
+        now = datetime.datetime.now(tz=when.tzinfo)
+        return max(0, int((when - now).total_seconds()))
+    except (TypeError, ValueError):
+        return DEFAULT_RETRY_AFTER_SECS
 
 
 def s3_path_prefix(dpla_id: str, partner: str) -> str:
@@ -74,14 +93,17 @@ def commons_api(params: dict) -> dict:
         try:
             with urllib.request.urlopen(req, timeout=60) as resp:
                 time.sleep(0.4)
-                return json.loads(resp.read())
+                data = json.loads(resp.read())
         except urllib.error.HTTPError as e:
             if e.code in (429, 503):
-                wait = int(e.headers.get("Retry-After", 30))
+                wait = _parse_retry_after(e.headers.get("Retry-After"))
                 logging.warning(f"rate-limited; sleeping {wait}s")
                 time.sleep(wait)
                 continue
             raise
+        if "error" in data:
+            raise RuntimeError(f"Commons API error: {data['error']}")
+        return data
     raise RuntimeError("Commons API retries exhausted")
 
 

--- a/tools/verify_item.py
+++ b/tools/verify_item.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+End-to-end verification that every S3 file for a DPLA item has its exact
+sha1 landed at its intended Commons title.
+
+For each ordinal under the item's S3 prefix this script:
+  1. reads the S3 object's sha1 from the CHECKSUM metadata,
+  2. reconstructs the intended Commons title via get_page_title() using
+     the DPLA item's source title and the S3 object's MIME-derived
+     extension,
+  3. queries the Commons MediaWiki API for the file at that intended
+     title and compares its sha1 to S3.
+
+Outcomes per ordinal:
+  CORRECT  — Commons file at the intended title has sha1 == S3 sha1
+  MISMATCH — file exists at the intended title with a different sha1
+  REDIRECT — intended title is a redirect (S3 sha1 isn't at the right name)
+  MISSING  — intended title has no page on Commons
+
+Exits 0 only when every ordinal is CORRECT. Anything else exits 1 so the
+script can be wired into a CI gate or a deploy verification loop.
+
+Usage:
+    python3 tools/verify_item.py <dpla_id> <partner>
+
+Output:
+    Summary printed to stdout, full per-ordinal detail written to
+    /tmp/verify_<dpla_id>.json for follow-up.
+"""
+
+import json
+import logging
+import mimetypes
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import boto3
+
+from ingest_wikimedia.s3 import S3_BUCKET
+from ingest_wikimedia.tools_context import ToolsContext
+from ingest_wikimedia.wikimedia import extract_strings, get_page_title
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+COMMONS_API = "https://commons.wikimedia.org/w/api.php"
+BATCH = 50
+DC_TITLE_FIELD = "title"  # under sourceResource
+
+
+def s3_path_prefix(dpla_id: str, partner: str) -> str:
+    return (
+        f"{partner}/images/{dpla_id[0]}/{dpla_id[1]}/"
+        f"{dpla_id[2]}/{dpla_id[3]}/{dpla_id}/"
+    )
+
+
+def commons_api(params: dict) -> dict:
+    """POST to the Commons API with maxlag + retries on 429/503."""
+    params = {**params, "format": "json", "formatversion": "2", "maxlag": "5"}
+    body = urllib.parse.urlencode(params).encode("utf-8")
+    req = urllib.request.Request(
+        COMMONS_API,
+        data=body,
+        headers={
+            "User-Agent": "dpla-bot-verify/1.0 (dominic@dp.la)",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+    )
+    for attempt in range(8):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                time.sleep(0.4)
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 503):
+                wait = int(e.headers.get("Retry-After", 30))
+                logging.warning(f"rate-limited; sleeping {wait}s")
+                time.sleep(wait)
+                continue
+            raise
+    raise RuntimeError("Commons API retries exhausted")
+
+
+def list_s3_ordinals(dpla_id: str, partner: str) -> dict[int, tuple[str, str, str]]:
+    """Return {ordinal: (key, sha1, content_type)} for every media file under
+    the item's S3 prefix."""
+    s3 = boto3.client("s3")
+    prefix = s3_path_prefix(dpla_id, partner)
+    out: dict[int, tuple[str, str, str]] = {}
+    name_re = re.compile(r"^(\d+)_" + re.escape(dpla_id) + r"$")
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=S3_BUCKET, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            m = name_re.match(key.rsplit("/", 1)[-1])
+            if not m:
+                continue
+            head = s3.head_object(Bucket=S3_BUCKET, Key=key)
+            sha1 = head.get("Metadata", {}).get("sha1", "")
+            ct = head.get("ContentType", "")
+            out[int(m.group(1))] = (key, sha1, ct)
+    return out
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        sys.exit("Usage: verify_item.py <dpla_id> <partner>")
+    dpla_id, partner = sys.argv[1], sys.argv[2]
+    logging.info(f"Verifying {dpla_id} (partner={partner})…")
+
+    # DPLA item title (needed to reconstruct the intended Commons titles)
+    ctx = ToolsContext.init(partner)
+    item_metadata = ctx.get_dpla().get_item_metadata(dpla_id)
+    if not item_metadata:
+        sys.exit(f"DPLA item {dpla_id} not found")
+    title_string = extract_strings(
+        item_metadata.get("sourceResource", {}), DC_TITLE_FIELD
+    )
+    logging.info(f"  item title: {title_string}")
+
+    s3_files = list_s3_ordinals(dpla_id, partner)
+    if not s3_files:
+        sys.exit(f"No S3 ordinals under prefix {s3_path_prefix(dpla_id, partner)}")
+    ordinals = sorted(s3_files)
+    multipage = len(ordinals) > 1
+    logging.info(
+        f"  S3: {len(ordinals)} ordinals, range {ordinals[0]}..{ordinals[-1]}; "
+        f"{'multi-page' if multipage else 'single-page'}"
+    )
+
+    def expected_title(ord_num: int, content_type: str) -> str:
+        ext = mimetypes.guess_extension(content_type) or ".jpg"
+        if ext == ".bin":
+            ext = ".jpg"
+        return get_page_title(
+            title_string, dpla_id, ext, ord_num if multipage else None
+        )
+
+    correct = 0
+    mismatches: list[dict] = []
+    redirects: list[dict] = []
+    missing: list[dict] = []
+
+    for i in range(0, len(ordinals), BATCH):
+        batch = ordinals[i : i + BATCH]
+        title_to_ord: dict[str, tuple[int, str]] = {}
+        for o in batch:
+            _, sha1, ct = s3_files[o]
+            title_to_ord[f"File:{expected_title(o, ct)}"] = (o, sha1)
+
+        data = commons_api(
+            {
+                "action": "query",
+                "titles": "|".join(title_to_ord),
+                "prop": "imageinfo|info",
+                "iiprop": "sha1",
+            }
+        )
+        pages = {p["title"]: p for p in data["query"]["pages"]}
+        norm = {n["from"]: n["to"] for n in data["query"].get("normalized", [])}
+
+        for sent, (o, s3_sha1) in title_to_ord.items():
+            page = pages.get(norm.get(sent, sent))
+            if not page or page.get("missing"):
+                missing.append({"ordinal": o, "title": sent})
+                continue
+            if page.get("redirect"):
+                redirects.append({"ordinal": o, "title": sent})
+                continue
+            info = page.get("imageinfo") or []
+            c_sha1 = info[0].get("sha1", "") if info else ""
+            if c_sha1 == s3_sha1:
+                correct += 1
+            else:
+                mismatches.append(
+                    {
+                        "ordinal": o,
+                        "title": sent,
+                        "s3_sha1": s3_sha1,
+                        "commons_sha1": c_sha1,
+                    }
+                )
+
+        logging.info(
+            f"  scanned {min(i + BATCH, len(ordinals))}/{len(ordinals)}  "
+            f"correct={correct} mismatch={len(mismatches)} "
+            f"redirect={len(redirects)} missing={len(missing)}"
+        )
+
+    total = len(ordinals)
+    all_correct = correct == total
+    print("\n" + "=" * 70)
+    print(f"VERIFICATION REPORT: {dpla_id}")
+    print(f"  item title:  {title_string}")
+    print(f"  S3 ordinals: {total}")
+    print(f"  CORRECT (S3 sha1 == Commons sha1 at intended title): {correct}")
+    print(f"  MISMATCH (different content):                        {len(mismatches)}")
+    print(f"  REDIRECT at intended title:                          {len(redirects)}")
+    print(f"  MISSING on Commons:                                  {len(missing)}")
+    print(f"  {'PASS ✓' if all_correct else 'FAIL ✗'}")
+    print("=" * 70)
+
+    for label, items in (
+        ("Mismatches (S3 sha1 ≠ Commons sha1)", mismatches),
+        ("Redirects at intended title (should be real files)", redirects),
+        ("Missing on Commons (should be uploaded)", missing),
+    ):
+        if items:
+            print(f"\n{label}:")
+            for it in items[:40]:
+                s3s = it.get("s3_sha1", "")
+                cs = it.get("commons_sha1", "")
+                detail = f"  S3 {s3s[:12]}…  Commons {cs[:12]}…" if s3s else ""
+                print(f"  page {it['ordinal']:4d}  {it['title']}{detail}")
+            if len(items) > 40:
+                print(f"  …and {len(items) - 40} more")
+
+    out_path = f"/tmp/verify_{dpla_id}.json"
+    with open(out_path, "w") as f:
+        json.dump(
+            {
+                "dpla_id": dpla_id,
+                "partner": partner,
+                "title": title_string,
+                "total_ordinals": total,
+                "correct": correct,
+                "mismatches": mismatches,
+                "redirects": redirects,
+                "missing": missing,
+                "pass": all_correct,
+            },
+            f,
+            indent=2,
+        )
+    print(f"\nFull report: {out_path}")
+
+    sys.exit(0 if all_correct else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The S3-vs-Commons verification on item \`190aa1b74ca34559e61c25e9dbb97a61\` after the PR #203 re-run found 3 ordinals (44, 182, 183) where the bot still couldn't land the S3 content at the intended title. The intended titles were redirects to *different* DPLA items — created on 2022-11-02 by user \`Mdaniels5757\` as cross-item dedups. The source institution updated those ordinals' images sometime between 2022 and 2026, so the redirect targets' sha1s no longer match S3.

The old bot behavior on this case:
1. \`_resolve_redirect_move\` saw the redirect target had a different DPLA ID, returned \`None\`
2. caller had no fallback for that condition, left \`wiki_file_page\` as a redirect
3. upload to the redirect failed: \`Failed: File already uploaded\`

Only acceptable outcome: S3 sha1 lands at intended title. Whether the redirect there was created by yesterday's bug, a 2022 human, or a stale move is irrelevant — overwrite and land the source content.

## Changes

- **\`_resolve_redirect_overwrite\`**: drop the same-DPLA-ID guard that previously made cross-item redirects unresolvable. Add a \`preserve_from_target\` parameter (default \`True\`). Callers pass \`False\` when the target is a foreign DPLA item — we don't want to inherit its \`{{Image extracted}}\` parent link or unrelated categories.

- **\`_resolve_redirect_move\`**: drop the now-redundant DPLA-ID guard (caller now classifies before invoking) and tighten the return type from \`pywikibot.FilePage | None\` to \`pywikibot.FilePage\`.

- **\`process_file\` redirect-handling branch**: classify the redirect target into three cases:
  1. **Same-DPLA-ID title-text drift** → try \`_resolve_redirect_move\`; on \`ArticleExistsConflictError\`, fall back to overwrite + tag old file as duplicate.
  2. **Same-item different-page relic** (PR #203 case) → \`_resolve_redirect_overwrite\` with \`preserve_from_target=True\`, no tag.
  3. **Cross-item or no-DPLA-ID legacy** (this PR's new case) → \`_resolve_redirect_overwrite\` with \`preserve_from_target=False\`, no tag.

## Test plan

- [ ] After merge + deploy, re-run \`/wikimedia-upload 190aa1b74ca34559e61c25e9dbb97a61\` — should resolve all 3 remaining redirects (pages 44, 182, 183).
- [ ] Verify final state: \`pages 44, 182, 183\` are real files with sha1 matching S3.
- [ ] Re-run the verification script — expect \`CORRECT: 184, MISMATCH: 0, REDIRECT: 0, MISSING: 0\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Fixes S3 file placement for DPLA items with cross-item redirect issues. When an intended Commons title is a redirect, the uploader now classifies the redirect and either moves the target or overwrites the redirect at the intended title so the S3 SHA1 lands at the intended Commons File: title, avoiding "File already uploaded" errors.

## Changes to tools/uploader.py
- Improved hash-drift/redirect resolution in process_file:
  - Classifies redirect targets into three cases and handles each:
    1. Same-DPLA-ID title-text drift → attempt move; on ArticleExistsConflictError, fall back to in-place overwrite and tag the old file as duplicate.
    2. Same-item different-page relic → in-place overwrite while preserving target metadata.
    3. Cross-item or no-DPLA-ID legacy → in-place overwrite without preserving target metadata.
  - Removed same-DPLA-ID guards from helpers so the caller performs classification.
- Helper signature changes:
  - _resolve_redirect_move(...) now returns pywikibot.FilePage (no Optional).
  - _resolve_redirect_overwrite(..., preserve_from_target: bool = True) added; returns tuple[pywikibot.FilePage, str].

## New file: tools/verify_item.py
- Adds a standalone verification script that:
  - Reads S3 object sha1 and content type, reconstructs intended Commons titles, queries the Commons API in batches (with robust Retry-After parsing and stronger Commons API error handling), and classifies ordinals as CORRECT, MISMATCH, REDIRECT, or MISSING.
  - Prints a summary, writes detailed JSON to /tmp/verify_<dpla_id>.json, and exits 0 only when all ordinals are CORRECT.
- Usage: python3 tools/verify_item.py <dpla_id> <partner>

## Test Plan
- After merge and deploy, re-run uploader for DPLA item 190aa1b74ca34559e61c25e9dbb97a61 and verify with tools/verify_item.py. Expectations: problematic ordinals become real files and verification shows CORRECT counts (e.g., CORRECT: 184, MISMATCH: 0, REDIRECT: 0, MISSING: 0 for the identified set).

## Deployment Notes / Impact
- Requires deployment of the updated uploader code to take effect (redeploy the service running the uploader — e.g., trigger CI/CD pipeline or ECS task/service redeploy). The verify_item.py script is a manual utility and does not auto-run.
- No changes to environment variables or AWS Secrets Manager keys.
- No database migrations.
- No shared infrastructure configuration (CodePipeline, CodeBuild, ECS task definitions, IAM) changes are included by this PR.
- No public-facing API changes or endpoint shape modifications.
- No security-sensitive credential handling changes introduced.

## Additional commit-level note
- verify_item.py includes a commit improving Retry-After parsing (supports delay-seconds and HTTP-date per RFC 7231 with 30s default) and stronger Commons API error handling (raise RuntimeError on API error objects even with HTTP 200), making verification retries and error reporting more robust.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->