### PR TITLE
sdc-sync: optional --from-s3 mode (PR 1 of 5: integrate into wikimedia pipeline)

### DIFF
--- a/tools/sdc-sync.py
+++ b/tools/sdc-sync.py
@@ -56,8 +56,9 @@ parser.add_argument(
     action="store",
     default=None,
     help=(
-        "Read each DPLA item's metadata from <partner>/<dpla_id>/dpla-map.json "
-        "in S3 (staged by get-ids-es) instead of calling api.dp.la. Falls back "
+        "Read each DPLA item's metadata from the dpla-map.json staged in S3 "
+        "by get-ids-es (under the partner's sharded item prefix; resolved by "
+        "S3Client.get_item_metadata) instead of calling api.dp.la. Falls back "
         "to api.dp.la when an item's dpla-map.json is missing."
     ),
 )
@@ -1132,9 +1133,11 @@ def dpla_claims(
 def _fetch_dpla_doc_from_api(dpla_id, dpla_api):
     """Fetch a single DPLA item's inner doc from the public DPLA API.
 
-    Returns the inner doc (same shape as an ES `_source` and as
-    `<partner>/<dpla_id>/dpla-map.json` in S3) on success, or None on API
-    error. Retries once after a 30-second sleep on the first network failure.
+    Returns the inner doc (same shape as an ES `_source` and as the
+    dpla-map.json staged in S3 under the partner's sharded item prefix) on
+    success, or None on API error. Retries once after a 30-second sleep on
+    the first network failure; if the retry also raises, returns None so
+    parsed() can treat the item as Missing rather than aborting the batch.
     """
     try:
         response = requests.get(
@@ -1144,10 +1147,14 @@ def _fetch_dpla_doc_from_api(dpla_id, dpla_api):
     except Exception:
         print(" -- Sleeping 30 seconds and retrying...")
         time.sleep(30)
-        response = requests.get(
-            f"https://api.dp.la/v2/items/{dpla_id}?api_key={dpla_api}",
-            timeout=15,
-        ).json()
+        try:
+            response = requests.get(
+                f"https://api.dp.la/v2/items/{dpla_id}?api_key={dpla_api}",
+                timeout=15,
+            ).json()
+        except Exception as retry_e:
+            print(f" -- DPLA API retry failed for {dpla_id}: {retry_e!r}")
+            return None
     try:
         return response["docs"][0]
     except Exception:
@@ -1160,8 +1167,9 @@ def _fetch_dpla_doc_from_s3(s3_client, partner, dpla_id):
     """Read a single DPLA item's inner doc from S3.
 
     `get-ids-es` stages the ES `_source` for every eligible item as
-    `<partner>/<dpla_id>/dpla-map.json`. Returns the parsed doc on success,
-    None when the object is missing or unparseable. A None return lets
+    dpla-map.json under the partner's sharded item prefix (resolved by
+    S3Client.get_item_metadata). Returns the parsed doc on success, None
+    when the object is missing or unparseable. A None return lets
     `parsed()` fall back to the DPLA API path so we never silently skip an
     item just because it hasn't been staged yet.
     """

--- a/tools/sdc-sync.py
+++ b/tools/sdc-sync.py
@@ -1169,11 +1169,29 @@ def _fetch_dpla_doc_from_s3(s3_client, partner, dpla_id):
     `get-ids-es` stages the ES `_source` for every eligible item as
     dpla-map.json under the partner's sharded item prefix (resolved by
     S3Client.get_item_metadata). Returns the parsed doc on success, None
-    when the object is missing or unparseable. A None return lets
-    `parsed()` fall back to the DPLA API path so we never silently skip an
-    item just because it hasn't been staged yet.
+    when the object is missing, unparseable, or temporarily unreachable.
+    A None return lets `parsed()` fall back to the DPLA API path so we
+    never silently skip an item just because it hasn't been staged yet
+    or S3 had a hiccup.
+
+    `get_item_file` (the backing helper) returns None cleanly only for
+    404/NoSuchKey — any other ClientError (5xx, throttling, permissions)
+    re-raises. Wrap so transient infrastructure errors trigger the API
+    fallback instead of aborting the whole batch.
     """
-    raw = s3_client.get_item_metadata(partner, dpla_id)
+    # Lazy import keeps the --help path from pulling in botocore. Only
+    # reached when --from-s3 was set, by which point boto3 is already
+    # loaded via S3Client; this import is a cached no-op then.
+    from botocore.exceptions import ClientError
+
+    try:
+        raw = s3_client.get_item_metadata(partner, dpla_id)
+    except ClientError as e:
+        print(
+            f" -- S3 fetch failed for {partner}/{dpla_id} ({e!r}); "
+            "falling back to api.dp.la."
+        )
+        return None
     if raw is None:
         return None
     try:

--- a/tools/sdc-sync.py
+++ b/tools/sdc-sync.py
@@ -49,6 +49,18 @@ parser.add_argument(
     default=0,
     help="When using --cat, stop after this many files (0 = no limit)",
 )
+parser.add_argument(
+    "--from-s3",
+    dest="from_s3",
+    metavar="PARTNER",
+    action="store",
+    default=None,
+    help=(
+        "Read each DPLA item's metadata from <partner>/<dpla_id>/dpla-map.json "
+        "in S3 (staged by get-ids-es) instead of calling api.dp.la. Falls back "
+        "to api.dp.la when an item's dpla-map.json is missing."
+    ),
+)
 args = parser.parse_args()
 
 method = "livecat"
@@ -97,6 +109,16 @@ subject_ids = requests.get(
     "https://raw.githubusercontent.com/DominicBM/ingestion3/develop/src/main/resources/subjects.json",
     timeout=30,
 ).json()
+
+# When --from-s3 <partner> is set, parsed() reads each item's dpla-map.json
+# from S3 instead of calling api.dp.la. Imported lazily so that --help doesn't
+# pay the boto3 import cost.
+_s3_partner = args.from_s3
+_s3_client = None
+if _s3_partner is not None:
+    from ingest_wikimedia.s3 import S3Client
+
+    _s3_client = S3Client()
 
 # This is the JSON used for formatting a claim. The P459 -> Q61848113 (determination method) qualifier is hardcoded in for everything DPLA adds. Not all data types have the same format for value, so this is formatted in the function for each property added.
 
@@ -1107,28 +1129,89 @@ def dpla_claims(
         print(" --- Saved removals!")
 
 
-def parsed(dpla_id, dpla_api):
-    print(f" -- Accessing DPLA ID {dpla_id}")
+def _fetch_dpla_doc_from_api(dpla_id, dpla_api):
+    """Fetch a single DPLA item's inner doc from the public DPLA API.
+
+    Returns the inner doc (same shape as an ES `_source` and as
+    `<partner>/<dpla_id>/dpla-map.json` in S3) on success, or None on API
+    error. Retries once after a 30-second sleep on the first network failure.
+    """
     try:
-        dpla = requests.get(
+        response = requests.get(
             f"https://api.dp.la/v2/items/{dpla_id}?api_key={dpla_api}",
             timeout=15,
         ).json()
     except Exception:
         print(" -- Sleeping 30 seconds and retrying...")
         time.sleep(30)
-        dpla = requests.get(
+        response = requests.get(
             f"https://api.dp.la/v2/items/{dpla_id}?api_key={dpla_api}",
             timeout=15,
         ).json()
-    print(f" -- Accessed DPLA ID {dpla_id}")
-
     try:
-        dpla = dpla["docs"][0]
+        return response["docs"][0]
     except Exception:
-        print(dpla)
+        print(response)
         print("DPLA API returned error.")
         return None
+
+
+def _fetch_dpla_doc_from_s3(s3_client, partner, dpla_id):
+    """Read a single DPLA item's inner doc from S3.
+
+    `get-ids-es` stages the ES `_source` for every eligible item as
+    `<partner>/<dpla_id>/dpla-map.json`. Returns the parsed doc on success,
+    None when the object is missing or unparseable. A None return lets
+    `parsed()` fall back to the DPLA API path so we never silently skip an
+    item just because it hasn't been staged yet.
+    """
+    raw = s3_client.get_item_metadata(partner, dpla_id)
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except Exception as e:
+        print(f" -- S3 dpla-map.json for {dpla_id} failed to parse: {e}")
+        return None
+
+
+def parsed(dpla_id, dpla_api):
+    """Resolve a DPLA item to the 13-tuple consumed by process_one().
+
+    Source-of-truth selection:
+      * When --from-s3 <partner> is configured, try S3 first. On miss
+        (object not present, parse error), fall back to api.dp.la so a
+        not-yet-staged item still syncs.
+      * Otherwise hit api.dp.la directly.
+
+    Returns None when neither source has a usable doc — process_one()
+    treats that as a Missing ID.
+    """
+    print(f" -- Accessing DPLA ID {dpla_id}")
+
+    dpla = None
+    if _s3_partner is not None:
+        dpla = _fetch_dpla_doc_from_s3(_s3_client, _s3_partner, dpla_id)
+        if dpla is not None:
+            print(f" -- Loaded {dpla_id} from S3 ({_s3_partner})")
+    if dpla is None:
+        dpla = _fetch_dpla_doc_from_api(dpla_id, dpla_api)
+
+    print(f" -- Accessed DPLA ID {dpla_id}")
+
+    if dpla is None:
+        return None
+    return _parse_dpla_doc(dpla, dpla_id)
+
+
+def _parse_dpla_doc(dpla, dpla_id):
+    """Parse a DPLA item's inner doc into the 13-tuple consumed by
+    process_one().
+
+    Pure transformation over the doc, except for the optional batched
+    Wikidata reconciliation call for NARA `exactMatch` subjects (which has
+    no cheaper place to live until PR 2 moves it into get-ids-es).
+    """
     hub = hubs[dpla["provider"]["name"]]["Wikidata"]
     institution = hubs[dpla["provider"]["name"]]["institutions"][
         dpla["dataProvider"]["name"]


### PR DESCRIPTION
## Summary

First step toward folding `sdc-sync` into the wikimedia-upload pipeline (per the recently-merged sdc-sync PR #229 follow-up plan). This PR is opt-in: default behavior is unchanged.

- **Refactor.** `parsed()` is split into:
  - `_fetch_dpla_doc_from_api(dpla_id, dpla_api)` — existing API path.
  - `_fetch_dpla_doc_from_s3(s3_client, partner, dpla_id)` — new; reads `<partner>/<dpla_id>/dpla-map.json` staged by `get-ids-es`.
  - `_parse_dpla_doc(dpla, dpla_id)` — pure transformation, no I/O.
- **New flag** `--from-s3 <PARTNER>`. When set, `parsed()` tries S3 first and falls back to api.dp.la on miss, so the flag is safe across hubs with mixed staging state.
- `S3Client` is imported lazily so `--help` doesn't pay the boto3 cost.

## Why

`sdc-sync` currently makes one `api.dp.la/v2/items/<id>` call per file. `get-ids-es` already stages the same ES `_source` document for every eligible item to S3 as `dpla-map.json`. Reading from S3 instead removes the DPLA-API hot loop from the eventual partner-driven SDC phase (the bigger win that lands in PR 4).

## Test plan

- [x] `--help` works (no boto3 / network / login).
- [x] Legacy `--file "File:…"` (no `--from-s3`): unchanged behavior, hits api.dp.la, idempotent.
- [x] `--file … --from-s3 minnesota` against a Grant County file: log line `Loaded … from S3 (minnesota)`, no api.dp.la call, idempotent.
- [x] `--file … --from-s3 bpl` (wrong partner for that item): silent fallback to api.dp.la, item still processes correctly.
- [x] `ruff check` + `ruff format` clean.

## Next

- **PR 2** — precompute SDC at `get-ids-es` time, stage `sdc.json` next to `dpla-map.json`. Batches Wikidata reconciliation across the whole hub.
- **PR 3** — uploader emits per-item `upload-result.json` so the SDC phase knows which ordinals to attempt.
- **PR 4** — partner-driven SDC phase replaces `--cat/--file/--lists` (which stay as fallbacks for one release).
- **PR 5** — `/wikimedia-upload sdc <target>` Slack command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds an opt-in --from-s3 <PARTNER> CLI flag to tools/sdc-sync.py so the script can read each DPLA item’s staged dpla-map.json from S3 (via S3Client.get_item_metadata using the partner’s sharded item prefix) before falling back to the public DPLA API. This is PR 1 of 5 to integrate sdc-sync into the wikimedia-upload pipeline.

Key changes
- New CLI flag: --from-s3 PARTNER (opt-in). When set, parsed() attempts S3 first and falls back to the public DPLA API on missing/unparseable S3 objects.
- Refactor parsed() into three helpers:
  - _fetch_dpla_doc_from_s3(s3_client, partner, dpla_id): reads staged ES _source (dpla-map.json) via S3Client.get_item_metadata; returns None on missing/unparseable content so caller can fall back.
  - _fetch_dpla_doc_from_api(dpla_id, dpla_api): existing API path, now retries once after a 30s sleep on initial request failure; retry failures return None (avoids aborting the batch).
  - _parse_dpla_doc(dpla, dpla_id): pure transformation of the inner doc into the 13-tuple consumed by process_one().
- S3Client import is lazy (only imported when --from-s3 is supplied) so --help won’t require boto3.
- Minor help/docstring updates clarifying that the S3 key is resolved via S3Client.get_item_metadata (the sharded item prefix), not a literal <partner>/<dpla_id>/dpla-map.json path.
- Internal module-level S3 state introduced (_s3_partner, _s3_client).
- Patch size: ~+120/-11 lines.

Behavioral notes
- S3-first mode is tolerant: an absent or unparseable S3 object silently falls back to api.dp.la so mixed staging across hubs is safe.
- API fetch retry behavior hardened: a failed retry returns None instead of raising and aborting the batch.

Compatibility, deployment, and infra impact
- Backwards compatible and opt-in: default (API-only) behavior unchanged.
- No pipeline trigger, ECS redeploy, or other deployment required for this change (script-only).
- No new or renamed environment variables or AWS Secrets Manager keys.
- No database migrations.
- No changes to shared CI/CD, CodePipeline/CodeBuild/ECS task definitions, or IAM policies in this PR.
- Uses existing boto3 credential chain and the same S3 usage pattern; lazy import limits runtime impact unless --from-s3 is used.

Security considerations
- Introduces an additional external input (S3-staged JSON). Reads use the existing S3Client and boto3 credential chain; no new credential handling or secret storage changes were introduced. Fallback to the public API reduces risk of skipping items when staging is incomplete.

Tests & formatting
- Tests exercise --help, legacy API mode, successful S3 reads, and S3-miss fallback to API.
- Ruff/format checks clean.

Notes / follow-ups
- This is PR 1 of 5. Subsequent PRs will precompute SDC at get-ids-es time and stage sdc.json, emit per-item upload-result.json from the uploader, replace current invocation modes with a partner-driven SDC phase, and add a /wikimedia-upload sdc Slack command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->