### PR TITLE
downloader: actually persist refresh writes so S3 LastModified advances

### DIFF
--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -83,6 +83,116 @@ def test_upload_proceeds_when_checksum_matches_but_zero_bytes(downloader):
     obj.upload_fileobj.assert_called_once()
 
 
+def test_upload_force_overwrite_touches_via_copy_when_sha1_matches(downloader):
+    """Refresh / overwrite path: when the freshly-downloaded SHA1 matches
+    the existing S3 object, we must update LastModified via copy-self
+    instead of skipping. Skipping was the bug that made `--max-age-days`
+    refreshes run forever — every periodic refresh would log "Refreshing
+    X: file is 554 days old", actually re-download the bytes, see the
+    matching SHA1, skip the upload, and leave the S3 LastModified at the
+    original write, so next run still saw the file as 554+ days old.
+    """
+    sha1 = "abc123"
+    existing_metadata = {CHECKSUM: sha1, "custom": "preserved"}
+    obj = MagicMock()
+    obj.metadata = existing_metadata
+    obj.content_length = 1024
+
+    mock_s3 = MagicMock()
+    mock_s3.Object.return_value = obj
+    downloader.s3_client.get_s3.return_value = mock_s3
+
+    with patch(
+        "builtins.open",
+        return_value=MagicMock(
+            __enter__=lambda s: BytesIO(b"data"), __exit__=MagicMock(return_value=False)
+        ),
+    ):
+        with patch("os.stat") as mock_stat:
+            mock_stat.return_value.st_size = 1024
+            result = downloader.upload_file_to_s3(
+                "/tmp/fake",
+                "dest/path",
+                "image/jpeg",
+                sha1,
+                force_overwrite=True,
+            )
+
+    assert result is True
+    # copy_object must be called to touch LastModified
+    mock_s3.meta.client.copy_object.assert_called_once()
+    kwargs = mock_s3.meta.client.copy_object.call_args.kwargs
+    assert kwargs["MetadataDirective"] == "REPLACE"
+    # MetadataDirective REPLACE drops every header not re-supplied — the full
+    # existing metadata (including CHECKSUM and any custom keys) must be
+    # passed back in. See lessons.md "AWS S3 copy_object with
+    # MetadataDirective".
+    assert kwargs["Metadata"][CHECKSUM] == sha1
+    assert kwargs["Metadata"]["custom"] == "preserved"
+    # Body re-upload must NOT happen — bytes are identical.
+    obj.upload_fileobj.assert_not_called()
+    downloader.tracker.increment.assert_called_once_with(Result.DOWNLOADED)
+
+
+def test_upload_force_overwrite_uploads_when_sha1_differs(downloader):
+    """When force_overwrite=True and the new SHA1 differs from the existing
+    S3 object's SHA1, the standard upload path runs (no SHA1-match guard
+    to begin with, so behavior here matches the default case)."""
+    obj = _make_s3_obj("old_sha", 1024)
+
+    mock_s3 = MagicMock()
+    mock_s3.Object.return_value = obj
+    downloader.s3_client.get_s3.return_value = mock_s3
+
+    fake_file = BytesIO(b"new content")
+    fake_file.name = "/tmp/fake"
+
+    with patch("builtins.open") as mock_open:
+        mock_open.return_value.__enter__ = lambda s: fake_file
+        mock_open.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("os.stat") as mock_stat:
+            mock_stat.return_value.st_size = len(b"new content")
+            result = downloader.upload_file_to_s3(
+                "/tmp/fake",
+                "dest/path",
+                "image/jpeg",
+                "new_sha",
+                force_overwrite=True,
+            )
+
+    assert result is True
+    obj.upload_fileobj.assert_called_once()
+    mock_s3.meta.client.copy_object.assert_not_called()
+
+
+def test_upload_default_skips_when_sha1_matches(downloader):
+    """Existing behavior preserved: without force_overwrite, a matching
+    SHA1 short-circuits the upload (no copy-self, no upload)."""
+    sha1 = "abc123"
+    obj = _make_s3_obj(sha1, 1024)
+
+    mock_s3 = MagicMock()
+    mock_s3.Object.return_value = obj
+    downloader.s3_client.get_s3.return_value = mock_s3
+
+    with patch(
+        "builtins.open",
+        return_value=MagicMock(
+            __enter__=lambda s: BytesIO(b"data"), __exit__=MagicMock(return_value=False)
+        ),
+    ):
+        with patch("os.stat") as mock_stat:
+            mock_stat.return_value.st_size = 1024
+            result = downloader.upload_file_to_s3(
+                "/tmp/fake", "dest/path", "image/jpeg", sha1
+            )
+
+    assert result is False
+    obj.upload_fileobj.assert_not_called()
+    mock_s3.meta.client.copy_object.assert_not_called()
+    downloader.tracker.increment.assert_called_once_with(Result.SKIPPED)
+
+
 def test_upload_proceeds_when_content_length_unreadable(downloader):
     sha1 = "abc123"
     obj = _make_s3_obj(sha1, None)  # None → TypeError on int()

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -65,10 +65,23 @@ class Downloader:
         destination_path: str,
         content_type: str,
         sha1: str,
