### PR TITLE
get-ids-es: bound S3-write futures to prevent OOM on large hubs

### DIFF
--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -47,6 +47,10 @@ from ingest_wikimedia.slack import notify_phase_start
 ES_URL = "http://search-prod1.internal.dp.la:9200/dpla_alias/_search"
 PAGE_SIZE = 500
 S3_WRITE_WORKERS = 10
+# Maximum S3-write futures kept in memory at once. When the limit is reached
+# the ES scan pauses until one write completes, keeping peak RAM bounded
+# regardless of hub size.
+MAX_IN_FLIGHT = S3_WRITE_WORKERS * 20
 
 IIIF_MANIFEST_FIELD = "iiifManifest"
 MEDIA_MASTER_FIELD = "mediaMaster"
@@ -173,7 +177,9 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
             print("--collection cannot be empty.", file=sys.stderr)
             sys.exit(1)
         if institution is None:
-            print("--collection requires --institution to be specified.", file=sys.stderr)
+            print(
+                "--collection requires --institution to be specified.", file=sys.stderr
+            )
             sys.exit(1)
 
     try:
@@ -207,6 +213,7 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
 
     with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
         futures: dict = {}
+        failed = 0
 
         while True:
             query = build_query(
@@ -254,10 +261,21 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
 
                 print(dpla_id)
 
+                # Keep the in-flight dict bounded so peak RAM stays constant
+                # regardless of hub size. When full, block until the earliest
+                # write completes before accepting more work.
+                if len(futures) >= MAX_IN_FLIGHT:
+                    done = next(as_completed(futures))
+                    try:
+                        done.result()
+                    except Exception as e:
+                        failed += 1
+                        logging.warning(f"S3 write failed for {futures[done]}: {e}")
+                    del futures[done]
+
             search_after = hits[-1]["sort"]
 
-        # Wait for all S3 writes and surface any errors.
-        failed = 0
+        # Drain remaining in-flight writes.
         for future in as_completed(futures):
             try:
                 future.result()
@@ -265,7 +283,8 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
                 failed += 1
                 logging.warning(f"S3 write failed for {futures[future]}: {e}")
         if failed:
-            print(f"Warning: {failed} S3 writes failed", file=sys.stderr)
+            print(f"Error: {failed} S3 writes failed", file=sys.stderr)
+            raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `MAX_IN_FLIGHT = S3_WRITE_WORKERS * 20` (200) constant to cap how many S3-write futures accumulate in memory at once
- Drains one completed future whenever the in-flight dict reaches the limit, keeping peak RAM at ~2 MB regardless of hub size (was ~4–5 GB for Texas/BPL/NARA, which crashed the instance)
- Moves `failed = 0` initialization above the ES scan loop so it covers both the inline drain and the final drain
- Aligns S3 failure handling with `get_ids_nara.py`: prints `Error:` and exits with status 1 on any write failures, rather than printing `Warning:` and silently continuing with incomplete S3 metadata

## Root cause

The original code submitted all N futures to the thread pool before draining any of them. Each Future holds a reference to the full ES source document (~2–10 KB of JSON) until it is explicitly deleted. For large hubs (Texas ~252K items, BPL ~301K, NARA ~332K) this accumulated 4–5 GB of live objects before any writes were drained, exhausting the 7.6 GB instance when running alongside other pipeline sessions.

## Test plan

- [ ] Run `get-ids-es texas` solo on EC2 and confirm memory stays flat (< 200 MB) throughout
- [ ] Confirm CSV line count matches prior run (~252K)
- [ ] Confirm S3 `dpla-map.json` files are staged correctly for a sample of IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR addresses an out-of-memory issue in the `get-ids-es` script when processing large DPLA hubs. The script previously submitted all Elasticsearch-sourced items to S3 write futures before draining any, causing each future to hold a reference to the full ES source document (~2-10 KB). For large hubs (e.g., Texas ~252K items), this accumulated ~4-5 GB in live memory objects.

### Changes
- Introduces `MAX_IN_FLIGHT = S3_WRITE_WORKERS * 20` (200) to cap concurrent S3-write futures in memory
- Implements inline draining: when the in-flight futures dict reaches the limit, the script blocks to drain one completed future before accepting more work, keeping peak RAM bounded at ~2 MB regardless of hub size
- Moves `failed = 0` initialization above the Elasticsearch scan loop so failure counting applies to both inline draining and final drain
- Aligns S3 error handling with `get-ids-nara.py`: on any S3 write failure, the script now prints an error message to stderr and exits with status 1 (previously logged warnings and continued with incomplete S3 metadata)
- Minor reformatting of the `--collection requires --institution` error message

### Impact
- No environment variables, AWS Secrets Manager keys, or infrastructure configuration changes
- No database migrations or API changes
- No security implications
- No manual pipeline trigger or ECS redeployment required—this is a standalone script improvement that can be deployed as part of normal container updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->