### PR TITLE
uploader: detect and tag trailing-page orphans after each item

### DIFF
--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -12,6 +12,8 @@ class Result(Enum):
     NO_MEDIA = auto()
     BAD_IMAGE_API = auto()
     RETIRED = auto()
+    ORPHANS_TAGGED = auto()
+    ORPHANS_FLAGGED = auto()
 
 
 class Tracker:

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -180,14 +180,18 @@ def test_orphan_check_tags_trailing_orphan_with_matching_sha1():
     s3_client = _stub_s3_client_for_assets({1: "aaa", 2: "bbb", 3: "ccc"})
     ordinal_exts = {1: ".jpg", 2: ".jpg", 3: ".jpg"}
     page_labels = {1: "1", 2: "2", 3: "3"}
-    orphan_title = "Some Item - DPLA - abcd1234abcd1234abcd1234abcd1234 (page 4).jpg"
-    expected_keep = "Some Item - DPLA - abcd1234abcd1234abcd1234abcd1234 (page 3).jpg"
+    base = "Some Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
+    orphan_title = f"{base} (page 4).jpg"
+    expected_keep = f"{base} (page 3).jpg"
 
     with (
         patch("tools.uploader.pywikibot.FilePage") as fp,
         patch("tools.uploader.tag_as_duplicate") as tag_mock,
     ):