+        force_overwrite: bool = False,
     ) -> bool:
         """
-        Uploads the file to S3. Returns True if the file was uploaded, False if it
-        already existed with a matching checksum and was skipped.
+        Uploads the file to S3. Returns True if the file was uploaded (or
+        touched via copy-self), False if it already existed with a matching
+        checksum and the caller did not request a forced overwrite.
+
+        `force_overwrite=True` is set by `process_media` whenever the caller
+        intends the resulting S3 object to reflect a fresh fetch — either
+        the caller passed `overwrite=True`, or the per-key age check
+        decided the existing S3 object was too old to trust. Without this
+        flag, an existing-SHA1 match silently skipped the upload, leaving
+        the S3 `LastModified` timestamp pinned to the original (long-ago)
+        write. Every subsequent refresh run then saw the same stale
+        timestamp, re-downloaded the same bytes, hit the same skip, and
+        the file's age in S3 never moved — wasting hours of network and
+        compute on every periodic refresh.
         """
         try:
             # Defence-in-depth: refuse to upload a 0-byte local file regardless
@@ -106,6 +119,35 @@ class Downloader:
                 if obj_metadata and obj_metadata.get(CHECKSUM) == sha1:
                     try:
                         if int(obj.content_length) > 0:
+                            if force_overwrite:
+                                # Refresh / overwrite path: SHA1 matches the
+                                # existing S3 object, so re-uploading the same
+                                # bytes is wasteful. Use copy-object onto the
+                                # same key to update LastModified without
+                                # re-transferring the body. MetadataDirective
+                                # "REPLACE" silently drops any metadata not
+                                # explicitly passed (per lessons.md
+                                # "AWS S3 copy_object with MetadataDirective"),
+                                # so we re-supply the full metadata dict.
+                                logging.info(
+                                    "Already at correct SHA1; touching S3 "
+                                    "LastModified via copy-object."
+                                )
+                                new_metadata = dict(obj_metadata)
+                                new_metadata[CHECKSUM] = sha1
+                                s3.meta.client.copy_object(
+                                    Bucket=S3_BUCKET,
+                                    Key=destination_path,
+                                    CopySource={
+                                        "Bucket": S3_BUCKET,
+                                        "Key": destination_path,
+                                    },
+                                    ContentType=content_type,
+                                    Metadata=new_metadata,
+                                    MetadataDirective="REPLACE",
+                                )
+                                self.tracker.increment(Result.DOWNLOADED)
+                                return True
                             logging.info("Already exists.")
                             self.tracker.increment(Result.SKIPPED)
                             return False
@@ -235,6 +277,13 @@ class Downloader:
             destination_path = self.s3_client.get_media_s3_path(
                 dpla_id, ordinal, partner
             )
+            # Track whether we're proceeding because the caller asked to
+            # overwrite or because the age check decided to refresh. Either
+            # way, upload_file_to_s3 must persist the new write even when
+            # the SHA1 matches what's already in S3 — otherwise the
+            # LastModified timestamp never advances and the file is
+            # re-attempted indefinitely on subsequent refresh runs.
+            is_refresh = False
             if not overwrite:
                 age_days = self._s3_key_age_days(destination_path)
                 if age_days is not None:
@@ -246,6 +295,7 @@ class Downloader:
                         f"Refreshing {dpla_id} {ordinal}: S3 file is "
                         f"{age_days:.0f} days old (threshold: {max_age_days})."
                     )
+                    is_refresh = True
 
             if sleep_secs != 0:
                 time.sleep(sleep_secs)
@@ -259,10 +309,15 @@ class Downloader:
 
             sha1 = self.local_fs.get_file_hash(temp_file_name)
 
