### PR TITLE
slack: enrich pipeline-fail notification with exit code + log tail

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -125,11 +125,16 @@ def notify_pipeline_fail() -> None:
     """Post a pipeline-step failure notification to Slack.
 
     Reads from the environment:
-      DPLA_SLACK_BOT_TOKEN   — required to post
-      WIKIMEDIA_SESSION_LABEL — identifies the target in the message
-      WIKIMEDIA_LAST_EXIT    — exit code of the failed step (best-effort)
-      WIKIMEDIA_PARTNER_DIR  — absolute path to the partner dir, used to
-                               locate the most recent log for tailing
+      DPLA_SLACK_BOT_TOKEN     — required to post
+      WIKIMEDIA_SESSION_LABEL  — identifies the target in the message
+      WIKIMEDIA_LAST_EXIT      — exit code of the failed step (best-effort)
+      WIKIMEDIA_PARTNER_DIR    — absolute path to the partner dir, used to
+                                 locate the most recent log for tailing
+      WIKIMEDIA_TARGET_IS_LAST — "1" iff this is the final target in the
+                                 batch; switches the message suffix from
+                                 "skipping to next target" to "no further
+                                 targets in batch", which is accurate even
+                                 for single-target sessions
 
     Designed to be called as a one-liner from a shell failure handler:
         rc=$?; WIKIMEDIA_LAST_EXIT=$rc python3 -c \\
@@ -144,10 +149,11 @@ def notify_pipeline_fail() -> None:
     label = os.environ.get("WIKIMEDIA_SESSION_LABEL") or "unknown"
     rc_suffix = _decode_exit_code(os.environ.get("WIKIMEDIA_LAST_EXIT"))
 
-    msg = (
-        f"❌ `wikimedia-{label}`: pipeline step failed{rc_suffix}"
-        " — skipping to next target"
+    is_last = os.environ.get("WIKIMEDIA_TARGET_IS_LAST") == "1"
+    tail_phrase = (
+        "no further targets in batch" if is_last else "skipping to next target"
     )
+    msg = f"❌ `wikimedia-{label}`: pipeline step failed{rc_suffix} — {tail_phrase}"
 
     log_path = _find_latest_log(os.environ.get("WIKIMEDIA_PARTNER_DIR", ""), label)
     if log_path is not None:

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -1,5 +1,7 @@
+import glob
 import logging
 import os
+import re
 from typing import Literal
 
 import requests
@@ -31,12 +33,107 @@ def post_message(token: str, text: str) -> None:
         raise RuntimeError(f"Slack API error: {data.get('error')}")
 
 
+# exit code → short hint shown in the Slack failure message.  Anything >128 is
+# a bash-encoded signal (128 + signal number).  137 in particular is SIGKILL,
+# which the OOM killer uses — so seeing it in the message is a strong "this was
+# probably an OOM" hint without having to SSM in and check dmesg.
+_EXIT_CODE_HINTS: dict[int, str] = {
+    137: "SIGKILL — likely OOM",
+    143: "SIGTERM",
+    139: "SIGSEGV",
+    134: "SIGABRT",
+    130: "SIGINT (Ctrl-C)",
+}
+
+
+def _decode_exit_code(rc_str: str | None) -> str:
+    """Render a `(exit N — meaning)` suffix for the failure message."""
+    if not rc_str:
+        return ""
+    try:
+        rc = int(rc_str)
+    except ValueError:
+        return ""
+    if rc == 0:
+        return ""
+    hint = _EXIT_CODE_HINTS.get(rc)
+    if hint is None and rc > 128:
+        hint = f"signal {rc - 128}"
+    return f" (exit {rc}" + (f" — {hint})" if hint else ")")
+
+
+def _find_latest_log(partner_dir: str, label: str) -> str | None:
+    """Return the most recently modified log file matching this label, or None.
+
+    Logs are named `{timestamp}-{label}-{phase}.log` under `<partner_dir>/logs/`.
+    """
+    if not partner_dir or not os.path.isdir(partner_dir):
+        return None
+    pattern = os.path.join(partner_dir, "logs", f"*-{label}-*.log")
+    candidates = glob.glob(pattern)
+    if not candidates:
+        return None
+    return max(candidates, key=os.path.getmtime)
+
+
+# Counted markers shown in the failure summary.  Patterns match what the
+# downloader and uploader currently emit, anchored loosely so log-format
+# tweaks don't silently zero them out.  Skip subcategories aren't split out
+# because "Skipping ... Already exists" would double-count under a generic
+# "Skipping" pattern — the log tail conveys reasons more usefully anyway.
+_LOG_MARKERS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("uploaded", re.compile(r"Uploaded to https://commons", re.IGNORECASE)),
+    ("skipped", re.compile(r"^\[INFO\].*Skipping ", re.MULTILINE)),
+    ("downloaded", re.compile(r"^\[INFO\].*Downloaded ", re.MULTILINE)),
+    ("failed", re.compile(r"^\[(ERROR|WARNING)\].*Failed", re.MULTILINE)),
+)
+
+
+def _summarize_log(log_path: str, tail_lines: int = 8) -> str | None:
+    """Read the log and produce a short multi-line summary.
+
+    Tries to be cheap: only reads up to ~2 MB from the end of the file.  Counts
+    common markers and tails the last N lines so the cause of the failure is
+    visible without SSM-ing in.
+    """
+    try:
+        size = os.path.getsize(log_path)
+        read_size = min(size, 2 * 1024 * 1024)
+        with open(log_path, "rb") as f:
+            f.seek(size - read_size)
+            data = f.read().decode("utf-8", errors="replace")
+    except OSError:
+        return None
+
+    counts = []
+    for label, pat in _LOG_MARKERS:
+        n = len(pat.findall(data))
+        if n:
+            counts.append(f"{n} {label}")
+
+    tail = "\n".join(data.splitlines()[-tail_lines:])
+
+    parts = [f"Log: `{os.path.basename(log_path)}`"]
+    if counts:
+        parts.append("Counts so far: " + ", ".join(counts))
+    if tail:
+        parts.append("Last lines:\n```\n" + tail + "\n```")
+    return "\n".join(parts)
+
+
 def notify_pipeline_fail() -> None:
     """Post a pipeline-step failure notification to Slack.
 
