### PR TITLE
downloader: refuse 0-byte downloads and 0-byte uploads at the source

### DIFF
--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -106,6 +106,99 @@ def test_upload_proceeds_when_content_length_unreadable(downloader):
     obj.upload_fileobj.assert_called_once()
 
 
+def test_upload_refuses_zero_byte_local_file_no_existing(downloader):
+    # Defense in depth: even if download_file_to_temp_path's raise-on-empty
+    # check were to be bypassed, upload_file_to_s3 must not write a 0-byte
+    # object to S3. This is the bug that created stubs in the first place.
+    from botocore.exceptions import ClientError
+
+    mock_s3 = MagicMock()
+    # Existing object doesn't exist → 404 when .metadata is read
+    obj = MagicMock()
+    type(obj).metadata = property(
+        lambda _: (_ for _ in ()).throw(
+            ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+            )
+        )
+    )
+    mock_s3.Object.return_value = obj
+    downloader.s3_client.get_s3.return_value = mock_s3
+
+    with patch("os.stat") as mock_stat:
+        mock_stat.return_value.st_size = 0  # 0-byte local file
+        result = downloader.upload_file_to_s3(
+            "/tmp/empty", "dest/path", "image/jpeg", "abc123"
+        )
+
+    assert result is False
+    obj.upload_fileobj.assert_not_called()
+    downloader.tracker.increment.assert_any_call(Result.FAILED)
+
+
+def test_upload_refuses_zero_byte_local_file_over_existing_valid(downloader):
+    # Existing S3 has valid content; new download is 0 bytes — must not
+    # overwrite, and must not silently SKIP either (FAILED is the honest
+    # signal — the download produced no usable content).
+    obj = _make_s3_obj("existing_sha", 1024)
+    mock_s3 = MagicMock()
+    mock_s3.Object.return_value = obj
+    downloader.s3_client.get_s3.return_value = mock_s3
+
+    with patch("os.stat") as mock_stat:
+        mock_stat.return_value.st_size = 0
+        result = downloader.upload_file_to_s3(
+            "/tmp/empty", "dest/path", "image/jpeg", "new_sha"
+        )
+
+    assert result is False
+    obj.upload_fileobj.assert_not_called()
+    downloader.tracker.increment.assert_any_call(Result.FAILED)
+
+
+# ---------------------------------------------------------------------------
+# download_file_to_temp_path raises on empty body (HTTP 200 + 0 bytes)
+# ---------------------------------------------------------------------------
+
+
+def test_download_raises_on_zero_byte_response(downloader, tmp_path):
+    # Simulates the OCLC ContentDM scenario that originally created the stubs:
+    # HTTP 200 OK from the source, but the body delivers zero chunks (clean
+    # close after headers, or empty content). The download must raise so
+    # process_media skips the upload and the FAILED tracker fires.
+    response = MagicMock()
+    response.raise_for_status = MagicMock()  # no exception
+    response.headers = {"content-length": "0"}
+    response.iter_content.return_value = []  # no chunks delivered
+    downloader.http_session.get.return_value = response
+
+    local_file = tmp_path / "empty.jpg"
+    import pytest
+
+    with pytest.raises(RuntimeError, match="0 bytes"):
+        downloader.download_file_to_temp_path(
+            "http://example.com/x.jpg", str(local_file)
+        )
+
+    # The on-disk file should have been created (open(... "wb")) but stay empty
+    assert local_file.exists()
+    assert local_file.stat().st_size == 0
+
+
+def test_download_succeeds_on_nonempty_response(downloader, tmp_path):
+    # Sanity check: when chunks are delivered, no exception, file contains content.
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.headers = {"content-length": "12"}
+    response.iter_content.return_value = [b"hello ", b"world!"]
+    downloader.http_session.get.return_value = response
+
+    local_file = tmp_path / "good.jpg"
+    downloader.download_file_to_temp_path("http://example.com/x.jpg", str(local_file))
+
+    assert local_file.read_bytes() == b"hello world!"
+
+
 # ---------------------------------------------------------------------------
 # Fix 2: HTTP session created once at init, reused per download
 # ---------------------------------------------------------------------------

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -134,6 +134,8 @@ def test_upload_refuses_zero_byte_local_file_no_existing(downloader):
     assert result is False
     obj.upload_fileobj.assert_not_called()
     downloader.tracker.increment.assert_any_call(Result.FAILED)
+    # Lock in "at the source" — guard fires before any S3 lookup.
+    downloader.s3_client.get_s3.assert_not_called()
 
 
 def test_upload_refuses_zero_byte_local_file_over_existing_valid(downloader):
@@ -154,6 +156,9 @@ def test_upload_refuses_zero_byte_local_file_over_existing_valid(downloader):
     assert result is False
     obj.upload_fileobj.assert_not_called()
     downloader.tracker.increment.assert_any_call(Result.FAILED)
