### PR TITLE
status: pass grep -E -- so leading-dash label pattern isn't read as a flag

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -55,11 +55,17 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
 
     # Get session creation time and most recent log for this label — no shell
     # variables needed, avoiding outer-bash expansion of $f inside bash -c.
+    #
+    # The anchored regex from log_filename_pattern_for_label starts with `-`,
+    # which without `--` makes grep interpret the pattern as a command-line
+    # option flag (e.g. `-b`/`-p`/`-l`...) and emit "invalid option" errors.
+    # The `--` terminator forces grep to treat the next argument as the
+    # pattern. See lessons.md "grep patterns starting with `-`".
     label_pattern = shlex.quote(log_filename_pattern_for_label(label))
     precheck = ssm_run(
         client,
         f"tmux display-message -t {session_name} -p '#{{session_created}}' 2>/dev/null || echo 0; "
-        f"ls -t {log_dir}/ 2>/dev/null | grep -E {label_pattern} | head -1",
+        f"ls -t {log_dir}/ 2>/dev/null | grep -E -- {label_pattern} | head -1",
     )
     precheck_lines = precheck.splitlines()
     session_created = _safe_int(precheck_lines[0]) if precheck_lines else 0

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -55,3 +55,66 @@ def test_log_filename_pattern_handles_regex_metachars_in_label():
     assert pattern.search("20260522-100000-indiana+benjamin-harrison-download.log")
     # The `+` must NOT be treated as a regex quantifier ("indianabenjamin..." should fail)
     assert not pattern.search("20260522-100000-indianabenjamin-harrison-download.log")