-        fp.side_effect = _make_file_page_factory(existing={orphan_title: "ccc"})
+        # keep_title must also exist on Commons — otherwise we'd flag, not tag.
+        fp.side_effect = _make_file_page_factory(
+            existing={orphan_title: "ccc", expected_keep: "ccc"}
+        )
         _post_item_orphan_check(
             site=MagicMock(),
             s3_client=s3_client,
@@ -245,6 +249,8 @@ def test_orphan_check_handles_multiple_trailing_orphans():
     page_labels = {1: "1", 2: "2"}
     base = "Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
     existing = {
+        f"{base} (page 1).jpg": "aaa",  # keep target for (page 4) orphan
+        f"{base} (page 2).jpg": "bbb",  # keep target for (page 3) orphan
         f"{base} (page 3).jpg": "bbb",  # matches kept (page 2)
         f"{base} (page 4).jpg": "aaa",  # matches kept (page 1)
     }
@@ -283,7 +289,10 @@ def test_orphan_check_single_asset_probes_from_page_1():
     ordinal_exts = {1: ".jpg"}
     page_labels = {1: ""}
     base = "Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
-    existing = {f"{base} (page 1).jpg": "aaa"}
+    existing = {
+        f"{base}.jpg": "aaa",  # the kept no-suffix asset must exist on Commons
+        f"{base} (page 1).jpg": "aaa",  # orphan
+    }
 
     with (
         patch("tools.uploader.pywikibot.FilePage") as fp,
@@ -313,7 +322,10 @@ def test_orphan_check_dry_run_does_not_save():
     ordinal_exts = {1: ".jpg", 2: ".jpg"}
     page_labels = {1: "1", 2: "2"}
     base = "Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
-    existing = {f"{base} (page 3).jpg": "bbb"}
+    existing = {
+        f"{base} (page 2).jpg": "bbb",  # kept target must exist on Commons
+        f"{base} (page 3).jpg": "bbb",  # orphan
+    }
 
     with (
         patch("tools.uploader.pywikibot.FilePage") as fp,
@@ -353,7 +365,10 @@ def test_orphan_check_skips_gap_and_finds_orphan_past_it():
     page_labels = {1: ""}
     base = "Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
     # No (page 1).jpg; (page 2).jpg exists with the same SHA1 as the no-suffix asset.
-    existing = {f"{base} (page 2).jpg": "aaa"}
+    existing = {
+        f"{base}.jpg": "aaa",  # kept no-suffix target on Commons
+        f"{base} (page 2).jpg": "aaa",  # orphan past the gap
+    }
 
     with (
         patch("tools.uploader.pywikibot.FilePage") as fp,
@@ -375,6 +390,81 @@ def test_orphan_check_skips_gap_and_finds_orphan_past_it():
     assert tracker.count(Result.ORPHANS_TAGGED) == 1
     tag_mock.assert_called_once()
     assert tag_mock.call_args.kwargs["correct_filename"] == f"{base}.jpg"
+
+
+def test_orphan_check_flags_when_keep_title_does_not_exist():
+    """If the S3 asset whose SHA1 matches the orphan was never actually
+    uploaded (e.g. process_file SKIPPED it or aborted on timeout), the
+    keep_title we'd point at doesn't exist on Commons.  Don't create a
+    duplicate tag pointing at a phantom file — flag instead.
+    """
+    tracker = Tracker()
+    s3_client = _stub_s3_client_for_assets({1: "aaa", 2: "bbb"})
+    ordinal_exts = {1: ".jpg", 2: ".jpg"}
+    page_labels = {1: "1", 2: "2"}
+    base = "Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
+    # Orphan exists, but the kept target (page 2).jpg does NOT exist on Commons
+    # (e.g. process_file skipped that ordinal).
+    existing = {f"{base} (page 3).jpg": "bbb"}
+
+    with (
+        patch("tools.uploader.pywikibot.FilePage") as fp,
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+    ):
+        fp.side_effect = _make_file_page_factory(existing=existing)
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="Item",
+            partner="nara",
+            ordinal_exts=ordinal_exts,
+            page_labels=page_labels,
+            dry_run=False,
+        )
+
+    assert tracker.count(Result.ORPHANS_TAGGED) == 0
+    assert tracker.count(Result.ORPHANS_FLAGGED) == 1
+    tag_mock.assert_not_called()
+
+
+def test_orphan_check_flags_when_tag_save_fails():
+    """tag_as_duplicate raising shouldn't leave the orphan uncounted —
+    record it as FLAGGED so the run summary captures follow-up work."""
+    tracker = Tracker()
+    s3_client = _stub_s3_client_for_assets({1: "aaa", 2: "bbb"})
+    ordinal_exts = {1: ".jpg", 2: ".jpg"}
+    page_labels = {1: "1", 2: "2"}
+    base = "Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
+    existing = {
+        f"{base} (page 2).jpg": "bbb",  # keep target exists
+        f"{base} (page 3).jpg": "bbb",  # orphan
+    }
+
+    with (
+        patch("tools.uploader.pywikibot.FilePage") as fp,
+        patch(
+            "tools.uploader.tag_as_duplicate",
+            side_effect=RuntimeError("simulated save failure"),
+        ) as tag_mock,
+    ):
+        fp.side_effect = _make_file_page_factory(existing=existing)
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="Item",
+            partner="nara",
+            ordinal_exts=ordinal_exts,
+            page_labels=page_labels,
+            dry_run=False,
+        )
+
+    assert tag_mock.called  # we did try
+    assert tracker.count(Result.ORPHANS_TAGGED) == 0
+    assert tracker.count(Result.ORPHANS_FLAGGED) == 1
 
 
 def test_orphan_check_skips_extensions_with_no_assets():

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -7,7 +7,11 @@ category.
 
 from unittest.mock import MagicMock, patch
 
-from tools.uploader import _post_upload_touch_new_institutions
+from ingest_wikimedia.tracker import Result, Tracker
+from tools.uploader import (
+    _post_item_orphan_check,
+    _post_upload_touch_new_institutions,
+)
 
 
 def _ensurer_with(newly_created: set[str]) -> MagicMock:
@@ -96,3 +100,260 @@ def test_per_qid_exception_does_not_stop_remaining_qids(caplog):
     messages = " | ".join(r.message for r in caplog.records)
     assert "Q_bad" in messages
     assert "simulated commons search failure" in messages
+
+
+# --------------------------------------------------------------------------
+# _post_item_orphan_check
+# --------------------------------------------------------------------------
+
+
+def _stub_s3_client_for_assets(assets_by_ordinal: dict[int, str]):
+    """Mock S3Client whose objects return CHECKSUM-keyed sha1 metadata."""
+
+    def _get_media_path(dpla_id, ordinal, partner):
+        return f"{partner}/images/x/x/x/x/{dpla_id}/{ordinal}_{dpla_id}"
+
+    def _object(_bucket, key):
+        ordinal = int(key.rsplit("/", 1)[1].split("_", 1)[0])
+        sha1 = assets_by_ordinal[ordinal]
+        obj = MagicMock()
+        obj.metadata = {"sha1": sha1}
+        return obj
+
+    s3_client = MagicMock()
+    s3_client.get_media_s3_path.side_effect = _get_media_path
+    inner = MagicMock()
+    inner.Object.side_effect = _object
+    s3_client.get_s3.return_value = inner
+    return s3_client
+
+
+def _make_file_page_factory(existing: dict[str, str]):
+    """Return a stub for pywikibot.FilePage(site, title).
+
+    `existing` maps Commons title → sha1 of the orphan file at that title.
+    Titles not in the map are treated as nonexistent (exists() == False).
+    """
+
+    def _factory(site, title):
+        page = MagicMock()
+        page.title.return_value = title
+        if title in existing:
+            page.exists.return_value = True
+            page.latest_file_info.sha1 = existing[title]
+        else:
+            page.exists.return_value = False
+            # Accessing latest_file_info on a nonexistent page would raise,
+            # but the code-under-test breaks the loop before reading it.
+        return page
+
+    return _factory
+
+
+def test_orphan_check_no_orphan_when_first_probe_is_missing():
+    """Item has 3 jpgs; (page 4).jpg doesn't exist → nothing to do."""
+    tracker = Tracker()
+    s3_client = _stub_s3_client_for_assets({1: "aaa", 2: "bbb", 3: "ccc"})
+    ordinal_exts = {1: ".jpg", 2: ".jpg", 3: ".jpg"}
+    page_labels = {1: "1", 2: "2", 3: "3"}
+
+    with patch("tools.uploader.pywikibot.FilePage") as fp:
+        fp.side_effect = _make_file_page_factory(existing={})
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="Some Item",
+            partner="nara",
+            ordinal_exts=ordinal_exts,
+            page_labels=page_labels,
+            dry_run=False,
+        )
+    assert tracker.count(Result.ORPHANS_TAGGED) == 0
+    assert tracker.count(Result.ORPHANS_FLAGGED) == 0
+
+
+def test_orphan_check_tags_trailing_orphan_with_matching_sha1():
+    """Item has 3 jpgs, (page 4).jpg exists with SHA1 of (page 3) → tag it."""
+    tracker = Tracker()
+    s3_client = _stub_s3_client_for_assets({1: "aaa", 2: "bbb", 3: "ccc"})
+    ordinal_exts = {1: ".jpg", 2: ".jpg", 3: ".jpg"}
+    page_labels = {1: "1", 2: "2", 3: "3"}
+    orphan_title = "Some Item - DPLA - abcd1234abcd1234abcd1234abcd1234 (page 4).jpg"
+    expected_keep = "Some Item - DPLA - abcd1234abcd1234abcd1234abcd1234 (page 3).jpg"
+
+    with (
+        patch("tools.uploader.pywikibot.FilePage") as fp,
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+    ):
+        fp.side_effect = _make_file_page_factory(existing={orphan_title: "ccc"})
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="Some Item",
+            partner="nara",
+            ordinal_exts=ordinal_exts,
+            page_labels=page_labels,
+            dry_run=False,
+        )
+
+    assert tracker.count(Result.ORPHANS_TAGGED) == 1
+    assert tracker.count(Result.ORPHANS_FLAGGED) == 0
+    tag_mock.assert_called_once()
+    kwargs = tag_mock.call_args.kwargs
+    assert kwargs["correct_filename"] == expected_keep
+
+
+def test_orphan_check_flags_orphan_with_unknown_sha1():
+    """Orphan exists but SHA1 isn't one of this item's S3 assets → flag, don't tag."""
+    tracker = Tracker()
+    s3_client = _stub_s3_client_for_assets({1: "aaa", 2: "bbb"})
+    ordinal_exts = {1: ".jpg", 2: ".jpg"}
+    page_labels = {1: "1", 2: "2"}
+    orphan_title = "T - DPLA - abcd1234abcd1234abcd1234abcd1234 (page 3).jpg"
+
+    with (
+        patch("tools.uploader.pywikibot.FilePage") as fp,
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+    ):
+        fp.side_effect = _make_file_page_factory(existing={orphan_title: "zzz_unknown"})
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="T",
+            partner="nara",
+            ordinal_exts=ordinal_exts,
+            page_labels=page_labels,
+            dry_run=False,
+        )
+
+    assert tracker.count(Result.ORPHANS_FLAGGED) == 1
+    assert tracker.count(Result.ORPHANS_TAGGED) == 0
+    tag_mock.assert_not_called()
+
+
+def test_orphan_check_handles_multiple_trailing_orphans():
+    """Item now has 2 jpgs; (page 3) and (page 4) are both orphans."""
+    tracker = Tracker()
+    s3_client = _stub_s3_client_for_assets({1: "aaa", 2: "bbb"})
+    ordinal_exts = {1: ".jpg", 2: ".jpg"}
+    page_labels = {1: "1", 2: "2"}
+    base = "Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
+    existing = {
+        f"{base} (page 3).jpg": "bbb",  # matches kept (page 2)
+        f"{base} (page 4).jpg": "aaa",  # matches kept (page 1)
+    }
+
+    with (
+        patch("tools.uploader.pywikibot.FilePage") as fp,
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+    ):
+        fp.side_effect = _make_file_page_factory(existing=existing)
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="Item",
+            partner="nara",
+            ordinal_exts=ordinal_exts,
+            page_labels=page_labels,
+            dry_run=False,
+        )
+
+    assert tracker.count(Result.ORPHANS_TAGGED) == 2
+    assert tag_mock.call_count == 2
+    keep_targets = {c.kwargs["correct_filename"] for c in tag_mock.call_args_list}
+    assert keep_targets == {f"{base} (page 1).jpg", f"{base} (page 2).jpg"}
+
+
+def test_orphan_check_single_asset_probes_from_page_1():
+    """Single-asset items use no-suffix titles, so (page 1) and up are orphans.
+
+    Common signature: item used to be multi-page and got reduced to one asset,
+    so its (page 1).jpg / (page 2).jpg / ... linger beyond the no-suffix file.
+    """
+    tracker = Tracker()
+    s3_client = _stub_s3_client_for_assets({1: "aaa"})
+    ordinal_exts = {1: ".jpg"}
+    page_labels = {1: ""}
+    base = "Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
+    existing = {f"{base} (page 1).jpg": "aaa"}
+
+    with (
+        patch("tools.uploader.pywikibot.FilePage") as fp,
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+    ):
+        fp.side_effect = _make_file_page_factory(existing=existing)
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="Item",
+            partner="nara",
+            ordinal_exts=ordinal_exts,
+            page_labels=page_labels,
+            dry_run=False,
+        )
+
+    assert tracker.count(Result.ORPHANS_TAGGED) == 1
+    tag_mock.assert_called_once()
+    assert tag_mock.call_args.kwargs["correct_filename"] == f"{base}.jpg"
+
+
+def test_orphan_check_dry_run_does_not_save():
+    tracker = Tracker()
+    s3_client = _stub_s3_client_for_assets({1: "aaa", 2: "bbb"})
+    ordinal_exts = {1: ".jpg", 2: ".jpg"}
+    page_labels = {1: "1", 2: "2"}
+    base = "Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
+    existing = {f"{base} (page 3).jpg": "bbb"}
+
+    with (
+        patch("tools.uploader.pywikibot.FilePage") as fp,
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+    ):
+        fp.side_effect = _make_file_page_factory(existing=existing)
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="Item",
+            partner="nara",
+            ordinal_exts=ordinal_exts,
+            page_labels=page_labels,
+            dry_run=True,
+        )
+
+    # Dry-run still increments TAGGED (it counts the intent), but does not
+    # actually call tag_as_duplicate.
+    assert tracker.count(Result.ORPHANS_TAGGED) == 1
+    tag_mock.assert_not_called()
+
+
+def test_orphan_check_skips_extensions_with_no_assets():
+    """Empty ordinal_exts (e.g. stubs-only) → no probing, no errors."""
+    tracker = Tracker()
+    s3_client = _stub_s3_client_for_assets({})
+    with patch("tools.uploader.pywikibot.FilePage") as fp:
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="Item",
+            partner="nara",
+            ordinal_exts={},
+            page_labels={},
+            dry_run=False,
+        )
+    fp.assert_not_called()
+    assert tracker.count(Result.ORPHANS_TAGGED) == 0
+    assert tracker.count(Result.ORPHANS_FLAGGED) == 0

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -467,6 +467,72 @@ def test_orphan_check_flags_when_tag_save_fails():
     assert tracker.count(Result.ORPHANS_FLAGGED) == 1
 
 
