### PR TITLE
wikimedia: narrow &/= page-title escaping to actual query-string pattern

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -75,6 +75,84 @@ def _break_query_string_pattern(title: str) -> str:
     return title
 
 
+# All Commons namespace canonical names + aliases as of 2026-05-23 (snapshot of
+# `action=query&meta=siteinfo&siprop=namespaces|namespacealiases`). If the
+# prefix of an item title (before the first `:`) matches one of these, the
+# API would mis-route the upload into that namespace. The list is stable in
+# practice; if Commons adds a namespace later, the worst case is the new
+# prefix is treated as title text rather than a namespace alias — same as
+# the old unconditional `:` → `-` replacement, never worse.
+_MW_NAMESPACE_PREFIXES: frozenset[str] = frozenset(
+    [
+        "campaign",
+        "campaign talk",
+        "cat",
+        "category",
+        "category talk",
+        "com",
+        "commons",
+        "commons talk",
+        "creator",
+        "creator talk",
+        "data",
+        "data talk",
+        "event",
+        "event talk",
+        "file",
+        "file talk",
+        "help",
+        "help talk",
+        "image",
+        "image talk",
+        "institution",
+        "institution talk",
+        "media",
+        "mediawiki",
+        "mediawiki talk",
+        "module",
+        "module talk",
+        "museum",
+        "museum talk",
+        "project",
+        "project talk",
+        "sequence",
+        "sequence talk",
+        "special",
+        "talk",
+        "template",
+        "template talk",
+        "timedtext",
+        "timedtext talk",
+        "topic",
+        "translations",
+        "translations talk",
+        "user",
+        "user talk",
+    ]
+)
+
+
+def _break_namespace_prefix_colon(title: str) -> str:
+    """If a title begins with `<namespace>:`, replace just that first colon
+    with `-` so the API doesn't mis-parse the upload as a `<namespace>:<rest>`
+    page in the wrong namespace. Mid-title colons (which Commons accepts
+    fine — e.g. `Boston, Mass.: City Hall`) are left intact.
+
+    DPLA records occasionally start with strings like `Image: …` or
+    `Media: …`; under the old unconditional `:` → `-` rule these were
+    correctly safe but every *other* mid-title colon got mangled too.
+    """
+    head, sep, _tail = title.partition(":")
+    if not sep:
+        return title
+    # MediaWiki treats spaces and underscores as equivalent in namespace
+    # names, and case-folds the first letter; normalise both before lookup.
+    normalised = head.strip().replace("_", " ").lower()
+    if normalised in _MW_NAMESPACE_PREFIXES:
+        return title.replace(":", "-", 1)
+    return title
+
+
 def get_page_title(
     item_title: str, dpla_identifier: str, suffix: str, page=None
 ) -> str:
@@ -83,15 +161,13 @@ def get_page_title(
     the title of the image.
     """
     escaped_title = (
-        _break_query_string_pattern(item_title[:181])
+        _break_namespace_prefix_colon(_break_query_string_pattern(item_title[:181]))
         .replace("''", '"')  # titleblacklist: double-apostrophe rule → double-quote
-        .replace("[", "(")
-        .replace("]", ")")
-        .replace("{", "(")
-        .replace("}", ")")
-        .replace("/", "-")
-        .replace(":", "-")
-        .replace("#", "-")
+        .replace("[", "(")  # MediaWiki: forbidden in page names
+        .replace("]", ")")  # MediaWiki: forbidden in page names
+        .replace("{", "(")  # MediaWiki: forbidden in page names
+        .replace("}", ")")  # MediaWiki: forbidden in page names
+        .replace("#", "-")  # MediaWiki: forbidden (URL fragment separator)
         .replace(
             "|", "-"
         )  # wikitext table/link syntax; breaks Commons extension detection

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -55,6 +55,26 @@ def is_download_only(content_type: str) -> bool:
     return content_type in DOWNLOAD_ONLY_CONTENT_TYPES
 
 
+def _break_query_string_pattern(title: str) -> str:
+    """Break the `&...=` query-string blacklist pattern only when both chars
+    are present.
+
+    The bot's older "always replace `&` with `+` and `=` with `-`" behavior
+    was over-eager: titles containing only one of the two are not rejected
+    by Commons (the blacklist rule the lesson cites needs both, in order,
+    to look like a URL query string). Over-replacing forced drift-correction
+    renames of perfectly good Commons titles like
+    `... suffragiis & orationibus. - DPLA - …` into the uglier
+    `... suffragiis + orationibus. - DPLA - …` form.
+
+    Only when both characters appear in the same title do we substitute, so
+    legitimate use of either character alone is preserved.
+    """
+    if "&" in title and "=" in title:
+        return title.replace("&", "+").replace("=", "-")
+    return title
+
+
 def get_page_title(
     item_title: str, dpla_identifier: str, suffix: str, page=None
 ) -> str:
@@ -63,10 +83,8 @@ def get_page_title(
     the title of the image.
     """
     escaped_title = (
-        item_title[:181]
+        _break_query_string_pattern(item_title[:181])
         .replace("''", '"')  # titleblacklist: double-apostrophe rule → double-quote
-        .replace("&", "+")  # titleblacklist: query-string pattern (&...=)
-        .replace("=", "-")  # titleblacklist: query-string pattern (&...=)
         .replace("[", "(")
         .replace("]", ")")
         .replace("{", "(")

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -95,6 +95,55 @@ def test_get_page_title_breaks_query_string_when_both_present():
     assert "filter-value+other-thing" in title
 
 
+def test_get_page_title_preserves_slash():
+    """Slashes are valid in Commons File: titles — no subpage handling in
+    File namespace — and must NOT be rewritten to `-`."""
+    title = get_page_title("Page 1/2 of the survey", "abcd" * 8, ".jpg")
+    assert "/" in title
+    assert "Page 1/2 of the survey" in title
+
+
+def test_get_page_title_preserves_mid_title_colon():
+    """Colons mid-title are valid on Commons (e.g. `Boston, Mass.: City Hall`)
+    and must NOT be rewritten when there's no namespace prefix."""
+    title = get_page_title("Boston, Mass.: City Hall", "abcd" * 8, ".jpg")
+    assert ":" in title
+    assert "Boston, Mass.: City Hall" in title
+
+
+def test_get_page_title_breaks_namespace_prefix_colon():
+    """When a title begins with `<namespace>:`, the first colon must be
+    replaced so the API doesn't mis-route the upload into that namespace."""
+    # `Image:` is a File namespace alias on Commons — would re-route the upload.
+    title = get_page_title("Image: New England farmhouse", "abcd" * 8, ".jpg")
+    # First colon (the namespace-collision one) → `-`
+    assert title.startswith("Image- New England farmhouse")
+
+
+def test_get_page_title_namespace_prefix_check_is_case_insensitive():
+    """MediaWiki case-folds the first letter of namespace names."""
+    for prefix in ("image:", "IMAGE:", "Image :", "image  :"):
+        title = get_page_title(f"{prefix} test", "abcd" * 8, ".jpg")
+        assert ":" not in title.split(" - DPLA -")[0], (
+            f"Namespace prefix {prefix!r} should have triggered colon replacement"
+        )
+
+
+def test_get_page_title_only_breaks_first_colon_when_namespace_match():
+    """Even when the prefix matches a namespace, only the FIRST colon is
+    replaced — any later colons in the title are mid-title and preserved."""
+    title = get_page_title("Image: Boston, Mass.: City Hall", "abcd" * 8, ".jpg")
+    # First `:` after `Image` is replaced, but the mid-title `:` after `Mass.` survives.
+    assert title.startswith("Image- Boston, Mass.:")
+
+
+def test_get_page_title_passes_through_non_namespace_prefix():
+    """A `:` after non-namespace text must be preserved."""
+    title = get_page_title("Notes:1865 inventory", "abcd" * 8, ".jpg")
+    # `Notes` is not a namespace; the `:` stays.
+    assert title.startswith("Notes:1865 inventory")
+
+
 def test_license_to_markup_code():
     rights_uri = "http://creativecommons.org/licenses/by/4.0/"
     markup_code = license_to_markup_code(rights_uri)

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -52,6 +52,49 @@ def test_get_page_title():
     assert title == expected_title
 
 
+def test_get_page_title_preserves_ampersand_when_no_equals():
+    """Regression: titles containing `&` alone (no `=`) must NOT be rewritten.
+
+    Replacing `&` unconditionally caused drift-correction renames of good
+    Commons titles like `... suffragiis & orationibus. - DPLA - ...` into
+    the uglier `... suffragiis + orationibus. - DPLA - ...` form.
+    """
+    title = get_page_title(
+        "Hore beate Marie - cum multis suffragiis & orationibus.",
+        "e01f0774b6ae80e4745504ab554f93b5",
+        ".jpg",
+        205,
+    )
+    assert "&" in title
+    assert "+" not in title
+
+
+def test_get_page_title_preserves_equals_when_no_ampersand():
+    """`=` alone (no `&`) is fine — only the joint pattern is blacklisted."""
+    title = get_page_title(
+        "E=mc² and other formulas",
+        "abcd" * 8,
+        ".jpg",
+    )
+    assert "=" in title
+    # `-` may appear in the DPLA-ID/extension fragments but not from `=` rewriting.
+    # Verify the original character is preserved.
+    assert "E=mc" in title
+
+
+def test_get_page_title_breaks_query_string_when_both_present():
+    """When both `&` and `=` appear, substitute to break the blacklist pattern."""
+    title = get_page_title(
+        "filter=value&other=thing",
+        "abcd" * 8,
+        ".jpg",
+    )
+    # Both characters get rewritten so the title no longer matches `&...=`.
+    assert "&" not in title
+    assert "=" not in title
+    assert "filter-value+other-thing" in title
+
+
 def test_license_to_markup_code():
     rights_uri = "http://creativecommons.org/licenses/by/4.0/"
     markup_code = license_to_markup_code(rights_uri)


### PR DESCRIPTION
## Summary

Stop the bot from renaming perfectly good Commons file titles when the source title contains `&`, `/`, or a mid-title `:`. This started as a single-character fix for `&` and grew into a full audit of every substitution in `get_page_title()` against the live Commons titleblacklist and MediaWiki page-name rules.

### What happened

User spotted this move on Commons:
https://commons.wikimedia.org/w/index.php?title=File:Hore_beate_Marie_virginis_secundum_romanum_totaliter_ad_Longu_sine_require_-_cum_multis_suffragiis_%2B_orationibus._-_DPLA_-_e01f0774b6ae80e4745504ab554f93b5_(page_205).jpg&diff=prev&oldid=1218880136

The bot moved
- `…suffragiis **&** orationibus. - DPLA - e01f0774b6ae80e4745504ab554f93b5 (page 205).jpg`

to
- `…suffragiis **+** orationibus. - DPLA - e01f0774b6ae80e4745504ab554f93b5 (page 205).jpg`

The original title was already on Commons and perfectly valid — `&` alone has never been rejected. `find_file_by_hash` saw the live file at the un-rewritten name, `get_page_title` computed the rewritten name, the two differed, drift-correction logic kicked in, the file got renamed away from a good title into an uglier form, and the whole pipeline (CommonsDelinker request, Slack noise, etc.) ran for what should have been a no-op.

### Audit, against the current Commons titleblacklist

| Substitution | Real titleblacklist rule? | MediaWiki-forbidden? | Verdict |
|---|---|---|---|
| `''` → `"` | ✅ Line 123: `File:.*'{2,}.*` | — | Keep |
| `&...=` together → `+...-` | (historical, PR #132) | — | **Narrow** to "both present" |
| `[ ] { }` → `( )` | — | ✅ `Title::legalChars` | Keep |
| `#` → `-` | — | ✅ URL fragment separator | Keep |
| `\|` → `-` | — | ✅ wikitext separator | Keep |
| `�` → `’` | ✅ Line 17 (Specials block) | — | Keep |
| `:` → `-` | — | ❌ valid mid-title | **Narrow** to namespace prefix only |
| `/` → `-` | — | ❌ valid in File: titles | **Drop** outright |

All three "narrow / drop" changes are in this PR. Empirical verification: `action=query&titles=File:Test/Sub.jpg`, `File:Boston: City Hall.jpg`, etc. all return `missing` (title is valid, just no page) rather than `invalid`.

### Implementation

Two new helpers in `ingest_wikimedia/wikimedia.py`:

1. **`_break_query_string_pattern(title)`** — substitutes `&` → `+` and `=` → `-` only when **both** characters appear in the same title.
2. **`_break_namespace_prefix_colon(title)`** — if the title's prefix-before-first-`:` matches one of the 44 Commons canonical namespace names / aliases (snapshotted from `meta=siteinfo`), replaces just that first colon with `-` to avoid mis-routing the upload into a foreign namespace. Spaces/underscores and case are normalised the same way MediaWiki does. Mid-title colons in titles like `Boston, Mass.: City Hall` are left intact.

The bare `.replace("/", "-")` and `.replace(":", "-")` calls are gone from `get_page_title()`.

### Self-healing

For every file previously renamed under the over-eager rules, the next run will:
- Find the file at its `+`/`-` rewritten title via SHA-1 (`find_file_by_hash`)
- Compute the correct (un-rewritten) title via `get_page_title()`
- See drift → rename back via existing drift-correction logic

No one-off rescue script needed.

### Note on parallel-session collision

The first push of this work landed on a branch named `fix-page-title-amp-overcorrection`, but a parallel session had pushed an unrelated `tests/test_s3.py` mock fix to that same branch name. To keep the changes separate this PR moved to `fix-amp-overcorrection-clean`. The `fix-page-title-amp-overcorrection` branch on origin now holds only the unrelated `test_s3.py` fix and can be merged or renamed independently.

### Lessons recorded

Two new entries in `~/.claude/lessons.md`:
- **Title-blacklist character substitutions: guard on the actual rule, not on any single character** (over-eager substitutions cascade through drift correction)
- **Audit ALL normalization rules whenever you change one — they share the same cascade risk** (don't stop at the reported rule; the same class of bug almost certainly lives in siblings)

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] Standalone unit tests of both helpers — all cases match expectations
- [x] Regression tests in `tests/test_wikimedia.py`:
  - `&` alone preserved
  - `=` alone preserved
  - Both `&` and `=` → substituted
  - `/` preserved
  - Mid-title `:` preserved
  - `Image: …` (namespace prefix) → first `:` → `-`
  - Case-insensitive namespace check (`IMAGE:`, `image:`, `Image :`, `image  :`)
  - Multiple colons → only first one replaced if namespace match
  - Non-namespace prefix (`Notes:`) → colon preserved
- [ ] CI: pytest + ruff green
- [ ] Next bot upload run shows the over-renamed files drifting back to their correct titles automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR refines title-escaping in get_page_title() to avoid over-correcting valid Commons File titles (e.g., replacing & → +) by limiting substitutions to actual query-string patterns and respecting MediaWiki namespace rules. It fixes a user-reported case where the bot unnecessarily renamed valid filenames, causing drift-correction churn.

## Changes

### ingest_wikimedia/wikimedia.py
- Reworked get_page_title() to remove unconditional .replace("/", "-") and .replace(":", "-") and route targeted substitutions through two new helpers:
  - _break_query_string_pattern(title): replace & → + and = → - only when both characters appear in the same title (query-string pattern).
  - _break_namespace_prefix_colon(title): replace only the first colon with - when the normalized prefix-before-first-: matches one of the 44 canonical Commons/MediaWiki namespace names/aliases (case- and underscore/space-normalized). Mid-title colons are preserved.
- Kept other substitutions unchanged: consecutive single quotes → double-quote, []/{} → (), # → -, | → -, and Unicode replacement U+FFFD → ’.
- Removed unconditional slash → - substitution (slashes are allowed in File: titles).

No public function signatures were changed; new helpers/constants are private.

### tests/test_wikimedia.py
- Added regression/unit tests covering:
  - Preservation of standalone & and = characters.
  - Correct rewriting when both & and = are present.
  - Preservation of / and mid-title colons.
  - Namespace-prefix colon rewriting for various namespace aliases and case variants (only first colon rewritten when appropriate).
- ruff and unit tests added; CI (pytest + ruff) pending.

## Self-Healing Behavior
Previously over-renamed files will be discovered by SHA-1 at their rewritten names; get_page_title() will compute the corrected title and existing drift-correction logic will rename them back automatically.

## Deployment / Infra / Security Notes (explicit)
- No manual pipeline trigger, ECS redeployment, or special runtime deployment action required beyond standard code deployment.
- No environment variables or AWS Secrets Manager keys were added/removed/renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM).
- No public API response shape or endpoints were changed.
- No new credential handling or external-auth changes introduced; security surface unchanged.

## Testing Status
- Local linting and unit tests added and passing locally.
- CI (pytest + ruff) and the next bot run are pending.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->