+
+
+def test_get_phase_and_progress_grep_uses_double_dash_separator():
+    """Regression: get_phase_and_progress must pass `grep -E -- {pattern}`,
+    not `grep -E {pattern}`, because the pattern starts with `-` (see the
+    test above). Without `--`, grep emits "invalid option" and the status
+    reporter silently misclassifies every label.
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    captured_commands: list[str] = []
+
+    def fake_ssm_run(_client, command, **_kwargs):
+        captured_commands.append(command)
+        # First call is the precheck (session_created + ls|grep); subsequent
+        # calls only happen if a log file was returned. Return an empty
+        # session_created and no log file so we exit early.
+        if not captured_commands or len(captured_commands) == 1:
+            return "0\n"
+        return ""
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
+        get_phase_and_progress(
+            client=None,
+            session="wikimedia-bpl+phillips-academy",
+            hub="bpl",
+            label="bpl+phillips-academy",
+        )
+
+    assert captured_commands, "get_phase_and_progress should have invoked ssm_run"
+    precheck = captured_commands[0]
+    assert "grep -E -- " in precheck, (
+        f"precheck must use `grep -E --` to keep grep from treating the "
+        f"leading-`-` pattern as an option; got: {precheck!r}"
+    )
+
+
+def test_log_filename_pattern_always_starts_with_dash():
+    """Regression: any pattern this builder returns begins with `-`, which
+    means callers invoking grep with it MUST use `--` (or `-e <pattern>`)
+    to keep grep from interpreting the leading `-` as a flag.
+
+    Without that terminator, grep emits `invalid option -- 'X'` for whatever
+    follows the dash and exits non-zero — silently returning no matches.
+    `head -1` then returns empty, get_phase_and_progress returns None for
+    every label, and the status reporter falls back to "Generating IDs" on
+    the first pending label of every multi-target session.
+    """
+    from scripts.wikimedia_upload_status import log_filename_pattern_for_label
+
+    for label in (
+        "bpl",
+        "bpl+phillips-academy",
+        "indiana+benjamin-harrison",
+        "nara",
+        "retry-indiana",
+    ):
+        assert log_filename_pattern_for_label(label).startswith("-"), (
+            f"Pattern for {label!r} must lead with `-` so the anchor before "
+            "the label binds; callers must compensate with `grep -E --`."
+        )


### PR DESCRIPTION
## Summary

Hotfix for a regression PR #222 introduced. Without this, **every chained-session status report silently returns "Generating IDs on the first pending label"** — even when the session has been running for hours and is in a totally different phase.

### Symptom

User ran `/wikimedia-status`. Got back, among others:

> `wikimedia-bhl+phillips-academy-oliver-wendell-holmes-library-archiveorg+bpl+phillips-academy+...` `[bhl+phillips-academy-oliver-wendell-holmes-library-archiveorg]` Generating IDs

The `bhl` target failed days ago (no EC2 dir at the time) and the session is currently uploading `bpl+massachusetts-archives` (upload log 406KB, growing as of `19:07 UTC`). The reporter showed the failed first label.

Three other chained sessions on the same `/wikimedia-status` output reported the same wrong "Generating IDs" verdict against their first pending label, ditto.

### Root cause

PR #222 anchored the per-label log selector with `-{label}-(download|upload)\.log$`. The pattern's first character is `-`. The status code shell pipeline was:

```bash
ls -t /home/ec2-user/ingest-wikimedia/<hub>/logs/ 2>/dev/null \
  | grep -E '-<label>-(download|upload)\.log$' \
  | head -1
```

`grep -E '-...'` sees the leading `-` as the next CLI flag and tries to parse `-b`/`-p`/`-l`/... — emitting `grep: invalid option -- 'p'` to stderr and exiting non-zero. The pipeline silently returns no match, `head -1` returns empty, `get_phase_and_progress` sees no log file and returns `None`, and the outer loop falls into the "no label has a log → return first_pending with Generating IDs" branch.

I verified this against the live EC2 instance:

```
$ ls -t /home/ec2-user/ingest-wikimedia/bpl/logs/ | grep -E '-bpl\+phillips-academy-(download|upload)\.log$' | head -1
grep: invalid option -- 'p'
Usage: grep [OPTION]... PATTERNS [FILE]...
```

And confirmed that the fix recovers the correct behavior:

```
$ ls -t /home/ec2-user/ingest-wikimedia/bpl/logs/ | grep -E -- '-bpl\+phillips-academy-(download|upload)\.log$' | head -1
20260522-203316-bpl+phillips-academy-upload.log
```

### Fix

Insert `--` between `-E` and the pattern in the precheck command so grep stops parsing options before the pattern.

### Regression tests

- **`test_log_filename_pattern_always_starts_with_dash`**: documents the property so future modifications don't drop the `-` anchor without also re-checking callers.
- **`test_get_phase_and_progress_grep_uses_double_dash_separator`**: mocks `ssm_run` and asserts the precheck command contains `grep -E -- `. This catches the exact regression that bit us today.

### Lesson recorded

> **grep patterns starting with `-`: always pass via `grep -E --` (or `-e <pattern>`)**
>
> Default to writing `grep -E -- "$pattern"` defensively. In code generators that build grep commands from user-controlled patterns, make `--` part of the literal template, not optional.

(Added to `~/.claude/lessons.md`.)

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] Verified against live EC2 that without `--` the grep fails, with `--` it returns the right file
- [x] New tests assert both the pattern shape and the command-construction
- [ ] CI: pytest + ruff green
- [ ] Next `/wikimedia-status` shows the active target's real phase, not "Generating IDs" on the first pending label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a regression in the Wikimedia upload status checker introduced by PR `#222`, where per-label log filename patterns anchored with a leading hyphen (`-{label}-(download|upload).log$`) were being misinterpreted by grep as command-line option flags instead of pattern literals. When grep failed to find matching log files, the status command incorrectly reported "Generating IDs" for the first pending label in every multi-target session, regardless of actual session state.

## Changes

**scripts/wikimedia_upload_status.py** (7 lines added, 1 removed)
- Updated the SSM command in `get_phase_and_progress` to use `grep -E -- <pattern>` instead of `grep -E <pattern>`
- The `--` operator explicitly terminates grep's option parsing, forcing it to treat the leading-dash pattern as a literal string rather than parsing its characters as flags
- Added explanatory comments documenting the issue and the necessity of the `--` separator

**tests/test_wikimedia_upload_status.py** (63 new lines)
- Added `test_log_filename_pattern_always_starts_with_dash()`: Verifies that the pattern builder always returns strings starting with `-`, documenting the requirement that callers must use `grep -E --` (or equivalent) to safely use these patterns
- Added `test_get_phase_and_progress_grep_uses_double_dash_separator()`: Mocks `ssm_run` and asserts that the precheck command includes `grep -E --`, preventing regression of this grep invocation bug

## Testing & Verification

The fix has been reproduced and validated on a live EC2 instance. Regression tests have been added to prevent this issue from recurring. Local ruff and format checks have passed; CI pytest and ruff checks are pending.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->