+def test_orphan_check_uses_declared_count_when_sha1_metadata_missing():
+    """An in-range ordinal that's missing CHECKSUM metadata on S3 must still
+    count toward expected_count for probe-boundary purposes — otherwise the
+    probe would start inside the legitimate page range and could tag a real
+    page as a duplicate of itself.
+
+    Scenario: 3 jpgs declared in ordinal_exts; ordinal 2's S3 metadata is
+    missing the sha1 key.  Probe must still start at (page 4), not (page 3).
+    """
+
+    def _stub_s3_with_one_missing_checksum():
+        # ordinal 1 and 3 have SHA1; ordinal 2 returns metadata without 'sha1'.
+        sha1s = {1: "aaa", 3: "ccc"}
+
+        def _get_media_path(dpla_id, ordinal, partner):
+            return f"{partner}/images/x/x/x/x/{dpla_id}/{ordinal}_{dpla_id}"
+
+        def _object(_bucket, key):
+            ordinal = int(key.rsplit("/", 1)[1].split("_", 1)[0])
+            obj = MagicMock()
+            obj.metadata = {"sha1": sha1s[ordinal]} if ordinal in sha1s else {}
+            return obj
+
+        s3_client = MagicMock()
+        s3_client.get_media_s3_path.side_effect = _get_media_path
+        inner = MagicMock()
+        inner.Object.side_effect = _object
+        s3_client.get_s3.return_value = inner
+        return s3_client
+
+    tracker = Tracker()
+    s3_client = _stub_s3_with_one_missing_checksum()
+    ordinal_exts = {1: ".jpg", 2: ".jpg", 3: ".jpg"}
+    page_labels = {1: "1", 2: "2", 3: "3"}
+    base = "Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
+    # (page 3) is a legitimate page — its SHA1 happens to match ordinal 3's.
+    # If the probe started at (page 3), it would tag a real page as a dup.
+    # No (page 4) → nothing to tag overall.
+    existing = {f"{base} (page 3).jpg": "ccc"}
+
+    with (
+        patch("tools.uploader.pywikibot.FilePage") as fp,
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+    ):
+        fp.side_effect = _make_file_page_factory(existing=existing)
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="Item",
+            partner="nara",
+            ordinal_exts=ordinal_exts,
+            page_labels=page_labels,
+            dry_run=False,
+        )
+
+    assert tracker.count(Result.ORPHANS_TAGGED) == 0
+    assert tracker.count(Result.ORPHANS_FLAGGED) == 0
+    tag_mock.assert_not_called()
+    # And the FilePage probe must not have hit (page 3) — it would have
+    # if we used the SHA1-filtered count of 2 instead of the declared 3.
+    probed_titles = [call.args[1] for call in fp.call_args_list]
+    assert f"{base} (page 3).jpg" not in probed_titles
+
+
 def test_orphan_check_skips_extensions_with_no_assets():
     """Empty ordinal_exts (e.g. stubs-only) → no probing, no errors."""
     tracker = Tracker()

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -338,6 +338,45 @@ def test_orphan_check_dry_run_does_not_save():
     tag_mock.assert_not_called()
 
 
