### PR TITLE
get-ids-es, get-ids-nara: guard S3 failure counter with a Lock

### DIFF
--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -209,13 +209,15 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
 
     s3_sem = threading.BoundedSemaphore(_S3_QUEUE_DEPTH)
     failed = [0]
+    failed_lock = threading.Lock()
 
     def _on_s3_done(dpla_id: str):
         def callback(future: Future) -> None:
             s3_sem.release()
             exc = future.exception()
             if exc:
-                failed[0] += 1
+                with failed_lock:
+                    failed[0] += 1
                 logging.warning(f"S3 write failed for {dpla_id}: {exc}")
 
         return callback

--- a/tools/get_ids_nara.py
+++ b/tools/get_ids_nara.py
@@ -352,13 +352,15 @@ def main() -> None:
 
     s3_sem = threading.BoundedSemaphore(_S3_QUEUE_DEPTH)
     failed = [0]
+    failed_lock = threading.Lock()
 
     def _on_s3_done(dpla_id: str):
         def callback(future: Future) -> None:
             s3_sem.release()
             exc = future.exception()
             if exc:
-                failed[0] += 1
+                with failed_lock:
+                    failed[0] += 1
                 logging.warning(f"S3 write failed for {dpla_id}: {exc}")
 
         return callback


### PR DESCRIPTION
Replaces #213 (closed when its stacked base branch was deleted on merge of #212).

## Summary

- Adds a `threading.Lock` to guard the `failed[0] += 1` increment in both `get_ids_es.py` and `get_ids_nara.py`
- The done callback runs on a `ThreadPoolExecutor` worker thread; two concurrent S3 failures can race across the read-modify-write and drop an update
- Lock is defined alongside `failed = [0]` in `main()` (not module-level, so it resets correctly if `main` is called multiple times in tests)

## Why

`failed[0] += 1` compiles to LOAD + INPLACE_ADD + STORE across list indexing — not a single atomic operation. Under CPython's GIL this race is rare in practice (S3 failures are uncommon and callbacks rarely overlap), but it's a correctness issue worth fixing. The lock adds negligible overhead on the error path only.

## Test plan

- [ ] Verify both files look symmetric (`failed_lock = threading.Lock()` alongside `failed = [0]`, `with failed_lock: failed[0] += 1` in callback)
- [ ] No change in happy-path behaviour — lock is only acquired when `future.exception()` is non-None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds thread-safe guards to the shared S3 write failure counter in both `tools/get_ids_es.py` and `tools/get_ids_nara.py`. The changes prevent race conditions when multiple S3 write callbacks fail concurrently.

## Changes

**tools/get_ids_es.py** and **tools/get_ids_nara.py**:
- Introduces `failed_lock = threading.Lock()` alongside `failed = [0]` within the `main()` function
- Wraps the failure counter increment in the S3 write completion callback with `with failed_lock: failed[0] += 1`

The lock is scoped to the function (not module-level) so it resets correctly when `main()` is called multiple times in tests.

## Rationale

The `failed[0] += 1` operation compiles to multiple bytecode instructions (LOAD, INPLACE_ADD, STORE) and is not atomic. When ThreadPoolExecutor callbacks on different worker threads execute concurrently, increments can race and drop updates. The lock ensures thread-safe counter updates with negligible overhead confined to the error path.

## Impact

No deployment, configuration, or infrastructure changes required. The lock is only acquired when S3 write failures occur, leaving happy-path behavior unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->