-    Reads DPLA_SLACK_BOT_TOKEN and WIKIMEDIA_SESSION_LABEL from the environment.
+    Reads from the environment:
+      DPLA_SLACK_BOT_TOKEN   — required to post
+      WIKIMEDIA_SESSION_LABEL — identifies the target in the message
+      WIKIMEDIA_LAST_EXIT    — exit code of the failed step (best-effort)
+      WIKIMEDIA_PARTNER_DIR  — absolute path to the partner dir, used to
+                               locate the most recent log for tailing
+
     Designed to be called as a one-liner from a shell failure handler:
-        python3 -c 'from ingest_wikimedia.slack import notify_pipeline_fail; notify_pipeline_fail()'
+        rc=$?; WIKIMEDIA_LAST_EXIT=$rc python3 -c \\
+          'from ingest_wikimedia.slack import notify_pipeline_fail; notify_pipeline_fail()'
     """
     token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
     if not token:
@@ -45,11 +142,21 @@ def notify_pipeline_fail() -> None:
         )
         return
     label = os.environ.get("WIKIMEDIA_SESSION_LABEL") or "unknown"
+    rc_suffix = _decode_exit_code(os.environ.get("WIKIMEDIA_LAST_EXIT"))
+
+    msg = (
+        f"❌ `wikimedia-{label}`: pipeline step failed{rc_suffix}"
+        " — skipping to next target"
+    )
+
+    log_path = _find_latest_log(os.environ.get("WIKIMEDIA_PARTNER_DIR", ""), label)
+    if log_path is not None:
+        summary = _summarize_log(log_path)
+        if summary:
+            msg += "\n" + summary
+
     try:
-        post_message(
-            token,
-            f"❌ `wikimedia-{label}`: pipeline step failed — skipping to next target",
-        )
+        post_message(token, msg)
     except Exception:
         logging.warning(
             "Failed to post pipeline failure notification to Slack", exc_info=True

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -66,14 +66,21 @@ def _find_latest_log(partner_dir: str, label: str) -> str | None:
     """Return the most recently modified log file matching this label, or None.
 
     Logs are named `{timestamp}-{label}-{phase}.log` under `<partner_dir>/logs/`.
