### PR TITLE
refactor: extract bounded S3 staging pattern into ingest_wikimedia/staging.py

### DIFF
--- a/ingest_wikimedia/staging.py
+++ b/ingest_wikimedia/staging.py
@@ -1,0 +1,72 @@
+"""Shared helpers for bounded async S3 staging in the get-ids-* tools.
+
+Both get-ids-es and get-ids-nara follow the same pattern when writing ES
+source documents to S3: a BoundedSemaphore caps in-flight writes so the
+executor queue never holds more than n_workers * 4 documents in memory,
+and a done callback releases the slot and counts failures under a Lock.
+"""
+
+import json
+import logging
+import threading
+from collections.abc import Callable
+from concurrent.futures import Future
+
+from .s3 import S3Client
+
+_QUEUE_DEPTH_MULTIPLIER = 4
+
+
+def stage_item_to_s3(
+    s3_client: S3Client, partner: str, dpla_id: str, source: dict
+) -> None:
+    """Write item metadata JSON to S3 as dpla-map.json.
+
+    Raises on failure so the caller's ThreadPoolExecutor can observe it via
+    future.exception() in the done callback.
+    """
+    s3_client.write_item_metadata(partner, dpla_id, json.dumps(source))
+
+
+def make_s3_stage_context(
+    n_workers: int,
+) -> tuple[threading.BoundedSemaphore, list[int], Callable[[str], Callable]]:
+    """Return (sem, failed, on_done_factory) for bounded async S3 staging.
+
+    The semaphore limits in-flight S3 writes to n_workers * 4, preventing
+    the executor queue from growing unboundedly and holding thousands of ES
+    source documents in memory.  The done callback releases the slot, counts
+    failures under a Lock, and logs a warning for each one.
+
+    Typical usage::
+
+        s3_sem, failed, _on_s3_done = make_s3_stage_context(S3_WRITE_WORKERS)
+
+        with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
+            for dpla_id, source in items:
+                s3_sem.acquire()
+                future = executor.submit(
+                    stage_item_to_s3, s3_client, partner, dpla_id, source
+                )
+                future.add_done_callback(_on_s3_done(dpla_id))
+
+        if failed[0]:
+            print(f"Error: {failed[0]} S3 writes failed", file=sys.stderr)
+            raise SystemExit(1)
+    """
+    sem = threading.BoundedSemaphore(n_workers * _QUEUE_DEPTH_MULTIPLIER)
+    failed = [0]
+    lock = threading.Lock()
+
+    def on_done(dpla_id: str) -> Callable:
+        def callback(future: Future) -> None:
+            sem.release()
+            exc = future.exception()
+            if exc:
+                with lock:
+                    failed[0] += 1
+                logging.warning(f"S3 write failed for {dpla_id}: {exc}")
+
+        return callback
+
+    return sem, failed, on_done

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -33,7 +33,8 @@ consumed by the downloader and uploader:
 import json
 import logging
 import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
 
 import click
 import requests
@@ -47,10 +48,9 @@ from ingest_wikimedia.slack import notify_phase_start
 ES_URL = "http://search-prod1.internal.dp.la:9200/dpla_alias/_search"
 PAGE_SIZE = 500
 S3_WRITE_WORKERS = 10
-# Maximum S3-write futures kept in memory at once. When the limit is reached
-# the ES scan pauses until one write completes, keeping peak RAM bounded
-# regardless of hub size.
-MAX_IN_FLIGHT = S3_WRITE_WORKERS * 20
+# Prevents the executor queue from growing unboundedly and holding thousands of
+# ES source documents in memory.
+_S3_QUEUE_DEPTH = S3_WRITE_WORKERS * 4
 
 IIIF_MANIFEST_FIELD = "iiifManifest"
 MEDIA_MASTER_FIELD = "mediaMaster"
