### PR TITLE
get-ids-es: replace polling drain with BoundedSemaphore

### DIFF
--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -33,7 +33,8 @@ consumed by the downloader and uploader:
 import json
 import logging
 import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
 
 import click
 import requests
@@ -47,10 +48,9 @@ from ingest_wikimedia.slack import notify_phase_start
 ES_URL = "http://search-prod1.internal.dp.la:9200/dpla_alias/_search"
 PAGE_SIZE = 500
 S3_WRITE_WORKERS = 10
-# Maximum S3-write futures kept in memory at once. When the limit is reached
-# the ES scan pauses until one write completes, keeping peak RAM bounded
-# regardless of hub size.
-MAX_IN_FLIGHT = S3_WRITE_WORKERS * 20
+# Prevents the executor queue from growing unboundedly and holding thousands of
+# ES source documents in memory.
+_S3_QUEUE_DEPTH = S3_WRITE_WORKERS * 4
 
 IIIF_MANIFEST_FIELD = "iiifManifest"
 MEDIA_MASTER_FIELD = "mediaMaster"
@@ -145,11 +145,7 @@ def build_query(
     return query
 
 
-def stage_to_s3(s3_client: S3Client, partner: str, dpla_id: str, source: dict) -> None:
-    """Write the item's full metadata to S3 as dpla-map.json.
-
-    Raises on failure so the caller's ThreadPoolExecutor can observe and count it.
-    """
+def _stage_to_s3(s3_client: S3Client, partner: str, dpla_id: str, source: dict) -> None:
     s3_client.write_item_metadata(partner, dpla_id, json.dumps(source))
 
 
@@ -211,10 +207,20 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
     s3_client = S3Client()
     search_after = None
 
-    with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
-        futures: dict = {}
-        failed = 0
+    s3_sem = threading.BoundedSemaphore(_S3_QUEUE_DEPTH)
+    failed = [0]
 
+    def _on_s3_done(dpla_id: str):
+        def callback(future: Future) -> None:
+            s3_sem.release()
+            exc = future.exception()
+            if exc:
+                failed[0] += 1
+                logging.warning(f"S3 write failed for {dpla_id}: {exc}")
+
+        return callback
+
+    with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
         while True:
             query = build_query(
                 provider_name, eligible_dp_names, collection, search_after
@@ -253,38 +259,19 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
                 # distinguish fresh ES-sourced objects from legacy API ones.
                 source["_staged_by_get_ids_es"] = True
 
-                # Stage full metadata to S3 asynchronously.
+                s3_sem.acquire()
                 future = executor.submit(
-                    stage_to_s3, s3_client, partner, dpla_id, source
+                    _stage_to_s3, s3_client, partner, dpla_id, source
                 )
-                futures[future] = dpla_id
+                future.add_done_callback(_on_s3_done(dpla_id))
 
                 print(dpla_id)
 
-                # Keep the in-flight dict bounded so peak RAM stays constant
-                # regardless of hub size. When full, block until the earliest
-                # write completes before accepting more work.
-                if len(futures) >= MAX_IN_FLIGHT:
-                    done = next(as_completed(futures))
-                    try:
-                        done.result()
-                    except Exception as e:
-                        failed += 1
-                        logging.warning(f"S3 write failed for {futures[done]}: {e}")
-                    del futures[done]
-
             search_after = hits[-1]["sort"]
 
-        # Drain remaining in-flight writes.
-        for future in as_completed(futures):
-            try:
-                future.result()
-            except Exception as e:
-                failed += 1
-                logging.warning(f"S3 write failed for {futures[future]}: {e}")
-        if failed:
-            print(f"Error: {failed} S3 writes failed", file=sys.stderr)
-            raise SystemExit(1)
+    if failed[0]:
+        print(f"Error: {failed[0]} S3 writes failed", file=sys.stderr)
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Replaces the `MAX_IN_FLIGHT` futures-dict + `as_completed` drain loop (PR #210) with a `threading.BoundedSemaphore` — the same pattern used in `get_ids_nara.py`
- Depth is `S3_WRITE_WORKERS × 4 = 40` (down from `× 20 = 200`), keeping at most 40 ES source documents in memory at once
- The `with ThreadPoolExecutor(...) as executor:` context manager drains all in-flight futures on exit via `shutdown(wait=True)`, so no explicit `as_completed` loop is needed
- `_stage_to_s3` renamed to private (`_` prefix) since it's only called by the executor

## Why

The previous polling approach (PR #210) held up to 200 source documents in the futures dict before draining. The semaphore pattern blocks the ES scan thread at submission time, keeping the queue bounded regardless of hub size. This unifies the two ID-generation tools behind a single concurrency pattern.

## Test plan

- [ ] Run `get-ids-es texas` on EC2 — confirm 252K IDs produced, memory stays flat throughout
- [ ] Confirm no change in S3 staging behaviour (dpla-map.json files written as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR refactors concurrency in tools/get_ids_es.py to use a threading.BoundedSemaphore and Future done-callbacks instead of a size-limited futures dict polled with as_completed, aligning its pattern with get_ids_nara.py.

Key changes
- Replace MAX_IN_FLIGHT/dict + as_completed drain with a BoundedSemaphore (_S3_QUEUE_DEPTH = S3_WRITE_WORKERS × 4 = 40) that blocks the ES scan thread at submission time so at most 40 ES source documents are held in memory concurrently.
- Use ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) and rely on its context manager (shutdown(wait=True)) to drain in-flight futures instead of an explicit as_completed loop.
- Replace public stage_to_s3(...) with private _stage_to_s3(...) (only called by executor).
- Use Future done-callbacks to release the semaphore and count/log S3 write failures; the script exits non-zero if any S3 writes fail.
- Minor import/constant adjustments to support the new coordination pattern.

Behavioral / operational notes (explicit checks requested)
- No pipeline trigger or ECS redeployment required — this is a change to a Python CLI tool only.
- No environment variables or AWS Secrets Manager keys are added/removed/renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task defs, IAM policies).
- No public API response shape changes or endpoint additions/removals.
- No new security-sensitive credential handling or auth model changes; external inputs are unchanged (still derives IIIF manifests from isShownAt when applicable).

Testing plan described by author
- Run get-ids-es texas on EC2 to confirm ~252K IDs are produced and memory usage remains flat.
- Verify S3 staging behavior unchanged (dpla-map.json files continue to be written as before).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->