### PR TITLE
quality pass: single awk pass for log counts, dead-code in test, MAX_API_RETRIES

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -93,6 +93,14 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
     csv_path = shlex.quote(f"{base}/{label}.csv")
 
     sep = "__WM_SEP__"
+    # One awk pass counts all four marker lines in a single sequential read
+    # of the log; the previous code ran four separate `grep -c` invocations
+    # over the same file (plus the COUNTS: probe), which on multi-GB NARA
+    # logs translated to four full sequential reads and four SSM round-trips
+    # of pipeline setup overhead. Output is still four lines (dpla_id,
+    # uploaded, skipping, counts) in the same order as before, followed by
+    # the CSV total from `wc -l`. The `|| printf` fallback covers the
+    # missing-file case symmetrically with the old `|| true`.
     out = ssm_run(
         client,
         f"date +%s; "
@@ -100,11 +108,14 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
         f"echo {sep}; "
         f"tail -5 {log_path}; "
         f"echo {sep}; "
-        f"grep -c 'DPLA ID:' {log_path} 2>/dev/null || true; "
-        f"grep -c 'Uploaded to' {log_path} 2>/dev/null || true; "
-        f"grep -c 'Skipping.*Already exists on commons' {log_path} 2>/dev/null || true; "
-        f"wc -l < {csv_path} 2>/dev/null || echo 0; "
-        f"grep -c 'COUNTS:' {log_path} 2>/dev/null || true",
+        f"awk '"
+        f"/DPLA ID:/ {{d++}} "
+        f"/Uploaded to/ {{u++}} "
+        f"/Skipping.*Already exists on commons/ {{s++}} "
+        f"/COUNTS:/ {{c++}} "
+        f"END {{ print d+0; print u+0; print s+0; print c+0 }}"
+        f"' {log_path} 2>/dev/null || printf '0\\n0\\n0\\n0\\n'; "
+        f"wc -l < {csv_path} 2>/dev/null || echo 0",
     )
 
     sections = out.split(f"{sep}\n", 2)
@@ -119,11 +130,14 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
     tail = sections[1].strip() if len(sections) > 1 else ""
     count_lines = sections[2].strip().splitlines() if len(sections) > 2 else []
 
+    # Layout matches the awk-then-wc shell command above: the awk pass emits
+    # four counts (DPLA-ID, Uploaded, Skipping, COUNTS) and then `wc -l`
+    # emits the CSV total — five lines in total.
     dpla_id_count = _safe_int(count_lines[0]) if len(count_lines) > 0 else 0
     uploaded_count = _safe_int(count_lines[1]) if len(count_lines) > 1 else 0
     skipped_count = _safe_int(count_lines[2]) if len(count_lines) > 2 else 0
-    total = _safe_int(count_lines[3]) if len(count_lines) > 3 else 0
-    counts_marker = _safe_int(count_lines[4]) if len(count_lines) > 4 else 0
+    counts_marker = _safe_int(count_lines[3]) if len(count_lines) > 3 else 0
+    total = _safe_int(count_lines[4]) if len(count_lines) > 4 else 0
 
     def pct(n: int) -> str:
         return f"{n / total * 100:.1f}" if total > 0 else "?"

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -74,7 +74,7 @@ def test_get_phase_and_progress_grep_uses_double_dash_separator():
         # First call is the precheck (session_created + ls|grep); subsequent
         # calls only happen if a log file was returned. Return an empty
         # session_created and no log file so we exit early.
-        if not captured_commands or len(captured_commands) == 1:
+        if len(captured_commands) == 1:
             return "0\n"
         return ""
 

--- a/tools/verify_item.py
+++ b/tools/verify_item.py
@@ -65,6 +65,10 @@ BATCH = 50
 # Fallback when a 429/503 response carries no Retry-After header. 30s is
 # Commons' usual maxlag retry window; long enough to clear most throttles.
 DEFAULT_RETRY_AFTER_SECS = 30
+# Maximum retry attempts for transient 429/503 responses from Commons.
+# Eight attempts with the typical 30-60s back-off covers ~5-10 minutes
+# of cumulative throttle without giving up on long-running batches.
+MAX_API_RETRIES = 8
 # Inter-request courtesy delay between Commons API calls. Keeps sustained
 # request rate well under the unauthenticated ceiling so we never trigger
 # the per-IP limiter on long verification runs.
@@ -99,7 +103,7 @@ def commons_api(params: dict) -> dict:
             "Content-Type": "application/x-www-form-urlencoded",
         },
     )
-    for attempt in range(8):
+    for attempt in range(MAX_API_RETRIES):
         try:
             with urllib.request.urlopen(req, timeout=60) as resp:
                 time.sleep(INTER_REQUEST_SLEEP_SECS)


