### PR TITLE
uploader: skip drift correction when SHA1 is duplicated in source asset list

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -1,3 +1,4 @@
+import logging
 import mimetypes
 import re
 import typing
@@ -272,7 +273,10 @@ def collect_duplicate_source_sha1s(
 
     SHA1 metadata read failures (transient S3 errors, stub ordinals)
     are tolerated — those ordinals are simply absent from the count,
-    which conservatively keeps the SHA1 out of the duplicate set.
+    which conservatively keeps the SHA1 out of the duplicate set.  We
+    DO log the skipped ordinal: under-counting silently would cause
+    _resolve_hash_drift to incorrectly treat a legitimate sibling as
+    drift and move/redirect it, so visibility matters for diagnosis.
     """
     counts: Counter[str] = Counter()
     for i in range(1, num_files + 1):
@@ -280,7 +284,12 @@ def collect_duplicate_source_sha1s(
         try:
             s3_obj = s3_client.get_s3().Object(S3_BUCKET, s3_path)
             sha1 = (s3_obj.metadata or {}).get(CHECKSUM)
-        except Exception:
+        except Exception as ex:
+            logging.warning(
+                f"collect_duplicate_source_sha1s: skipped ordinal {i} for "
+                f"{dpla_id} (path={s3_path}): {ex}; duplicate detection may "
+                f"under-count this item"
+            )
             continue
         if sha1:
             counts[sha1] += 1

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -13,7 +13,7 @@ from pywikibot.site import APISite, BaseSite
 from pywikibot.tools.chars import replace_invisible
 
 
-from .common import get_list, get_str, get_dict
+from .common import CHECKSUM, get_list, get_str, get_dict
 from .s3 import S3_BUCKET, S3Client
 from .dpla import (
     WIKIDATA_FIELD_NAME,
@@ -251,6 +251,40 @@ def compute_ordinal_exts_and_page_labels(
             page_labels[ordinal] = ""
 
     return ordinal_exts, page_labels
+
+
+def collect_duplicate_source_sha1s(
+    s3_client: S3Client,
+    dpla_id: str,
+    partner: str,
+    num_files: int,
+) -> set[str]:
+    """Return SHA1s that appear at TWO OR MORE positions in this item's S3
+    asset list.
+
+    A SHA1 in this set means the source data has the same file content
+    listed at multiple ordinals — both/all positions are legitimate per
+    the source and should land at their own Commons titles.  Without
+    this knowledge, _resolve_hash_drift would see SHA1 X already at
+    (page A), be asked to upload it to (page B), and conclude that
+    (page A) is drift to be moved over (page B).  That's wrong: both
+    positions should exist as separate Commons pages.
+
+    SHA1 metadata read failures (transient S3 errors, stub ordinals)
+    are tolerated — those ordinals are simply absent from the count,
+    which conservatively keeps the SHA1 out of the duplicate set.
+    """
+    counts: Counter[str] = Counter()
+    for i in range(1, num_files + 1):
+        s3_path = s3_client.get_media_s3_path(dpla_id, i, partner)
+        try:
+            s3_obj = s3_client.get_s3().Object(S3_BUCKET, s3_path)
+            sha1 = (s3_obj.metadata or {}).get(CHECKSUM)
+        except Exception:
+            continue
+        if sha1:
+            counts[sha1] += 1
+    return {sha1 for sha1, n in counts.items() if n > 1}
 
 
 def license_to_markup_code(rights_uri: str) -> str:

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -9,6 +9,7 @@ from ingest_wikimedia.wikimedia import (
     get_permissions,
     escape_wiki_strings,
     join,
+    collect_duplicate_source_sha1s,
     compute_ordinal_exts_and_page_labels,
     extract_page_ordinal_from_commons_title,
     extract_strings,
@@ -498,6 +499,74 @@ def test_page_labels_clienterror_treated_as_stub_placeholder():
     exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 3)
     assert exts == {1: ".jpg", 2: "", 3: ".jpg"}
     assert labels == {1: "1", 2: "", 3: "2"}
+
+
+# collect_duplicate_source_sha1s — drift logic must recognize legit duplicates
+def _fake_s3_client_with_sha1s(sha1_by_ord: dict[int, str | None]):
+    """Mock S3Client whose Object().metadata['sha1'] returns the configured sha1
+    per ordinal. None means the ordinal raises (treated as missing)."""
+    s3_client = MagicMock()
+
+    def get_obj(bucket, path):
+        ord_num = int(path.rsplit("/", 1)[-1].split("_", 1)[0])
+        sha1 = sha1_by_ord.get(ord_num)
+        if sha1 is None:
+            raise RuntimeError("missing")
+        obj = MagicMock()
+        obj.metadata = {"sha1": sha1}
+        return obj
+
+    boto3_resource = MagicMock()
+    boto3_resource.Object.side_effect = get_obj
+    s3_client.get_s3.return_value = boto3_resource
+    s3_client.get_media_s3_path.side_effect = lambda d, i, p: (
+        f"{p}/images/{d[0]}/{d[1]}/{d[2]}/{d[3]}/{d}/{i}_{d}"
+    )
+    return s3_client
+
+
+def test_collect_duplicate_source_sha1s_all_unique():
+    s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: "bbb", 3: "ccc"})
+    assert collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 3) == set()
+
+
+def test_collect_duplicate_source_sha1s_one_pair_repeats():
+    # Sherman pattern: same content at positions 1 and 12.
+    s3 = _fake_s3_client_with_sha1s(
+        {
+            1: "aaa",
+            2: "bbb",
+            3: "ccc",
+            4: "ddd",
+            5: "eee",
+            6: "fff",
+            7: "ggg",
+            8: "hhh",
+            9: "iii",
+            10: "jjj",
+            11: "kkk",
+            12: "aaa",
+            13: "bbb",
+        }
+    )
+    assert collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 13) == {"aaa", "bbb"}
+
+
+def test_collect_duplicate_source_sha1s_same_sha1_three_times():
+    s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: "bbb", 3: "aaa", 4: "aaa"})
+    assert collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 4) == {"aaa"}
+
+
+def test_collect_duplicate_source_sha1s_handles_missing_metadata():
+    # Read failures are tolerated; affected ordinals are absent from the count.
+    s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: None, 3: "aaa"})
+    assert collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 3) == {"aaa"}
+
+
+def test_collect_duplicate_source_sha1s_skips_empty_sha1():
+    # Empty sha1 metadata (e.g. truncated) is not counted as duplicate-of-itself.
+    s3 = _fake_s3_client_with_sha1s({1: "", 2: "", 3: "aaa"})
+    assert collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 3) == set()
 
 
 def test_page_labels_non_404_clienterror_propagates():

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -563,6 +563,19 @@ def test_collect_duplicate_source_sha1s_handles_missing_metadata():
     assert collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 3) == {"aaa"}
 
 
+def test_collect_duplicate_source_sha1s_logs_skipped_ordinals(caplog):
+    """Silent skips would hide drift miscorrection; ensure each failed read
+    produces a WARNING line so an operator can see why the count is low."""
+    import logging as _logging
+
+    s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: None, 3: "aaa"})
+    with caplog.at_level(_logging.WARNING):
+        collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 3)
+    messages = " | ".join(r.message for r in caplog.records)
+    assert "skipped ordinal 2" in messages
+    assert "under-count" in messages
+
+
 def test_collect_duplicate_source_sha1s_skips_empty_sha1():
     # Empty sha1 metadata (e.g. truncated) is not counted as duplicate-of-itself.
     s3 = _fake_s3_client_with_sha1s({1: "", 2: "", 3: "aaa"})

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -42,6 +42,7 @@ from ingest_wikimedia.wikimedia import (
     IGNORE_WIKIMEDIA_WARNINGS,
     MIME_UNKNOWN_EXT,
     build_title_drift_move_reason,
+    collect_duplicate_source_sha1s,
     compute_ordinal_exts_and_page_labels,
     get_page_title,
     get_wiki_text,
@@ -110,6 +111,7 @@ class Uploader:
         page_label: str,
         verbose: bool,
         dry_run: bool,
+        duplicate_source_sha1s: set[str] | None = None,
     ):
         temp_file = self.local_fs.get_temp_file()
 
@@ -230,21 +232,39 @@ class Uploader:
                 drift_action: str | None = None
                 force_ignore_warnings = False
                 if existing_file is not None:
-                    drift_action = self._resolve_hash_drift(
-                        existing_file=existing_file,
-                        page_title=page_title,
-                        dpla_id=dpla_id,
-                        ordinal=ordinal,
-                        wiki_markup=wiki_markup,
-                    )
-                    if drift_action == "moved":
-                        self.tracker.increment(Result.UPLOADED)
-                        return
-                    elif drift_action == "upload_and_tag":
-                        drift_old_filename = existing_file.title(with_ns=False)
+                    if duplicate_source_sha1s and sha1 in duplicate_source_sha1s:
+                        # The source data legitimately lists this SHA1 at
+                        # multiple positions within the item.  The existing
+                        # Commons file at another title is a valid sibling,
+                        # not drift to be migrated — both positions should
+                        # exist as separate Commons pages.  Upload to our
+                        # title and leave the other alone.
+                        logging.info(
+                            f"Source asset list contains the same SHA1 at "
+                            f"multiple positions for {dpla_id} {ordinal}; "
+                            f"existing file at "
+                            f"[[File:{existing_file.title(with_ns=False)}]] "
+                            f"is a legitimate sibling, not drift. Uploading "
+                            f"to [[File:{page_title}]] without disturbing it."
+                        )
+                        drift_action = "upload_only"
                         force_ignore_warnings = True
-                    else:  # "upload_only"
-                        force_ignore_warnings = True
+                    else:
+                        drift_action = self._resolve_hash_drift(
+                            existing_file=existing_file,
+                            page_title=page_title,
+                            dpla_id=dpla_id,
+                            ordinal=ordinal,
+                            wiki_markup=wiki_markup,
+                        )
+                        if drift_action == "moved":
+                            self.tracker.increment(Result.UPLOADED)
+                            return
+                        elif drift_action == "upload_and_tag":
+                            drift_old_filename = existing_file.title(with_ns=False)
+                            force_ignore_warnings = True
+                        else:  # "upload_only"
+                            force_ignore_warnings = True
 
                 with tqdm(
                     total=s3_object.content_length,
@@ -753,6 +773,16 @@ class Uploader:
                 self.s3_client, dpla_id, partner, len(files)
             )
 
+            # Identify SHA1s that legitimately appear at MORE THAN ONE
+            # position in the source asset list.  process_file uses this to
+            # short-circuit drift correction when its SHA1 is in the set —
+            # the existing Commons file at another title is a valid sibling,
+            # not a drift artefact, and both positions should remain as
+            # separate Commons pages.
+            duplicate_source_sha1s = collect_duplicate_source_sha1s(
+                self.s3_client, dpla_id, partner, len(files)
+            )
+
             for ordinal, _ in enumerate(
                 tqdm(
                     files, desc="Uploading Files", leave=False, unit="File", ncols=100
@@ -773,6 +803,7 @@ class Uploader:
                         page_label,
                         verbose,
                         dry_run,
+                        duplicate_source_sha1s=duplicate_source_sha1s,
                     )
                 except UploadTimeoutError as ex:
                     self.handle_upload_exception(ex)


### PR DESCRIPTION
## Summary

- Closes a drift-logic blind spot where a source provider that lists the same SHA1 at two positions in its asset list causes the uploader to collapse the two positions into one Commons file plus a redirect (or a `{{Duplicate}}` tag).
- Concrete case found today: Ohio Digital Network item `2e9d3ca5d4c772d9e3da903fe4812265` (\"Sherman case docket\") — source's `mediaMaster` lists the same JPG at positions 1 and 12 and another at 2 and 13. The uploader, processing ord 12, found SHA1 X already at `(page 1).jpg` (from ord 1's upload earlier in the same run), concluded this was drift, and moved `(page 1)` → `(page 12)`. The result: `(page 1)` became a redirect when it should have stayed a real file. Same for `(page 2)` → `(page 13)`.
- This was producing entries on `User:CommonsDelinker/commands/filemovers`. Out of 148 \"Title drift correction\" entries currently there, 7 were confirmed by analysis to be this bug. Those 7 have been remediated manually (redirects re-uploaded as real files, filemovers entries removed) outside this PR — this PR prevents recurrence.

## What changes

- **`collect_duplicate_source_sha1s`** (new helper in `ingest_wikimedia/wikimedia.py`): scans the item's S3 assets and returns the set of SHA1s that appear at ≥2 positions. Resilient to read failures (treats them as absent rather than raising) and ignores empty SHA1 metadata.
- **`process_item`**: computes this set once per item via the new helper, alongside the existing `compute_ordinal_exts_and_page_labels` pre-scan.
- **`process_file`**: takes the set as a new keyword arg. Before invoking `_resolve_hash_drift`, if the file's SHA1 is in the duplicated set, log it explicitly and route to the `upload_only` path with `force_ignore_warnings=True`. The existing Commons file at the other title is correctly recognized as a legitimate sibling, not drift to be migrated.

## Why upload_only + force_ignore_warnings

When the same SHA1 already lives at another Commons title, a vanilla upload trips MediaWiki's `fileexists-shared-forbidden` warning. The existing `upload_only` branch already sets `force_ignore_warnings=True` and `chunk_size=0`, which is the exact combination needed to bypass it via the direct upload path. No new plumbing needed — just routing the new case into the existing escape hatch.

## Test plan
- [x] `pytest tests/test_wikimedia.py tests/test_uploader.py` — 66 tests pass (61 existing + 5 new for the helper)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- New tests cover: all-unique SHA1s, one-pair-repeats (Sherman pattern), three-times-repeated, missing-metadata-tolerated, empty-SHA1-skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a bug where the uploader incorrectly treated duplicate source assets (files with identical SHA1s at different ordinal positions) as drift, causing earlier Commons uploads to be moved or redirected. For example, when an item had identical JPGs at positions 1 & 12, processing ordinal 12 would convert the page 1 upload to a redirect.

## Technical Approach

The fix introduces pre-scan detection of duplicate SHA1s at the item level:

- **New function `collect_duplicate_source_sha1s()`** in `ingest_wikimedia/wikimedia.py` scans all S3 assets for an item, identifies SHA1s appearing at two or more ordinals, and returns the set of duplicated SHA1s. It logs a WARNING if any S3 read fails, noting the ordinal and indicating potential under-counting of duplicates.
- **Modified `process_item()`** calls the new function and passes the duplicate SHA1 set to each file processed.
- **Modified `process_file()`** accepts the duplicate SHA1 set as an optional parameter. When a file's SHA1 is in the duplicate set, the upload is routed through `upload_only` with `force_ignore_warnings=True`, bypassing `_resolve_hash_drift` so the existing Commons file at a different title is treated as a legitimate sibling rather than drift to be migrated.

## Changes by File

**ingest_wikimedia/wikimedia.py** (+44/-1)
- Added `collect_duplicate_source_sha1s()` function with resilient error handling for S3 read failures

**tests/test_wikimedia.py** (+82/-0)
- Added `_fake_s3_client_with_sha1s()` test helper
- Added 6 new tests covering all-unique SHA1s, single duplicate pairs, three-times repeated SHA1s, missing metadata, empty SHA1 handling, and warning logging for skipped ordinals due to read failures

**tools/uploader.py** (+45/-14)
- Updated `process_file()` signature to accept optional `duplicate_source_sha1s` parameter
- Added logic to check for duplicated SHA1s and route to upload-only flow when detected

## Testing & Validation

- All 66 tests pass (61 existing + 5 new)
- Code formatting and ruff checks pass clean
- Addressed reviewer feedback in commit df8d286 to add explicit WARNING logging when S3 reads fail during duplicate detection

## Deployment Notes

No manual pipeline trigger, ECS redeployment, environment variable changes, database migrations, or shared infrastructure modifications required. This is a targeted code change to the uploader logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->