### PR TITLE
launch: preflight-check partner directory existence on EC2

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -360,6 +360,38 @@ def main() -> None:
             f" ({available_mb} MB of {total_mb} MB). Threshold is {MEMORY_HEADROOM_PCT}%.",
         )
 
+    # Verify every requested partner has a working directory on EC2. Pywikibot
+    # expects per-partner config.toml / user-config.py / user-password.py /
+    # apicache; without them the pipeline's first `cd {base}` silently fails
+    # and Slack only sees the generic "pipeline step failed" message. Catching
+    # this here gives a clear, actionable error before any tmux work starts.
+    unique_pdirs = sorted({PARTNER_DIR.get(c, c) for c, _, _, _, _ in targets})
+    print(f"Checking partner directories exist: {unique_pdirs}")
+    check_cmd = "; ".join(
+        f"test -d /home/ec2-user/ingest-wikimedia/{shlex.quote(d)} || echo MISSING:{d}"
+        for d in unique_pdirs
+    )
+    try:
+        dir_check_out = ssm_run(ssm, check_cmd)
+    except Exception as e:
+        _slack_fail(response_url, f"⚠️ Failed to check partner directories: {e}")
+    missing_dirs = sorted(
+        line.split(":", 1)[1]
+        for line in dir_check_out.splitlines()
+        if line.startswith("MISSING:")
+    )
+    if missing_dirs:
+        missing_list = ", ".join(f"`{d}`" for d in missing_dirs)
+        _slack_fail(
+            response_url,
+            f"⚠️ Cannot launch `{session_name}`: partner directory missing on EC2"
+            f" for {missing_list}. Initialize each one by copying config.toml,"
+            f" user-config.py, and user-password.py from an existing partner dir"
+            f" (e.g. `cp -p /home/ec2-user/ingest-wikimedia/bpl/{{config.toml,"
+            f"user-config.py,user-password.py}} /home/ec2-user/ingest-wikimedia/"
+            f"<new-partner>/`).",
+        )
+
     # Check for any existing session that includes one of the requested targets.
     # Maps each requested label to the existing session name(s) it conflicts with.
     print(f"Checking for existing sessions that overlap with {session_name}...")


### PR DESCRIPTION
## Summary

Diagnose the structural cause when a "pipeline step failed — skipping to next target" message turns out to be a missing-partner-directory issue, before any tmux work starts.

### What happens today

Adding a new partner slug to `PARTNER_HUBS` doesn't create its working directory on EC2. Pywikibot expects per-partner `config.toml`, `user-config.py`, `user-password.py`, and `apicache/`. Without them, the pipeline's first step (`cd /home/ec2-user/ingest-wikimedia/<partner>`) silently fails, the `||` failure handler runs `notify_pipeline_fail`, and Slack only sees:

> ❌ `wikimedia-bhl+phillips-academy-oliver-wendell-holmes-library-archiveorg`: pipeline step failed — skipping to next target

Nothing in that message indicates the cause is structural (vs. transient / data / API).

### Fix

Add an SSM preflight `test -d` for every unique partner directory in the batch, positioned between the memory-headroom check and the tmux-conflict check. If any are missing, fail launch with a clear, actionable Slack message:

> ⚠️ Cannot launch `wikimedia-…`: partner directory missing on EC2 for `bhl`, `ia`. Initialize each one by copying config.toml, user-config.py, and user-password.py from an existing partner dir (e.g. `cp -p /home/ec2-user/ingest-wikimedia/bpl/{config.toml,user-config.py,user-password.py} /home/ec2-user/ingest-wikimedia/<new-partner>/`).

This catches new-partner setup omissions before tmux even spins up — no half-run batches, no opaque Slack noise.

### Manifested by

The 2026-05-22 launch of `bhl|Phillips Academy, Oliver Wendell Holmes Library (archive.org)` plus chained `ia|...` institution targets. Both `bhl` and `ia` are listed in `PARTNER_HUBS` but neither has an EC2 working directory.

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [ ] CI: pytest + ruff green
- [ ] Next launch with a missing partner dir produces the new actionable Slack message
- [ ] Next launch with all partner dirs present runs normally (preflight passes silently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Summary: Preflight Check for Partner Directories on EC2

## Overview
This PR adds a validation step to `scripts/wikimedia_launch.py` that verifies the existence of per-partner working directories on the EC2 host before the pipeline launches. The check prevents failed runs when partner directories are missing and provides a clear, actionable Slack message to users.

## Problem Statement
When a new partner slug is added to `PARTNER_HUBS` without creating the corresponding EC2 directory, the pipeline silently fails at the initial `cd /home/ec2-user/ingest-wikimedia/<partner>` command. This results in an opaque Slack message ("pipeline step failed — skipping to next target") that doesn't indicate the structural cause (missing partner config files and apicache/), making troubleshooting difficult.

## Solution
Adds a preflight check that:
- Computes unique partner directories from `PARTNER_DIR` and `targets`
- Runs SSM `test -d` commands to verify `/home/ec2-user/ingest-wikimedia/{dir}` exists for each partner
- Parses response for missing directories
- Aborts the workflow via `_slack_fail` with a specific message listing missing partners and providing an actionable bootstrap command (e.g., `cp -p` from an existing partner for config.toml, user-config.py, user-password.py)
- Executes after the memory-headroom check and before tmux-conflict detection

## Changes
- **File modified**: `scripts/wikimedia_launch.py` (+32 lines, -0 lines)
- Implementation adds partner directory validation logic to the preflight checks

## Impact Assessment

### Deployment & Operations
- **Manual intervention required**: No redeployment needed; changes are to the launch script itself
- **Pipeline trigger**: No manual pipeline trigger required; the check is integrated into the existing launch workflow
- **ECS/Infrastructure changes**: None; this is a script-level validation addition with no changes to ECS task definitions, CodePipeline configuration, or CodeBuild setup

### Configuration & Secrets
- **Environment variables**: No new environment variables added or modified
- **AWS Secrets Manager keys**: No changes to secrets configuration
- **Configuration files**: No changes to shared infrastructure configuration

### Data & Security
- **Database migrations**: Not applicable
- **API changes**: No public-facing API modifications
- **Security implications**: Minimal; the check validates directory existence through existing SSM infrastructure and provides clearer error messages without introducing new credential handling or data access patterns

### Testing
- Ruff code checks passing; CI pytest and ruff validation pending
- Verification required: new Slack message should appear when directories are missing and normal runs should execute when directories exist

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->