### PR TITLE
get-ids-es, get-ids-nara: guard S3 failure counter with a Lock

### DIFF
--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -33,7 +33,8 @@ consumed by the downloader and uploader:
 import json
 import logging
 import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
 
 import click
 import requests
@@ -47,10 +48,9 @@ from ingest_wikimedia.slack import notify_phase_start
 ES_URL = "http://search-prod1.internal.dp.la:9200/dpla_alias/_search"
 PAGE_SIZE = 500
 S3_WRITE_WORKERS = 10
-# Maximum S3-write futures kept in memory at once. When the limit is reached
-# the ES scan pauses until one write completes, keeping peak RAM bounded
-# regardless of hub size.
-MAX_IN_FLIGHT = S3_WRITE_WORKERS * 20
+# Prevents the executor queue from growing unboundedly and holding thousands of
+# ES source documents in memory.
+_S3_QUEUE_DEPTH = S3_WRITE_WORKERS * 4
 
 IIIF_MANIFEST_FIELD = "iiifManifest"
 MEDIA_MASTER_FIELD = "mediaMaster"
@@ -145,11 +145,7 @@ def build_query(
     return query
 
 
-def stage_to_s3(s3_client: S3Client, partner: str, dpla_id: str, source: dict) -> None:
-    """Write the item's full metadata to S3 as dpla-map.json.
-
-    Raises on failure so the caller's ThreadPoolExecutor can observe and count it.
-    """
+def _stage_to_s3(s3_client: S3Client, partner: str, dpla_id: str, source: dict) -> None:
     s3_client.write_item_metadata(partner, dpla_id, json.dumps(source))
 
 
@@ -211,10 +207,20 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
     s3_client = S3Client()
     search_after = None
 
-    with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
-        futures: dict = {}
-        failed = 0
+    s3_sem = threading.BoundedSemaphore(_S3_QUEUE_DEPTH)
+    failed = [0]
 
+    def _on_s3_done(dpla_id: str):
+        def callback(future: Future) -> None:
+            s3_sem.release()
+            exc = future.exception()
+            if exc:
+                failed[0] += 1
+                logging.warning(f"S3 write failed for {dpla_id}: {exc}")
+
+        return callback
+
+    with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
         while True:
             query = build_query(
                 provider_name, eligible_dp_names, collection, search_after
@@ -253,38 +259,19 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
                 # distinguish fresh ES-sourced objects from legacy API ones.
                 source["_staged_by_get_ids_es"] = True
 
-                # Stage full metadata to S3 asynchronously.
+                s3_sem.acquire()
                 future = executor.submit(
-                    stage_to_s3, s3_client, partner, dpla_id, source
+                    _stage_to_s3, s3_client, partner, dpla_id, source
                 )
-                futures[future] = dpla_id
+                future.add_done_callback(_on_s3_done(dpla_id))
 
                 print(dpla_id)
 
-                # Keep the in-flight dict bounded so peak RAM stays constant
-                # regardless of hub size. When full, block until the earliest
-                # write completes before accepting more work.
-                if len(futures) >= MAX_IN_FLIGHT:
-                    done = next(as_completed(futures))
-                    try:
-                        done.result()
-                    except Exception as e:
-                        failed += 1
-                        logging.warning(f"S3 write failed for {futures[done]}: {e}")
-                    del futures[done]
-
             search_after = hits[-1]["sort"]
 
-        # Drain remaining in-flight writes.
-        for future in as_completed(futures):
-            try:
-                future.result()
-            except Exception as e:
-                failed += 1
-                logging.warning(f"S3 write failed for {futures[future]}: {e}")
-        if failed:
-            print(f"Error: {failed} S3 writes failed", file=sys.stderr)
-            raise SystemExit(1)
+    if failed[0]:
+        print(f"Error: {failed[0]} S3 writes failed", file=sys.stderr)
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -209,13 +209,15 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
 
     s3_sem = threading.BoundedSemaphore(_S3_QUEUE_DEPTH)
     failed = [0]
+    failed_lock = threading.Lock()
 
     def _on_s3_done(dpla_id: str):
         def callback(future: Future) -> None:
             s3_sem.release()
             exc = future.exception()
             if exc:
-                failed[0] += 1
+                with failed_lock:
+                    failed[0] += 1
                 logging.warning(f"S3 write failed for {dpla_id}: {exc}")
 
         return callback

--- a/tools/get_ids_nara.py
+++ b/tools/get_ids_nara.py
@@ -352,13 +352,15 @@ def main() -> None:
 
     s3_sem = threading.BoundedSemaphore(_S3_QUEUE_DEPTH)
     failed = [0]
+    failed_lock = threading.Lock()
 
     def _on_s3_done(dpla_id: str):
         def callback(future: Future) -> None:
             s3_sem.release()
             exc = future.exception()
             if exc:
-                failed[0] += 1
+                with failed_lock:
+                    failed[0] += 1
                 logging.warning(f"S3 write failed for {dpla_id}: {exc}")
 
         return callback


### PR DESCRIPTION
## Summary

- Adds a `threading.Lock` to guard the `failed[0] += 1` increment in both `get_ids_es.py` and `get_ids_nara.py`
- The done callback runs on a `ThreadPoolExecutor` worker thread; two concurrent S3 failures can race across the read-modify-write and drop an update
- Stacked on #212 (the semaphore unification) since `get_ids_es.py`'s `_on_s3_done` pattern lives there

## Why

`failed[0] += 1` compiles to LOAD + INPLACE_ADD + STORE across list indexing — not a single atomic operation. Under CPython's GIL this race is rare in practice (S3 failures are uncommon and callbacks rarely overlap), but it's a correctness issue worth fixing. The lock adds negligible overhead on the error path only.

## Test plan

- [ ] Verify both files look symmetric (`failed_lock = threading.Lock()` alongside `failed = [0]`, `with failed_lock: failed[0] += 1` in callback)
- [ ] No change in happy-path behaviour — lock is only acquired when `future.exception()` is non-None

🤖 Generated with [Claude Code](https://claude.com/claude-code)