### PR TITLE
launch: run EC2 code update as ec2-user; heal prior root-owned files

### DIFF
--- a/ingest_wikimedia/ssm.py
+++ b/ingest_wikimedia/ssm.py
@@ -9,11 +9,27 @@ SSM_POLL_INTERVAL = 5
 SSM_MAX_POLLS = 60  # 5 minutes
 
 
-def ssm_run(client, cmd: str) -> str:
+def ssm_run(client, cmd: str, *, as_root: bool = False) -> str:
+    """Run cmd on EC2 via AWS-RunShellScript SSM, default ec2-user context.
+
+    The AWS-RunShellScript document executes as root by default. Most
+    pipeline commands need to act on the ec2-user-owned working tree and
+    venv, so by default we wrap the command in `sudo -u ec2-user bash -c`.
+
+    Pass as_root=True to bypass the wrapper and run with full root
+    privilege — needed for the rare operations only root can do, such as
+    `chown` of files owned by a different user. Callers that need root
+    should be explicit about it; the default keeps file ownership
+    consistently under ec2-user.
+    """
+    if as_root:
+        wrapped = cmd
+    else:
+        wrapped = f"sudo -u ec2-user bash -c {shlex.quote(cmd)}"
     resp = client.send_command(
         InstanceIds=[INSTANCE_ID],
         DocumentName="AWS-RunShellScript",
-        Parameters={"commands": [f"sudo -u ec2-user bash -c {shlex.quote(cmd)}"]},
+        Parameters={"commands": [wrapped]},
     )
     cmd_id = resp["Command"]["CommandId"]
     for attempt in range(SSM_MAX_POLLS):

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -260,19 +260,29 @@ def main() -> None:
         if github_sha
         else ""
     )
-    # SSM commands run as root by default. If any earlier root-context run
-    # imported a package from the venv, Python would have written its
-    # `__pycache__/` as root-owned — leaving subsequent ec2-user `uv sync`
-    # invocations unable to delete or update those package directories
-    # ("Permission denied: ... lxml/__pycache__"). Two-step fix:
+    # `ssm_run` wraps every command in `sudo -u ec2-user bash -c` by
+    # default. That's correct for the actual update (we want git clone, cp,
+    # and uv sync to run as ec2-user so they never create root-owned
+    # files), but `chown -R` of root-owned files needs CAP_CHOWN, which
+    # ec2-user does not have. So the heal step uses ssm_run(..., as_root=True)
+    # to bypass the wrapper and run with the AWS-RunShellScript document's
+    # default root context.
     #
-    #   1. Heal any pre-existing root-owned files by chowning the repo
-    #      and the /tmp staging dir back to ec2-user (root privilege
-    #      needed, so we keep this step in the default SSM root context).
-    #   2. Wrap the entire update in `sudo -u ec2-user bash -c '...'` so
-    #      git clone / cp / uv sync all run as ec2-user, never creating
-    #      new root-owned cache files in the first place.
-    update_cmd_inner = (
+    # The earlier "Permission denied: ... lxml/__pycache__" failure mode
+    # came from prior root-context Python imports (back when the update
+    # itself ran as root) leaving root-owned `__pycache__/` inside an
+    # otherwise ec2-user-owned venv. The heal step cleans those up; the
+    # ec2-user-run update step prevents them from being recreated.
+    heal_cmd = (
+        "chown -R ec2-user:ec2-user /home/ec2-user/ingest-wikimedia/ && "
+        "(chown -R ec2-user:ec2-user /tmp/ingest-wikimedia-update 2>/dev/null || true)"
+    )
+    try:
+        ssm_run(ssm, heal_cmd, as_root=True)
+    except Exception as e:
+        _slack_fail(response_url, f"⚠️ Failed to heal EC2 file ownership: {e}")
+
+    update_cmd = (
         "cd /tmp && rm -rf ingest-wikimedia-update && "
         "git clone --depth 1 https://github.com/dpla/ingest-wikimedia.git ingest-wikimedia-update && "
         + pin_step
@@ -281,11 +291,6 @@ def main() -> None:
         "cp ingest-wikimedia-update/pyproject.toml /home/ec2-user/ingest-wikimedia/pyproject.toml && "
         "cp ingest-wikimedia-update/uv.lock /home/ec2-user/ingest-wikimedia/uv.lock && "
         "/home/ec2-user/.local/bin/uv sync --project /home/ec2-user/ingest-wikimedia && echo UPDATE_DONE"
-    )
-    update_cmd = (
-        "chown -R ec2-user:ec2-user /home/ec2-user/ingest-wikimedia/ && "
-        "(chown -R ec2-user:ec2-user /tmp/ingest-wikimedia-update 2>/dev/null || true) && "
-        f"sudo -u ec2-user bash -c {shlex.quote(update_cmd_inner)}"
     )
     out = ""
     try:

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -260,7 +260,19 @@ def main() -> None:
         if github_sha
         else ""
     )
