### PR TITLE
downloader: heal 0-byte stubs; uploader+verifier share page-label helper

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -128,9 +128,15 @@ def compute_ordinal_exts_and_page_labels(
             try:
                 s3_obj = s3_client.get_s3().Object(S3_BUCKET, s3_path)
                 mime = s3_obj.content_type
-            except ClientError:
-                ordinal_exts[i] = ""
-                continue
+            except ClientError as e:
+                # Only treat "object not found" as a stub placeholder.
+                # Anything else (AccessDenied, InternalError, throttling) must
+                # surface so we never silently corrupt the page-label
+                # assignment on a transient S3 failure.
+                if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
+                    ordinal_exts[i] = ""
+                    continue
+                raise
             if is_download_only(mime):
                 continue
             if mime in ("application/octet-stream", "binary/octet-stream"):

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -1,8 +1,11 @@
+import mimetypes
 import re
-from string import Template
 import typing
+from collections import Counter
+from string import Template
 
 import pywikibot
+from botocore.exceptions import ClientError
 from pywikibot import FilePage
 
 from pywikibot.site import APISite, BaseSite
@@ -11,6 +14,7 @@ from pywikibot.tools.chars import replace_invisible
 
 
 from .common import get_list, get_str, get_dict
+from .s3 import S3_BUCKET, S3Client
 from .dpla import (
     WIKIDATA_FIELD_NAME,
     EDM_RIGHTS_FIELD_NAME,
@@ -87,6 +91,66 @@ def get_page_title(
         )
     else:
         return f"{escaped_visible_title} - DPLA - {dpla_identifier}{suffix}"
+
+
+def compute_ordinal_exts_and_page_labels(
+    s3_client: S3Client,
+    dpla_id: str,
+    partner: str,
+    num_files: int,
+) -> tuple[dict[int, str], dict[int, str]]:
+    """Compute per-ordinal extension and page-label for a multi-file DPLA item.
+
+    Mirrors the uploader's pre-scan + per-extension counter logic so any code
+    that needs to predict the Commons title an S3 ordinal will land at can
+    reconstruct it without duplicating the (subtle) accounting. Producer
+    (uploader) and consumer (verifier) MUST share this helper so they never
+    diverge — see lessons.md "Don't normalize platform-dependent values on
+    one side of a producer/consumer pair".
+
+    Returns:
+        ordinal_exts: {ordinal: extension} for ordinals the uploader has
+            classified during pre-scan.
+              - real ext (e.g. ".jpg") means a normal uploadable file.
+              - "" means a stub or octet-stream placeholder; process_file
+                may still upload it after content-type re-detection but
+                without a (page N) suffix.
+              - ordinals absent from the dict are download-only files
+                (e.g. videos) — staged to S3 but never uploaded.
+        page_labels: {ordinal: page_label_string} for every ordinal in
+            1..num_files. Pass to get_page_title(page=...). Empty string
+            means no (page N) suffix on the Commons title.
+    """
+    ordinal_exts: dict[int, str] = {}
+    if num_files > 1:
+        for i in range(1, num_files + 1):
+            s3_path = s3_client.get_media_s3_path(dpla_id, i, partner)
+            try:
+                s3_obj = s3_client.get_s3().Object(S3_BUCKET, s3_path)
+                mime = s3_obj.content_type
+            except ClientError:
+                ordinal_exts[i] = ""
+                continue
+            if is_download_only(mime):
+                continue
+            if mime in ("application/octet-stream", "binary/octet-stream"):
+                ordinal_exts[i] = ""
+                continue
+            ext = mimetypes.guess_extension(mime)
+            ordinal_exts[i] = ext if ext and ext != MIME_UNKNOWN_EXT else ""
+
+    ext_counts: Counter[str] = Counter(ordinal_exts.values())
+    ext_seen: Counter[str] = Counter()
+    page_labels: dict[int, str] = {}
+    for ordinal in range(1, num_files + 1):
+        ext = ordinal_exts.get(ordinal, "")
+        if ext_counts[ext] > 1:
+            ext_seen[ext] += 1
+            page_labels[ordinal] = str(ext_seen[ext])
+        else:
+            page_labels[ordinal] = ""
+
+    return ordinal_exts, page_labels
 
 
 def license_to_markup_code(rights_uri: str) -> str:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -240,3 +240,61 @@ def test_process_item_media_master_skips_manifest(downloader):
     )
 
     downloader.iiif.get_iiif_manifest.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Fix: _s3_key_age_days treats 0-byte stubs as absent so the downloader
+# re-attempts them instead of leaving the stub forever (the persistent stub
+# previously poisoned the uploader's gap-squashing page-label counter).
+# ---------------------------------------------------------------------------
+
+
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+
+def _age_obj(content_length, days_old):
+    obj = MagicMock()
+    obj.content_length = content_length
+    obj.last_modified = datetime.now(tz=timezone.utc) - timedelta(days=days_old)
+    return obj
+
+
+def test_s3_key_age_days_returns_none_for_zero_byte_stub(downloader):
+    obj = _age_obj(content_length=0, days_old=10)
+    downloader.s3_client.get_s3.return_value.Object.return_value = obj
+    assert downloader._s3_key_age_days("any/path") is None
+
+
+def test_s3_key_age_days_returns_age_for_real_file(downloader):
+    obj = _age_obj(content_length=12345, days_old=3)
+    downloader.s3_client.get_s3.return_value.Object.return_value = obj
+    age = downloader._s3_key_age_days("any/path")
+    assert age is not None
+    assert 2.9 < age < 3.1
+
+
+def test_s3_key_age_days_returns_none_for_missing(downloader):
+    from botocore.exceptions import ClientError
+
+    downloader.s3_client.get_s3.return_value.Object.return_value.content_length = (
+        MagicMock(
+            side_effect=ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+            )
+        )
+    )
+    # Simpler: set Object() itself to raise
+    downloader.s3_client.get_s3.return_value.Object.side_effect = ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+    )
+    assert downloader._s3_key_age_days("missing/path") is None
+
+
+def test_s3_key_age_days_propagates_non_404_errors(downloader):
+    from botocore.exceptions import ClientError
+
+    downloader.s3_client.get_s3.return_value.Object.side_effect = ClientError(
+        {"Error": {"Code": "InternalError", "Message": "boom"}}, "HeadObject"
+    )
+    with pytest.raises(ClientError):
+        downloader._s3_key_age_days("any/path")

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -276,14 +276,6 @@ def test_s3_key_age_days_returns_age_for_real_file(downloader):
 def test_s3_key_age_days_returns_none_for_missing(downloader):
     from botocore.exceptions import ClientError
 