+    # Lock in "at the source" — guard fires before any S3 lookup, even
+    # when an existing object would otherwise be queried.
+    downloader.s3_client.get_s3.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -69,6 +69,23 @@ class Downloader:
         already existed with a matching checksum and was skipped.
         """
         try:
+            # Defence-in-depth: refuse to upload a 0-byte local file regardless
+            # of whether an S3 object already exists. The primary check lives
+            # in download_file_to_temp_path (which raises before reaching this
+            # point), but if anything ever calls upload_file_to_s3 with a
+            # 0-byte file, we must not turn it into a stub. Stubs poison the
+            # uploader's page-label counter and require a subsequent re-run
+            # to heal — see the "Graceful failure handling: audit ALL code
+            # paths" lesson.
+            if os.stat(file).st_size == 0:
+                logging.warning(
+                    f"Refusing to upload 0-byte file to "
+                    f"s3://{S3_BUCKET}/{destination_path}; "
+                    f"treat as failed download"
+                )
+                self.tracker.increment(Result.FAILED)
+                return False
+
             with open(file, "rb") as f:
                 s3 = self.s3_client.get_s3()
                 obj = s3.Object(S3_BUCKET, destination_path)
@@ -83,22 +100,6 @@ class Downloader:
                     else:
                         # Just in case (dunno why this would happen)
                         raise e
-
-                # Don't overwrite a valid existing S3 file with a 0-byte download
-                # (e.g. a transient empty HTTP response from the source server).
-                # Use `is not None` rather than truthiness — empty metadata dicts ({})
-                # are falsy but still indicate the object exists.
-                # Only access obj.content_length when obj_metadata is not None: accessing
-                # it on a non-existent object triggers a second HEAD request (another 404).
-                if obj_metadata is not None and os.stat(file).st_size == 0:
-                    existing_size = int(obj.content_length or 0)
-                    if existing_size > 0:
-                        logging.warning(
-                            f"New download is 0 bytes; keeping existing file at "
-                            f"s3://{S3_BUCKET}/{destination_path}"
-                        )
-                        self.tracker.increment(Result.SKIPPED)
-                        return False
 
                 if obj_metadata and obj_metadata.get(CHECKSUM) == sha1:
                     try:
@@ -139,8 +140,19 @@ class Downloader:
 
     def download_file_to_temp_path(self, media_url: str, local_file: str):
         """
-        Tries to get a local copy of a file to stick in S3 later
+        Tries to get a local copy of a file to stick in S3 later.
+
+        Raises RuntimeError if the download fails OR if the response body
+        was empty. A 0-byte download (HTTP 200 + empty body, or a clean
+        close after the headers with no chunks) must be treated as a
+        failure: silently accepting it would cause upload_file_to_s3 to
+        write a 0-byte stub to S3 (the existing 0-byte guard there only
+        protects against overwriting an *existing* non-zero S3 file,
+        not against creating a stub from scratch). Stubs in S3 then
+        poison the uploader's page-label counter and have to be healed
+        on a subsequent run.
         """
+        bytes_written = 0
         try:
             response = self.http_session.get(media_url, stream=True)
             response.raise_for_status()
@@ -159,9 +171,16 @@ class Downloader:
                     for chunk in response.iter_content(DOWNLOAD_BUFFER_SIZE):
                         t.update(len(chunk))
                         f.write(chunk)
+                        bytes_written += len(chunk)
 
         except Exception as e:
             raise RuntimeError(f"Failed downloading {media_url} to local") from e
+
+        if bytes_written == 0:
+            raise RuntimeError(
+                f"Downloaded 0 bytes from {media_url} — treating as failure "
+                f"(HTTP 200 + empty body or stalled stream)"
+            )
 
     def _s3_key_age_days(self, s3_path: str) -> float | None:
         """Return the age in days of an S3 object, or None if it does not exist


### PR DESCRIPTION
## Summary

PR #205 made the downloader **re-attempt** 0-byte stubs that already existed in S3, but it didn't stop new stubs from being created. This PR closes that loop: the downloader now treats a 0-byte download as a failure and refuses to write 0-byte files to S3 from any code path.

## Why this matters

Stubs in S3 poison the uploader's pre-scan: a 0-byte file gets classified as a `binary/octet-stream` "" placeholder, which the per-extension page-label counter then skips. Every ordinal after the stub gets its Commons page number shifted back by one. The off-by-one cascade only heals when the stub itself is healed — which is hostage to the source server cooperating on a future run.

## Root-cause sequence (verified against today's logs)

