### PR TITLE
status: anchor label log selection so sibling labels don't steal the match

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -7,6 +7,7 @@ the /wikimedia-status Slack slash command via Lambda).
 
 import logging
 import os
+import re
 import shlex
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -19,6 +20,21 @@ from ingest_wikimedia.ssm import REGION, ssm_run
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
 _UPLOAD_COMPLETE_PREFIX = "Upload complete"
+
+
+def log_filename_pattern_for_label(label: str) -> str:
+    """Anchored regex matching log filenames for exactly this label.
+
+    Log filenames follow "{YYYYMMDD}-{HHMMSS}-{label}-(download|upload).log".
+    The pattern must match `…-bpl+phillips-academy-download.log` and NOT
+    `…-bpl+phillips-academy-andover-download.log` — otherwise sibling
+    labels whose names extend this one steal the log selection and the
+    status report sticks on the wrong target. See lessons.md
+    "Log filename phase detection".
+    """
+    return rf"-{re.escape(label)}-(download|upload)\.log$"
+
+
 _DOWNLOAD_COMPLETE_PREFIX = "Download complete"
 # A session that hasn't written a log line in this many seconds is considered hung.
 # Uploads normally complete items in seconds; downloads in seconds to low minutes.
@@ -39,11 +55,11 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
 
     # Get session creation time and most recent log for this label — no shell
     # variables needed, avoiding outer-bash expansion of $f inside bash -c.
-    label_prefix = shlex.quote(label + "-")
+    label_pattern = shlex.quote(log_filename_pattern_for_label(label))
     precheck = ssm_run(
         client,
         f"tmux display-message -t {session_name} -p '#{{session_created}}' 2>/dev/null || echo 0; "
-        f"ls -t {log_dir}/ 2>/dev/null | grep -F {label_prefix} | head -1",
+        f"ls -t {log_dir}/ 2>/dev/null | grep -E {label_pattern} | head -1",
     )
     precheck_lines = precheck.splitlines()
     session_created = _safe_int(precheck_lines[0]) if precheck_lines else 0

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -1,0 +1,57 @@
+"""Tests for scripts/wikimedia_upload_status.py helpers."""
+
+import re
+
+
+def test_log_filename_pattern_matches_only_exact_label():
+    """Sibling labels that extend the search label must NOT match.
+
+    Regression test for the status-stuck-on-wrong-target bug: when a chained
+    pipeline runs both `bpl+phillips-academy` and `bpl+phillips-academy-andover`,
+    the status fetcher must not pick up the andover log when checking on
+    bpl+phillips-academy (or vice versa). A bare substring match misclassified
+    these and reported the wrong target's log file.
+    """
+    from scripts.wikimedia_upload_status import log_filename_pattern_for_label
+
+    pattern = re.compile(log_filename_pattern_for_label("bpl+phillips-academy"))
+
+    # Exact-label matches
+    assert pattern.search("20260522-203316-bpl+phillips-academy-download.log")
+    assert pattern.search("20260522-203316-bpl+phillips-academy-upload.log")
+
+    # Sibling labels whose names extend "bpl+phillips-academy" must NOT match
+    assert not pattern.search(
+        "20260523-065246-bpl+phillips-academy-andover-download.log"
+    )
+    assert not pattern.search("20260523-065248-bpl+phillips-academy-andover-upload.log")
+
+    # Legacy hub-only logs must NOT match (different format, handled separately)
+    assert not pattern.search("20260513-211920-bpl-download.log")
+    assert not pattern.search("20260513-211920-bpl-upload.log")
+
+    # Unrelated hub must NOT match
+    assert not pattern.search("20260522-100000-ia+phillips-academy-download.log")
+
+
+def test_log_filename_pattern_matches_only_phase_suffixes():
+    """Only -download.log and -upload.log are valid phase logs."""
+    from scripts.wikimedia_upload_status import log_filename_pattern_for_label
+
+    pattern = re.compile(log_filename_pattern_for_label("nara"))
+    assert pattern.search("20260522-100000-nara-download.log")
+    assert pattern.search("20260522-100000-nara-upload.log")
+    # Other phases (e.g. legacy retirer logs) must NOT match
+    assert not pattern.search("20251220-012010-nara-retirer.log")
+    assert not pattern.search("20260522-100000-nara-fix.log")
+
+
+def test_log_filename_pattern_handles_regex_metachars_in_label():
+    """Labels contain `+` which is a regex metacharacter — must be escaped."""
+    from scripts.wikimedia_upload_status import log_filename_pattern_for_label
+
+    pattern = re.compile(log_filename_pattern_for_label("indiana+benjamin-harrison"))
+    # The literal label should match
+    assert pattern.search("20260522-100000-indiana+benjamin-harrison-download.log")
+    # The `+` must NOT be treated as a regex quantifier ("indianabenjamin..." should fail)
+    assert not pattern.search("20260522-100000-indianabenjamin-harrison-download.log")


### PR DESCRIPTION
## Summary

