### PR TITLE
fix: validate ES responses in get-ids-es to catch silent partial pagination

### DIFF
--- a/ingest_wikimedia/es.py
+++ b/ingest_wikimedia/es.py
@@ -17,6 +17,7 @@ requirement.
 """
 
 import signal
+import threading
 from typing import Any
 
 import requests
@@ -42,7 +43,15 @@ def post_es(query: dict) -> requests.Response:
     main thread, providing a true ceiling on total request time.
 
     Raises TimeoutError if the request exceeds ES_HARD_TIMEOUT seconds.
+    Raises RuntimeError if called from a non-main thread — `signal.alarm()` is
+    a no-op from worker threads but the alarm still fires on the main thread,
+    silently corrupting whatever the main thread is doing.
     """
+    if threading.current_thread() is not threading.main_thread():
+        raise RuntimeError(
+            "post_es() must be called from the main thread "
+            "(SIGALRM-based timeout only works on the main thread)"
+        )
     signal.alarm(ES_HARD_TIMEOUT)
     try:
         return requests.post(ES_URL, json=query, timeout=30)

--- a/ingest_wikimedia/es.py
+++ b/ingest_wikimedia/es.py
@@ -1,0 +1,72 @@
+"""Shared Elasticsearch helpers for the get-ids-* tools.
+
+Both tools paginate ES with `search_after` and need the same two protections
+against silent partial results:
+
+  * a hard wall-clock timeout via SIGALRM (catches ES connections that stall
+    mid-response — `requests`' timeout only fires when no bytes arrive)
+  * a response validator that raises on `timed_out` or shard failures, so an
+    HTTP-200 partial response cannot be mistaken for an empty page and silently
+    end pagination (see lessons.md: "Elasticsearch queries: validate `timed_out`
+    and `_shards.failed` before consuming results")
+
+Must be imported on the main thread: `signal.signal()` raises ValueError when
+called from any other thread.  The get-ids-* CLI tools import this at module
+load before spinning up their ThreadPoolExecutor, which satisfies the
+requirement.
+"""
+
+import signal
+from typing import Any
+
+import requests
+
+ES_URL = "http://search-prod1.internal.dp.la:9200/dpla_alias/_search"
+ES_HARD_TIMEOUT = 120
+
+
+def _alarm_handler(signum: int, frame: object) -> None:
+    raise TimeoutError(f"ES query exceeded {ES_HARD_TIMEOUT}s")
+
+
+# Registered once at import time; only signal.alarm() is toggled per request.
+signal.signal(signal.SIGALRM, _alarm_handler)
+
+
+def post_es(query: dict) -> requests.Response:
+    """POST to ES_URL with a hard wall-clock timeout via SIGALRM.
+
+    `requests` timeout=30 fires only when no bytes arrive for 30s — it cannot
+    catch ES stalling mid-response (drip-feeding bytes or holding an open
+    connection indefinitely). SIGALRM interrupts the blocked socket read in the
+    main thread, providing a true ceiling on total request time.
+
+    Raises TimeoutError if the request exceeds ES_HARD_TIMEOUT seconds.
+    """
+    signal.alarm(ES_HARD_TIMEOUT)
+    try:
+        return requests.post(
+            ES_URL,
+            json=query,
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+    finally:
+        signal.alarm(0)
+
+
+def check_es_response(data: dict[str, Any]) -> None:
+    """Raise if the response was partial — timed-out or had shard failures.
+
+    An ES response can return HTTP 200 while containing partial data — one or
+    more shards may have timed out or failed.  In paginated search_after loops
+    that exit on empty `hits`, a partial response silently truncates the result
+    set.  Always call this after parsing the JSON, before reading `hits`.
+    """
+    if data.get("timed_out"):
+        raise RuntimeError("Elasticsearch query timed out — results may be incomplete")
+    shards = data.get("_shards", {})
+    if shards.get("failed", 0) > 0:
+        raise RuntimeError(
+            f"Elasticsearch query had {shards['failed']} shard failure(s)"
+        )

--- a/ingest_wikimedia/es.py
+++ b/ingest_wikimedia/es.py
@@ -45,12 +45,7 @@ def post_es(query: dict) -> requests.Response:
     """
     signal.alarm(ES_HARD_TIMEOUT)
     try:
-        return requests.post(
-            ES_URL,
-            json=query,
-            headers={"Content-Type": "application/json"},
-            timeout=30,
-        )
+        return requests.post(ES_URL, json=query, timeout=30)
     finally:
         signal.alarm(0)
 

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -38,12 +38,12 @@ import requests
 
 from ingest_wikimedia.banlist import Banlist
 from ingest_wikimedia.dpla import DPLA, DPLA_PARTNERS, INSTITUTIONS_URL
+from ingest_wikimedia.es import check_es_response, post_es
 from ingest_wikimedia.iiif import IIIF
 from ingest_wikimedia.s3 import S3Client
 from ingest_wikimedia.slack import notify_phase_start
 from ingest_wikimedia.staging import make_s3_stage_context, stage_item_to_s3
 
-ES_URL = "http://search-prod1.internal.dp.la:9200/dpla_alias/_search"
 PAGE_SIZE = 500
 S3_WRITE_WORKERS = 10
 
@@ -205,14 +205,10 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
             query = build_query(
                 provider_name, eligible_dp_names, collection, search_after
             )
-            response = requests.post(
-                ES_URL,
-                json=query,
-                headers={"Content-Type": "application/json"},
-                timeout=30,
-            )
+            response = post_es(query)
             response.raise_for_status()
             page = response.json()
+            check_es_response(page)
             hits = page["hits"]["hits"]
 
             if not hits:

--- a/tools/get_ids_nara.py
+++ b/tools/get_ids_nara.py
@@ -22,24 +22,21 @@ Output: one DPLA ID per line to stdout. Redirect to produce the IDs CSV:
 """
 
 import logging
-import signal
 import sys
 from concurrent.futures import ThreadPoolExecutor
 
 import click
-import requests
 
 from ingest_wikimedia.banlist import Banlist
+from ingest_wikimedia.es import ES_HARD_TIMEOUT, check_es_response, post_es
 from ingest_wikimedia.s3 import S3Client
 from ingest_wikimedia.slack import notify_phase_start
 from ingest_wikimedia.staging import make_s3_stage_context, stage_item_to_s3
 
-ES_URL = "http://search-prod1.internal.dp.la:9200/dpla_alias/_search"
 PAGE_SIZE = 500
 S3_WRITE_WORKERS = 4
 PARTNER = "nara"
 NARA_PROVIDER = "National Archives and Records Administration"
-_ES_HARD_TIMEOUT = 120
 
 # --- Tunable priority thresholds ---
 # Collections or formats exceeding these counts are deferred to future runs,
@@ -118,10 +115,10 @@ def _fetch_buckets(field: str, extra_filters: list[dict] | None = None) -> list[
             },
             "aggs": {"values": {"composite": composite_agg}},
         }