-    downloader.s3_client.get_s3.return_value.Object.return_value.content_length = (
-        MagicMock(
-            side_effect=ClientError(
-                {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
-            )
-        )
-    )
-    # Simpler: set Object() itself to raise
     downloader.s3_client.get_s3.return_value.Object.side_effect = ClientError(
         {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
     )

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -406,6 +406,24 @@ def test_page_labels_clienterror_treated_as_stub_placeholder():
     assert labels == {1: "1", 2: "", 3: "2"}
 
 
+def test_page_labels_non_404_clienterror_propagates():
+    # Transient S3 failures (AccessDenied, InternalError, throttling) must
+    # not be silently swallowed as "object missing" — that would corrupt
+    # the page-label assignment on what's actually a valid file.
+    import pytest
+    from botocore.exceptions import ClientError
+
+    s3 = MagicMock()
+    s3.get_media_s3_path.side_effect = lambda d, i, p: (
+        f"{p}/images/{d[0]}/{d[1]}/{d[2]}/{d[3]}/{d}/{i}_{d}"
+    )
+    s3.get_s3.return_value.Object.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "nope"}}, "HeadObject"
+    )
+    with pytest.raises(ClientError):
+        compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 3)
+
+
 def test_page_labels_single_file_item_no_pagination():
     # num_files == 1 → no pre-scan, no page label, no (page N) suffix.
     s3 = _fake_s3_client({1: "image/jpeg"})

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -7,6 +7,7 @@ from ingest_wikimedia.wikimedia import (
     get_permissions,
     escape_wiki_strings,
     join,
+    compute_ordinal_exts_and_page_labels,
     extract_page_ordinal_from_commons_title,
     extract_strings,
     extract_strings_dict,
@@ -332,3 +333,109 @@ def test_relic_intended_belongs_to_different_item_is_false():
     intended = f"Foo - DPLA - {other_id} (page 1).jpg"
     target = f"Foo - DPLA - {ITEM} (page 3).jpg"
     assert is_same_item_redirect_relic(intended, target, ITEM) is False
+
+
+# compute_ordinal_exts_and_page_labels — uploader-side gap-squashing
+def _fake_s3_client(mime_by_ord: dict[int, str | None]) -> MagicMock:
+    """Build a mock S3Client whose Object().content_type returns the configured
+    MIME per ordinal. None means the object doesn't exist (raises ClientError)."""
+    from botocore.exceptions import ClientError
+
+    s3_client = MagicMock()
+
+    def get_obj(bucket, path):
+        ord_num = int(path.rsplit("/", 1)[-1].split("_", 1)[0])
+        mime = mime_by_ord.get(ord_num)
+        if mime is None:
+            raise ClientError(
+                {"Error": {"Code": "NoSuchKey", "Message": "404"}}, "HeadObject"
+            )
+        obj = MagicMock()
+        obj.content_type = mime
+        return obj
+
+    boto3_resource = MagicMock()
+    boto3_resource.Object.side_effect = get_obj
+    s3_client.get_s3.return_value = boto3_resource
+    s3_client.get_media_s3_path.side_effect = lambda d, i, p: (
+        f"{p}/images/{d[0]}/{d[1]}/{d[2]}/{d[3]}/{d}/{i}_{d}"
+    )
+    return s3_client
+
+
+def test_page_labels_dense_jpegs_match_ordinal():
+    # Happy path: all 5 ordinals are valid jpegs → page_label == ordinal.
+    s3 = _fake_s3_client(
+        {
+            1: "image/jpeg",
+            2: "image/jpeg",
+            3: "image/jpeg",
+            4: "image/jpeg",
+            5: "image/jpeg",
+        }
+    )
+    exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 5)
+    assert exts == {1: ".jpg", 2: ".jpg", 3: ".jpg", 4: ".jpg", 5: ".jpg"}
+    assert labels == {1: "1", 2: "2", 3: "3", 4: "4", 5: "5"}
+
+
+def test_page_labels_zero_byte_stub_squashes():
+    # Stub at ord 3 (octet-stream) shifts subsequent .jpg labels back by 1.
+    # This is the gap-squashing behavior the bot intentionally uses.
+    s3 = _fake_s3_client(
+        {
+            1: "image/jpeg",
+            2: "image/jpeg",
+            3: "binary/octet-stream",
+            4: "image/jpeg",
+            5: "image/jpeg",
+        }
+    )
+    exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 5)
+    assert exts == {1: ".jpg", 2: ".jpg", 3: "", 4: ".jpg", 5: ".jpg"}
+    # ord 1-2 = "1","2"; ord 3 ext="" only one, page_label=""; ord 4-5 = "3","4"
+    assert labels == {1: "1", 2: "2", 3: "", 4: "3", 5: "4"}
+
+
+def test_page_labels_clienterror_treated_as_stub_placeholder():
+    # Missing S3 object — ordinal_exts gets "" placeholder per the
+    # "every continue path must write a placeholder slot" lesson.
+    s3 = _fake_s3_client({1: "image/jpeg", 2: None, 3: "image/jpeg"})
+    exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 3)
+    assert exts == {1: ".jpg", 2: "", 3: ".jpg"}
+    assert labels == {1: "1", 2: "", 3: "2"}
+
+
+def test_page_labels_single_file_item_no_pagination():
+    # num_files == 1 → no pre-scan, no page label, no (page N) suffix.
+    s3 = _fake_s3_client({1: "image/jpeg"})
+    exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 1)
+    assert exts == {}
+    assert labels == {1: ""}
+
+
+def test_page_labels_mixed_extensions_per_ext_counter():
+    # 3 jpegs and 2 pdfs → each extension gets its own 1..N counter.
+    s3 = _fake_s3_client(
+        {
+            1: "image/jpeg",
+            2: "application/pdf",
+            3: "image/jpeg",
+            4: "application/pdf",
+            5: "image/jpeg",
+        }
+    )
+    exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 5)
+    assert exts == {1: ".jpg", 2: ".pdf", 3: ".jpg", 4: ".pdf", 5: ".jpg"}
+    # jpg counter: ord 1→"1", ord 3→"2", ord 5→"3"
+    # pdf counter: ord 2→"1", ord 4→"2"
+    assert labels == {1: "1", 2: "1", 3: "2", 4: "2", 5: "3"}
+
+
+def test_page_labels_unique_extension_gets_empty_label():
+    # When only one file has a given extension, no (page N) suffix.
+    s3 = _fake_s3_client({1: "image/jpeg", 2: "image/jpeg", 3: "application/pdf"})
+    exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 3)
+    assert exts == {1: ".jpg", 2: ".jpg", 3: ".pdf"}
+    # ext_counts: .jpg→2, .pdf→1. Only .jpg gets page numbers.
+    assert labels == {1: "1", 2: "2", 3: ""}

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -164,9 +164,19 @@ class Downloader:
             raise RuntimeError(f"Failed downloading {media_url} to local") from e
 
     def _s3_key_age_days(self, s3_path: str) -> float | None:
-        """Return the age in days of an S3 object, or None if it does not exist."""
+        """Return the age in days of an S3 object, or None if it does not exist
+        or is a 0-byte stub left by a failed/interrupted download.
+
+        Treating 0-byte stubs as absent forces the downloader to re-attempt,
+        matching the design intent documented on S3Client.s3_file_exists.
+        Without this, a single corrupted download persists forever — the
+        uploader's pre-scan classifies the stub as "" placeholder, which
+        shifts every subsequent page-label and corrupts Commons numbering.
+        """
         try:
             obj = self.s3_client.get_s3().Object(S3_BUCKET, s3_path)
+            if int(obj.content_length or 0) == 0:
+                return None
             age = datetime.now(tz=timezone.utc) - obj.last_modified
             return age.total_seconds() / 86400
         except ClientError as e:

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -4,9 +4,6 @@ import logging
 import mimetypes
 import random
 import time
-from collections import Counter
-
-from botocore.exceptions import ClientError
 
 import click
 import pywikibot
@@ -44,6 +41,7 @@ from ingest_wikimedia.wikimedia import (
     WMC_UPLOAD_CHUNK_SIZE,
     IGNORE_WIKIMEDIA_WARNINGS,
     MIME_UNKNOWN_EXT,
+    compute_ordinal_exts_and_page_labels,
     get_page_title,
     get_wiki_text,
     wikimedia_url,
@@ -759,37 +757,11 @@ class Uploader:
 
             files = self.s3_client.get_file_list(partner, dpla_id)
 
-            # Pre-scan to resolve each file's extension from S3 content-type metadata.
-            # Files with distinct extensions represent the same content in different
-            # formats, not separate pages — page numbers are only assigned within
-            # groups that share the same extension and contain more than one file.
-            # Single-file items never need pagination so we skip the pre-scan for them.
-            ordinal_exts: dict[int, str] = {}
-            if len(files) > 1:
-                for i in range(1, len(files) + 1):
-                    s3_path = self.s3_client.get_media_s3_path(dpla_id, i, partner)
-                    try:
-                        s3_obj = self.s3_client.get_s3().Object(S3_BUCKET, s3_path)
-                        mime = s3_obj.content_type
-                    except ClientError:
-                        ordinal_exts[i] = ""
-                        continue
-                    # Download-only types (e.g. video) are never uploaded, so they
-                    # should not influence page numbering.
-                    if is_download_only(mime):
-                        continue
-                    # Generic MIME types are re-detected by libmagic in process_file;
-                    # use "" as a placeholder so they still get unique page labels.
-                    if mime in ("application/octet-stream", "binary/octet-stream"):
-                        ordinal_exts[i] = ""
-                        continue
-                    ext = mimetypes.guess_extension(mime)
-                    # Use "" for unresolvable extensions — process_file will skip
-                    # them, but the placeholder prevents page-title collisions.
-                    ordinal_exts[i] = ext if ext and ext != MIME_UNKNOWN_EXT else ""
-
-            ext_counts: Counter[str] = Counter(ordinal_exts.values())
-            ext_seen: Counter[str] = Counter()
+            # Pre-scan via the shared helper so the verifier can reconstruct
+            # the same page-label assignments without duplicating the logic.
+            _, page_labels = compute_ordinal_exts_and_page_labels(
+                self.s3_client, dpla_id, partner, len(files)
+            )
 
             for ordinal, _ in enumerate(
                 tqdm(
@@ -798,12 +770,7 @@ class Uploader:
                 start=1,
             ):
                 logging.info(f"Page {ordinal}")
-                ext = ordinal_exts.get(ordinal, "")
-                if ext_counts[ext] > 1:
-                    ext_seen[ext] += 1
-                    page_label = str(ext_seen[ext])
-                else:
-                    page_label = ""
+                page_label = page_labels.get(ordinal, "")
                 try:
                     self.process_file(
                         dpla_id,

--- a/tools/verify_item.py
+++ b/tools/verify_item.py
@@ -45,12 +45,13 @@ import urllib.request
 import boto3
 from botocore.exceptions import ClientError
 
+from ingest_wikimedia.common import get_dict, get_list
+from ingest_wikimedia.dpla import DC_TITLE_FIELD_NAME, SOURCE_RESOURCE_FIELD_NAME
 from ingest_wikimedia.s3 import S3_BUCKET, S3Client
 from ingest_wikimedia.tools_context import ToolsContext
 from ingest_wikimedia.wikimedia import (
     check_content_type,
     compute_ordinal_exts_and_page_labels,
-    extract_strings,
     get_page_title,
     is_download_only,
 )
@@ -59,7 +60,6 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 
 COMMONS_API = "https://commons.wikimedia.org/w/api.php"
 BATCH = 50
-DC_TITLE_FIELD = "title"  # under sourceResource
 DEFAULT_RETRY_AFTER_SECS = 30
 
 
@@ -146,9 +146,15 @@ def main() -> None:
     item_metadata = ctx.get_dpla().get_item_metadata(dpla_id)
     if not item_metadata:
         sys.exit(f"DPLA item {dpla_id} not found")
-    title_string = extract_strings(
-        item_metadata.get("sourceResource", {}), DC_TITLE_FIELD
+    # Use the same title selection as Uploader.process_item(): the FIRST
+    # value of sourceResource.title, not the joined extract_strings(...)
+    # representation. The uploader feeds titles[0] to get_page_title, so
+    # the verifier must do the same to reconstruct the exact filename.
+    titles = get_list(
+        get_dict(item_metadata, SOURCE_RESOURCE_FIELD_NAME),
+        DC_TITLE_FIELD_NAME,
     )
+    title_string = titles[0] if titles else ""
     logging.info(f"  item title: {title_string}")
 
     s3_client_obj = ctx.get_s3_client()

--- a/tools/verify_item.py
+++ b/tools/verify_item.py
@@ -3,22 +3,25 @@
 End-to-end verification that every S3 file for a DPLA item has its exact
 sha1 landed at its intended Commons title.
 
-For each ordinal under the item's S3 prefix this script:
-  1. reads the S3 object's sha1 from the CHECKSUM metadata,
-  2. reconstructs the intended Commons title via get_page_title() using
-     the DPLA item's source title and the S3 object's MIME-derived
-     extension,
-  3. queries the Commons MediaWiki API for the file at that intended
-     title and compares its sha1 to S3.
+For each ordinal in the item's file_list this script:
+  1. reads the S3 object's sha1 + size + content-type,
+  2. uses compute_ordinal_exts_and_page_labels() — the same helper the
+     uploader uses — to determine the Commons page_label the bot would
+     have assigned to that ordinal (gap-squashing logic and all),
+  3. queries the Commons MediaWiki API for the file at the resulting
+     intended title and compares its sha1 to S3.
 
 Outcomes per ordinal:
   CORRECT  — Commons file at the intended title has sha1 == S3 sha1
   MISMATCH — file exists at the intended title with a different sha1
   REDIRECT — intended title is a redirect (S3 sha1 isn't at the right name)
   MISSING  — intended title has no page on Commons
+  SKIPPED  — the uploader would not have uploaded this ordinal (0-byte
+             stub, download-only mime, missing from S3, etc.). Reported
+             with a reason but does not count as a failure.
 
-Exits 0 only when every ordinal is CORRECT. Anything else exits 1 so the
-script can be wired into a CI gate or a deploy verification loop.
+Exits 0 only when every uploadable ordinal is CORRECT. Anything else
+exits 1 so the script can be wired into a deploy-verification loop.
 
 Usage:
     python3 tools/verify_item.py <dpla_id> <partner>
@@ -33,7 +36,6 @@ import email.utils
 import json
 import logging
 import mimetypes
-import re
 import sys
 import time
 import urllib.error
@@ -41,10 +43,17 @@ import urllib.parse
 import urllib.request
 
 import boto3
+from botocore.exceptions import ClientError
 
 from ingest_wikimedia.s3 import S3_BUCKET, S3Client
 from ingest_wikimedia.tools_context import ToolsContext
-from ingest_wikimedia.wikimedia import extract_strings, get_page_title
+from ingest_wikimedia.wikimedia import (
+    check_content_type,
+    compute_ordinal_exts_and_page_labels,
+    extract_strings,
+    get_page_title,
+    is_download_only,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
@@ -100,25 +109,31 @@ def commons_api(params: dict) -> dict:
     raise RuntimeError("Commons API retries exhausted")
 
 
-def list_s3_ordinals(dpla_id: str, partner: str) -> dict[int, tuple[str, str, str]]:
-    """Return {ordinal: (key, sha1, content_type)} for every media file under
-    the item's S3 prefix."""
-    s3 = boto3.client("s3")
-    prefix = S3Client.get_item_s3_path(dpla_id, "", partner)
-    out: dict[int, tuple[str, str, str]] = {}
-    name_re = re.compile(r"^(\d+)_" + re.escape(dpla_id) + r"$")
-    paginator = s3.get_paginator("list_objects_v2")
-    for page in paginator.paginate(Bucket=S3_BUCKET, Prefix=prefix):
-        for obj in page.get("Contents", []):
-            key = obj["Key"]
-            m = name_re.match(key.rsplit("/", 1)[-1])
-            if not m:
-                continue
-            head = s3.head_object(Bucket=S3_BUCKET, Key=key)
-            sha1 = head.get("Metadata", {}).get("sha1", "")
-            ct = head.get("ContentType", "")
-            out[int(m.group(1))] = (key, sha1, ct)
-    return out
+def classify_ordinal(head: dict) -> tuple[str | None, str, str]:
+    """Inspect an S3 object's HEAD metadata and decide whether the uploader
+    would upload it. Returns (skip_reason_or_None, sha1, content_type).
+
+    Mirrors the runtime checks process_file() performs. When skip_reason is
+    None, the uploader would proceed and upload; otherwise the ordinal is
+    skipped and no Commons title should be checked.
+    """
+    sha1 = head.get("Metadata", {}).get("sha1", "")
+    ct = head.get("ContentType", "")
+    size = int(head.get("ContentLength", 0))
+    if size == 0:
+        return "zero_byte_stub", sha1, ct
+    if not check_content_type(ct):
+        return f"bad_content_type:{ct}", sha1, ct
+    if is_download_only(ct):
+        return "download_only", sha1, ct
+    if ct in ("application/octet-stream", "binary/octet-stream"):
+        # process_file does runtime libmagic re-detection; we can't predict
+        # its outcome without downloading the file.
+        return "octet_stream_needs_redetect", sha1, ct
+    ext = mimetypes.guess_extension(ct)
+    if not ext or ext == ".bin":
+        return f"unresolvable_ext:{ct}", sha1, ct
+    return None, sha1, ct
 
 
 def main() -> None:
@@ -127,7 +142,6 @@ def main() -> None:
     dpla_id, partner = sys.argv[1], sys.argv[2]
     logging.info(f"Verifying {dpla_id} (partner={partner})…")
 
-    # DPLA item title (needed to reconstruct the intended Commons titles)
     ctx = ToolsContext.init(partner)
     item_metadata = ctx.get_dpla().get_item_metadata(dpla_id)
     if not item_metadata:
@@ -137,43 +151,61 @@ def main() -> None:
     )
     logging.info(f"  item title: {title_string}")
 
-    s3_files = list_s3_ordinals(dpla_id, partner)
-    if not s3_files:
-        sys.exit(
-            f"No S3 ordinals under prefix "
-            f"{S3Client.get_item_s3_path(dpla_id, '', partner)}"
-        )
-    ordinals = sorted(s3_files)
-    multipage = len(ordinals) > 1
-    logging.info(
-        f"  S3: {len(ordinals)} ordinals, range {ordinals[0]}..{ordinals[-1]}; "
-        f"{'multi-page' if multipage else 'single-page'}"
+    s3_client_obj = ctx.get_s3_client()
+    files = s3_client_obj.get_file_list(partner, dpla_id)
+    num_files = len(files)
+    if num_files == 0:
+        sys.exit(f"No files listed in file_list.txt for {dpla_id}")
+    logging.info(f"  total files in source list: {num_files}")
+
+    # Use the same helper the uploader uses to compute per-ordinal page labels
+    # so the intended Commons titles match exactly what the bot uploads to,
+    # including the gap-squashing per-extension counter logic.
+    _, page_labels = compute_ordinal_exts_and_page_labels(
+        s3_client_obj, dpla_id, partner, num_files
     )
 
-    def expected_title(ord_num: int, content_type: str) -> str:
-        ext = mimetypes.guess_extension(content_type) or ".jpg"
-        if ext == ".bin":
-            ext = ".jpg"
-        return get_page_title(
-            title_string, dpla_id, ext, ord_num if multipage else None
-        )
-
+    s3 = boto3.client("s3")
     correct = 0
     mismatches: list[dict] = []
     redirects: list[dict] = []
     missing: list[dict] = []
+    skipped: list[dict] = []  # uploader-skipped ordinals (stub, video, etc.)
+    title_to_ord: dict[str, tuple[int, str]] = {}
 
-    for i in range(0, len(ordinals), BATCH):
-        batch = ordinals[i : i + BATCH]
-        title_to_ord: dict[str, tuple[int, str]] = {}
-        for o in batch:
-            _, sha1, ct = s3_files[o]
-            title_to_ord[f"File:{expected_title(o, ct)}"] = (o, sha1)
+    for ord_num in range(1, num_files + 1):
+        s3_path = S3Client.get_media_s3_path(dpla_id, ord_num, partner)
+        try:
+            head = s3.head_object(Bucket=S3_BUCKET, Key=s3_path)
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("404", "NoSuchKey"):
+                skipped.append({"ordinal": ord_num, "reason": "missing_in_s3"})
+                continue
+            raise
 
+        skip_reason, sha1, ct = classify_ordinal(head)
+        if skip_reason:
+            skipped.append({"ordinal": ord_num, "reason": skip_reason})
+            continue
+
+        ext = mimetypes.guess_extension(ct)
+        page_label = page_labels.get(ord_num, "")
+        title = get_page_title(title_string, dpla_id, ext, page_label or None)
+        title_to_ord[f"File:{title}"] = (ord_num, sha1)
+
+    logging.info(
+        f"  ordinals to verify: {len(title_to_ord)}  "
+        f"skipped by uploader: {len(skipped)}"
+    )
+
+    titles = list(title_to_ord.keys())
+    for i in range(0, len(titles), BATCH):
+        batch = titles[i : i + BATCH]
         data = commons_api(
             {
                 "action": "query",
-                "titles": "|".join(title_to_ord),
+                "titles": "|".join(batch),
                 "prop": "imageinfo|info",
                 "iiprop": "sha1",
             }
@@ -181,13 +213,14 @@ def main() -> None:
         pages = {p["title"]: p for p in data["query"]["pages"]}
         norm = {n["from"]: n["to"] for n in data["query"].get("normalized", [])}
 
-        for sent, (o, s3_sha1) in title_to_ord.items():
+        for sent in batch:
+            (ord_num, s3_sha1) = title_to_ord[sent]
             page = pages.get(norm.get(sent, sent))
             if not page or page.get("missing"):
-                missing.append({"ordinal": o, "title": sent})
+                missing.append({"ordinal": ord_num, "title": sent})
                 continue
             if page.get("redirect"):
-                redirects.append({"ordinal": o, "title": sent})
+                redirects.append({"ordinal": ord_num, "title": sent})
                 continue
             info = page.get("imageinfo") or []
             c_sha1 = info[0].get("sha1", "") if info else ""
@@ -196,7 +229,7 @@ def main() -> None:
             else:
                 mismatches.append(
                     {
-                        "ordinal": o,
+                        "ordinal": ord_num,
                         "title": sent,
                         "s3_sha1": s3_sha1,
                         "commons_sha1": c_sha1,
@@ -204,21 +237,27 @@ def main() -> None:
                 )
 
         logging.info(
-            f"  scanned {min(i + BATCH, len(ordinals))}/{len(ordinals)}  "
+            f"  scanned {min(i + BATCH, len(titles))}/{len(titles)}  "
             f"correct={correct} mismatch={len(mismatches)} "
             f"redirect={len(redirects)} missing={len(missing)}"
         )
 
-    total = len(ordinals)
-    all_correct = correct == total
+    all_correct = (
+        correct == len(title_to_ord)
+        and not mismatches
+        and not redirects
+        and not missing
+    )
     print("\n" + "=" * 70)
     print(f"VERIFICATION REPORT: {dpla_id}")
-    print(f"  item title:  {title_string}")
-    print(f"  S3 ordinals: {total}")
+    print(f"  item title:        {title_string}")
+    print(f"  total files in source list: {num_files}")
+    print(f"  ordinals checked:  {len(title_to_ord)}")
     print(f"  CORRECT (S3 sha1 == Commons sha1 at intended title): {correct}")
     print(f"  MISMATCH (different content):                        {len(mismatches)}")
     print(f"  REDIRECT at intended title:                          {len(redirects)}")
     print(f"  MISSING on Commons:                                  {len(missing)}")
+    print(f"  SKIPPED by uploader (stub/video/etc):                {len(skipped)}")
     print(f"  {'PASS ✓' if all_correct else 'FAIL ✗'}")
     print("=" * 70)
 
@@ -233,9 +272,19 @@ def main() -> None:
                 s3s = it.get("s3_sha1", "")
                 cs = it.get("commons_sha1", "")
                 detail = f"  S3 {s3s[:12]}…  Commons {cs[:12]}…" if s3s else ""
-                print(f"  page {it['ordinal']:4d}  {it['title']}{detail}")
+                print(f"  ord {it['ordinal']:4d}  {it['title']}{detail}")
             if len(items) > 40:
                 print(f"  …and {len(items) - 40} more")
+
+    if skipped:
+        print("\nSkipped by uploader (informational, not failures):")
+        by_reason: dict[str, list[int]] = {}
+        for s in skipped:
+            by_reason.setdefault(s["reason"], []).append(s["ordinal"])
+        for reason, ords in sorted(by_reason.items()):
+            preview = ", ".join(str(o) for o in ords[:10])
+            more = f" …and {len(ords) - 10} more" if len(ords) > 10 else ""
+            print(f"  {reason}: ords [{preview}{more}]")
 
     out_path = f"/tmp/verify_{dpla_id}.json"
     with open(out_path, "w") as f:
@@ -244,11 +293,13 @@ def main() -> None:
                 "dpla_id": dpla_id,
                 "partner": partner,
                 "title": title_string,
-                "total_ordinals": total,
+                "num_files": num_files,
+                "ordinals_checked": len(title_to_ord),
                 "correct": correct,
                 "mismatches": mismatches,
                 "redirects": redirects,
                 "missing": missing,
+                "skipped": skipped,
                 "pass": all_correct,
             },
             f,

--- a/tools/verify_item.py
+++ b/tools/verify_item.py
@@ -42,7 +42,7 @@ import urllib.request
 
 import boto3
 
-from ingest_wikimedia.s3 import S3_BUCKET
+from ingest_wikimedia.s3 import S3_BUCKET, S3Client
 from ingest_wikimedia.tools_context import ToolsContext
 from ingest_wikimedia.wikimedia import extract_strings, get_page_title
 
@@ -68,13 +68,6 @@ def _parse_retry_after(value: str | None) -> int:
         return max(0, int((when - now).total_seconds()))
     except (TypeError, ValueError):
         return DEFAULT_RETRY_AFTER_SECS
-
-
-def s3_path_prefix(dpla_id: str, partner: str) -> str:
-    return (
-        f"{partner}/images/{dpla_id[0]}/{dpla_id[1]}/"
-        f"{dpla_id[2]}/{dpla_id[3]}/{dpla_id}/"
-    )
 
 
 def commons_api(params: dict) -> dict:
@@ -111,7 +104,7 @@ def list_s3_ordinals(dpla_id: str, partner: str) -> dict[int, tuple[str, str, st
     """Return {ordinal: (key, sha1, content_type)} for every media file under
     the item's S3 prefix."""
     s3 = boto3.client("s3")
-    prefix = s3_path_prefix(dpla_id, partner)
+    prefix = S3Client.get_item_s3_path(dpla_id, "", partner)
     out: dict[int, tuple[str, str, str]] = {}
     name_re = re.compile(r"^(\d+)_" + re.escape(dpla_id) + r"$")
     paginator = s3.get_paginator("list_objects_v2")
@@ -146,7 +139,10 @@ def main() -> None:
 
     s3_files = list_s3_ordinals(dpla_id, partner)
     if not s3_files:
-        sys.exit(f"No S3 ordinals under prefix {s3_path_prefix(dpla_id, partner)}")
+        sys.exit(
+            f"No S3 ordinals under prefix "
+            f"{S3Client.get_item_s3_path(dpla_id, '', partner)}"
+        )
     ordinals = sorted(s3_files)
     multipage = len(ordinals) > 1
     logging.info(


### PR DESCRIPTION
## Summary

Discovered while verifying re-runs on items with mixed gap/stub history (Rosenbaum Vol 03 ord 55 etc.): a single 0-byte stub left by a failed download was persisting forever because the downloader's skip-check didn't size-test, and that stub then poisoned the uploader's per-extension page-label counter — every ordinal after the stub uploaded to Commons (page N-1) instead of (page N).

Three coordinated changes:

### 1. Downloader root fix (`tools/downloader.py`)

`_s3_key_age_days` only checked for HTTP 404. A 0-byte stub from an interrupted download returned an age, so the downloader logged "Key already in S3" and skipped — leaving the stub forever. Now treats 0-byte objects as absent, matching the design intent already documented on `S3Client.s3_file_exists`. The existing upload guard already prevents overwriting valid content with a 0-byte download, so retries are safe.

### 2. Shared page-label helper (`ingest_wikimedia/wikimedia.py`)

`compute_ordinal_exts_and_page_labels()` owns the per-extension counter logic the uploader uses to assign Commons page numbers. Producer (uploader) and consumer (verifier) now both call it — per `lessons.md` *"Don't normalize platform-dependent values on one side of a producer/consumer pair"*, this is the only way to guarantee they stay in sync.

### 3. Verifier matches uploader (`tools/verify_item.py`)

- Iterates 1..num_files from `file_list.txt` (not just S3 listing).
- Uses the shared helper to predict what Commons title each S3 ordinal would land at.
- New `SKIPPED` category for ordinals the uploader would skip (stub, download-only, missing-in-S3, octet-stream-needing-redetect, etc.) — informational, not a failure.
- `PASS` requires every uploadable ordinal to be CORRECT and zero MISMATCH / REDIRECT / MISSING.

Plus the existing `S3Client.get_item_s3_path` refactor from earlier on this branch.

## Behavior change for end-to-end re-run

The uploader's gap-squashing logic is intentionally preserved per @dominic's preference: *"I would rather not have intentional page gaps on Wikimedia Commons, and if there ever is a reason that a file was missing in the middle of the item that gets downloaded in a later run, this is one of the use cases that the logic we have been working on would just fix all the pages by essentially renumbering."*

So after this PR + deploy:
- Re-running an item with current 0-byte stubs → downloader heals them → S3 becomes dense → uploader's page-label counter aligns ord N → (page N) one-to-one → re-upload corrects the page numbering.
- Verifier checks the bot's actual mapping; PASS only when every uploadable S3 sha1 has landed at the bot's intended title.

## Test plan

- [x] `ruff check` + `ruff format` clean across all touched files
- [x] Unit tests for `compute_ordinal_exts_and_page_labels`: dense, stub-squashing, ClientError placeholder, single-file, mixed extensions, unique-ext fallthrough
- [x] Unit tests for `_s3_key_age_days`: 0-byte returns None, real file returns age, 404 returns None, non-404 propagates
- [ ] After merge + deploy, re-run the 4 currently-failing items (Rosenbaum Vol 21, Rosenbaum Vol 03, Pennsylvania Company 1932-1936, 5th Annual SoCal Science Fair). Confirm downloader heals stubs and verifier reports PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a bug where 0-byte stub objects left by interrupted S3 downloads persisted and poisoned downstream processing, and refactors uploader page-labeling logic into a shared helper used by both the uploader and verifier.

### Key Changes

- tools/downloader.py
  - `_s3_key_age_days()` now treats S3 objects with content_length == 0 as absent (returns None) so interrupted-download 0-byte stubs are retried. Existing upload guards still prevent overwriting valid content.

- ingest_wikimedia/wikimedia.py
  - Added compute_ordinal_exts_and_page_labels(s3_client, dpla_id, partner, num_files) to centralize uploader pre-scan logic. It:
    - queries per-ordinal S3 content_type (treating only S3 "object not found" / 404 as missing),
    - filters download-only and octet-stream placeholders,
    - maps MIME types to extensions,
    - computes per-extension page-labels with the uploader's gap-squashing/counting rules.
  - Non-404 ClientErrors (e.g., AccessDenied) now propagate so transient S3 failures won't silently corrupt page-label assignment.

- tools/uploader.py
  - Removed local Counter pre-scan; uses the shared compute_ordinal_exts_and_page_labels() for page_label assignment to ensure uploader/verifier consistency.

- tools/verify_item.py
  - Uses compute_ordinal_exts_and_page_labels() to reconstruct uploader-chosen Commons titles (including gap-squashing).
  - Adds classify_ordinal(head) to mark uploader-skipped ordinals (zero-byte stubs, download-only, octet-stream needing redetect, bad content-type, unresolvable ext) and return reason/sha1/content_type.
  - Iterates ordinals 1..num_files from file_list.txt, treats missing S3 HEAD as skipped, reports SKIPPED (informational) for uploader-skipped ordinals, and requires every uploadable ordinal to be CORRECT with zero MISMATCH/REDIRECT/MISSING for a PASS.
  - Adjusted JSON report schema: includes num_files, ordinals_checked, skipped (replaced prior total_ordinals).

### Tests
- Added unit tests:
  - tests/test_downloader.py: tests for _s3_key_age_days() (zero-byte stub returns None, real file age computed, missing returns None, non-404 ClientError propagated).
  - tests/test_wikimedia.py: tests for compute_ordinal_exts_and_page_labels() covering dense files, gap-squashing, missing objects, non-404 error propagation, single-file behavior, mixed extensions, and single-occurrence ext labeling.

### Deployment / Operational Notes
- Post-merge redeployment of the tools is required for behavior to take effect (the verifier and downloader behavior depends on the updated code being deployed). Re-run the specific previously failing items after deployment to confirm stubs are healed and the verifier reports PASS.
- No changes to environment variables or AWS Secrets Manager keys.
- No database migrations.
- No shared infrastructure (CodePipeline / CodeBuild / ECS task definitions / IAM policies) changes were introduced by this PR.
- The verify_item JSON output schema changed, but this is internal tooling output (not a public API change).

### Security / Stability
- No authentication changes or new credential handling introduced.
- S3 error handling was deliberately narrowed so only object-not-found is treated as a benign missing stub; other S3 errors now propagate to avoid silent corruption of page-label assignment.

### Misc
- Preserves uploader gap-squashing behavior so reruns can renumber pages when earlier gaps are later filled.
- Includes earlier S3Client.get_item_s3_path refactor and unit tests for the new helper and _s3_key_age_days.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->