Fix the multi-target chained-session status bug where the Slack status report sticks on `Uploading (starting…)` for the wrong target after the chain has moved on.

### Symptom

A chained session containing both `bpl+phillips-academy` and `bpl+phillips-academy-andover` was reported as:
```
[bpl+phillips-academy] Uploading (starting…)
```
indefinitely, while the chain was actually well past phillips-academy and downloading `bpl+massachusetts-archives`.

### Root cause

`get_phase_and_progress` selects a label's most recent log file with:

```python
f"ls -t {log_dir}/ | grep -F {shlex.quote(label + '-')} | head -1"
```

`grep -F "{label}-"` does substring matching. For `label="bpl+phillips-academy"` it also matches `…-bpl+phillips-academy-andover-download.log`. With `ls -t` ordering by mtime, whichever sibling wrote most recently wins — and that sibling's log is either empty (still in upload startup) or completed, producing a misleading status.

### Fix

Anchor the match with a regex bounded on both sides:

```python
pattern = rf"-{re.escape(label)}-(download|upload)\.log$"
```

- leading `-` before the escaped label
- `-(download|upload).log` anchored at end of line

Extract pattern-building into `log_filename_pattern_for_label()` so the bug is unit-testable. `scripts/wikimedia_upload_status.py` previously had no tests.

### Same family of bugs

This is the symmetric companion to the existing `lessons.md` entry **"Log filename phase detection: match the suffix, not a substring"** (about *detecting* a phase from a filename). That lesson is about the inner `if log_file.endswith("-download.log")` check inside `get_phase_and_progress`; this fix is about *filtering* the candidate filenames in the first place. Both directions need anchored matching. A new lesson has been added to `~/.claude/lessons.md` to flag the filter-side variant going forward.

### Labels in the current batch affected

Three sibling pairs in the 2026-05-22 chained launch hit this collision:

- `bpl+phillips-academy` / `bpl+phillips-academy-andover`
- `ia+phillips-academy` / `ia+phillips-academy-archives-and-special-collections`
- `bpl+massachusetts-department-of-conservation-and-recreation` / `bpl+massachusetts-department-of-conservation-and-recreation-office-of-watershed-management-wachusett-watershed-office-west-boylston`

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] Standalone regex verification — all 9 positive/negative cases match expectations
- [x] New `tests/test_wikimedia_upload_status.py` covers: exact-label match, sibling-extension rejection, legacy hub-only rejection, phase-suffix-only matching, and regex-metachar-in-label safety
- [ ] CI: pytest picks up the new test
- [ ] Next status report on the active chained session shows the correct target

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Bug Fix: Status Report Label Selection

Fixes a bug in multi-target chained-session status reporting where Slack could show an incorrect persistent `Uploading (starting…)` status for the wrong target after the chain progressed.

### Root Cause
`get_phase_and_progress()` selected a label’s most recent log via a substring grep (`grep -F "{label}-"`) over `ls -t` output. Labels that are prefixes of sibling labels (e.g., `bpl+phillips-academy` vs `bpl+phillips-academy-andover`) could match the wrong log file; the most recently written sibling log then determined the reported phase. Three sibling label pairs were observed in the 2026-05-22 chained launch.

### Solution
Constructed an anchored, escaped regex to match only exact label log filenames ending with `-{label}-(download|upload).log$`, and extracted pattern construction into a new helper:
- Added `log_filename_pattern_for_label(label: str) -> str` which escapes regex metacharacters, anchors the match at EOL, and restricts phase suffixes to `-download.log` or `-upload.log`.
- Updated `get_phase_and_progress()` to use `grep -E` with the anchored pattern instead of `grep -F` with a prefix.

This prevents sibling/partial-label matches and ensures only download/upload phase logs are considered.

### Changes
- scripts/wikimedia_upload_status.py (+18/-2)
  - Added `log_filename_pattern_for_label()`
  - Replaced substring-based grep with anchored regex usage in the SSM precheck within `get_phase_and_progress()`
- tests/test_wikimedia_upload_status.py (+57/-0)
  - Added tests:
    - `test_log_filename_pattern_matches_only_exact_label()` — rejects sibling/extended labels
    - `test_log_filename_pattern_matches_only_phase_suffixes()` — accepts only `-download.log` and `-upload.log`
    - `test_log_filename_pattern_handles_regex_metachars_in_label()` — ensures metacharacters (e.g., `+`) are escaped and treated literally
  - Added a standalone regex verification with positive/negative cases

Also added a lessons.md entry documenting the filename-matching/filter-side variant of this class of bug.

### Deployment / Infra Impact
- No manual pipeline trigger or ECS redeployment required.
- No environment variables, AWS Secrets Manager keys, database migrations, shared infra (CodePipeline/CodeBuild/ECS/IAM) changes, or public API changes.
- Change takes effect on the next run of the existing wikimedia-upload-status workflow (scheduled and Slack-invocable).

### Testing Status
- Unit tests for the pattern builder added and exercised locally; local ruff checks pass.
- CI pytest integration and live status-report verification remain pending.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->