### PR TITLE
categories: close Wikidata replication-lag race that lands files in 'unknown institution'

### DIFF
--- a/ingest_wikimedia/categories.py
+++ b/ingest_wikimedia/categories.py
@@ -31,8 +31,24 @@ class CategoryEnsurer:
         self.commons_site = commons_site
         self.dry_run = dry_run
         self._ensured: set[str] = set()
+        # Institutions for which this session actually created new P8464
+        # infrastructure (i.e. took the slow path in ensure()).  Callers can read
+        # this to know whose files may have lost the race against Wikidata
+        # replication lag and should be touched after upload to force re-render.
+        self._newly_created: set[str] = set()
         self._hub_category_qids: dict[str, str] = {}
         self._wikidata_repo: BaseSite | None = None
+
+    @property
+    def newly_created(self) -> set[str]:
+        """Q-IDs of institutions whose P8464 was first added in this session.
+
+        Subsequent uploads of these institutions' files can race Wikidata's
+        replication to Commons and land in `Media contributed by the Digital
+        Public Library of America with unknown institution`.  See
+        :func:`touch_institution_files`.
+        """
+        return self._newly_created.copy()
 
     @property
     def _repo(self) -> BaseSite:
@@ -115,6 +131,10 @@ class CategoryEnsurer:
         logging.info(f"Added P8464 to {institution_qid} → {category_qid}")
 
         self._ensured.add(institution_qid)
