### PR TITLE
tools: retroactive metadata rescue for pre-#202 title-drift overwrites

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -419,6 +419,24 @@ _IMAGE_EXTRACTED_RE = re.compile(r"\{\{Image extracted\|[^{}]*\}\}", re.IGNORECA
 _CATEGORY_RE = re.compile(r"\[\[Category:[^\]\n]+\]\]")
 
 
+def extract_preserved_metadata(
+    text: str,
+) -> tuple[list[str], list[str], list[str]]:
+    """Extract preserved-metadata items from a wikitext blob.
+
+    Returns three lists of matched template/link strings in
+    (pd_usgov, image_extracted, categories) order. Each list is
+    deduplicated in first-occurrence order. Used by both the uploader
+    (to merge into a freshly-generated Artwork block) and the rescue
+    tool (to diff against current page text and add back what was
+    stripped by an earlier title-drift overwrite).
+    """
+    pd = list(dict.fromkeys(_PD_USGOV_RE.findall(text)))
+    ie = list(dict.fromkeys(_IMAGE_EXTRACTED_RE.findall(text)))
+    cat = list(dict.fromkeys(_CATEGORY_RE.findall(text)))
+    return pd, ie, cat
+
+
 def merge_preserved_wikitext(existing_text: str, new_artwork: str) -> str:
     """Append preserved metadata from existing_text to new_artwork.
 
@@ -437,8 +455,7 @@ def merge_preserved_wikitext(existing_text: str, new_artwork: str) -> str:
     Duplicates within each preserved group are collapsed.
     """
     parts: list[str] = [new_artwork.rstrip()]
-    for pattern in (_PD_USGOV_RE, _IMAGE_EXTRACTED_RE, _CATEGORY_RE):
-        group = list(dict.fromkeys(pattern.findall(existing_text)))
+    for group in extract_preserved_metadata(existing_text):
         if group:
             parts.append("")
             parts.extend(group)

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -9,6 +9,7 @@ from ingest_wikimedia.wikimedia import (
     join,
     compute_ordinal_exts_and_page_labels,
     extract_page_ordinal_from_commons_title,
+    extract_preserved_metadata,
     extract_strings,
     extract_strings_dict,
     is_same_item_redirect_relic,
@@ -457,3 +458,53 @@ def test_page_labels_unique_extension_gets_empty_label():
     assert exts == {1: ".jpg", 2: ".jpg", 3: ".pdf"}
     # ext_counts: .jpg→2, .pdf→1. Only .jpg gets page numbers.
     assert labels == {1: "1", 2: "2", 3: ""}
+
+
+# extract_preserved_metadata — the underlying helper used by both
+# merge_preserved_wikitext and the rescue script
+def test_extract_preserved_metadata_empty_text():
+    pd, ie, cat = extract_preserved_metadata("")
+    assert pd == []
+    assert ie == []
+    assert cat == []
+
+
+def test_extract_preserved_metadata_each_category():
+    text = (
+        "Some prose.\n"
+        "{{PD-USGov}}\n"
+        "{{PD-USGov-NARA}}\n"
+        "|other versions={{Image extracted|1=Parent.jpg}}\n"
+        "[[Category:Foo]]\n"
+        "[[Category:Bar|sort]]\n"
+    )
+    pd, ie, cat = extract_preserved_metadata(text)
+    assert pd == ["{{PD-USGov}}", "{{PD-USGov-NARA}}"]
+    assert ie == ["{{Image extracted|1=Parent.jpg}}"]
+    assert cat == ["[[Category:Foo]]", "[[Category:Bar|sort]]"]
+
+
+def test_extract_preserved_metadata_dedupes_in_order():
+    # Duplicates within the same category are collapsed in first-occurrence order.
+    text = (
+        "[[Category:Foo]] [[Category:Bar]] [[Category:Foo]]\n"
+        "{{PD-USGov}} {{PD-USGov}}\n"
+    )
+    pd, ie, cat = extract_preserved_metadata(text)
+    assert pd == ["{{PD-USGov}}"]
+    assert ie == []
+    assert cat == ["[[Category:Foo]]", "[[Category:Bar]]"]
+
+
+def test_extract_preserved_metadata_returns_what_merge_uses():
+    # Sanity: merge_preserved_wikitext must produce the same items in
+    # the same order as extract_preserved_metadata. This pins them
+    # together — if anyone refactors the regexes on one side only, this
+    # fails fast (see lessons.md "Don't normalize on one side of a
+    # producer/consumer pair").
+    existing = "[[Category:Foo]]\n{{PD-USGov}}\n{{Image extracted|1=Parent.jpg}}\n"
+    artwork = "== {{int:filedesc}} ==\n{{Artwork|title=Example}}"
+    merged = merge_preserved_wikitext(existing, artwork)
+    pd, ie, cat = extract_preserved_metadata(existing)
+    for item in pd + ie + cat:
+        assert item in merged, f"merge_preserved_wikitext lost {item!r}"

--- a/tools/rescue_preserved_metadata.py
+++ b/tools/rescue_preserved_metadata.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""
+Rescue PD-USGov / Image-extracted / Category metadata from file pages
+that DPLA bot's title-drift correction edits overwrote *before* PR #202
+introduced ``merge_preserved_wikitext``.
+
+The bug: pre-PR-#202, ``_move_to_correct_title`` and
+``_resolve_redirect_overwrite`` wrote a freshly-generated ``{{Artwork}}``
+block to the page, blowing away any pre-existing license tags, parent
+``{{Image extracted}}`` links, and ``[[Category:...]]`` membership added
+by humans or earlier bot runs. PR #202 fixed forward behavior but did
+nothing for the ~1.5-3k pages already stripped.
+
+For each affected page this script:
+  1. Finds the EARLIEST title-drift overwrite in the page's history.
+  2. Walks back to the most recent non-redirect predecessor revision
+     (page moves transfer history, so this picks up the original
+     pre-move content; redirect-overwrite cases skip the redirect
+     revision).
+  3. Extracts ``extract_preserved_metadata(...)`` from that revision.
+  4. Diffs against the current page text — finds items that exist in
+     the pre-strip revision but not the current page.
+  5. If anything is missing, appends the missing items to the current
+     text in the same order ``merge_preserved_wikitext`` uses and saves.
+
+Idempotent: pages already showing all preserved items are skipped.
+
+Usage:
+    python3 tools/rescue_preserved_metadata.py [--dry-run] [--max N]
+                                              [--since YYYY-MM-DD]
+"""
+
+import argparse
+import logging
+import sys
+import time
+
+sys.path.insert(0, "/home/ec2-user/ingest-wikimedia")
+
+import pywikibot  # noqa: E402
+
+from ingest_wikimedia.wikimedia import (  # noqa: E402
+    extract_preserved_metadata,
+    get_page,
+    get_site,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+# Edit-summary substrings that identify a title-drift TEXT overwrite (not
+# the move log event, which doesn't change wikitext). Match both the
+# pre-PR-#202 form ``(DPLA ID xxx)`` and the post-PR-#202 form with the
+# ``[[dpla:xxx|xxx]]`` link — only the prefix matters here.
+TITLE_DRIFT_OVERWRITE_PATTERNS = (
+    "Update description after title drift correction",
+    "Replacing redirect with DPLA metadata for title drift correction",
+)
+
+RESCUE_EDIT_SUMMARY = (
+    "Restore metadata stripped by earlier title-drift correction "
+    "(rescued from pre-strip revision)"
+)
+
+FILE_NAMESPACE = 6
+
+
+def find_affected_pages(site, since=None, max_pages=None):
+    """Iterate DPLA bot's File-namespace contribs and yield unique
+    (page_title, earliest_drift_revid) for any contrib whose comment
+    matches a title-drift overwrite pattern.
+
+    ``since`` is a YYYY-MM-DD string; only contribs with timestamp >=
+    this are considered (Commons API expects ISO 8601).
+    """
+    bot = pywikibot.User(site, "DPLA bot")
+    earliest: dict[str, int] = {}
+    total_seen = 0
+
+    kwargs = {"namespaces": [FILE_NAMESPACE]}
+    if since:
+        kwargs["start"] = pywikibot.Timestamp.fromISOformat(f"{since}T00:00:00Z")
+
+    for entry in bot.contributions(**kwargs):
+        page, revid, ts, comment = entry
+        total_seen += 1
+        if total_seen % 5000 == 0:
+            logging.info(
+                f"  scanned {total_seen} contribs; "
+                f"{len(earliest)} candidate pages so far"
+            )
+
+        if not any(p in (comment or "") for p in TITLE_DRIFT_OVERWRITE_PATTERNS):
+            continue
+
+        title = page.title()
+        # Keep the OLDEST drift edit per page (smallest revid). The
+        # pre-strip state is the predecessor of THAT edit.
+        if title not in earliest or revid < earliest[title]:
+            earliest[title] = revid
+
+        if max_pages and len(earliest) >= max_pages:
+            break
+
+    logging.info(
+        f"Scanned {total_seen} bot contribs; "
+        f"found {len(earliest)} unique pages with title-drift overwrites"
+    )
+    return earliest
+
+
+def _is_redirect_text(text: str) -> bool:
+    return text.lstrip().lower().startswith("#redirect")
+
+
+def get_pre_strip_text(site, page_title, drift_revid, max_walk=10):
+    """Walk back from drift_revid through older revisions and return the
+    text of the most recent non-redirect predecessor.
+
+    Page moves transfer revision history to the new title, so for a
+    move-then-strip sequence the predecessor IS the original rich
+    content (the move itself doesn't change text). For a
+    redirect-overwrite sequence the immediate predecessor IS the
+    redirect markup — skip it and walk back to the last content
+    revision.
+
+    Returns (text, revid) or (None, None) if no non-redirect predecessor
+    found within max_walk steps.
+    """
+    request = pywikibot.data.api.Request(
+        site=site,
+        parameters={
+            "action": "query",
+            "prop": "revisions",
+            "titles": page_title,
+            "rvprop": "content|ids|timestamp|comment|user",
+            "rvslots": "main",
+            "rvstartid": drift_revid,
+            "rvdir": "older",
+            "rvlimit": max_walk + 1,
+        },
+    )
+    data = request.submit()
+    for _, p in data.get("query", {}).get("pages", {}).items():
+        revs = p.get("revisions", []) or []
+        # First entry is drift_revid itself; subsequent entries are
+        # older revisions (newest-to-oldest).
+        for rev in revs[1:]:
+            text = rev.get("slots", {}).get("main", {}).get("*", "")
+            if text and not _is_redirect_text(text):
+                return text, rev.get("revid")
+    return None, None
+
+
+def compute_rescue(pre_strip_text, current_text):
+    """Return (missing_pd, missing_ie, missing_cat) — items in
+    pre_strip_text but absent from current_text. Empty lists mean
+    nothing to rescue."""
+    pre_pd, pre_ie, pre_cat = extract_preserved_metadata(pre_strip_text)
+    cur_pd, cur_ie, cur_cat = extract_preserved_metadata(current_text)
+
+    cur_pd_set, cur_ie_set, cur_cat_set = set(cur_pd), set(cur_ie), set(cur_cat)
+    missing_pd = [x for x in pre_pd if x not in cur_pd_set]
+    missing_ie = [x for x in pre_ie if x not in cur_ie_set]
+    missing_cat = [x for x in pre_cat if x not in cur_cat_set]
+    return missing_pd, missing_ie, missing_cat
+
+
+def build_rescued_text(current_text, missing_pd, missing_ie, missing_cat):
+    """Append missing items to current_text in the same order
+    ``merge_preserved_wikitext`` uses."""
+    parts = [current_text.rstrip()]
+    for group in (missing_pd, missing_ie, missing_cat):
+        if group:
+            parts.append("")
+            parts.extend(group)
+    return "\n".join(parts) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Retroactive metadata rescue for title-drift overwrites."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Inspect without saving (default: writes to Commons).",
+    )
+    parser.add_argument(
+        "--max",
+        type=int,
+        default=None,
+        help="Process at most N pages (after discovery). Useful for testing.",
+    )
+    parser.add_argument(
+        "--since",
+        type=str,
+        default=None,
+        help="Only consider bot contribs newer than this YYYY-MM-DD date.",
+    )
+    parser.add_argument(
+        "--sleep",
+        type=float,
+        default=0.5,
+        help="Seconds to sleep between save operations (default: 0.5).",
+    )
+    args = parser.parse_args()
+
+    logging.info("Logging in to Commons…")
+    site = get_site()
+    logging.info(f"Logged in as: {site.user()}")
+    logging.info(f"Mode: {'DRY RUN' if args.dry_run else 'LIVE (will save)'}")
+    if args.since:
+        logging.info(f"Filtering bot contribs since: {args.since}")
+
+    earliest = find_affected_pages(site, since=args.since, max_pages=None)
+
+    processed = 0
+    rescued = 0
+    nothing_missing = 0
+    no_predecessor = 0
+    page_missing = 0
+    errors = 0
+
+    for page_title, drift_revid in earliest.items():
+        if args.max and processed >= args.max:
+            break
+        processed += 1
+
+        pre_text, pre_revid = get_pre_strip_text(site, page_title, drift_revid)
+        if pre_text is None:
+            logging.warning(
+                f"  no non-redirect predecessor for {page_title} "
+                f"(drift revid {drift_revid})"
+            )
+            no_predecessor += 1
+            continue
+
+        page = get_page(site, page_title)
+        if not page.exists():
+            logging.warning(f"  {page_title} no longer exists")
+            page_missing += 1
+            continue
+
+        current_text = page.text or ""
+        missing_pd, missing_ie, missing_cat = compute_rescue(pre_text, current_text)
+
+        if not (missing_pd or missing_ie or missing_cat):
+            nothing_missing += 1
+            continue
+
+        rescued += 1
+        logging.info(
+            f"  RESCUE {page_title}: "
+            f"+{len(missing_pd)} PD-USGov, "
+            f"+{len(missing_ie)} Image-extracted, "
+            f"+{len(missing_cat)} Category "
+            f"(pre-strip rev {pre_revid})"
+        )
+
+        if args.dry_run:
+            continue
+
+        new_text = build_rescued_text(current_text, missing_pd, missing_ie, missing_cat)
+        try:
+            page.text = new_text
+            page.save(summary=RESCUE_EDIT_SUMMARY, minor=False)
+            time.sleep(args.sleep)
+        except Exception as e:
+            logging.warning(f"  save failed for {page_title}: {e}")
+            errors += 1
+
+    logging.info(
+        f"\nDONE: processed={processed}  rescued={rescued}  "
+        f"nothing_missing={nothing_missing}  "
+        f"no_predecessor={no_predecessor}  "
+        f"page_missing={page_missing}  errors={errors}"
+    )
+    sys.exit(0 if errors == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Before PR #202 added `merge_preserved_wikitext`, every "Update description after title drift correction" or "Replacing redirect with DPLA metadata for title drift correction" edit by the bot wholesale-replaced the page's wikitext with a freshly-generated `{{Artwork}}` block. That stripped any pre-existing PD-USGov license tags, `{{Image extracted}}` parent-page links, and `[[Category:...]]` membership that humans (or earlier bot runs) had added.

PR #202 fixed forward behavior. This PR adds a one-off cleanup tool for the ~1.5-3k pages already stripped.

## How it works

For each page identified by scanning DPLA bot's File-namespace contribs for the two title-drift overwrite comment patterns:

1. Find the **earliest** such edit (lowest revid) — that's where the strip happened.
2. Walk back through page history to the **most recent non-redirect predecessor**. Page moves transfer revision history to the new title, so for `_move_to_correct_title` cases this lands on the original pre-move rich content. For `_resolve_redirect_overwrite` cases the immediate predecessor is the redirect markup — the walk skips it and finds the prior content revision.
3. Extract `(pd, image_extracted, categories)` from that revision via the new public `extract_preserved_metadata()` helper.
4. Diff against the **current** page text.
5. If any items are missing, append them in the same order `merge_preserved_wikitext` uses and save with a clear edit summary.

**Idempotent** — pages already showing all preserved items are skipped. The script can be re-run safely.

## Producer/consumer hygiene

Refactored `merge_preserved_wikitext` to call a new public `extract_preserved_metadata()` helper. The rescue script uses the same helper, so they share the regex definitions — per the `lessons.md` *"Don't normalize platform-dependent values on one side of a producer/consumer pair"* rule. A pinning test asserts that everything `extract_preserved_metadata()` returns shows up in `merge_preserved_wikitext`'s output, so a future refactor on one side fails the test if the other isn't kept in sync.

## Usage

```bash
# Default: live (will save to Commons)
python3 tools/rescue_preserved_metadata.py

# Dry run — log what would be rescued without saving
python3 tools/rescue_preserved_metadata.py --dry-run

# Limit to N pages (useful for a sanity sample before unleashing)
python3 tools/rescue_preserved_metadata.py --dry-run --max 20

# Only consider bot contribs since a date
python3 tools/rescue_preserved_metadata.py --since 2026-04-01
```

Final log line summarises `processed / rescued / nothing_missing / no_predecessor / page_missing / errors`. Exits non-zero only if there were save errors.

## Test plan

- [x] `ruff check --fix` + `ruff format` clean
- [x] Helper tests: empty text, each category, dedupe in order, and a pin that asserts `extract_preserved_metadata` output is a subset of `merge_preserved_wikitext` output
- [x] Local sanity check of `compute_rescue`: full diff, idempotent re-run, partial overlap
- [ ] After merge + deploy, run with `--dry-run --max 20` on EC2 to spot-check the candidates and confirm pre-strip revisions look correct
- [ ] Run with `--dry-run` (full scope) to log all pages that would be rescued
- [ ] Run live, monitor edit rate (`--sleep` defaults to 0.5s between saves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a one-off rescue tool (`tools/rescue_preserved_metadata.py`) to recover metadata lost during earlier title-drift correction edits, along with refactoring shared metadata extraction logic into a reusable helper function.

## Changes

**ingest_wikimedia/wikimedia.py**
- Introduces new public helper `extract_preserved_metadata(text: str)` that extracts PD-USGov license tags, `{{Image extracted}}` templates, and `[[Category:...]]` entries from wikitext
- Refactors `merge_preserved_wikitext()` to use this new helper instead of duplicating regex logic

**tests/test_wikimedia.py**
- Adds comprehensive unit tests for `extract_preserved_metadata()` covering empty input, deduplication, category sort keys, and first-occurrence order preservation
- Includes pinning test asserting that extracted metadata items appear in `merge_preserved_wikitext()` output

**tools/rescue_preserved_metadata.py** (new file)
- CLI tool that scans the bot's File-namespace edit history for title-drift overwrite edits
- For each affected page, walks back through history to find the most recent non-redirect predecessor revision
- Extracts preserved metadata from that predecessor and compares against current page text
- Appends missing items to the current page (idempotent; skips pages with all items present)
- Supports `--dry-run`, `--max N`, `--since DATE` flags; defaults to live mode with 0.5s sleep between saves
- Requires manual execution; not part of any automated pipeline

## Deployment considerations

**No manual pipeline trigger or ECS redeployment required.** The rescue tool is a one-off script for manual execution (hardcoded for EC2 environment at `/home/ec2-user/ingest-wikimedia`). It uses existing authentication via `get_site()`.

**No environment variables, AWS Secrets Manager keys, database migrations, or infrastructure configuration changes.**

**No public API changes.**

**Limited security footprint.** The tool authenticates with existing credentials (no new auth mechanisms) and performs reads from Commons history followed by optional saves. Dry-run mode is available for testing before live execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->