+    Tolerates the rare race where a candidate disappears between glob and stat —
+    raising OSError here would suppress the Slack failure notification entirely.
     """
     if not partner_dir or not os.path.isdir(partner_dir):
         return None
     pattern = os.path.join(partner_dir, "logs", f"*-{label}-*.log")
-    candidates = glob.glob(pattern)
-    if not candidates:
-        return None
-    return max(candidates, key=os.path.getmtime)
+    newest: tuple[float, str] | None = None
+    for path in glob.glob(pattern):
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            continue
+        if newest is None or mtime > newest[0]:
+            newest = (mtime, path)
+    return newest[1] if newest is not None else None
 
 
 # Counted markers shown in the failure summary.  Patterns match what the

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -515,8 +515,10 @@ def main() -> None:
     # notify_fail_cmd uses single-quoted Python inside a double-quoted tmux argument.
     # Single quotes are literal characters inside double-quoted bash strings, so the
     # inner Python code reaches the interpreter verbatim without needing any escaping.
+    # `rc=$?` captures the failing step's exit code so the Slack message can decode
+    # signals like 137 (SIGKILL / probable OOM) and 143 (SIGTERM).
     notify_fail_cmd = (
-        "python3 -c "
+        "rc=$?; WIKIMEDIA_LAST_EXIT=$rc python3 -c "
         "'from ingest_wikimedia.slack import notify_pipeline_fail; notify_pipeline_fail()'"
     )
     setup = " && ".join(
@@ -554,8 +556,12 @@ def main() -> None:
             if dpla_id is not None
             else "unset WIKIMEDIA_SINGLE_ITEM"
         )
+        # WIKIMEDIA_PARTNER_DIR is read by notify_pipeline_fail() to locate
+        # the most recent log for this target and include a tail + counts in
+        # the Slack failure message.
         label_export = (
             f"export WIKIMEDIA_SESSION_LABEL={shlex.quote(session_label)}; "
+            f"export WIKIMEDIA_PARTNER_DIR={shlex.quote(base)}; "
             f"{single_item_env}"
         )
         dl_age_opt = (

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -528,7 +528,10 @@ def main() -> None:
         ]
     )
     target_blocks = []
-    for canonical, institution, session_label, dpla_id, collection in targets:
+    last_idx = len(targets) - 1
+    for idx, (canonical, institution, session_label, dpla_id, collection) in enumerate(
+        targets
+    ):
         pdir = PARTNER_DIR.get(canonical, canonical)
         base = f"/home/ec2-user/ingest-wikimedia/{pdir}"
         # Use a per-target CSV filename so concurrent institution-level and
@@ -558,10 +561,19 @@ def main() -> None:
         )
         # WIKIMEDIA_PARTNER_DIR is read by notify_pipeline_fail() to locate
         # the most recent log for this target and include a tail + counts in
-        # the Slack failure message.
+        # the Slack failure message.  WIKIMEDIA_TARGET_IS_LAST switches the
+        # failure suffix language ("no further targets in batch" vs
+        # "skipping to next target"); the unset is required so a failure
+        # earlier in the batch doesn't inherit a stale "is last" flag.
+        is_last_env = (
+            "export WIKIMEDIA_TARGET_IS_LAST=1"
+            if idx == last_idx
+            else "unset WIKIMEDIA_TARGET_IS_LAST"
+        )
         label_export = (
             f"export WIKIMEDIA_SESSION_LABEL={shlex.quote(session_label)}; "
             f"export WIKIMEDIA_PARTNER_DIR={shlex.quote(base)}; "
+            f"{is_last_env}; "
             f"{single_item_env}"
         )
         dl_age_opt = (

--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -212,8 +212,10 @@ def main() -> None:
     if partner:
         session_name += f"-{partner}"
 
+    # `rc=$?` captures the failing step's exit code so the Slack message can
+    # decode signals like 137 (SIGKILL / probable OOM) and 143 (SIGTERM).
     notify_fail_cmd = (
-        "python3 -c "
+        "rc=$?; WIKIMEDIA_LAST_EXIT=$rc python3 -c "
         "'from ingest_wikimedia.slack import notify_pipeline_fail; notify_pipeline_fail()'"
     )
     setup = " && ".join(
@@ -233,8 +235,12 @@ def main() -> None:
         pdir = PARTNER_DIR.get(slug, slug)
         base = shlex.quote(f"/home/ec2-user/ingest-wikimedia/{pdir}")
         session_label = f"retry-{slug}"
+        # WIKIMEDIA_PARTNER_DIR is read by notify_pipeline_fail() to locate the
+        # most recent log for this target and include a tail + counts in the
+        # Slack failure message.
         label_export = (
             f"export WIKIMEDIA_SESSION_LABEL={shlex.quote(session_label)}; "
+            f"export WIKIMEDIA_PARTNER_DIR={base}; "
             "unset WIKIMEDIA_SINGLE_ITEM"
         )
         download_csv = type_csvs.get("download")

--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -231,16 +231,26 @@ def main() -> None:
     # safe: the uploader checks each file's SHA-1 against Commons before uploading
     # and skips files already present, so re-running on overlapping IDs is harmless.
     target_blocks = []
-    for slug, type_csvs in hub_csvs.items():
+    hub_items = list(hub_csvs.items())
+    last_idx = len(hub_items) - 1
+    for idx, (slug, type_csvs) in enumerate(hub_items):
         pdir = PARTNER_DIR.get(slug, slug)
         base = shlex.quote(f"/home/ec2-user/ingest-wikimedia/{pdir}")
         session_label = f"retry-{slug}"
         # WIKIMEDIA_PARTNER_DIR is read by notify_pipeline_fail() to locate the
         # most recent log for this target and include a tail + counts in the
-        # Slack failure message.
+        # Slack failure message.  WIKIMEDIA_TARGET_IS_LAST switches the failure
+        # suffix language for the last target so single-target retries don't
+        # claim to be "skipping to next target" when there isn't one.
+        is_last_env = (
+            "export WIKIMEDIA_TARGET_IS_LAST=1"
+            if idx == last_idx
+            else "unset WIKIMEDIA_TARGET_IS_LAST"
+        )
         label_export = (
             f"export WIKIMEDIA_SESSION_LABEL={shlex.quote(session_label)}; "
             f"export WIKIMEDIA_PARTNER_DIR={base}; "
+            f"{is_last_env}; "
             "unset WIKIMEDIA_SINGLE_ITEM"
         )
         download_csv = type_csvs.get("download")

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,0 +1,105 @@
+"""Tests for the pure helpers in ingest_wikimedia.slack.
+
+The network-touching paths (`post_message`, `notify_pipeline_fail`'s actual
+HTTP call) are not covered here — these tests exercise the decoding /
+log-summary logic that produces the message body.
+"""
+
+import os
+import tempfile
+import time
+
+import pytest
+
+from ingest_wikimedia.slack import (
+    _decode_exit_code,
+    _find_latest_log,
+    _summarize_log,
+)
+
+
+@pytest.mark.parametrize(
+    "rc, expected",
+    [
+        ("0", ""),
+        ("", ""),
+        (None, ""),
+        ("not-a-number", ""),
+        ("1", " (exit 1)"),
+        ("2", " (exit 2)"),
+        ("137", " (exit 137 — SIGKILL — likely OOM)"),
+        ("143", " (exit 143 — SIGTERM)"),
+        ("139", " (exit 139 — SIGSEGV)"),
+        ("134", " (exit 134 — SIGABRT)"),
+        ("130", " (exit 130 — SIGINT (Ctrl-C))"),
+        # >128 but not in the named table → generic "signal N" hint
+        ("150", " (exit 150 — signal 22)"),
+        ("129", " (exit 129 — signal 1)"),
+    ],
+)
+def test_decode_exit_code(rc, expected):
+    assert _decode_exit_code(rc) == expected
+
+
+def test_find_latest_log_picks_most_recent_match(tmp_path):
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    label = "nara+center-for-legislative-archives"
+
+    # Two matching logs at different mtimes plus one non-matching log.
+    older = logs_dir / f"20260520-100000-{label}-download.log"
+    newer = logs_dir / f"20260522-211856-{label}-upload.log"
+    decoy = logs_dir / "20260522-220000-other-label-upload.log"
+    for p in (older, newer, decoy):
+        p.write_text("x")
+    os.utime(older, (time.time() - 3600, time.time() - 3600))
+    os.utime(newer, (time.time(), time.time()))
+
+    found = _find_latest_log(str(tmp_path), label)
+    assert found == str(newer)
+
+
+def test_find_latest_log_returns_none_when_no_match(tmp_path):
+    (tmp_path / "logs").mkdir()
+    assert _find_latest_log(str(tmp_path), "nope") is None
+
+
+def test_find_latest_log_handles_missing_dir():
+    with tempfile.TemporaryDirectory() as t:
+        # No logs/ subdir, no matching files.
+        assert _find_latest_log(t, "anything") is None
+    # Non-existent path.
+    assert _find_latest_log("/nonexistent/path", "anything") is None
+    # Empty partner_dir.
+    assert _find_latest_log("", "anything") is None
+
+
+def test_summarize_log_counts_markers_and_tails_last_lines(tmp_path):
+    log = tmp_path / "test.log"
+    lines = [
+        "[INFO] Starting upload",
+        "[INFO] Uploaded to https://commons.wikimedia.org/wiki/File:Foo.jpg",
+        "[INFO] Uploaded to https://commons.wikimedia.org/wiki/File:Bar.jpg",
+        "[INFO] Skipping abc 1: Already exists on commons.",
+        "[INFO] Skipping abc 2: Already exists on commons.",
+        "[INFO] Skipping abc 3: Already exists on commons.",
+        "[INFO] Skipping def 1: Bad content type.",
+        "[ERROR] Failed: Upload error for xyz",
+        "[INFO] Page 100",
+    ]
+    log.write_text("\n".join(lines) + "\n")
+
+    summary = _summarize_log(str(log), tail_lines=3)
+    assert summary is not None
+    assert "test.log" in summary
+    assert "2 uploaded" in summary
+    # All four "Skipping" lines (3x already-exists + 1x bad-content-type).
+    assert "4 skipped" in summary
+    assert "1 failed" in summary
+    # Tail should show the last 3 lines.
+    assert "Page 100" in summary
+    assert "Failed: Upload error" in summary
+
+
+def test_summarize_log_missing_file_returns_none(tmp_path):
+    assert _summarize_log(str(tmp_path / "nope.log")) is None

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -8,6 +8,7 @@ log-summary logic that produces the message body.
 import os
 import tempfile
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -15,6 +16,7 @@ from ingest_wikimedia.slack import (
     _decode_exit_code,
     _find_latest_log,
     _summarize_log,
+    notify_pipeline_fail,
 )
 
 
@@ -103,3 +105,61 @@ def test_summarize_log_counts_markers_and_tails_last_lines(tmp_path):
 
 def test_summarize_log_missing_file_returns_none(tmp_path):
     assert _summarize_log(str(tmp_path / "nope.log")) is None
+
+
+def _capture_message(env: dict) -> str:
+    """Run notify_pipeline_fail() with `env` and return the posted message."""
+    sent = {}
+
+    def fake_post(token, text):
+        sent["text"] = text
+
+    with (
+        patch.dict(os.environ, env, clear=True),
+        patch("ingest_wikimedia.slack.post_message", side_effect=fake_post),
+    ):
+        notify_pipeline_fail()
+    return sent.get("text", "")
+
+
+def test_notify_pipeline_fail_says_skipping_to_next_when_not_last():
+    msg = _capture_message(
+        {
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": "nara+foo",
+            "WIKIMEDIA_LAST_EXIT": "1",
+        }
+    )
+    assert "skipping to next target" in msg
+    assert "no further targets in batch" not in msg
+
+
+def test_notify_pipeline_fail_says_no_further_when_last():
+    msg = _capture_message(
+        {
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": "nara+foo",
+            "WIKIMEDIA_LAST_EXIT": "137",
+            "WIKIMEDIA_TARGET_IS_LAST": "1",
+        }
+    )
+    assert "no further targets in batch" in msg
+    assert "skipping to next target" not in msg
+    # The OOM hint should still be included.
+    assert "SIGKILL" in msg
+
+
+def test_notify_pipeline_fail_treats_any_value_other_than_1_as_not_last():
+    # Defensive: an empty or "0" value should be treated as "not last" so a
+    # half-set env doesn't accidentally claim there are no more targets.
+    for value in ("", "0", "false", "no"):
+        msg = _capture_message(
+            {
+                "DPLA_SLACK_BOT_TOKEN": "x",
+                "WIKIMEDIA_SESSION_LABEL": "x",
+                "WIKIMEDIA_TARGET_IS_LAST": value,
+            }
+        )
+        assert "skipping to next target" in msg, (
+            f"value {value!r} should be treated as not-last"
+        )


### PR DESCRIPTION
## Problem

When a target in a multi-target wikimedia run fails, Slack gets the generic message:

> ❌ \`wikimedia-<label>\`: pipeline step failed — skipping to next target

That gives no signal on cause. The 2026-05-22 \`nara+center-for-legislative-archives\` OOM kill was a concrete case: the uploader hit ~5.7 GB RSS, the kernel SIGKILLed it, bash saw exit 137, the message above was posted — but with no way to tell from Slack alone whether this was an OOM, a SIGTERM, a normal exception, or how much work had completed before the failure.  Required SSM-ing into the box and tailing logs to learn anything.

## Change

\`notify_pipeline_fail()\` now optionally reads two new env vars and uses them to enrich the message:

| Env var | Source | Effect |
|---|---|---|
| \`WIKIMEDIA_LAST_EXIT\` | \`rc=\$?\` in the bash failure handler | Decoded into a hint: \`137 → SIGKILL — likely OOM\`, \`143 → SIGTERM\`, \`139 → SIGSEGV\`, \`134 → SIGABRT\`, \`130 → SIGINT\`. Anything else >128 falls back to \`signal N\`. |
| \`WIKIMEDIA_PARTNER_DIR\` | Set alongside \`WIKIMEDIA_SESSION_LABEL\` in the launch script | Used to locate \`<partner_dir>/logs/*-<label>-*.log\`, read the last ~2 MB, count progress markers, and tail the last 8 lines into the Slack message. |

Both env vars are optional — if either is missing, the new code degrades cleanly to the original generic message. Both \`scripts/wikimedia_launch.py\` and \`scripts/wikimedia_retry.py\` now set them.

The progress markers counted (cheap regex pass over the tail of the log):

- \`uploaded\` — \`Uploaded to https://commons…\`
- \`skipped\` — \`[INFO] Skipping …\`
- \`downloaded\` — \`[INFO] Downloaded …\`
- \`failed\` — \`[(ERROR|WARNING)] … Failed\`

Skip subcategories aren't split (e.g. \"already on Commons\" vs \"bad content type\") because the patterns overlap and double-count. The log tail conveys reasons more usefully anyway.

## What the same Slack message would look like now

\`\`\`
❌ \`wikimedia-nara+center-for-legislative-archives\`: pipeline step failed (exit 137 — SIGKILL — likely OOM) — skipping to next target
Log: \`20260522-211856-nara+center-for-legislative-archives-upload.log\`
Counts so far: 369 uploaded, 367 skipped
Last lines:
\`\`\`\`
[INFO] 23:59:56: Skipping 405714d95f606141d383ccc3ef22908b 366: Already exists on commons.
[INFO] 23:59:57: Hash drift for 405714d95f606141d383ccc3ef22908b 369: SHA1 found at same-item page 369; uploading to correct title only.
\`\`\`\`
\`\`\`

## Test plan

- 18 new tests in \`tests/test_slack.py\` — all pass on Python 3.13. Covers:
  - exit-code decoding (every named signal + a few generic >128 + invalid input)
  - log-file matching (correct mtime priority, label-collision avoidance, missing dir / missing file fall-through)
  - log summary (marker counts, tail-line extraction, missing-file handling)
- The added env-var contract is purely additive — running the deployed code with the OLD launcher (no \`WIKIMEDIA_LAST_EXIT\` / \`WIKIMEDIA_PARTNER_DIR\` set) produces exactly the original message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR enriches Slack pipeline-failure notifications by decoding exit codes and attaching compact tails of partner logs when available.

### Key Changes
- ingest_wikimedia/slack.py
  - Decodes WIKIMEDIA_LAST_EXIT into human-readable hints for common signal-encoded exit codes (e.g., 137 → SIGKILL — likely OOM; 143 → SIGTERM; 139 → SIGSEGV; 134 → SIGABRT; 130 → SIGINT). Unknown codes >128 fall back to "signal N".
  - Locates the most recently modified partner log under WIKIMEDIA_PARTNER_DIR matching WIKIMEDIA_SESSION_LABEL, reads the last ~2 MB, counts progress markers via regex (uploaded, skipped, downloaded, failed), and appends a compact summary including the last ~8 lines to the Slack message.
  - Honors WIKIMEDIA_TARGET_IS_LAST to choose wording ("skipping to next target" vs "no further targets in batch").
  - Handles a race where a candidate log file can disappear between globbing and stat by skipping OSError-raising candidates and falling back to None if none remain.

- scripts/wikimedia_launch.py and scripts/wikimedia_retry.py
  - Capture step exit status (rc=$?) and export it as WIKIMEDIA_LAST_EXIT for the notifier.
  - Export WIKIMEDIA_PARTNER_DIR alongside WIKIMEDIA_SESSION_LABEL so the notifier can locate partner logs.
  - Export WIKIMEDIA_TARGET_IS_LAST for the final target (unset for earlier targets) so notifier wording reflects whether more targets remain.

- tests/test_slack.py
  - Adds ~18 tests covering exit-code decoding, log-file matching (mtime selection, label-collision behavior, missing dir/file), log summarization (marker counts and tail inclusion), and notify_pipeline_fail message variations based on WIKIMEDIA_TARGET_IS_LAST.
  - Tests pass on Python 3.13 (per author).

### Environment Variable Changes
This PR introduces (adds) the following optional environment variables (backward-compatible):
- WIKIMEDIA_LAST_EXIT — exit code captured by launcher scripts for richer hints in Slack messages.
- WIKIMEDIA_PARTNER_DIR — base partner directory used to locate logs for the session label.
- WIKIMEDIA_TARGET_IS_LAST — flag exported by launcher scripts when the current target is the final one to adjust message wording.

No existing environment variables or AWS Secrets Manager keys are removed or renamed.

### Deployment & Infrastructure Notes
- No database migrations, API response changes, IAM policy changes, or shared infra config (CodePipeline/CodeBuild/ECS task definitions) are included.
- To get the enriched Slack messages at runtime, the updated launcher scripts must be deployed (the scripts export the new env vars). A normal code deploy of the updated scripts suffices; no special manual pipeline trigger or ECS redeployment beyond the deploy of these changes is required.
- No new Secrets Manager keys are added.

### Security & Safety
- No new credentials or secret handling introduced.
- The notifier reads local partner log files from a directory provided via WIKIMEDIA_PARTNER_DIR (no network fetches). This exposes snippets of log contents in Slack messages; ensure partner log content is acceptable to surface in notifications.
- The change is additive and backward-compatible when the new env vars are absent.

### Tests
- ~18 new unit tests added for slack helpers and notify_pipeline_fail behavior; added tests exercise decoding, log discovery, summarization, and message variations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->