1. `http_session.get()` returns HTTP 200 (so `raise_for_status` doesn't fire).
2. The response body is empty — `Content-Length: 0`, or a clean connection close after headers, or `iter_content` yields no chunks for any other reason.
3. `open(local_file, "wb")` has already truncated the local file to 0 bytes on its first call.
4. The for-loop over `iter_content` runs zero iterations. No exception.
5. `download_file_to_temp_path` returns successfully — but the local file is 0 bytes.
6. `upload_file_to_s3` is called. The pre-existing 0-byte guard only protected against *overwriting* an existing non-zero S3 file — it allowed creating a 0-byte stub from scratch.

## Fix

**Two coordinated changes** per the `lessons.md` *"Graceful failure handling: audit ALL code paths that trigger the same error"* lesson:

1. **`download_file_to_temp_path`**: counts `bytes_written` across chunks and raises `RuntimeError` after the loop if zero. The exception propagates to `process_media`'s outer try/except — same `"Failed: ..."` log + `Result.FAILED` increment as any other download failure.

2. **`upload_file_to_s3`**: refuses any 0-byte upload regardless of whether an S3 object already exists (defense in depth — protects against any future caller bypassing #1). Increments `Result.FAILED`. Replaces the prior conditional guard that only fired when the existing S3 file was already non-zero.

## Behavior change

| Scenario | Old behavior | New behavior |
|---|---|---|
| 0-byte local + no existing S3 | **0-byte stub uploaded to S3** (BUG) | Refused; `FAILED` logged |
| 0-byte local + valid existing S3 | Skipped, existing kept (`SKIPPED`) | Refused, existing kept (`FAILED`) |
| 0-byte local + 0-byte existing S3 | 0-byte over 0-byte (no-op) | Refused (`FAILED`) |
| Non-zero local | unchanged | unchanged |

(The `FAILED` vs `SKIPPED` change for the second row is intentional — a 0-byte download is a real failure, not a routine skip.)

## Test plan

- [x] `ruff check --fix` + `ruff format` clean
- [x] Unit tests:
  - `upload_file_to_s3` with 0-byte local + no existing S3 → refused, `FAILED`
  - `upload_file_to_s3` with 0-byte local + valid existing S3 → refused, `FAILED`, existing untouched
  - `download_file_to_temp_path` with empty response body → raises `"0 bytes"`
  - `download_file_to_temp_path` with chunks delivered → succeeds, file populated
- [x] Existing tests untouched, still pass under the new behavior (verified `bytes_written` counter doesn't require mocking `os.stat` so prior tests with mocked `open` still work)
- [ ] After merge + deploy, re-run an affected item (e.g. `12c715e66c9cad543e881ce3416332d9` Rosenbaum Vol 03) and confirm the stub at ord 55 is no longer creatable. If the source URL still resets on EC2, the run will log `Failed:` for ord 55 instead of silently shifting all subsequent pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR prevents creation of 0-byte file stubs in S3 by refusing 0-byte downloads and refusing to upload 0-byte local files. It fixes a regression where prior behavior could create 0-byte S3 stubs that break the uploader's pre-scan and cause Commons page-numbering cascades.

## Changes Made

### tools/downloader.py
- download_file_to_temp_path: tracks bytes_written while streaming HTTP response chunks and raises RuntimeError if zero bytes were written (HTTP 200 + empty body or stalled stream). Ensures the download step fails before any upload is attempted.
- upload_file_to_s3: defends against uploading any 0-byte local file by checking local file size first; if zero, logs, increments Result.FAILED, returns False and does not call S3. Removes reliance on inspecting S3 object state to avoid creating or overwriting stubs.
- _s3_key_age_days: treats 0-byte S3 objects as absent (unchanged in intent but present in code), so 0-byte stubs will be re-attempted rather than considered valid.

### tests/test_downloader.py
Added/updated tests to enforce and lock in the behavior:
- test_upload_refuses_zero_byte_local_file_no_existing: verifies upload is refused for 0-byte local file when S3 object does not exist; asserts upload not attempted, Result.FAILED incremented, and no S3 HEAD/get_s3 call occurs.
- test_upload_refuses_zero_byte_local_file_over_existing_valid: verifies upload is refused for 0-byte local file even when a valid S3 object exists; asserts no overwrite, Result.FAILED incremented, and no S3 lookup call occurs.
- test_download_raises_on_zero_byte_response: simulates HTTP 200 with content-length 0 and no chunks; asserts download_file_to_temp_path raises RuntimeError (mentions "0 bytes") and that an empty local file was created.
- test_download_succeeds_on_nonempty_response: sanity check that streamed chunks are written correctly.

## Behavioral Changes
- 0-byte local + no existing S3: previously created a 0-byte stub; now upload is refused and marked FAILED.
- 0-byte local + valid existing S3: previously skipped (SKIPPED); now upload is refused and marked FAILED (existing S3 object kept).
- 0-byte local + 0-byte existing S3: now refused and marked FAILED.
- Non-zero local files: unchanged.

## Tests & QA
- Unit tests added/updated to cover the zero-byte download and upload refusal cases and chunked downloads. Existing tests around session reuse, S3 age logic, and manifest caching remain.
- Commit message indicates a planned post-merge manual re-run on an affected item to confirm end-to-end behavior.

## Impact Notes
- No infrastructure changes, no new/removed environment variables or AWS Secrets Manager keys, no database migrations, and no public API shape changes.
- No security-config or credential-handling changes beyond existing retry behavior for CredentialRetrievalError.
- No manual pipeline trigger or ECS redeployment is required for this library/tooling change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->