@@ -145,11 +145,7 @@ def build_query(
     return query
 
 
-def stage_to_s3(s3_client: S3Client, partner: str, dpla_id: str, source: dict) -> None:
-    """Write the item's full metadata to S3 as dpla-map.json.
-
-    Raises on failure so the caller's ThreadPoolExecutor can observe and count it.
-    """
+def _stage_to_s3(s3_client: S3Client, partner: str, dpla_id: str, source: dict) -> None:
     s3_client.write_item_metadata(partner, dpla_id, json.dumps(source))
 
 
@@ -211,10 +207,20 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
     s3_client = S3Client()
     search_after = None
 
-    with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
-        futures: dict = {}
-        failed = 0
+    s3_sem = threading.BoundedSemaphore(_S3_QUEUE_DEPTH)
+    failed = [0]
 
+    def _on_s3_done(dpla_id: str):
+        def callback(future: Future) -> None:
+            s3_sem.release()
+            exc = future.exception()
+            if exc:
+                failed[0] += 1
+                logging.warning(f"S3 write failed for {dpla_id}: {exc}")
+
+        return callback
+
+    with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
         while True:
             query = build_query(
                 provider_name, eligible_dp_names, collection, search_after
@@ -253,38 +259,19 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
                 # distinguish fresh ES-sourced objects from legacy API ones.
                 source["_staged_by_get_ids_es"] = True
 
-                # Stage full metadata to S3 asynchronously.
+                s3_sem.acquire()
                 future = executor.submit(
-                    stage_to_s3, s3_client, partner, dpla_id, source
+                    _stage_to_s3, s3_client, partner, dpla_id, source
                 )
-                futures[future] = dpla_id
+                future.add_done_callback(_on_s3_done(dpla_id))
 
                 print(dpla_id)
 
-                # Keep the in-flight dict bounded so peak RAM stays constant
-                # regardless of hub size. When full, block until the earliest
-                # write completes before accepting more work.
-                if len(futures) >= MAX_IN_FLIGHT:
-                    done = next(as_completed(futures))
-                    try:
-                        done.result()
-                    except Exception as e:
-                        failed += 1
-                        logging.warning(f"S3 write failed for {futures[done]}: {e}")
-                    del futures[done]
-
             search_after = hits[-1]["sort"]
 
-        # Drain remaining in-flight writes.
-        for future in as_completed(futures):
-            try:
-                future.result()
-            except Exception as e:
-                failed += 1
-                logging.warning(f"S3 write failed for {futures[future]}: {e}")
-        if failed:
-            print(f"Error: {failed} S3 writes failed", file=sys.stderr)
-            raise SystemExit(1)
+    if failed[0]:
+        print(f"Error: {failed[0]} S3 writes failed", file=sys.stderr)
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -30,11 +30,8 @@ consumed by the downloader and uploader:
     get-ids-es pa > pa/pa.csv
 """
 
-import json
-import logging
 import sys
-import threading
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 
 import click
 import requests
@@ -44,13 +41,11 @@ from ingest_wikimedia.dpla import DPLA, DPLA_PARTNERS, INSTITUTIONS_URL
 from ingest_wikimedia.iiif import IIIF
 from ingest_wikimedia.s3 import S3Client
 from ingest_wikimedia.slack import notify_phase_start
+from ingest_wikimedia.staging import make_s3_stage_context, stage_item_to_s3
 
 ES_URL = "http://search-prod1.internal.dp.la:9200/dpla_alias/_search"
 PAGE_SIZE = 500
 S3_WRITE_WORKERS = 10
-# Prevents the executor queue from growing unboundedly and holding thousands of
-# ES source documents in memory.
-_S3_QUEUE_DEPTH = S3_WRITE_WORKERS * 4
 
 IIIF_MANIFEST_FIELD = "iiifManifest"
 MEDIA_MASTER_FIELD = "mediaMaster"
@@ -145,10 +140,6 @@ def build_query(
     return query
 
 
-def _stage_to_s3(s3_client: S3Client, partner: str, dpla_id: str, source: dict) -> None:
-    s3_client.write_item_metadata(partner, dpla_id, json.dumps(source))
-
-
 @click.command()
 @click.argument("partner")
 @click.option(
@@ -207,20 +198,7 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
     s3_client = S3Client()
     search_after = None
 
-    s3_sem = threading.BoundedSemaphore(_S3_QUEUE_DEPTH)
-    failed = [0]
-    failed_lock = threading.Lock()
-
-    def _on_s3_done(dpla_id: str):
-        def callback(future: Future) -> None:
-            s3_sem.release()
-            exc = future.exception()
-            if exc:
-                with failed_lock:
-                    failed[0] += 1
-                logging.warning(f"S3 write failed for {dpla_id}: {exc}")
-
-        return callback
+    s3_sem, failed, _on_s3_done = make_s3_stage_context(S3_WRITE_WORKERS)
 
     with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
         while True:
@@ -263,7 +241,7 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
 
                 s3_sem.acquire()
                 future = executor.submit(
-                    _stage_to_s3, s3_client, partner, dpla_id, source
+                    stage_item_to_s3, s3_client, partner, dpla_id, source
                 )
                 future.add_done_callback(_on_s3_done(dpla_id))
 

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -209,13 +209,15 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
 
     s3_sem = threading.BoundedSemaphore(_S3_QUEUE_DEPTH)
     failed = [0]
+    failed_lock = threading.Lock()
 
     def _on_s3_done(dpla_id: str):
         def callback(future: Future) -> None:
             s3_sem.release()
             exc = future.exception()
             if exc:
-                failed[0] += 1
+                with failed_lock:
+                    failed[0] += 1
                 logging.warning(f"S3 write failed for {dpla_id}: {exc}")
 
         return callback

--- a/tools/get_ids_nara.py
+++ b/tools/get_ids_nara.py
@@ -21,12 +21,10 @@ Output: one DPLA ID per line to stdout. Redirect to produce the IDs CSV:
     get-ids-nara > nara/nara.csv
 """
 
-import json
 import logging
 import signal
 import sys
-import threading
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 
 import click
 import requests
@@ -34,13 +32,11 @@ import requests
 from ingest_wikimedia.banlist import Banlist
 from ingest_wikimedia.s3 import S3Client
 from ingest_wikimedia.slack import notify_phase_start
+from ingest_wikimedia.staging import make_s3_stage_context, stage_item_to_s3
 
 ES_URL = "http://search-prod1.internal.dp.la:9200/dpla_alias/_search"
 PAGE_SIZE = 500
 S3_WRITE_WORKERS = 4
-# Max S3 writes queued + in-flight at once — prevents the executor queue from
-# growing unboundedly and holding thousands of ES source documents in memory.
-_S3_QUEUE_DEPTH = S3_WRITE_WORKERS * 4
 PARTNER = "nara"
 NARA_PROVIDER = "National Archives and Records Administration"
 _ES_HARD_TIMEOUT = 120
@@ -264,10 +260,6 @@ def build_collection_queries() -> list[str]:
     return [b["key"] for b in eligible]
 
 
-def _stage_to_s3(s3_client: S3Client, dpla_id: str, source: dict) -> None:
-    s3_client.write_item_metadata(PARTNER, dpla_id, json.dumps(source))
-
-
 @click.command()
 def main() -> None:
     """Print wiki-eligible NARA DPLA IDs to stdout, one per line.
@@ -350,20 +342,7 @@ def main() -> None:
             )
         )
 
-    s3_sem = threading.BoundedSemaphore(_S3_QUEUE_DEPTH)
-    failed = [0]
-    failed_lock = threading.Lock()
-
-    def _on_s3_done(dpla_id: str):
-        def callback(future: Future) -> None:
-            s3_sem.release()
-            exc = future.exception()
-            if exc:
-                with failed_lock:
-                    failed[0] += 1
-                logging.warning(f"S3 write failed for {dpla_id}: {exc}")
-
-        return callback
+    s3_sem, failed, _on_s3_done = make_s3_stage_context(S3_WRITE_WORKERS)
 
     with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
         for label, extra_filter in queries:
@@ -379,7 +358,9 @@ def main() -> None:
                 source["_staged_by_get_ids_es"] = True
 
                 s3_sem.acquire()
-                future = executor.submit(_stage_to_s3, s3_client, dpla_id, source)
+                future = executor.submit(
+                    stage_item_to_s3, s3_client, PARTNER, dpla_id, source
+                )
                 future.add_done_callback(_on_s3_done(dpla_id))
 
                 print(dpla_id)

--- a/tools/get_ids_nara.py
+++ b/tools/get_ids_nara.py
@@ -352,13 +352,15 @@ def main() -> None:
 
     s3_sem = threading.BoundedSemaphore(_S3_QUEUE_DEPTH)
     failed = [0]
+    failed_lock = threading.Lock()
 
     def _on_s3_done(dpla_id: str):
         def callback(future: Future) -> None:
             s3_sem.release()
             exc = future.exception()
             if exc:
-                failed[0] += 1
+                with failed_lock:
+                    failed[0] += 1
                 logging.warning(f"S3 write failed for {dpla_id}: {exc}")
 
         return callback


### PR DESCRIPTION
## Summary

- Creates `ingest_wikimedia/staging.py` with two shared functions:
  - `stage_item_to_s3(s3_client, partner, dpla_id, source)` — the thin S3 write wrapper (replaces private `_stage_to_s3` in each script)
  - `make_s3_stage_context(n_workers)` → `(sem, failed, on_done_factory)` — creates the `BoundedSemaphore`, failure counter, `Lock`, and `_on_s3_done` closure factory
- Both `get_ids_es.py` and `get_ids_nara.py` reduce their staging boilerplate to one line each: `s3_sem, failed, _on_s3_done = make_s3_stage_context(S3_WRITE_WORKERS)`
- Removes 13 lines of duplicated code from each script; removes `threading`, `Future`, `json` imports that were only needed by the now-shared code
- Resolves the `_stage_to_s3` signature difference (NARA used a module constant for `partner`; ES passed it at runtime) by always taking `partner` as an explicit parameter — NARA passes `PARTNER`, ES passes its CLI arg

## Why

The duplication meant any future fix (like the Lock added in #213) had to be applied twice. The extraction gives one place to change, one place to read, and a clear docstring explaining the bounded-staging contract.

## Stacking

Stacked on #213 (which adds the `Lock` to both files). When #212 and #213 merge, this PR's diff shrinks to just the extraction.

## Test plan

- [ ] `get-ids-es <partner>` — IDs produced, S3 staging behaviour unchanged
- [ ] `get-ids-nara` — IDs produced, S3 staging behaviour unchanged
- [ ] `ruff check ingest_wikimedia/staging.py tools/get_ids_es.py tools/get_ids_nara.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)