### PR TITLE
uploader: stop creating duplicate Commons files on same-item hash drift

### DIFF
--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -48,7 +48,6 @@ from ingest_wikimedia.wikimedia import (
     wikimedia_url,
     find_file_by_hash,
     extract_dpla_id_from_commons_title,
-    extract_page_ordinal_from_commons_title,
     is_same_item_redirect_relic,
     merge_preserved_wikitext,
     tag_as_duplicate,
@@ -594,33 +593,25 @@ class Uploader:
         actual_filename = existing_file.title(with_ns=False)
 
         # --- Hash collision safety check ---
-        # If the file at the wrong title was uploaded for a different DPLA ID
-        # and that ID is still a valid item, don't move or tag it — just upload
-        # our hash to the correct title and leave their file alone. This prevents
-        # ping-pong renaming between two valid items that happen to share a hash.
+        # Cross-item collision: the file at the wrong title was uploaded for a
+        # different DPLA ID.  If that other ID is still a valid item, we don't
+        # move or tag — just upload our hash to the correct title and leave
+        # their file alone.  This prevents ping-pong renaming between two
+        # valid items that happen to share a hash.
+        #
+        # Same-item collision (same DPLA ID, different title) — including the
+        # post-PR-#173 case where the page-suffix on the existing file no
+        # longer matches the new naming scheme — always falls through to the
+        # Case 1/2/3 migration logic below.  A previous version of this code
+        # special-cased "same DPLA ID, different parsed ordinal" by returning
+        # "upload_only" to avoid disturbing a hypothetical hash-coincidence
+        # between two pages of the same item, but that branch fired routinely
+        # whenever PR #173's per-extension page-label scheme produced a
+        # different (or no) (page N) suffix from the existing Commons file —
+        # creating a silent duplicate at the new title while the old file
+        # stayed orphaned.  The invariant is: a given SHA1 should live at
+        # exactly one Commons title for a given DPLA ID, so always migrate.
         existing_dpla_id = extract_dpla_id_from_commons_title(actual_filename)
-        if existing_dpla_id == dpla_id:
-            # Same DPLA item — distinguish two cases:
-            #   (a) different page of a multi-page item carrying a coincident
-            #       sha1 (e.g. source-institution re-scan whose new page-N hash
-            #       matches what was uploaded as page-M last run). Don't move
-            #       or tag — the right ordinal will be uploaded directly.
-            #   (b) same logical page but the free-text portion of the title
-            #       changed across runs (a legitimate rename). Fall through so
-            #       Case 1/3 can move the existing file to the new title.
-            actual_page = extract_page_ordinal_from_commons_title(actual_filename)
-            intended_page = extract_page_ordinal_from_commons_title(page_title)
-            # Compare the two parsed ordinals so the decision is based on logical
-            # Commons page numbering rather than the S3 iteration index (which
-            # can diverge from intended_page in edge cases). None==None for a
-            # single-page item title-text rename falls through to Case 1/3.
-            if actual_page != intended_page:
-                logging.info(
-                    f"Hash drift for {dpla_id} {ordinal}: SHA1 found at "
-                    f"same-item page {actual_page} [[File:{actual_filename}]]; "
-                    f"uploading to correct title only."
-                )
-                return "upload_only"
 
         if existing_dpla_id and existing_dpla_id != dpla_id:
             try:


### PR DESCRIPTION
## Problem

The 2026-05-22 \`nara+center-for-legislative-archives\` upload session created ~877 confirmed duplicate Commons files before it was OOM-killed.  Every multi-file item in the CSV had a \`.jpg\` + \`.pdf\` pair; the uploader treated each page as same-item hash drift and silently uploaded a *new* file at the un-suffixed title while leaving the existing \`(page N)\` file orphaned.

### Concrete example

DPLA item \`0013a4d7803043534194e0259d1bade7\` — *Petition from People for the American Way Opposed to the Flag Burning Constitutional Amendment*:

- **Old title (still on Commons, untouched):** \`Petition… - DPLA - 0013a4d7… (page 1).jpg\`
- **New title (newly uploaded by the killed session):** \`Petition… - DPLA - 0013a4d7….jpg\` — bit-identical content, no \`(page N)\` suffix.

Two Commons files. Same SHA-1. No redirect, no \`{{Duplicate}}\` tag connecting them. ~876 more like this.

## Root cause

\`_resolve_hash_drift\` returned \`\"upload_only\"\` for *same-item* drift whenever the parsed \`(page N)\` ordinal of the existing file differed from the intended title's ordinal.  The branch was intended to skip the rare case where two pages of one item happen to share a SHA-1.

PR #173 (merged 2026-05-15) changed the Commons title scheme to only number files within same-extension groups.  Items with mixed extensions (\`.jpg\` + \`.pdf\`) now produce intended titles **with no \`(page N)\` suffix**, while existing Commons files still have their old suffix.  The ordinals never match — the branch fires on every page — and the design invariant *\"one SHA-1 should live at exactly one Commons title for a given DPLA ID\"* is silently broken.

## Fix

Remove the same-item-different-ordinal early \`return \"upload_only\"\`.  All same-item drift now falls through to the existing Case 1/2/3 migration logic:

- **Case 3** (intended title is free): server-side **move** of the existing file to the new title, leaving a redirect at the old title.  This is the dominant case for PR #173-induced drift.
- **Case 1** (intended is a redirect to our existing file): same move.
- **Case 2** (intended title has different content): \`upload_and_tag\` — upload the correct hash at the intended title and tag the old title as a duplicate.

Cross-item collision handling (the original \`upload_only\` use case) is unchanged.

The genuine same-item SHA-1-coincidence case that the old branch protected is still safe in practice: \`find_file_by_hash\` ranks the file at \`preferred_title\` first, so when both pages are correctly at their per-extension labels, each call finds its own page and short-circuits to **SKIP** without reaching \`_resolve_hash_drift\` at all.

## Test plan

- Full test suite passes on EC2 (Python 3.13): 99 passed, 1 pre-existing s3-mock failure unrelated to this change.
- Once merged, the next session that processes a mixed-extension item will move the old \`(page N)\` file to its new un-suffixed title rather than creating a duplicate.  Subsequent runs will see the file at its intended title and SKIP cleanly.

## Cleanup of damage from the killed session

Not addressed in this PR.  The ~877 duplicate Commons files from the 2026-05-22 Center for Legislative Archives session still exist (old \`(page N)\` files + new un-suffixed copies).  A follow-up task should either tag the old files as duplicates or move them and redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes a bug that caused duplicate Wikimedia Commons files when the same DPLA item produced pages with different file extensions (e.g., .jpg + .pdf). After PR `#173` removed “(page N)” suffixes for single-extension items, existing Commons files kept the old suffixed names. _resolve_hash_drift previously returned upload_only for same-DPLA-item hash collisions when parsed page ordinals differed, causing the uploader to create new unsuffixed files and leave the old suffixed files orphaned (≈877 duplicates observed in a 2026-05-22 run). This PR removes that early upload_only return so same-item collisions follow the existing migration logic instead of creating duplicates.

## Changes

- tools/uploader.py:
  - Removed import of extract_page_ordinal_from_commons_title.
  - Updated _resolve_hash_drift: eliminate the early upload_only branch for same-DPLA-item collisions with differing parsed ordinals so those cases fall through to the standard Case 1/2/3 migration handling:
    - Case 3: server-side move of the existing file to the intended title (redirect left at old title).
    - Case 1: same server-side move when intended title redirects to the existing file.
    - Case 2: upload_and_tag — upload correct content at the intended title and tag the old title as a duplicate.
  - Cross-item collision handling is unchanged: if the colliding hash is owned by a different, verifiable DPLA item, the method still returns upload_only to avoid interfering with another item’s files.

Tests: Full suite run on EC2 (Python 3.13) — 99 tests passed; 1 pre-existing, unrelated s3-mock failure.

Cleanup: Removal of the ~877 duplicate files produced by the killed session is not included in this PR.

## Deployment & Infrastructure

- No manual pipeline trigger or ECS redeployment required for this code change.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No public-facing API changes.
- No security-sensitive changes (no auth or credential handling changes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->