### PR DESCRIPTION
## Summary

Three actionable improvements out of a 9-finding Copilot review on post-#226 code, after triage. Six findings were verified as false positives or unreachable and left alone — see breakdown below.

### Fixed

**`scripts/wikimedia_upload_status.py`** — replace four sequential `grep -c` scans with one `awk` pass. The previous code did:

```bash
grep -c 'DPLA ID:' "$log"
grep -c 'Uploaded to' "$log"
grep -c 'Skipping.*Already exists on commons' "$log"
grep -c 'COUNTS:' "$log"
```

Every status poll re-read the same log file four times. Multi-GB NARA upload logs made this expensive both in per-call SSM overhead and disk I/O.

```bash
awk '/DPLA ID:/ {d++} /Uploaded to/ {u++} /Skipping.*Already exists on commons/ {s++} /COUNTS:/ {c++} END { print d+0; print u+0; print s+0; print c+0 }' "$log"
```

One pass, four counts. Verified against a real 1.9MB log on EC2: old and new emit identical numbers (`3552 / 8309 / 0 / 1`). The Python parsing was updated to match the new output order (counts come first, `wc -l` total last).

**`tests/test_wikimedia_upload_status.py`** — drop the dead `not captured_commands` branch in the fake_ssm_run mock. `captured_commands.append(command)` runs before the check, so `not captured_commands` is always False at that point.

**`tools/verify_item.py`** — name the `range(8)` retry count as `MAX_API_RETRIES`, consistent with `BATCH`, `DEFAULT_RETRY_AFTER_SECS`, `INTER_REQUEST_SLEEP_SECS` (the magic-number sibling from PR #211's audit).

### Skipped — false positives

| # | File:Line | Claim | Why skip |
|---|---|---|---|
| 2 | `wikimedia_upload_status.py:249` | `partition("-")` "fragile" if days contained `-` | Days is always an integer in the format spec; the dash can't appear there |
| 4 | `test_wikimedia.py:73-78` | Missing test for `page=0` | Unreachable — `compute_ordinal_exts_and_page_labels` produces labels starting at 1 |
| 5 | `test_wikimedia.py:125-129` | Test could be stricter | Confused — the test verifies the exact correct behavior of "only first colon replaced" |
| 6 | `resolve_dpla_ids.py:59-60` | ES errors not wrapped in try/except | Workable as-is: ES failure means no IDs resolve; whole-batch failure is the correct outcome, surfaced via SSM exit code to launch's existing handling |
| 7 | `resolve_dpla_ids.py:112` | Uses `write_item_metadata` direct; others use `stage_item_to_s3` | Functionally identical — `stage_item_to_s3` is literally `s3_client.write_item_metadata(...)` wrapped for the bounded-async executor pattern; this caller doesn't need that wrapper |
| 9 | `verify_item.py:228` | Redirect-resolved titles may not map back via `norm` | The code doesn't pass `redirects` as a prop, so MW doesn't auto-resolve; existing `page.get("redirect")` flag correctly handles the unresolved-redirect case |

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] Awk parity check on real EC2 log (1.9MB `bpl+phillips-academy-upload.log`): old and new emit identical 4-number output
- [ ] CI: pytest + ruff green
- [ ] Next `/wikimedia-status` poll on a multi-target session continues to show the same phase/progress numbers as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR implements three code quality improvements identified in a Copilot review:

### Performance: Single-pass log parsing in `scripts/wikimedia_upload_status.py`
Replaced four sequential `grep -c` invocations that repeatedly re-read the same log file with a single `awk` pass that counts all four patterns in one read. This optimization addresses measurable overhead on large log files (multi-GB NARA upload logs previously scanned 4× per status poll). The awk-derived output order was rearranged (counts first, CSV total last) with corresponding updates to the Python parsing logic. Verified against a real 1.9 MB log file for count parity.

### Code cleanup: Dead-code removal in `tests/test_wikimedia_upload_status.py`
Removed an unreachable branch in the `fake_ssm_run` mock's early-return condition. The `not captured_commands` check was unreachable because `captured_commands.append(command)` executes before the conditional check.

### Code quality: Named constant in `tools/verify_item.py`
Replaced the hardcoded retry count `range(8)` with a named constant `MAX_API_RETRIES = 8`, including inline documentation of the rationale. This aligns with existing constants in the same file (`BATCH`, `DEFAULT_RETRY_AFTER_SECS`, `INTER_REQUEST_SLEEP_SECS`), consistent with the treatment given similar constants in PR `#211`.

All changes are purely operational improvements with no impact on infrastructure, pipelines, APIs, environment variables, or security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->