+def test_orphan_check_skips_gap_and_finds_orphan_past_it():
+    """Single-asset item with no (page 1) but (page 2) stranded — gap tolerance
+    must let the probe reach it.
+
+    Real case observed: LBJ 1956 Desk Diary I (DPLA 72e2342079...) — the item
+    is now single-page (no-suffix .jpg authoritative) but (page 2).jpg lingers
+    with no (page 1).jpg adjacent to it (a previous session handled the
+    (page 1) slot via move/tag, leaving (page 2) stranded).
+    """
+    tracker = Tracker()
+    s3_client = _stub_s3_client_for_assets({1: "aaa"})
+    ordinal_exts = {1: ".jpg"}
+    page_labels = {1: ""}
+    base = "Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
+    # No (page 1).jpg; (page 2).jpg exists with the same SHA1 as the no-suffix asset.
+    existing = {f"{base} (page 2).jpg": "aaa"}
+
+    with (
+        patch("tools.uploader.pywikibot.FilePage") as fp,
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+    ):
+        fp.side_effect = _make_file_page_factory(existing=existing)
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="Item",
+            partner="nara",
+            ordinal_exts=ordinal_exts,
+            page_labels=page_labels,
+            dry_run=False,
+        )
+
+    assert tracker.count(Result.ORPHANS_TAGGED) == 1
+    tag_mock.assert_called_once()
+    assert tag_mock.call_args.kwargs["correct_filename"] == f"{base}.jpg"
+
+
 def test_orphan_check_skips_extensions_with_no_assets():
     """Empty ordinal_exts (e.g. stubs-only) → no probing, no errors."""
     tracker = Tracker()

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1027,6 +1027,22 @@ def _post_item_orphan_check(
 
             if orphan_sha1 in sha1_to_kept:
                 keep_title = sha1_to_kept[orphan_sha1]
+                # process_file may have SKIPPED the ordinal whose SHA1 we
+                # matched (bad mime, octet-stream, empty file, etc.), or the
+                # item may have aborted on UploadTimeoutError before reaching
+                # it.  In either case the kept_title we'd point at doesn't
+                # actually exist on Commons.  Confirm it does before pointing
+                # an orphan at a phantom target.
+                keep_page = pywikibot.FilePage(site, keep_title)
+                if not keep_page.exists():
+                    logging.warning(
+                        f"Orphan [[File:{candidate_title}]] (SHA1 {orphan_sha1}) "
+                        f"would point at [[File:{keep_title}]] but that title "
+                        f"does not exist on Commons (asset likely skipped or "
+                        f"upload aborted); flagging instead of tagging."
+                    )
+                    tracker.increment(Result.ORPHANS_FLAGGED)
+                    continue
                 if dry_run:
                     logging.info(
                         f"[DRY RUN] would tag orphan [[File:{candidate_title}]] "
@@ -1052,9 +1068,12 @@ def _post_item_orphan_check(
                     )
                     tracker.increment(Result.ORPHANS_TAGGED)
                 except Exception as e:
+                    # The orphan remains unresolved; record as FLAGGED so the
+                    # run summary accurately reflects follow-up work needed.
                     logging.warning(
                         f"Failed to tag orphan [[File:{candidate_title}]]: {e}"
                     )
+                    tracker.increment(Result.ORPHANS_FLAGGED)
             else:
                 logging.warning(
                     f"Orphan beyond asset count: [[File:{candidate_title}]] "

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -913,6 +913,12 @@ _REPLICATION_SETTLE_SECS = 10
 # DPLA item has more pages than this.
 _ORPHAN_PROBE_CEILING = 500
 
+# Tolerate small gaps in the probe sequence — orphans aren't always
+# contiguous.  E.g. a previous session may have moved or deleted (page N)
+# while leaving (page N+1) stranded.  Two consecutive misses is enough to
+# call the trail finished.
+_ORPHAN_GAP_TOLERANCE = 2
+
 
 def _post_item_orphan_check(
     site,
@@ -938,8 +944,10 @@ def _post_item_orphan_check(
         so any (page N) at all is an orphan — probe from page 1.
       - If count >= 2 the expected titles are (page 1)..(page N), so probe
         from page N+1.
-      - Probe upward via FilePage.exists() (page-info API, not search) until
-        the first non-existent page; that gap terminates the trail.
+      - Probe upward via FilePage.exists() (page-info API, not search),
+        tolerating up to _ORPHAN_GAP_TOLERANCE consecutive missing pages
+        — orphans aren't always contiguous (e.g. a prior session may have
+        moved or deleted (page N) while leaving (page N+1) stranded).
       - For each orphan found, compare its SHA1 to the SHA1 set of this
         item's S3 assets of the same extension:
           - match → tag as duplicate of the matching uploaded title
@@ -989,6 +997,7 @@ def _post_item_orphan_check(
         for sha1, kept_title in entries:
             sha1_to_kept.setdefault(sha1, kept_title)
 
+        consecutive_misses = 0
         for k in range(start_page, start_page + _ORPHAN_PROBE_CEILING):
             candidate_title = get_page_title(
                 item_title=item_title,
@@ -1000,7 +1009,11 @@ def _post_item_orphan_check(
             # cached result from a previous call within this session.
             candidate = pywikibot.FilePage(site, candidate_title)
             if not candidate.exists():
-                break  # gap → no more trailing orphans for this ext
+                consecutive_misses += 1
+                if consecutive_misses > _ORPHAN_GAP_TOLERANCE:
+                    break  # trail of misses long enough; stop scanning ext
+                continue
+            consecutive_misses = 0
 
             try:
                 orphan_sha1 = candidate.latest_file_info.sha1

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -749,7 +749,7 @@ class Uploader:
 
             # Pre-scan via the shared helper so the verifier can reconstruct
             # the same page-label assignments without duplicating the logic.
-            _, page_labels = compute_ordinal_exts_and_page_labels(
+            ordinal_exts, page_labels = compute_ordinal_exts_and_page_labels(
                 self.s3_client, dpla_id, partner, len(files)
             )
 
@@ -777,6 +777,30 @@ class Uploader:
                 except UploadTimeoutError as ex:
                     self.handle_upload_exception(ex)
                     break
+
+            # After the per-asset loop, look for "trailing-page orphan" Commons
+            # files for this item — pages whose ordinal exceeds the current
+            # source asset count for that extension. These are invisible to
+            # process_file (it only iterates the current asset list), so the
+            # Case 2 tag-as-duplicate path never fires for them when the
+            # source truncated pages off the end of a multi-page item.
+            # Wrap separately so a check failure doesn't get charged as
+            # FAILED against the item itself — the per-asset uploads have
+            # already succeeded at this point.
+            try:
+                _post_item_orphan_check(
+                    self.site,
+                    self.s3_client,
+                    self.tracker,
+                    dpla_id,
+                    title,
+                    partner,
+                    ordinal_exts,
+                    page_labels,
+                    dry_run,
+                )
+            except Exception as ex:
+                logging.warning(f"Orphan check failed for {dpla_id}: {ex}; continuing")
 
         except Exception as ex:
             logging.warning(
@@ -883,6 +907,148 @@ def main(ids_file, partner: str, dry_run: bool, verbose: bool) -> None:
 # practice, so give it real headroom.  Only paid when there's something to
 # touch, which is the rare "new institution this session" case.
 _REPLICATION_SETTLE_SECS = 10
+
+# Cap the per-extension trailing-orphan probe so a runaway naming scheme
+# never produces an unbounded loop of FilePage.exists() calls.  No real
+# DPLA item has more pages than this.
+_ORPHAN_PROBE_CEILING = 500
+
+
+def _post_item_orphan_check(
+    site,
+    s3_client: S3Client,
+    tracker: Tracker,
+    dpla_id: str,
+    item_title: str,
+    partner: str,
+    ordinal_exts: dict[int, str],
+    page_labels: dict[int, str],
+    dry_run: bool,
+) -> None:
+    """Tag Commons files whose page-number suffix exceeds the current source
+    asset count for this item — "trailing-page orphans" left behind when the
+    source truncated one or more pages from the end of a multi-page item.
+
+    These are invisible to process_file (which only iterates current asset
+    list positions), so Case 2's tag-as-duplicate never fires for them.
+
+    For each extension used by the item:
+      - Compute the expected per-extension page count from ordinal_exts.
+      - If count == 1 the expected Commons title is the no-suffix variant,
+        so any (page N) at all is an orphan — probe from page 1.
+      - If count >= 2 the expected titles are (page 1)..(page N), so probe
+        from page N+1.
+      - Probe upward via FilePage.exists() (page-info API, not search) until
+        the first non-existent page; that gap terminates the trail.
+      - For each orphan found, compare its SHA1 to the SHA1 set of this
+        item's S3 assets of the same extension:
+          - match → tag as duplicate of the matching uploaded title
+          - no match → log a WARNING for manual review (could be a real
+            unrelated upload at that title that we shouldn't touch)
+    """
+    # Build per-extension data: ext (with leading dot) → list of
+    # (sha1, kept_title) for the assets currently uploaded.
+    per_ext: dict[str, list[tuple[str, str]]] = {}
+    for ordinal in sorted(ordinal_exts):
+        ext = ordinal_exts[ordinal]
+        if not ext:
+            continue  # stub / octet-stream ordinal — no per-extension entry
+        page_label = page_labels.get(ordinal, "")
+        s3_path = s3_client.get_media_s3_path(dpla_id, ordinal, partner)
+        try:
+            s3_obj = s3_client.get_s3().Object(S3_BUCKET, s3_path)
+            sha1 = (s3_obj.metadata or {}).get(CHECKSUM)
+        except Exception as e:
+            logging.warning(
+                f"Orphan check: could not read SHA1 for {dpla_id} ord {ordinal}: {e}"
+            )
+            continue
+        if not sha1:
+            continue
+        kept_title = get_page_title(
+            item_title=item_title,
+            dpla_identifier=dpla_id,
+            suffix=ext,
+            page=page_label,
+        )
+        per_ext.setdefault(ext, []).append((sha1, kept_title))
+
+    for ext, entries in per_ext.items():
+        expected_count = len(entries)
+        if expected_count >= 2:
+            start_page = expected_count + 1
+        elif expected_count == 1:
+            start_page = 1
+        else:
+            continue
+
+        # First-seen-wins: if the same SHA1 appears at multiple kept titles
+        # (rare — happens when a source mediaMaster lists the same asset twice),
+        # any of the kept titles is a valid duplicate target.
+        sha1_to_kept: dict[str, str] = {}
+        for sha1, kept_title in entries:
+            sha1_to_kept.setdefault(sha1, kept_title)
+
+        for k in range(start_page, start_page + _ORPHAN_PROBE_CEILING):
+            candidate_title = get_page_title(
+                item_title=item_title,
+                dpla_identifier=dpla_id,
+                suffix=ext,
+                page=str(k),
+            )
+            # Fresh FilePage each iteration so .exists() doesn't return a
+            # cached result from a previous call within this session.
+            candidate = pywikibot.FilePage(site, candidate_title)
+            if not candidate.exists():
+                break  # gap → no more trailing orphans for this ext
+
+            try:
+                orphan_sha1 = candidate.latest_file_info.sha1
+            except Exception as e:
+                logging.warning(
+                    f"Orphan check: could not read orphan SHA1 for "
+                    f"[[File:{candidate_title}]]: {e}"
+                )
+                tracker.increment(Result.ORPHANS_FLAGGED)
+                continue
+
+            if orphan_sha1 in sha1_to_kept:
+                keep_title = sha1_to_kept[orphan_sha1]
+                if dry_run:
+                    logging.info(
+                        f"[DRY RUN] would tag orphan [[File:{candidate_title}]] "
+                        f"as duplicate of [[File:{keep_title}]] (DPLA ID {dpla_id})"
+                    )
+                    tracker.increment(Result.ORPHANS_TAGGED)
+                    continue
+                try:
+                    tag_as_duplicate(
+                        site,
+                        candidate,
+                        correct_filename=keep_title,
+                        reason=(
+                            "Trailing-page orphan: this title has no "
+                            "corresponding asset in the current DPLA source "
+                            "for this item; the matching asset is uploaded at "
+                            f"[[:File:{keep_title}]]."
+                        ),
+                    )
+                    logging.info(
+                        f"Tagged trailing-page orphan [[File:{candidate_title}]] "
+                        f"as duplicate of [[File:{keep_title}]] (DPLA ID {dpla_id})"
+                    )
+                    tracker.increment(Result.ORPHANS_TAGGED)
+                except Exception as e:
+                    logging.warning(
+                        f"Failed to tag orphan [[File:{candidate_title}]]: {e}"
+                    )
+            else:
+                logging.warning(
+                    f"Orphan beyond asset count: [[File:{candidate_title}]] "
+                    f"(SHA1 {orphan_sha1}) — not present in current S3 assets "
+                    f"for DPLA ID {dpla_id}; manual review needed."
+                )
+                tracker.increment(Result.ORPHANS_FLAGGED)
 
 
 def _post_upload_touch_new_institutions(

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -954,8 +954,22 @@ def _post_item_orphan_check(
           - no match → log a WARNING for manual review (could be a real
             unrelated upload at that title that we shouldn't touch)
     """
-    # Build per-extension data: ext (with leading dot) → list of
-    # (sha1, kept_title) for the assets currently uploaded.
+    # Declared per-extension page count from the pre-scan.  This is what
+    # determines the legitimate (page 1)…(page N) range for the item — we
+    # MUST derive the probe start from this and not from `per_ext` below,
+    # because an ordinal whose SHA1 we can't read still occupies a real
+    # page slot.  Underestimating expected_count would make the probe
+    # overlap a legitimate page and risk tagging it as a duplicate.
+    declared_ext_counts: dict[str, int] = {}
+    for ordinal in ordinal_exts:
+        ext = ordinal_exts[ordinal]
+        if not ext:
+            continue  # stub / octet-stream ordinal — not a per-extension slot
+        declared_ext_counts[ext] = declared_ext_counts.get(ext, 0) + 1
+
+    # Build per-extension SHA1→kept_title map for the assets we can hash.
+    # Used only to decide whether a found orphan is a duplicate of a known
+    # source asset — the probe boundary is driven by declared_ext_counts.
     per_ext: dict[str, list[tuple[str, str]]] = {}
     for ordinal in sorted(ordinal_exts):
         ext = ordinal_exts[ordinal]
@@ -981,8 +995,8 @@ def _post_item_orphan_check(
         )
         per_ext.setdefault(ext, []).append((sha1, kept_title))
 
-    for ext, entries in per_ext.items():
-        expected_count = len(entries)
+    for ext, expected_count in declared_ext_counts.items():
+        entries = per_ext.get(ext, [])
         if expected_count >= 2:
             start_page = expected_count + 1
         elif expected_count == 1:


### PR DESCRIPTION
## Summary

- Closes a blind spot in the upload pipeline: when a source provider truncates one or more pages off the end of a multi-page DPLA item, the stranded `(page N+1).<ext>`, `(page N+2).<ext>` … Commons pages were never re-examined. The upload loop only iterates the current asset list, so Case 2's tag-as-duplicate never fires for them.
- Adds a post-loop integrity check (`_post_item_orphan_check`) that probes upward per extension using `FilePage.exists()` — the page-info API, not search, so search-index lag doesn't affect it — and stops at the first gap.
- For each orphan found: compares its SHA1 to this item's current S3 assets. Match → tag as duplicate of the matching uploaded title. No match → log a `WARNING` for manual review (could be an unrelated upload at that title that we shouldn't auto-touch).
- New `Result` counters: `ORPHANS_TAGGED`, `ORPHANS_FLAGGED`.
- The retroactive backfill (running on EC2 now, separate script) found ≈66 sets of this kind that built up across NARA, PA, and SI sessions before today's tagging pass. This PR prevents the next batch.

## Why direct exists() and not search

The Commons search index has up to a few minutes of lag after an upload or move. If we relied on `list=search` here, we'd routinely make decisions on stale state right after writing — exactly the wrong moment. `FilePage.exists()` hits the live page-info endpoint, which reflects the current state immediately, so the integrity check sees the same Commons we just wrote to. A fresh `FilePage` is constructed per ordinal so pywikibot's per-object `exists()` cache doesn't return a stale `False`.

## What this does NOT cover

- Interior-page removals (e.g. page 4 dropped from a 6-page item) — already handled by the existing Case 2 logic during per-asset iteration.
- An entire extension disappearing from an item (e.g. all JPGs removed, only PDFs remain). Catching that would need to enumerate Commons files for the item, which is the search-index-lag scenario we're avoiding. Rare in practice; deferred.

## Test plan
- [x] `pytest tests/test_uploader.py` — 12 tests pass (5 existing + 7 new)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- Tests cover: no-orphan, matching-SHA1 tag, unknown-SHA1 flag, multiple trailing orphans, single-asset (no-suffix) items, dry-run path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->