-        response = _post_es(query)
+        response = post_es(query)
         response.raise_for_status()
         data = response.json()
-        _check_es_response(data)
+        check_es_response(data)
 
         page = data["aggregations"]["values"]
         # Composite agg buckets: {"key": {"key": <value>}, "doc_count": N}
@@ -134,46 +131,6 @@ def _fetch_buckets(field: str, extra_filters: list[dict] | None = None) -> list[
             break
 
     return buckets
-
-
-def _es_alarm_handler(signum: int, frame: object) -> None:
-    raise TimeoutError(f"ES query exceeded {_ES_HARD_TIMEOUT}s")
-
-
-# Registered once at import time; only signal.alarm() is toggled per request.
-signal.signal(signal.SIGALRM, _es_alarm_handler)
-
-
-def _post_es(query: dict) -> requests.Response:
-    """POST to ES_URL with a hard wall-clock timeout via SIGALRM.
-
-    requests timeout=30 fires only when no bytes arrive for 30s — it cannot
-    catch ES stalling mid-response (drip-feeding bytes or holding an open
-    connection indefinitely). SIGALRM interrupts the blocked socket read in the
-    main thread, providing a true ceiling on total request time.
-
-    Raises TimeoutError if the request exceeds _ES_HARD_TIMEOUT seconds.
-    """
-    signal.alarm(_ES_HARD_TIMEOUT)
-    try:
-        return requests.post(
-            ES_URL,
-            json=query,
-            headers={"Content-Type": "application/json"},
-            timeout=30,
-        )
-    finally:
-        signal.alarm(0)
-
-
-def _check_es_response(data: dict) -> None:
-    if data.get("timed_out"):
-        raise RuntimeError("Elasticsearch query timed out — results may be incomplete")
-    shards = data.get("_shards", {})
-    if shards.get("failed", 0) > 0:
-        raise RuntimeError(
-            f"Elasticsearch query had {shards['failed']} shard failure(s)"
-        )
 
 
 def _paginate(extra_filter: dict):
@@ -197,16 +154,16 @@ def _paginate(extra_filter: dict):
         if search_after is not None:
             query["search_after"] = search_after
         try:
-            response = _post_es(query)
+            response = post_es(query)
         except TimeoutError:
             logging.warning(
                 "ES paginate query timed out after %ds — skipping remaining pages for this batch",
-                _ES_HARD_TIMEOUT,
+                ES_HARD_TIMEOUT,
             )
             return
         response.raise_for_status()
         data = response.json()
-        _check_es_response(data)
+        check_es_response(data)
         hits = data["hits"]["hits"]
         if not hits:
             break

--- a/tools/resolve_dpla_ids.py
+++ b/tools/resolve_dpla_ids.py
@@ -17,10 +17,9 @@ Output format (one line per ID):
 import json
 
 import click
-import requests
 
 from ingest_wikimedia.banlist import Banlist
-from ingest_wikimedia.es import ES_URL, check_es_response
+from ingest_wikimedia.es import check_es_response, post_es
 from ingest_wikimedia.iiif import IIIF
 from ingest_wikimedia.partners import is_item_upload_eligible, resolve_slug
 from ingest_wikimedia.s3 import S3Client
@@ -38,13 +37,11 @@ def main(dpla_ids: tuple[str, ...]) -> None:
     s3_client = S3Client()
 
     # Single batched ES query for all IDs — avoids N round-trips.
-    resp = requests.post(
-        ES_URL,
-        json={
+    resp = post_es(
+        {
             "query": {"terms": {"id": list(dpla_ids)}},
             "size": len(dpla_ids),
-        },
-        timeout=10,
+        }
     )
     resp.raise_for_status()
     data = resp.json()

--- a/tools/resolve_dpla_ids.py
+++ b/tools/resolve_dpla_ids.py
@@ -20,11 +20,11 @@ import click
 import requests
 
 from ingest_wikimedia.banlist import Banlist
+from ingest_wikimedia.es import ES_URL, check_es_response
 from ingest_wikimedia.iiif import IIIF
 from ingest_wikimedia.partners import is_item_upload_eligible, resolve_slug
 from ingest_wikimedia.s3 import S3Client
 
-ES_URL = "http://search-prod1.internal.dp.la:9200/dpla_alias/_search"
 _IIIF_MANIFEST_FIELD = "iiifManifest"
 _MEDIA_MASTER_FIELD = "mediaMaster"
 _IS_SHOWN_AT_FIELD = "isShownAt"
@@ -48,13 +48,7 @@ def main(dpla_ids: tuple[str, ...]) -> None:
     )
     resp.raise_for_status()
     data = resp.json()
-    if data.get("timed_out"):
-        raise RuntimeError("Elasticsearch query timed out — results may be incomplete")
-    shards = data.get("_shards", {})
-    if shards.get("failed", 0) > 0:
-        raise RuntimeError(
-            f"Elasticsearch query had {shards['failed']} shard failure(s)"
-        )
+    check_es_response(data)
     hits = data.get("hits", {}).get("hits", [])
     found: dict[str, dict] = {hit["_source"]["id"]: hit["_source"] for hit in hits}
 


### PR DESCRIPTION
## Problem

The recent Texas `get-ids-es` run produced **252,485** IDs in the CSV, but ES holds **502,280** items matching the exact filter set. The 232K \"excess\" Texas IDs in S3 (in inventory but not in the CSV) all show up as fully eligible per current ES + institutions JSON criteria when sampled — they should have been in the CSV.

## Investigation summary

| Test | Result |
|---|---|
| ES `_count` with exact get-ids-es filter set | 502,280 |
| `texas.csv` from the killed run | 252,485 |
| S3 inventory: unique Texas DPLA IDs | 472,989 |
| S3 ∖ CSV (excess) | 231,914 |
| Sample of 200 excess IDs verified eligible per all current criteria | 199/200 |
| Banlist overlap with excess | 0 |
| `dpla_alias` backing indices | 1 (`dpla-all-20260508-154249`) |
| `id` field mapping | `keyword` |
| Duplicate IDs detected | 0 |
| Re-paginate live with `sort=[id, _doc]` | **502,280** (matches `_count`) |
| Re-paginate live with `sort=[id, _id]` | 502,280 (same) |

So the query and pagination are correct **when ES is healthy**. The Texas run almost certainly hit a transient ES partial-failure: a `timed_out: true` or `_shards.failed > 0` response with empty/short `hits`, which `get_ids_es.py` was reading as end-of-results. This dropped the loop at ~252K, then the script proceeded into the executor's drain phase (which is what the user observed before killing it).

`get_ids_nara.py` already had `_check_es_response()` + `_post_es()` with a SIGALRM hard timeout for exactly this scenario. `get_ids_es.py` was missing both — a direct regression of the lesson \"Elasticsearch queries: validate `timed_out` and `_shards.failed` before consuming results\".

## Change

- **New `ingest_wikimedia/es.py`**: shared `post_es()` (SIGALRM-bounded POST) and `check_es_response()` (raise on `timed_out` or shard failures).
- **`tools/get_ids_es.py`**: routes ES calls through the new helpers — **this is the actual bug fix**. A partial response now raises `RuntimeError` instead of silently terminating pagination.
- **`tools/get_ids_nara.py`**: dedups by importing from the new module — identical behaviour.
- **`tools/resolve_dpla_ids.py`**: third call site that had its own copy of the validator and the `ES_URL` constant — also routed through the shared module.

Net: -45 lines + new ~65-line shared module.

## Test plan

- [ ] Re-run `get-ids-es texas` — expect ~502K IDs in the CSV (vs. 252K before).
- [ ] If ES has a transient failure during the run, verify it raises `RuntimeError` loudly rather than exiting 0 with a partial CSV.
- [ ] `get-ids-nara` and `resolve-dpla-ids` behavioural smoke test — no regression expected (identical logic, just imported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes a critical bug where Elasticsearch partial-failure responses (e.g., `timed_out: true` or `_shards.failed > 0`) could be treated as empty pages and cause silent, truncated CSV outputs. A recent Texas run produced 252,485 CSV IDs while ES `_count` was 502,280; investigation found the run hit a transient ES partial failure that returned short/empty `hits` and prematurely stopped pagination. This PR makes paginated ES queries fail fast on partial responses so truncated CSVs are no longer produced silently.

## Changes

- New shared module: ingest_wikimedia/es.py
  - ES_URL = "http://search-prod1.internal.dp.la:9200/dpla_alias/_search"
  - ES_HARD_TIMEOUT = 120 (seconds)
  - post_es(query: dict) -> requests.Response
    - Posts JSON to ES_URL with requests socket timeout=30 and a process-level hard wall-clock timeout enforced via signal.alarm(SIGALRM).
    - Enforces that post_es() is called from the main thread; calling from a worker thread raises RuntimeError to avoid silent cross-thread SIGALRM effects.
    - Raises TimeoutError when the wall-clock timeout triggers.
  - check_es_response(data: dict[str, Any]) -> None
    - Raises RuntimeError if data["timed_out"] is truthy or if data["_shards"]["failed"] > 0, preventing HTTP-200 partial responses from being treated as successful end-of-pagination.
  - Registers SIGALRM handler at import time; importing this module from a non-main thread will raise (signal.signal() raises ValueError).

- tools/get_ids_es.py
  - Replaced inline ES POST/timeout logic with ingest_wikimedia.es.post_es() and check_es_response().
  - Each page response is validated via check_es_response(page) before reading `hits`, so partial responses raise instead of silently terminating pagination.

- tools/get_ids_nara.py
  - Removed duplicated local ES SIGALRM/validation plumbing and switched to shared post_es(), check_es_response(), and ES_HARD_TIMEOUT.
  - _fetch_buckets and _paginate use post_es()/check_es_response(); _paginate continues to catch TimeoutError and will log and skip remaining pages for the current batch (preserves previous behavior for hard-timeout).

- tools/resolve_dpla_ids.py
  - Replaced inline ES request/validation with post_es() + check_es_response() for the single batched query that resolves IDs.

- Net diff: new shared module (~76 lines) plus small edits across three tools (net ~+27 lines).

## Deployment / infra impact

- No manual pipeline trigger or ECS redeployment required for this code change to take effect.
- No additions, removals, or renames of environment variables or AWS Secrets Manager keys.
- No database migrations.
- No changes to shared infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM).
- No public API response shape changes or new endpoints.

## Threading / signal note (operational risk)

- ingest_wikimedia/es.py registers a SIGALRM handler at import time and documents/ enforces that post_es() must be called from the main thread. Importing the module or calling post_es() from worker threads is unsafe: signal.signal() raises ValueError if called from a non-main thread, and prior to the added guard an alarm triggered on the main thread could silently interrupt it. The module now fails loudly (ValueError at import or RuntimeError from post_es) if used incorrectly; ensure CLI tools import this module on the main thread before spawning worker threads.

## Security / credentials

- No changes to credential handling, secrets, or new external authentication surfaces.

## Testing plan

- Re-run get-ids-es for Texas — expect ~502,280 IDs matching ES `_count`.
- If ES transient failures occur, expect RuntimeError (for partial/failed ES response) or TimeoutError (for wall-clock timeout) instead of producing a truncated CSV.
- Smoke tests: run get-ids-nara and resolve-dpla-ids to confirm no regressions; get-ids-nara will log and skip remaining pages for a timed-out batch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->