+        # Reaching this point means we actually wrote new infrastructure this
+        # session.  Track separately so callers can force-rerender the
+        # institution's files once Wikidata replication has settled.
+        self._newly_created.add(institution_qid)
 
     def _get_hub_category_qid(self, hub_institution_qid: str) -> str:
         """
@@ -261,3 +281,42 @@ class CategoryEnsurer:
             self._item_claim("P8464", category_qid),
             summary="Add Commons content partnership category.",
         )
+
+
+def touch_institution_files(
+    commons_site: BaseSite,
+    institution_qid: str,
+    log_each: bool = False,
+) -> int:
+    """Force-rerender all Commons file pages that reference this institution.
+
+    Used to clear the Wikidata-replication-lag race: when CategoryEnsurer first
+    adds a ``P8464`` claim to an institution's Wikidata item, files uploaded in
+    the seconds immediately after may have rendered before the claim
+    propagated to Commons' Wikibase client cache.  Those files land in
+    ``Category:Media contributed by the Digital Public Library of America with
+    unknown institution`` and stay there until something forces re-render.
+
+    A null edit (``page.touch()``) is enough — MediaWiki re-expands the
+    ``{{ Institution | wikidata = Q… }}`` template, picks up the now-visible
+    ``P8464``, and the file moves to the correct category.
+
+    If ``log_each`` is True, every touched file is logged at INFO level (used
+    by ``fix-unknown-categories --verbose``).  Per-page errors are always
+    logged as warnings and counted as failures but don't abort the loop.
+
+    Returns the number of files successfully touched.
+    """
+    count = 0
+    for page in commons_site.search(
+        f'insource:"Institution" insource:"wikidata = {institution_qid}"',
+        namespaces=[6],
+    ):
+        if log_each:
+            logging.info(f"  Touching: {page.title()}")
+        try:
+            page.touch()
+            count += 1
+        except Exception as e:
+            logging.warning(f"Failed to touch '{page.title()}'", exc_info=e)
+    return count

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,164 @@
+"""Tests for ingest_wikimedia.categories.
+
+Focus is on the two pieces of new state/behaviour we rely on for the post-
+upload touch flow:
+
+* ``CategoryEnsurer.newly_created`` populates only when ``ensure()`` actually
+  writes new P8464 infrastructure — not on any of the three fast-paths.
+* ``touch_institution_files()`` iterates Commons' search results and calls
+  ``touch()`` on each, surviving per-page errors.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from ingest_wikimedia.categories import CategoryEnsurer, touch_institution_files
+
+
+def _new_ensurer():
+    """A CategoryEnsurer with a mocked commons_site, ready for unit tests."""
+    return CategoryEnsurer(commons_site=MagicMock())
+
+
+def test_newly_created_is_empty_initially():
+    e = _new_ensurer()
+    assert e.newly_created == set()
+
+
+def test_newly_created_skips_already_ensured_session_cache():
+    e = _new_ensurer()
+    e._ensured.add("Q100")
+    # ensure() should short-circuit on the session cache without touching
+    # _newly_created.
+    e.ensure("Q100", "Foo Institution", "Q999")
+    assert e.newly_created == set()
+
+
+def test_newly_created_skips_when_commons_category_already_exists():
+    e = _new_ensurer()
+    with patch.object(e, "_commons_category_exists", return_value=True):
+        e.ensure("Q200", "Foo Institution", "Q999")
+    assert e.newly_created == set()
+    assert "Q200" in e._ensured  # still marked as ensured for session
+
+
+def test_newly_created_skips_when_wikidata_p8464_already_set():
+    e = _new_ensurer()
+    with (
+        patch.object(e, "_commons_category_exists", return_value=False),
+        patch.object(e, "_institution_has_category", return_value=True),
+    ):
+        e.ensure("Q300", "Foo Institution", "Q999")
+    assert e.newly_created == set()
+    assert "Q300" in e._ensured
+
+
+def test_newly_created_populates_on_actual_creation():
+    e = _new_ensurer()
+    with (
+        patch.object(e, "_commons_category_exists", return_value=False),
+        patch.object(e, "_institution_has_category", return_value=False),
+        patch.object(e, "_get_hub_category_qid", return_value="Q888"),
+        patch.object(e, "_create_commons_category"),
+        patch.object(e, "_get_or_create_wikidata_category_item", return_value="Q777"),
+        patch.object(e, "_add_p8464_to_institution"),
+    ):
+        e.ensure("Q400", "Foo Institution", "Q999")
+    assert e.newly_created == {"Q400"}
+
+
+def test_newly_created_is_a_copy_not_the_internal_set():
+    e = _new_ensurer()
+    e._newly_created.add("Q500")
+    snapshot = e.newly_created
+    snapshot.add("Q501")
+    assert "Q501" not in e._newly_created
+
+
+def test_dry_run_does_not_count_as_newly_created():
+    """Dry-run goes through the slow path but doesn't actually write P8464.
+
+    The flag exists so callers know "if you touch these files now, they'll
+    pick up the new claim".  Dry-run means no claim was written, so post-run
+    touching would be a no-op at best and misleading at worst.
+    """
+    e = CategoryEnsurer(commons_site=MagicMock(), dry_run=True)
+    with (
+        patch.object(e, "_commons_category_exists", return_value=False),
+        patch.object(e, "_institution_has_category", return_value=False),
+        patch.object(e, "_get_hub_category_qid", return_value="Q888"),
+    ):
+        e.ensure("Q600", "Foo Institution", "Q999")
+    assert e.newly_created == set()
+
+
+def test_touch_institution_files_touches_each_search_hit():
+    site = MagicMock()
+    pages = [MagicMock(), MagicMock(), MagicMock()]
+    for i, p in enumerate(pages):
+        p.title.return_value = f"File:Foo page {i}.jpg"
+    site.search.return_value = iter(pages)
+
+    n = touch_institution_files(site, "Q123")
+
+    assert n == 3
+    for p in pages:
+        p.touch.assert_called_once()
+
+
+def test_touch_institution_files_continues_after_per_page_failure():
+    site = MagicMock()
+    good_a, bad, good_b = MagicMock(), MagicMock(), MagicMock()
+    for i, p in enumerate((good_a, bad, good_b)):
+        p.title.return_value = f"File:p{i}.jpg"
+    bad.touch.side_effect = RuntimeError("boom")
+    site.search.return_value = iter([good_a, bad, good_b])
+
+    n = touch_institution_files(site, "Q123")
+
+    assert n == 2
+    good_a.touch.assert_called_once()
+    good_b.touch.assert_called_once()
+
+
+def test_touch_institution_files_uses_expected_search_query():
+    site = MagicMock()
+    site.search.return_value = iter([])
+    touch_institution_files(site, "Q42")
+    site.search.assert_called_once_with(
+        'insource:"Institution" insource:"wikidata = Q42"', namespaces=[6]
+    )
+
+
+def test_touch_institution_files_log_each_logs_per_touch(caplog):
+    """``log_each=True`` (used by fix-unknown-categories --verbose) logs each touched title."""
+    import logging as _logging
+
+    site = MagicMock()
+    page_a, page_b = MagicMock(), MagicMock()
+    page_a.title.return_value = "File:A.jpg"
+    page_b.title.return_value = "File:B.jpg"
+    site.search.return_value = iter([page_a, page_b])
+
+    with caplog.at_level(_logging.INFO):
+        touch_institution_files(site, "Q1", log_each=True)
+
+    messages = " | ".join(r.message for r in caplog.records)
+    assert "File:A.jpg" in messages
+    assert "File:B.jpg" in messages
+
+
+def test_touch_institution_files_default_does_not_log_per_touch(caplog):
+    import logging as _logging
+
+    site = MagicMock()
+    page = MagicMock()
+    page.title.return_value = "File:Only.jpg"
+    site.search.return_value = iter([page])
+
+    with caplog.at_level(_logging.INFO):
+        touch_institution_files(site, "Q1")
+
+    messages = " | ".join(r.message for r in caplog.records)
+    # The "Touching: ..." per-page line should NOT appear by default; this is
+    # the regression guard for the new opt-in `log_each` flag.
+    assert "Touching" not in messages

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,0 +1,98 @@
+"""Tests for tools/uploader.py helpers.
+
+Currently focused on the end-of-run touch flow added to close the Wikidata
+replication-lag race that lands first-batch files in the unknown-institution
+category.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from tools.uploader import _post_upload_touch_new_institutions
+
+
+def _ensurer_with(newly_created: set[str]) -> MagicMock:
+    """Build a mock category_ensurer whose `newly_created` returns the given set."""
+    m = MagicMock()
+    # `newly_created` is a property on the real class; mirror that on the mock
+    # so attribute access (not call) returns the set.
+    type(m).newly_created = property(lambda self: set(newly_created))
+    return m
+
+
+def test_skips_when_category_ensurer_is_none():
+    with (
+        patch("tools.uploader.time.sleep") as sleep_mock,
+        patch("tools.uploader.touch_institution_files") as touch_mock,
+    ):
+        _post_upload_touch_new_institutions(MagicMock(), None, dry_run=False)
+    sleep_mock.assert_not_called()
+    touch_mock.assert_not_called()
+
+
+def test_skips_when_dry_run():
+    ensurer = _ensurer_with({"Q1", "Q2"})
+    with (
+        patch("tools.uploader.time.sleep") as sleep_mock,
+        patch("tools.uploader.touch_institution_files") as touch_mock,
+    ):
+        _post_upload_touch_new_institutions(MagicMock(), ensurer, dry_run=True)
+    sleep_mock.assert_not_called()
+    touch_mock.assert_not_called()
+
+
+def test_skips_when_newly_created_is_empty():
+    ensurer = _ensurer_with(set())
+    with (
+        patch("tools.uploader.time.sleep") as sleep_mock,
+        patch("tools.uploader.touch_institution_files") as touch_mock,
+    ):
+        _post_upload_touch_new_institutions(MagicMock(), ensurer, dry_run=False)
+    sleep_mock.assert_not_called()
+    touch_mock.assert_not_called()
+
+
+def test_sleeps_then_touches_each_newly_created_qid():
+    ensurer = _ensurer_with({"Q1", "Q2", "Q3"})
+    site = MagicMock()
+    with (
+        patch("tools.uploader.time.sleep") as sleep_mock,
+        patch("tools.uploader.touch_institution_files", return_value=4) as touch_mock,
+        patch("tools.uploader._REPLICATION_SETTLE_SECS", 10),
+    ):
+        _post_upload_touch_new_institutions(site, ensurer, dry_run=False)
+
+    sleep_mock.assert_called_once_with(10)
+    assert touch_mock.call_count == 3
+    qids_touched = {call.args[1] for call in touch_mock.call_args_list}
+    assert qids_touched == {"Q1", "Q2", "Q3"}
+    for call in touch_mock.call_args_list:
+        assert call.args[0] is site
+
+
+def test_per_qid_exception_does_not_stop_remaining_qids(caplog):
+    """If touch_institution_files raises for one institution, log it and
+    keep going for the others — losing one is far better than losing all."""
+    import logging as _logging
+
+    ensurer = _ensurer_with({"Q_good_1", "Q_bad", "Q_good_2"})
+
+    def side_effect(site, qid, **kwargs):
+        if qid == "Q_bad":
+            raise RuntimeError("simulated commons search failure")
+        return 7
+
+    with (
+        patch("tools.uploader.time.sleep"),
+        patch(
+            "tools.uploader.touch_institution_files", side_effect=side_effect
+        ) as touch_mock,
+        caplog.at_level(_logging.INFO),
+    ):
+        _post_upload_touch_new_institutions(MagicMock(), ensurer, dry_run=False)
+
+    qids_attempted = {call.args[1] for call in touch_mock.call_args_list}
+    assert qids_attempted == {"Q_good_1", "Q_bad", "Q_good_2"}
+
+    messages = " | ".join(r.message for r in caplog.records)
+    assert "Q_bad" in messages
+    assert "simulated commons search failure" in messages

--- a/tools/fix_unknown_categories.py
+++ b/tools/fix_unknown_categories.py
@@ -16,7 +16,7 @@ import time
 import click
 import pywikibot
 
-from ingest_wikimedia.categories import CategoryEnsurer
+from ingest_wikimedia.categories import CategoryEnsurer, touch_institution_files
 from ingest_wikimedia.logs import setup_logging
 from ingest_wikimedia.wikimedia import get_site, get_wikidata_site
 
@@ -118,19 +118,7 @@ def main(verbose: bool) -> None:
 
         # Touch all Commons file pages for this institution so the Wikidata Infobox
         # template re-evaluates and moves them out of the unknown-institution category.
-        count = 0
-        for page in commons_site.search(
-            f'insource:"Institution" insource:"wikidata = {institution_qid}"',
-            namespaces=[6],
-        ):
-            if verbose:
-                logging.info(f"  Touching: {page.title()}")
-            try:
-                page.touch()
-                count += 1
-            except Exception as e:
-                logging.warning(f"Failed to touch '{page.title()}'", exc_info=e)
-
+        count = touch_institution_files(commons_site, institution_qid, log_each=verbose)
         files_touched += count
         logging.info(f"Touched {count} files for {institution_name}")
 

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -27,7 +27,7 @@ from ingest_wikimedia.s3 import (
 )
 from ingest_wikimedia.tools_context import ToolsContext
 from ingest_wikimedia.tracker import Result, Tracker
-from ingest_wikimedia.categories import CategoryEnsurer
+from ingest_wikimedia.categories import CategoryEnsurer, touch_institution_files
 from ingest_wikimedia.dpla import (
     SOURCE_RESOURCE_FIELD_NAME,
     DC_TITLE_FIELD_NAME,
@@ -863,12 +863,56 @@ def main(ids_file, partner: str, dry_run: bool, verbose: bool) -> None:
         logging.info("\n" + str(tracker))
         logging.info(f"{elapsed} seconds.")
         local_fs.cleanup_temp_dir()
+        # Touch files for any institutions we set up this session.  Closes the
+        # Wikidata-replication-lag race that lands first-batch files in the
+        # "unknown institution" category; without this we rely on a periodic
+        # run of fix-unknown-categories to clean up after the fact.  The 10s
+        # pause is a cheap belt-and-suspenders against very-late ensure()
+        # calls — for typical runs replication has settled long before this.
+        _post_upload_touch_new_institutions(commons_site, category_ensurer, dry_run)
         notify_upload_complete(
             tracker=tracker,
             partner_label=f"wikimedia-{partner}",
             elapsed_seconds=elapsed,
             dry_run=dry_run,
         )
+
+
+# Wait between the last ensure() and the first touch.  Wikidata→Commons
+# replication is usually sub-second but we've seen first-file misses in
+# practice, so give it real headroom.  Only paid when there's something to
+# touch, which is the rare "new institution this session" case.
+_REPLICATION_SETTLE_SECS = 10
+
+
+def _post_upload_touch_new_institutions(
+    commons_site, category_ensurer: CategoryEnsurer, dry_run: bool
+) -> None:
+    """At end-of-run, force-rerender files for any institutions whose P8464
+    was first added this session — see touch_institution_files() docstring."""
+    if not category_ensurer or dry_run:
+        return
+    newly_created = category_ensurer.newly_created
+    if not newly_created:
+        return
+    logging.info(
+        f"Touching files for {len(newly_created)} newly-created institution(s) "
+        f"to clear any Wikidata-replication race; sleeping "
+        f"{_REPLICATION_SETTLE_SECS}s first..."
+    )
+    time.sleep(_REPLICATION_SETTLE_SECS)
+    total = 0
+    for inst_qid in sorted(newly_created):
+        try:
+            n = touch_institution_files(commons_site, inst_qid)
+        except Exception as e:
+            logging.warning(f"Search/touch for {inst_qid} failed: {e}")
+            continue
+        logging.info(f"  Touched {n} files for {inst_qid}")
+        total += n
+    logging.info(
+        f"Post-upload touch complete: {total} files across {len(newly_created)} institution(s)"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The uploader already calls `CategoryEnsurer.ensure()` before processing each DPLA item, creating the Commons category + Wikidata item + `P8464` link for any institution we haven't seen before. But there's a small race:

```
T0:   ensure() writes P8464 to Wikidata via API
T0+ε: uploader.upload(first file of the new institution)
T0+ε: Commons parser expands {{ Institution | wikidata = Q… }} and queries
      Wikibase for the claim list. If Wikidata's read replica hasn't yet
      propagated the P8464 write (a few seconds typical) → no P8464 found
      → file rendered into "unknown institution" → stays there until
      someone touches it.
```

We had `fix-unknown-categories` as a periodic backstop. This change closes the race in the uploader itself so the backstop becomes redundant.

## Change

- **`CategoryEnsurer.newly_created`**: a new `set[str]` populated only when `ensure()` actually takes the slow path (creates Commons category → creates Wikidata category item → writes P8464). All three fast-path skips (session cache, Commons category already exists, P8464 already set) leave it alone. Dry-run also leaves it alone — no P8464 was written, so post-run touching would be misleading.
- **`touch_institution_files(commons_site, qid, log_each=False)`**: extracted helper that does the search-and-touch loop used by both code paths. The `log_each` flag preserves `fix-unknown-categories --verbose`'s per-file logging.
- **`tools/uploader.py:main()` `finally`**: after the upload loop, sleep 10s (cheap belt-and-suspenders if the last `ensure()` was very recent) and call `touch_institution_files()` for each `newly_created` institution. Only paid when there's something to touch — typical session creates zero or one institution, so this finally-block runs in <1s most of the time.
- **`tools/fix_unknown_categories.py`**: replaces its inline search+touch with the shared helper (no behavior change; `--verbose` flag continues to work via `log_each=verbose`).

## Test plan

- New `tests/test_categories.py` covers:
  - All four `ensure()` paths: session cache hit, Commons cat already exists, P8464 already set, actual creation
  - `newly_created` returns a copy so callers can't mutate internal state
  - Dry-run does not count as newly created (no P8464 written)
  - `touch_institution_files()`: touches each search hit, survives per-page failures, uses the expected search query, log_each on/off
  - 12 tests, all passing on EC2 Python 3.13

## Operational impact

- Per upload run: one extra 10s sleep and one extra Commons search-and-touch per **newly-created** institution. Typical sessions create zero, so the new code path is a no-op. For sessions that do encounter a new institution, the cost is a few extra API calls at end-of-run.
- The `fix-unknown-categories` tool remains useful for cleaning up legacy "unknown institution" files from before this change, but should no longer have new entries to chase after future upload runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Pull Request Summary

### Problem
A race condition exists between writing P8464 claims to Wikidata and propagation to Commons' Wikibase read replica. When a new institution is created during an upload run, the first files for that institution can be rendered into "unknown institution" category because the replica doesn't yet show the new P8464 claim.

### Solution
The PR introduces tracking of newly-created institutions and a shared helper to force-rerender affected files after Wikidata replication settles:

1. **CategoryEnsurer.newly_created** (property): Returns a copy of an internal `_newly_created` set containing Q-IDs of institutions whose P8464 claim was first added in the current session. Populated only when `ensure()` takes the "slow path" that creates Commons category → Wikidata item → writes P8464; unaffected by cache hits, dry runs, or when category infrastructure already exists.

2. **touch_institution_files()** (new helper): Searches Commons namespace 6 for file pages containing an Institution parameter matching the given Q-ID, then issues null edits via `page.touch()` to force MediaWiki to re-render and pick up the now-visible P8464 claim. Returns count of successfully touched files; logs per-page failures as warnings but continues processing.

3. **tools/uploader.py integration**: Added `_post_upload_touch_new_institutions()` helper that executes in the finally block after cleanup. It sleeps 10 seconds (belt-and-suspenders against late replication) then touches files for each newly-created institution, handling per-institution failures gracefully and logging totals.

4. **tools/fix_unknown_categories.py refactoring**: Replaced inline search+touch loop with call to shared `touch_institution_files()` helper, preserving verbose logging behavior.

### Test Coverage
New tests cover:
- All four `ensure()` code paths and their effect on `newly_created`
- `newly_created` immutability (returns a copy)
- Dry-run behavior (exercises slow path but doesn't populate `newly_created`)
- `touch_institution_files()` search parameters, per-page error handling, and logging
- `_post_upload_touch_new_institutions()` guards (skips when ensurer is None, dry_run=True, or newly_created is empty), sleep behavior, exception handling, and QID ordering

### Operational Impact
- **No deployment or redeployment required** — pure code changes with no configuration, environment variables, or infrastructure changes
- Typical runs with zero newly-created institutions incur no added work
- New-institution runs add one 10-second sleep and one search-and-touch operation per new institution
- `fix-unknown-categories` remains available for legacy cleanup of existing misclassified files
- No impact to public APIs or data structures

### Changes Summary
- `ingest_wikimedia/categories.py`: +59 lines (CategoryEnsurer property + touch_institution_files helper)
- `tools/uploader.py`: +45 lines (replication-settle constant + post-upload touch integration)
- `tools/fix_unknown_categories.py`: -12 lines (refactored to use shared helper)
- `tests/test_categories.py`: +164 lines (new unit tests)
- `tests/test_uploader.py`: +98 lines (new integration tests)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->