### PR TITLE
launch: auto-bootstrap missing partner directories instead of failing

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -362,9 +362,11 @@ def main() -> None:
 
     # Verify every requested partner has a working directory on EC2. Pywikibot
     # expects per-partner config.toml / user-config.py / user-password.py /
-    # apicache; without them the pipeline's first `cd {base}` silently fails
-    # and Slack only sees the generic "pipeline step failed" message. Catching
-    # this here gives a clear, actionable error before any tmux work starts.
+    # apicache/; without them the pipeline's first `cd {base}` silently fails.
+    # Any missing partner dir is auto-initialized by copying the required
+    # pywikibot config from a template partner (bpl) — the bot account and
+    # config are the same across all partners, so this is a safe one-shot
+    # bootstrap. apicache/ is populated by pywikibot at first login.
     unique_pdirs = sorted({PARTNER_DIR.get(c, c) for c, _, _, _, _ in targets})
     print(f"Checking partner directories exist: {unique_pdirs}")
     check_cmd = "; ".join(
@@ -381,16 +383,50 @@ def main() -> None:
         if line.startswith("MISSING:")
     )
     if missing_dirs:
-        missing_list = ", ".join(f"`{d}`" for d in missing_dirs)
-        _slack_fail(
-            response_url,
-            f"⚠️ Cannot launch `{session_name}`: partner directory missing on EC2"
-            f" for {missing_list}. Initialize each one by copying config.toml,"
-            f" user-config.py, and user-password.py from an existing partner dir"
-            f" (e.g. `cp -p /home/ec2-user/ingest-wikimedia/bpl/{{config.toml,"
-            f"user-config.py,user-password.py}} /home/ec2-user/ingest-wikimedia/"
-            f"<new-partner>/`).",
+        # The bpl directory is the bootstrap template — it's a primary partner
+        # that always exists in practice. Refuse to bootstrap if even bpl is
+        # missing; that's a much bigger setup problem worth surfacing loudly.
+        if "bpl" in missing_dirs:
+            _slack_fail(
+                response_url,
+                f"⚠️ Cannot launch `{session_name}`: template partner directory"
+                f" `bpl` is missing on EC2. The bot relies on it as the source"
+                f" of pywikibot configuration when bootstrapping new partner"
+                f" directories. Manual setup required.",
+            )
+        print(f"Bootstrapping missing partner directories: {missing_dirs}")
+        # Single SSM round-trip: mkdir + cp -np for each missing dir. -n
+        # ("no-clobber") makes the copy idempotent if a config file already
+        # happens to be in place.
+        init_cmd = " && ".join(
+            f"mkdir -p /home/ec2-user/ingest-wikimedia/{shlex.quote(d)} && "
+            f"cp -np /home/ec2-user/ingest-wikimedia/bpl/config.toml"
+            f" /home/ec2-user/ingest-wikimedia/bpl/user-config.py"
+            f" /home/ec2-user/ingest-wikimedia/bpl/user-password.py"
+            f" /home/ec2-user/ingest-wikimedia/{shlex.quote(d)}/"
+            for d in missing_dirs
         )
+        try:
+            ssm_run(ssm, init_cmd)
+        except Exception as e:
+            _slack_fail(
+                response_url,
+                f"⚠️ Cannot launch `{session_name}`: failed to bootstrap"
+                f" partner directories {missing_dirs}: {e}",
+            )
+        bootstrapped_list = ", ".join(f"`{d}`" for d in missing_dirs)
+        print(f"Auto-bootstrapped partner directories: {bootstrapped_list}")
+        # Surface the bootstrap to Slack so the user sees what was created.
+        if slack_token:
+            try:
+                post_message(
+                    slack_token,
+                    f"🛠️ Bootstrapped new partner directories on EC2 for"
+                    f" `{session_name}`: {bootstrapped_list} (copied pywikibot"
+                    f" config from `bpl`).",
+                )
+            except Exception as e:
+                print(f"Failed to post bootstrap notification: {e}")
 
     # Check for any existing session that includes one of the requested targets.
     # Maps each requested label to the existing session name(s) it conflicts with.


### PR DESCRIPTION
## Summary

Follow-up to PR #218. That PR replaced the opaque "pipeline step failed" runtime error with a clear preflight error telling the user *exactly* which partner directories were missing and how to set them up manually. That solved the diagnosability problem — but it still requires manual intervention on every new-partner launch and aborts the whole batch even when most targets are fine.

This PR replaces the hard-stop with **auto-bootstrap**.

### Behavior change

When the preflight detects missing partner directories, instead of failing:

1. Refuse to bootstrap if `bpl/` itself is missing (that's a real setup problem — fail loud).
2. For each other missing partner dir:
   - `mkdir -p /home/ec2-user/ingest-wikimedia/<partner>/`
   - `cp -np /home/ec2-user/ingest-wikimedia/bpl/{config.toml,user-config.py,user-password.py} <partner>/`
   - `-n` makes the copy idempotent (skip files that already exist).
3. Post a Slack message announcing which directories were bootstrapped.
4. Continue with the rest of the launch.

The pywikibot config files are **identical** across all partners (same bot account, same site, same password). The other contents of a partner directory — `apicache/`, `throttle.ctrl`, `pywikibot-DPLA_bot.lwp`, `logs/`, per-target `*.csv` — are runtime state that pywikibot or the pipeline creates on demand. So the three-file copy is the complete bootstrap.

### Slack message

> 🛠️ Bootstrapped new partner directories on EC2 for `wikimedia-bhl+phillips-academy-...+ia+phillips-academy-...`: `bhl`, `ia` (copied pywikibot config from `bpl`).

…then the normal "Launching" message follows.

### Manifested by

The 2026-05-23 launch attempt of `bhl|Phillips Academy, Oliver Wendell Holmes Library (archive.org)` + chained `ia|...` institution targets was rejected by PR #218's preflight with the actionable-but-still-blocking error. With this PR, the same launch will succeed: the missing `bhl/` and `ia/` directories will be created and seeded from `bpl/`, and the launch will proceed.

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [ ] CI: pytest + ruff green
- [ ] Next launch including a new partner: confirm the bootstrap Slack message posts, the dirs are created on EC2 with the correct files, and the pipeline proceeds normally
- [ ] Re-launch with the same partner: confirm `cp -n` skips the existing files and the launch still proceeds (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Pull Request Summary: Launch Auto-Bootstrap Missing Partner Directories

**Changes**: Modified `scripts/wikimedia_launch.py` to replace the hard-fail preflight behavior for missing partner directories with auto-bootstrap functionality.

**Behavior**:
- Detects missing partner directories during the preflight check that runs before launching Wikimedia uploads on EC2
- If the `bpl` template directory is missing, the launch still fails with a clear error (indicates a critical setup problem)
- For any other missing partner directory, automatically:
  - Creates the directory with `mkdir -p /home/ec2-user/ingest-wikimedia/<partner>/`
  - Copies three pywikibot config files from `bpl/`: `config.toml`, `user-config.py`, and `user-password.py`
  - Uses `cp -np` (no-clobber flag) to make the operation idempotent
  - Continues the launch without blocking
- Posts a Slack message to announce which directories were bootstrapped (when `DPLA_SLACK_BOT_TOKEN` is available)

**Rationale**: Pywikibot configuration files are identical across all partners; other directory contents (`apicache/`, runtime state) are created on demand by pywikibot at first login. This bootstrap approach unblocks launches that include newly configured partners without requiring manual directory setup.

**Impact**: Enables launches to proceed when mixing established partners (e.g., `bpl`, `indiana`) with new ones (e.g., `bhl`, `ia`) in the same batch, eliminating the previous hard-stop that rejected the entire batch.

**No deployment or infrastructure changes required** — the script changes take effect on the next GitHub Actions workflow run.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->