### PR TITLE
commonsdelinker: cite Criterion 4 (harmonize) instead of Criterion 1

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -302,7 +302,8 @@ def get_wikidata_site() -> BaseSite:
 
 COMMONSDELINKER_PAGE = "User:CommonsDelinker/commands/filemovers"
 _COMMONSDELINKER_REASON = (
-    "[[COM:FR|File renamed]]: [[COM:FR#FR1|Criterion 1]] (original uploader's request)"
+    "[[COM:FR|File renamed]]: [[COM:FR#FR4|Criterion 4]] "
+    "(harmonize the names of a set of images)"
 )
 
 


### PR DESCRIPTION
## Summary

- Change CommonsDelinker file-rename rationale from `[[COM:FR#FR1|Criterion 1]] (original uploader's request)` to `[[COM:FR#FR4|Criterion 4]] (harmonize the names of a set of images)`.

## Why

We assumed every page we rename was originally uploaded by the bot itself, in which case Criterion 1 (uploader's own request) would be correct. In practice, many of the files we rename were originally uploaded by other users — we acquire a matching SHA-1 hash and then move the file to the canonical `<Title> - DPLA - <id>.<ext>` form. Citing Criterion 1 in those cases is factually wrong.

Criterion 4 ("to harmonize the file names of a set of images") accurately describes what the bot is doing: renaming files to a standard ID-suffixed naming convention.

Example of the existing edit pattern: https://commons.wikimedia.org/w/index.php?title=User:CommonsDelinker/commands/filemovers&diff=prev&oldid=1217966290

## Test plan

- [ ] Confirm next bot CommonsDelinker request cites FR4 and the harmonize wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updates the CommonsDelinker file-rename rationale in the `_COMMONSDELINKER_REASON` constant from [[COM:FR#FR1|Criterion 1]] (original uploader's request) to [[COM:FR#FR4|Criterion 4]] (harmonize the names of a set of images).

This change affects the wikitext reason text appended to CommonsDelinker universal-replace requests posted to the User:CommonsDelinker/commands/filemovers page. The new citation better reflects the actual use case: many renamed files were originally uploaded by other users and are matched by SHA-1, then renamed to the canonical `<Title> - DPLA - <id>.<ext>` form, making FR4 (harmonization) more factually accurate than FR1 (original uploader's request).

## Infrastructure Impact

This change requires a standard code deployment to take effect. The modified constant will be used by the next CommonsDelinker file-rename operation executed by the service after deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->