-    update_cmd = (
+    # SSM commands run as root by default. If any earlier root-context run
+    # imported a package from the venv, Python would have written its
+    # `__pycache__/` as root-owned — leaving subsequent ec2-user `uv sync`
+    # invocations unable to delete or update those package directories
+    # ("Permission denied: ... lxml/__pycache__"). Two-step fix:
+    #
+    #   1. Heal any pre-existing root-owned files by chowning the repo
+    #      and the /tmp staging dir back to ec2-user (root privilege
+    #      needed, so we keep this step in the default SSM root context).
+    #   2. Wrap the entire update in `sudo -u ec2-user bash -c '...'` so
+    #      git clone / cp / uv sync all run as ec2-user, never creating
+    #      new root-owned cache files in the first place.
+    update_cmd_inner = (
         "cd /tmp && rm -rf ingest-wikimedia-update && "
         "git clone --depth 1 https://github.com/dpla/ingest-wikimedia.git ingest-wikimedia-update && "
         + pin_step
@@ -269,6 +281,11 @@ def main() -> None:
         "cp ingest-wikimedia-update/pyproject.toml /home/ec2-user/ingest-wikimedia/pyproject.toml && "
         "cp ingest-wikimedia-update/uv.lock /home/ec2-user/ingest-wikimedia/uv.lock && "
         "/home/ec2-user/.local/bin/uv sync --project /home/ec2-user/ingest-wikimedia && echo UPDATE_DONE"
+    )
+    update_cmd = (
+        "chown -R ec2-user:ec2-user /home/ec2-user/ingest-wikimedia/ && "
+        "(chown -R ec2-user:ec2-user /tmp/ingest-wikimedia-update 2>/dev/null || true) && "
+        f"sudo -u ec2-user bash -c {shlex.quote(update_cmd_inner)}"
     )
     out = ""
     try:

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -1,0 +1,58 @@
+"""Tests for ingest_wikimedia/ssm.py — the AWS SSM wrapper helper."""
+
+from unittest.mock import MagicMock
+
+from ingest_wikimedia.ssm import ssm_run
+
+
+def _make_client_returning(stdout: str) -> MagicMock:
+    """Build a mock boto3 SSM client whose send_command + get_command_invocation
+    pair returns the given stdout from a Success-status invocation."""
+    client = MagicMock()
+    client.send_command.return_value = {"Command": {"CommandId": "test-cmd-id"}}
+    client.get_command_invocation.return_value = {
+        "Status": "Success",
+        "StandardOutputContent": stdout,
+    }
+    # Real boto3 clients expose .exceptions.InvocationDoesNotExist; the
+    # production code references it inside an `except` clause. The mock
+    # doesn't need a real exception class — set a Sentinel that no real
+    # invocation will raise so the polling loop reaches the Success branch.
+    client.exceptions.InvocationDoesNotExist = type(
+        "_FakeInvocationDoesNotExist", (Exception,), {}
+    )
+    return client
+
+
+def test_ssm_run_default_drops_to_ec2_user():
+    """Default behavior wraps the command in `sudo -u ec2-user bash -c`."""
+    client = _make_client_returning("ok")
+    ssm_run(client, "echo hello")
+    sent = client.send_command.call_args.kwargs["Parameters"]["commands"][0]
+    assert sent.startswith("sudo -u ec2-user bash -c "), sent
+    # The original command should appear inside the quoted argument.
+    assert "echo hello" in sent
+
+
+def test_ssm_run_as_root_bypasses_wrapper():
+    """`as_root=True` runs the raw command in the SSM root context with no
+    `sudo -u ec2-user` wrapper.
+
+    Regression test for PR #228's CodeRabbit finding: the launch script's
+    `chown -R ec2-user:ec2-user` heal step needs CAP_CHOWN to fix
+    root-owned files, which ec2-user does not have. The previous PR
+    revision sent the heal command through the default wrapper and so
+    failed with EPERM on every launch.
+    """
+    client = _make_client_returning("ok")
+    ssm_run(client, "chown -R ec2-user:ec2-user /home/ec2-user/repo", as_root=True)
+    sent = client.send_command.call_args.kwargs["Parameters"]["commands"][0]
+    assert sent == "chown -R ec2-user:ec2-user /home/ec2-user/repo"
+    assert "sudo -u ec2-user" not in sent
+
+
+def test_ssm_run_returns_stripped_stdout():
+    """Output is stripped of leading/trailing whitespace."""
+    client = _make_client_returning("  hello world  \n")
+    result = ssm_run(client, "echo")
+    assert result == "hello world"


### PR DESCRIPTION
## Summary

Fix the EC2 code-update step in `scripts/wikimedia_launch.py` so it (a) drops to `ec2-user` before running `uv sync`, and (b) heals any root-owned files left over from prior buggy runs. Without this, `/wikimedia-upload refresh heartland 365` and similar launches fail at update time with `Permission denied` deleting `lxml/__pycache__`.

### Symptom

User ran `/wikimedia-upload refresh heartland 365` (2026-05-24) and got:

> ⚠️ Failed to update EC2 code: SSM command ... ended with Failed: ... `error: failed to remove directory /home/ec2-user/ingest-wikimedia/.venv/lib/python3.13/site-packages/lxml/__pycache__: Permission denied (os error 13)`

### Root cause

SSM Run Command executes as root by default. The existing `update_cmd` runs `uv sync` in that root context. Every Python import there writes its `__pycache__/` as **root-owned**, inside an otherwise **ec2-user-owned** venv. On the next code update, `uv sync` tries to install a refreshed version of a package — that means deleting the old package dir first — and the delete fails on the root-owned `__pycache__` subdirectory.

Verified on EC2:

```
$ ls -ld /home/ec2-user/ingest-wikimedia/.venv/lib/python3.13/site-packages/lxml/__pycache__/
drwxr-xr-x. 2 root root 38 May 24 03:11 .../lxml/__pycache__/

$ find /home/ec2-user/ingest-wikimedia/.venv -name __pycache__ -not -user ec2-user
.../soupsieve/__pycache__
.../bs4/builder/__pycache__
.../bs4/__pycache__
.../pywikibot/pagegenerators/__pycache__
.../lxml/__pycache__
```

Five root-owned caches, all in an otherwise ec2-user-owned venv.

### Fix

Two steps, both inside the single SSM call:

1. **Heal** any pre-existing root-owned files:
   ```bash
   chown -R ec2-user:ec2-user /home/ec2-user/ingest-wikimedia/
   (chown -R ec2-user:ec2-user /tmp/ingest-wikimedia-update 2>/dev/null || true)
   ```
   This runs in the default SSM root context, which is where the chown privilege lives. The `|| true` swallows the missing-target case for the optional `/tmp` staging dir.

2. **Wrap** the rest of the update in `sudo -u ec2-user bash -c '...'`:
   ```python
   update_cmd_inner = (
       "cd /tmp && rm -rf ingest-wikimedia-update && "
       "git clone --depth 1 https://github.com/dpla/ingest-wikimedia.git ingest-wikimedia-update && "
       + pin_step
       + "cp -r ingest-wikimedia-update/ingest_wikimedia/* /home/ec2-user/ingest-wikimedia/ingest_wikimedia/ && "
       ...
       "/home/ec2-user/.local/bin/uv sync --project /home/ec2-user/ingest-wikimedia && echo UPDATE_DONE"
   )
   update_cmd = (
       "chown -R ec2-user:ec2-user /home/ec2-user/ingest-wikimedia/ && "
       "(chown -R ec2-user:ec2-user /tmp/ingest-wikimedia-update 2>/dev/null || true) && "
       f"sudo -u ec2-user bash -c {shlex.quote(update_cmd_inner)}"
   )
   ```
   The `shlex.quote(update_cmd_inner)` wraps the entire inner pipeline (including `&&`, `;`, `*`, etc.) safely in single quotes for `bash -c`. The pin-to-GITHUB_SHA branch inherits the ec2-user context too.

### Why this is self-healing

The chown step runs on every launch, so any EC2 instance that has been hit by the old bug recovers on the very next launch — no manual intervention required.

### Lesson recorded

> **SSM commands that touch user-owned dirs must drop to that user explicitly**
>
> Audit at the SSM-call boundary, not at the inner script — the inner script can't tell who's running it.

(Added to `~/.claude/lessons.md`.)

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [ ] CI: pytest + ruff green
- [ ] Next `/wikimedia-upload` call: confirm the SSM update command (a) heals the existing root-owned caches and (b) completes `uv sync` without permission errors
- [ ] After the next launch, confirm `find /home/ec2-user/ingest-wikimedia/.venv -not -user ec2-user` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes EC2 code-update permission errors by adding a privilege-aware "heal" step and extending the SSM command wrapper to support root-context execution.

### Changes

**scripts/wikimedia_launch.py**: Adds a "heal" step that runs before the code update to recursively `chown` root-owned files in `/home/ec2-user/ingest-wikimedia/` and optionally `/tmp/ingest-wikimedia-update` back to the `ec2-user` user. This prevents subsequent `uv sync` invocations (running as `ec2-user`) from failing when encountering root-owned `__pycache__` and other Python cache directories.

**ingest_wikimedia/ssm.py**: Extends `ssm_run()` with a keyword-only `as_root: bool = False` parameter. When `as_root=False` (default), commands are wrapped in `sudo -u ec2-user bash -c <cmd>` as before. When `as_root=True`, the raw command is sent to AWS SSM's `AWS-RunShellScript` document, executing with root privilege—necessary for operations like `chown` that require `CAP_CHOWN`. All existing calls remain backward-compatible.

**tests/test_ssm.py**: Adds three tests verifying (1) default wrapping behavior preserves the original command within the `sudo -u ec2-user bash -c` wrapper, (2) `as_root=True` sends the raw command without wrapping, and (3) returned stdout is stripped of leading/trailing whitespace.

### Design Notes

- The heal step runs as root (via `as_root=True`) to change file ownership; the subsequent update runs as `ec2-user` to prevent creating root-owned files in the first place.
- All environment variables remain unchanged; no new AWS Secrets Manager keys are introduced.
- No database migrations, ECS task definitions, CodePipeline changes, or public API modifications.
- The change is backward-compatible: all existing `ssm_run()` calls throughout the codebase continue to work without modification since `as_root` defaults to `False`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->