+            force_overwrite = overwrite or is_refresh
             for attempt in range(1, CREDENTIAL_RETRY_MAX + 1):
                 try:
                     if self.upload_file_to_s3(
-                        temp_file_name, destination_path, content_type, sha1
+                        temp_file_name,
+                        destination_path,
+                        content_type,
+                        sha1,
+                        force_overwrite=force_overwrite,
                     ):
                         self.tracker.increment(
                             Result.BYTES, os.stat(temp_file_name).st_size


### PR DESCRIPTION
## Summary

Fix a silent bug that made `--max-age-days` refresh runs do hours of work with **zero net progress**. The age check correctly decided that a file was stale and triggered a fresh download from the source, but `upload_file_to_s3`'s "identical content, skip" SHA1 short-circuit then prevented the write from actually landing in S3. Every periodic refresh re-downloaded the same bytes, computed the same SHA1, hit the same skip, and left every S3 object pinned to its original LastModified — so the next refresh saw the same "too old" age and repeated forever.

## Symptom

`wikimedia-northwest-heritage` ran a `refresh ... 365` pipeline four times over five days (May 19, 21, 22, 24). Each one re-downloaded the same 71k files from the source, marked 17k+ as `Refreshing X: S3 file is 5XX days old`, and persisted **zero** new bytes to dpla-wikimedia. Cross-check of a specific DPLA ID (`000045132221978c9a7cbc989260aeed`):

```
20260524-051028 (today)  Refreshing: 554 days old → Already exists.
20260522-033021 (May 22) Refreshing: 552 days old → Already exists.
20260521-064716 (May 21) Refreshing: 551 days old → Already exists.
20260519-192642 (May 19) Refreshing: 550 days old → Already exists.
```

The age ticks up exactly one day per run — proof the file's S3 LastModified hasn't moved.

## Root cause

`upload_file_to_s3` short-circuits the upload when the new SHA1 matches the existing S3 object's checksum — that's a legitimate "don't waste bandwidth re-uploading identical bytes" optimization for the normal write path. But `process_media` calls it from both paths:

```python
# downloader.process_media — refresh decision (looks correct)
if age_days >= max_age_days:
    logging.info(f"Refreshing {dpla_id}: S3 file is {age_days} days old.")
    # ... downloads, computes SHA1, calls upload_file_to_s3 ...

# downloader.upload_file_to_s3 — SHA1 short-circuit (looks correct in isolation)
if obj_metadata.get(CHECKSUM) == sha1:
    logging.info("Already exists.")
    return False   # ← silently aborts the refresh write
```

Composed, the refresh state machine never converges: refresh → download → SHA1 matches → skip → S3 LastModified stays pinned → refresh fires again next run.

## Fix

Add a `force_overwrite=False` parameter to `upload_file_to_s3`. In `process_media`, set it to `True` whenever the caller asked to overwrite OR the age check fell through to the refresh path:

```python
force_overwrite = overwrite or is_refresh
self.upload_file_to_s3(..., force_overwrite=force_overwrite)
```

In `upload_file_to_s3`, when `force_overwrite=True` and the SHA1 matches the existing object, **touch the object via `copy_object` onto the same key** with `MetadataDirective="REPLACE"` and the full existing metadata re-supplied (the `REPLACE` directive silently drops every header not re-passed, per the existing `lessons.md` entry on `AWS S3 copy_object with MetadataDirective="REPLACE"`). LastModified advances without re-transferring identical bytes:

```python
s3.meta.client.copy_object(
    Bucket=S3_BUCKET, Key=destination_path,
    CopySource={"Bucket": S3_BUCKET, "Key": destination_path},
    ContentType=content_type,
    Metadata=new_metadata,
    MetadataDirective="REPLACE",
)
```

## What this does NOT touch

- Normal (non-refresh, non-overwrite) writes: the existing SHA1-match skip is preserved untouched. `force_overwrite` defaults to `False`.
- Different-SHA1 cases: a fresh download with different bytes always re-uploaded via the normal path; that didn't have the bug.
- 0-byte refusal guards (PR #206): the `os.stat == 0` short-circuit runs before any of this logic, unchanged.

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] Three new tests in `tests/test_downloader.py`:
  - `force_overwrite=True` + matching SHA1 → `copy_object` called, body re-upload skipped, full metadata preserved on REPLACE
  - `force_overwrite=True` + differing SHA1 → normal upload path runs
  - Default (no `force_overwrite`) + matching SHA1 → existing skip behavior preserved
- [ ] CI: pytest + ruff green
- [ ] Next NWH `refresh` run shows files actually advancing in LastModified (e.g., a file that was 554 days old today shows as ~0 days old the next time it's checked)

## Lesson recorded

> **Periodic refresh: the refresh decision is meaningless unless the write actually advances LastModified**

(Added to `~/.claude/lessons.md`.) Captures the audit principle: any TTL-driven refresh path must be traced end-to-end to confirm the destination's modification timestamp actually advances — otherwise the refresh state machine never converges and the periodic re-runs do invisible work in a loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a bug in the periodic "refresh" workflow where re-downloaded files were not updating their S3 `LastModified` timestamp, causing repeated refresh cycles to show no progress. 

### Root Cause
The `upload_file_to_s3` method short-circuited uploads when the computed SHA1 matched the existing S3 object's stored checksum. During refresh runs, this meant files with unchanged content would not receive any S3 write operation, leaving `LastModified` unchanged.

### Solution
- Added `force_overwrite: bool = False` parameter to `Downloader.upload_file_to_s3()`
- When `force_overwrite=True` and the SHA1 matches, the method now performs an S3 `copy_object` of the object onto itself with `MetadataDirective="REPLACE"` and full metadata, advancing `LastModified` without re-transferring bytes
- Updated `process_media` to compute an `is_refresh` flag when staging determines an S3 key should be refreshed (age-based re-download)
- `process_media` passes `force_overwrite=True` to `upload_file_to_s3` when `is_refresh` is set

### Changes
- **tools/downloader.py**: Updated `upload_file_to_s3` method signature and implementation (+58/-3 lines)
- **tests/test_downloader.py**: Added three new unit tests covering the `force_overwrite` parameter behavior with matching SHA1 (copy_object called), differing SHA1 (normal upload), and default behavior (skip preserved) (+110/-0 lines)

### Backward Compatibility
Non-refresh, non-overwrite behavior is unchanged; the default `force_overwrite=False` preserves existing skip behavior when SHA1 matches.

### Status
Tests and ruff checks have passed. CI and validation against an actual refresh run are pending.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->