### PR TITLE
retry: clear stale *-retry.csv before scan so scope can't bleed across runs

### DIFF
--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -102,12 +102,23 @@ def main() -> None:
 
     # Scan logs for retryable failures. Pass the EC2 directory name rather than the
     # canonical slug so get-ids-retry can find the logs dir (e.g. "smithsonian" for "si").
+    #
+    # Clear any stale `*-retry.csv` left behind by prior invocations before the
+    # scan runs. The downstream `find {RETRY_DIR} -name '*-retry.csv'` step
+    # below picks up every CSV in the directory, so leftover files from a
+    # previous run silently expand the scope of this run: a request like
+    # `/wikimedia-upload retry 30 si` would launch retry pipelines for every
+    # other hub whose CSV happened to still be sitting in the dir from days or
+    # weeks ago. Clearing here makes the pipeline strictly reflect the current
+    # scan's output. There's no useful state to preserve across runs — every
+    # retry call is self-contained (scan → process → done).
     partner_desc = f" for `{partner}`" if partner else ""
     print(
         f"Scanning logs for retryable failures in the last {days} day(s){partner_desc}..."
     )
     scan_cmd = (
         f"mkdir -p {shlex.quote(RETRY_DIR)} && "
+        f"rm -f {shlex.quote(RETRY_DIR)}/*-retry.csv && "
         "source /home/ec2-user/ingest-wikimedia/.venv/bin/activate && "
         "cd /home/ec2-user/ingest-wikimedia && "
         f"get-ids-retry {days}"

--- a/tests/test_wikimedia_retry.py
+++ b/tests/test_wikimedia_retry.py
@@ -1,0 +1,103 @@
+"""Tests for scripts/wikimedia_retry.py."""
+
+from unittest.mock import MagicMock, patch
+
+
+def _run_main_and_capture_ssm_commands(argv: list[str]) -> list[str]:
+    """Run wikimedia_retry.main() with all external side-effects mocked, and
+    return the list of SSM command strings it tried to run.
+
+    The script ssm_runs three commands before launching the tmux pipeline:
+      1. EC2 code update (must echo `UPDATE_DONE` for the script to proceed)
+      2. The scan command (the one this PR is about — must clear stale
+         retry CSVs before invoking get-ids-retry)
+      3. The find + memory-check combined call
+
+    We short-circuit at step 3 by returning "No retryable failures found"
+    from step 2, which makes main() exit cleanly without trying to build
+    the tmux pipeline. This keeps the test focused and avoids having to
+    mock out the entire post-scan flow.
+    """
+    captured: list[str] = []
+
+    def fake_ssm_run(_client, command, **_kwargs):
+        captured.append(command)
+        # First call is update_cmd; must include "UPDATE_DONE" so main proceeds.
+        if "UPDATE_DONE" in command:
+            return "UPDATE_DONE"
+        # Second call is the scan; pretend it found nothing so main exits.
+        if "get-ids-retry" in command:
+            return "No retryable failures found in the last 30 days."
+        return ""
+
+    with (
+        patch("scripts.wikimedia_retry.ssm_run", side_effect=fake_ssm_run),
+        patch("scripts.wikimedia_retry.boto3.client", return_value=MagicMock()),
+        patch("sys.argv", argv),
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        from scripts import wikimedia_retry
+
+        try:
+            wikimedia_retry.main()
+        except SystemExit:
+            pass  # script exits cleanly on "no retryable failures"
+
+    return captured
+
+
+def test_retry_clears_stale_csvs_before_scan():
+    """Regression: a `/wikimedia-upload retry 30 si` call must not pick up
+    stale CSVs that previous (unrelated) retry runs left in
+    /home/ec2-user/ingest-wikimedia/retry/.
+
+    Before this fix, the scan only wrote `smithsonian-download-retry.csv`,
+    but `find {retry_dir} -name '*-retry.csv'` also matched leftover
+    `indiana-…`, `nara-…`, `ohio-…` CSVs from runs days or weeks earlier.
+    The tmux pipeline then launched retry blocks for every one of those
+    hubs, ignoring the user's explicit `si` scope entirely.
+
+    Assert that the SSM command which runs `get-ids-retry` also clears
+    any pre-existing `*-retry.csv` first, so `find` later sees only the
+    current scan's output.
+    """
+    commands = _run_main_and_capture_ssm_commands(
+        ["wikimedia_retry.py", "--days", "30", "--partner", "si"]
+    )
+
+    scan_cmds = [c for c in commands if "get-ids-retry" in c]
+    assert scan_cmds, f"No scan command was issued; saw: {commands!r}"
+    scan_cmd = scan_cmds[0]
+
+    rm_idx = scan_cmd.find("rm -f")
+    scan_idx = scan_cmd.find("get-ids-retry")
+    assert rm_idx >= 0, (
+        f"scan command is missing the stale-CSV clearing step: {scan_cmd!r}"
+    )
+    assert rm_idx < scan_idx, (
+        f"rm must come BEFORE get-ids-retry, otherwise it would delete the "
+        f"freshly-written CSVs: {scan_cmd!r}"
+    )
+    # Make sure the rm pattern is scoped to *-retry.csv only; deleting the
+    # whole directory contents would clobber unrelated files.
+    assert "*-retry.csv" in scan_cmd, (
+        f"rm pattern must be limited to *-retry.csv to avoid clobbering "
+        f"unrelated files in the retry dir: {scan_cmd!r}"
+    )
+
+
+def test_retry_clears_stale_csvs_even_when_no_partner_given():
+    """When the user runs `/wikimedia-upload retry 30` (no partner), the
+    scan still needs to clear stale CSVs so that hubs which legitimately
+    had no transient failures in the current window aren't re-launched
+    from leftover artifacts of a prior scan."""
+    commands = _run_main_and_capture_ssm_commands(
+        ["wikimedia_retry.py", "--days", "30"]
+    )
+
+    scan_cmds = [c for c in commands if "get-ids-retry" in c]
+    assert scan_cmds
+    scan_cmd = scan_cmds[0]
+    assert "rm -f" in scan_cmd
+    assert "*-retry.csv" in scan_cmd
+    assert scan_cmd.find("rm -f") < scan_cmd.find("get-ids-retry")


### PR DESCRIPTION
## Summary

Fix `/wikimedia-upload retry 30 <partner>` so the partner scope is actually respected. Without this, leftover CSVs from previous retry runs silently expanded every invocation's scope to include hubs the user didn't ask for.

### Symptom

User ran `/wikimedia-upload retry 30 si`. The launch message correctly showed `wikimedia-retry-30d-si` as the session name, but then it listed nine hubs as scope:

> 🔄 Launching `wikimedia-retry-30d-si` : `indiana`, `minnesota`, `mwdl`, `nara`, `ohio`, `p2p`, `pa`, `si`, `texas` (30 days of log history).

And the first hub it actually started downloading for was `indiana`, not `si`.

### Root cause

Today's `get-ids-retry --partner smithsonian` correctly wrote one CSV: `smithsonian-download-retry.csv`. The retry dir contents on EC2 right after launch:

```
smithsonian-download-retry.csv   May 24 21:30  ← today's fresh, correct output
pa-download-retry.csv            May 19 00:14  ← stale (5 days old)
ohio-download-retry.csv          May 19 00:14  ← stale
nara-download-retry.csv          May 19 00:14  ← stale
nara-upload-retry.csv            May 19 00:14  ← stale
texas-upload-retry.csv           May 17 17:24  ← stale (7 days old)
p2p-download-retry.csv           May 17 17:24  ← stale
p2p-upload-retry.csv             May 17 17:24  ← stale
mwdl-download-retry.csv          May 17 17:24  ← stale
minnesota-download-retry.csv     May 17 17:24  ← stale
indiana-download-retry.csv       May 17 17:23  ← stale
```

`wikimedia_retry.py` then ran:

```bash
find /home/ec2-user/ingest-wikimedia/retry/ -name '*-retry.csv' | sort
```

That `find` swept up all 11 files, and the tmux pipeline builder iterated over each one — building a retry block per hub. The user's `si` scope was simply ignored.

### Fix

Add a `rm -f {RETRY_DIR}/*-retry.csv` step to the same SSM command that runs `get-ids-retry`, so stale CSVs are cleared **before** new ones are written:

```python
scan_cmd = (
    f"mkdir -p {shlex.quote(RETRY_DIR)} && "
    f"rm -f {shlex.quote(RETRY_DIR)}/*-retry.csv && "      # ← new
    "source .../activate && "
    "cd /home/ec2-user/ingest-wikimedia && "
    f"get-ids-retry {days}"
)
```

The `rm` pattern is narrowed to `*-retry.csv` (not `*`) so any unrelated files in the dir aren't clobbered. There's no useful state to preserve across retry runs — every call is self-contained: scan logs → write CSVs → process CSVs → done. So clearing on every run is correct.

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] New `tests/test_wikimedia_retry.py` with two tests:
  - Partner-scoped retry: scan command includes `rm -f` BEFORE `get-ids-retry`, pattern narrowed to `*-retry.csv`
  - All-hubs retry: same guarantee — stale CSVs from a prior partner-scoped run can't expand the next all-hubs run's scope either
- [ ] CI: pytest + ruff green
- [ ] Re-run `/wikimedia-upload retry 30 si` after merge: confirm launch message shows only `si` in scope and the tmux pipeline runs only the smithsonian retry block

## Lesson recorded

> **Glob-then-iterate over a shared output dir: clear stale outputs or use unique subdirs**

(Added to `~/.claude/lessons.md`.) Captures the general pattern: any producer + glob-based consumer combination is at risk of stale-output bleed unless the producer side clears the directory or both sides agree on a unique-per-run subdirectory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bug fix: Prevent retry scope bleed from stale CSV files

This PR fixes a scope bleed bug in the `/wikimedia-upload retry` workflow where stale `*-retry.csv` files from previous runs were incorrectly included in the current retry session.

### Problem
Running `/wikimedia-upload retry 30 si` (for a specific partner, Smithsonian) would create a correctly-scoped session name (`wikimedia-retry-30d-si`), but the downstream scan would find and process CSV files from all nine hubs (indiana, minnesota, mwdl, nara, ohio, p2p, pa, si, texas) because stale files from prior runs lingered in the retry directory.

### Root Cause
The producer step (`get-ids-retry --partner ...`) wrote fresh CSV(s) with the correct scope, but the retry directory retained older CSVs from previous invocations. The consumer's unscoped `find ... *-retry.csv` globbing picked up all existing files, ignoring the requested partner scope.

### Solution
Added an `rm -f {RETRY_DIR}/*-retry.csv` step to the SSM command that runs before `get-ids-retry`, ensuring stale files are removed before new CSVs are written. The rm pattern is deliberately limited to `*-retry.csv` to avoid unintended file deletions.

### Changes
- **scripts/wikimedia_retry.py**: Modified the scan command to clear stale retry CSV files before invoking `get-ids-retry`; added explanatory comments detailing the bug
- **tests/test_wikimedia_retry.py**: Added regression tests covering both partner-scoped (`--partner si`) and all-hubs retry scenarios, verifying that the scan command includes the `rm -f` step and prevents stale-file scope bleed

### Testing
CI includes pytest and ruff (format/lint) checks covering the new test cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->