### PR TITLE
retry: pass --max-age-days 1 to downloader so refresh-failed files actually re-attempt

### DIFF
--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -268,7 +268,27 @@ def main() -> None:
         upload_csv = type_csvs.get("upload")
         steps = [f"cd {base}"]
         if download_csv:
-            steps.append(f"downloader {shlex.quote(download_csv)} {slug}")
+            # `--max-age-days 1` forces the downloader to actually re-attempt
+            # files whose S3 LastModified is older than ~now, instead of
+            # falling back to its CLI default of 365 days. The default was
+            # silently skipping any failed-refresh file that already had a
+            # stale S3 entry: the original run had set --max-age-days low
+            # (often 1) to refresh those files, the source request failed,
+            # and the S3 file stayed at its original (e.g. 58-day-old)
+            # write. The retry, defaulting to 365, would then see the same
+            # 58-day-old file as "fresh enough" and skip it — exactly the
+            # file the user was trying to retry.
+            #
+            # Passing 1 day here means: files successfully written by the
+            # prior run (S3 age ~= 0) skip correctly; files the prior run
+            # failed to refresh (S3 age >= 1 day) re-attempt; files never
+            # staged at all (no S3 entry) re-attempt unconditionally. This
+            # is independent of whatever --max-age-days the prior run used,
+            # because the retry is its own decision to re-fetch and should
+            # not need to inherit the prior threshold to be correct.
+            steps.append(
+                f"downloader --max-age-days 1 {shlex.quote(download_csv)} {slug}"
+            )
             steps.append(f"uploader {shlex.quote(download_csv)} {slug}")
         if upload_csv:
             steps.append(f"uploader {shlex.quote(upload_csv)} {slug}")

--- a/tests/test_wikimedia_retry.py
+++ b/tests/test_wikimedia_retry.py
@@ -86,6 +86,96 @@ def test_retry_clears_stale_csvs_before_scan():
     )
 
 
+def _run_main_and_capture_full_pipeline(argv: list[str]) -> list[str]:
+    """Like `_run_main_and_capture_ssm_commands` but lets main() proceed
+    past the scan step so the final tmux pipeline launch command is
+    captured. Returns the full list of SSM command strings issued in order.
+
+    Mock plan, in the order main() issues calls:
+      1. update_cmd                      → return "UPDATE_DONE"
+      2. scan_cmd (get-ids-retry)        → return a "found 1 failure" line
+      3. find + memory check             → return a CSV path + ample memory
+      4. tmux ls (conflict detection)    → return empty (no conflicts)
+      5. tmux new-session …              → captured for assertion
+    Any subsequent calls (Slack notification, etc.) return "" — they don't
+    matter for the assertions in this file.
+    """
+    captured: list[str] = []
+
+    def fake_ssm_run(_client, command, **_kwargs):
+        captured.append(command)
+        if "UPDATE_DONE" in command:
+            return "UPDATE_DONE"
+        if "get-ids-retry" in command:
+            # Pretend the scan found one failure so main keeps going.
+            return (
+                "Partner       Type    IDs  File\n"
+                "----------------------------------\n"
+                "smithsonian   download   1  /home/ec2-user/ingest-wikimedia/retry/smithsonian-download-retry.csv\n"
+            )
+        if "__MEM_CHECK__" in command:
+            return (
+                "/home/ec2-user/ingest-wikimedia/retry/smithsonian-download-retry.csv\n"
+                "__MEM_CHECK__\n"
+                "8000 5000"
+            )
+        # tmux ls and any later calls
+        return ""
+
+    with (
+        patch("scripts.wikimedia_retry.ssm_run", side_effect=fake_ssm_run),
+        patch("scripts.wikimedia_retry.boto3.client", return_value=MagicMock()),
+        patch("scripts.wikimedia_retry.post_message"),  # no real Slack
+        patch("sys.argv", argv),
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        from scripts import wikimedia_retry
+
+        try:
+            wikimedia_retry.main()
+        except SystemExit:
+            pass
+
+    return captured
+
+
+def test_retry_passes_max_age_days_one_to_downloader():
+    """Regression: the retry-driven downloader call must pass
+    `--max-age-days 1` instead of falling back to the CLI default of 365.
+
+    Without this flag, a refresh-failure retry would re-attempt the failed
+    file, see its S3 LastModified is N < 365 days old, log
+    "Key already in S3", and silently SKIP — exactly the file the user
+    was trying to retry. With --max-age-days 1, successful refreshes
+    (S3 age ~0 days) still skip correctly while refresh-failed files
+    (S3 age >= 1 day) actually re-attempt.
+
+    Scenario the bug bites:
+      * /wikimedia-upload refresh si 1 — file 4 of item X is 58 days
+        old in S3; refresh decides to refresh; source request fails
+        transiently; file 4's S3 LastModified stays at 58 days old.
+      * /wikimedia-upload retry 30 si — retry CSV includes item X;
+        downloader runs over item X's files; file 4's age (58) < default
+        365 → "Key already in S3" → SKIP. The retry user expected the
+        failed file to be re-attempted, but it was silently dropped.
+    """
+    commands = _run_main_and_capture_full_pipeline(
+        ["wikimedia_retry.py", "--days", "30", "--partner", "si"]
+    )
+
+    pipeline_cmds = [c for c in commands if "tmux new-session" in c]
+    assert pipeline_cmds, f"No tmux new-session command was issued; saw: {commands!r}"
+    pipeline_cmd = pipeline_cmds[0]
+
+    assert "downloader --max-age-days 1" in pipeline_cmd, (
+        f"The retry's downloader call must pass `--max-age-days 1` so "
+        f"refresh-failed files actually re-attempt; got: {pipeline_cmd!r}"
+    )
+    # Defence: make sure --max-age-days 1 immediately precedes the CSV path
+    # rather than appearing somewhere else in the command line.
+    assert "downloader --max-age-days 1 " in pipeline_cmd
+
+
 def test_retry_clears_stale_csvs_even_when_no_partner_given():
     """When the user runs `/wikimedia-upload retry 30` (no partner), the
     scan still needs to clear stale CSVs so that hubs which legitimately

--- a/tests/test_wikimedia_retry.py
+++ b/tests/test_wikimedia_retry.py
@@ -134,6 +134,10 @@ def _run_main_and_capture_full_pipeline(argv: list[str]) -> list[str]:
         try:
             wikimedia_retry.main()
         except SystemExit:
+            # main() reaches `_slack_fail` after the mocked tmux launch
+            # returns "" (no SESSION_STARTED), which calls sys.exit(1).
+            # That's expected in the mocked path — by that point we've
+            # already captured every SSM call the test cares about.
             pass
 
     return captured
@@ -171,9 +175,17 @@ def test_retry_passes_max_age_days_one_to_downloader():
         f"The retry's downloader call must pass `--max-age-days 1` so "
         f"refresh-failed files actually re-attempt; got: {pipeline_cmd!r}"
     )
-    # Defence: make sure --max-age-days 1 immediately precedes the CSV path
-    # rather than appearing somewhere else in the command line.
-    assert "downloader --max-age-days 1 " in pipeline_cmd
+    # Defence: make sure --max-age-days 1 is immediately followed by the
+    # CSV path and partner argument, not buried elsewhere in the command
+    # line. The substring match here pins the exact argument order the
+    # downloader CLI expects (`downloader [OPTIONS] IDS_FILE PARTNER`).
+    expected = (
+        "downloader --max-age-days 1 "
+        "/home/ec2-user/ingest-wikimedia/retry/smithsonian-download-retry.csv si"
+    )
+    assert expected in pipeline_cmd, (
+        f"expected substring not found; got: {pipeline_cmd!r}"
+    )
 
 
 def test_retry_clears_stale_csvs_even_when_no_partner_given():


### PR DESCRIPTION
## Summary

When the retry script invokes the downloader on its retry CSV, it should pass `--max-age-days 1` so files that had stale S3 entries from a failed refresh actually get re-attempted, instead of being silently skipped by the downloader's 365-day default.

## How the bug bites

Today's sequence that surfaced this:

1. `/wikimedia-upload refresh si 1` — refresh files >1 day old. 12 of the downloads failed.
2. `/wikimedia-upload retry 30 si` — retry the failed items. Reported back with all attempts as skips.

In today's specific run, the failing URL (`https://airandspace.si.edu/webimages/.../AerialAgeWeekly_March18-1918pgs54-56.pdf`) is a persistent HTTP 404 — that file was never in S3, so the age check returned None, the retry actually ran the download, and it 404'd again. The "all skipped" appearance was because the retry CSV identifies failed *items* (DPLA IDs), and the downloader iterates every file of every item; the other ~79 files of those items were freshly written by the refresh 75 minutes earlier and skipped correctly.

But **the bug the user was reasoning about is real for a different scenario**:

* A file already exists in S3 (e.g. 58 days old from a prior run).
* `/wikimedia-upload refresh si 1` decides to refresh it (`58 >= 1`).
* The source request fails transiently (rate limit, timeout, gateway 5xx).
* S3 LastModified stays at the 58-day-old original write.
* The retry CSV includes the item.
* `scripts/wikimedia_retry.py` runs `downloader {csv} {slug}` — **no `--max-age-days`**, so the downloader falls back to its CLI default of 365.
* The age check sees 58 days < 365 → logs `Key already in S3.` → increments SKIPPED.
* The file the user was trying to retry is silently dropped.

## Fix

`scripts/wikimedia_retry.py:271` becomes:

```python
steps.append(
    f"downloader --max-age-days 1 {shlex.quote(download_csv)} {slug}"
)
```

With `--max-age-days 1`:
- Files the prior run successfully wrote (S3 age ~ 0 days) still skip correctly (`0 < 1`).
- Files the prior run failed to refresh (S3 age >= 1 day) re-attempt.
- Files never staged at all (no S3 entry) re-attempt unconditionally via the existing age-check-returns-None path.

The retry doesn't need to inherit the prior run's threshold — it just needs its own threshold to be tight enough that anything older than the gap between the runs gets re-fetched.

Why `1` rather than `0`: `--max-age-days 0` would re-fetch *every* file regardless of state, including the ones the prior run successfully wrote, which is wasteful (re-touches that produce identical bytes). `1` is the sweet spot.

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] New `tests/test_wikimedia_retry.py::test_retry_passes_max_age_days_one_to_downloader` extends the existing mock harness to let `main()` proceed all the way through to the `tmux new-session` SSM call, then asserts the pipeline command contains `downloader --max-age-days 1 …`
- [ ] CI: pytest + ruff green
- [ ] After merge: confirm `/wikimedia-upload retry` runs that follow a refresh actually re-attempt the failed files (e.g. by triggering a refresh, killing it mid-run to force partial failures on items already in S3, then running retry and checking that the previously-failed files are re-downloaded rather than skipped)

## Lesson recorded

> **Retry / re-attempt logic must use a fresh-enough age threshold to actually re-attempt the failed work**

(Added to `~/.claude/lessons.md`.) Captures the general pattern: any retry path that delegates to a TTL-driven helper without explicitly setting the TTL is at risk of silently no-op'ing on the very work it's trying to retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a bug in the Wikimedia download retry pipeline where files that previously failed a refresh were silently skipped during retry attempts because the downloader used its 365-day default. The retry pipeline now invokes the downloader with --max-age-days 1 so refresh-failed files (S3 age ≥ 1 day) are re-attempted while recently-written files (S3 age ~0 days) remain skipped.

## Changes

- scripts/wikimedia_retry.py
  - Passes --max-age-days 1 to the downloader invocation in the retry pipeline:
    f"downloader --max-age-days 1 {shlex.quote(download_csv)} {slug}"
  - Adds inline comments explaining the rationale and how this differs from the original run's behavior.

- tests/test_wikimedia_retry.py
  - Adds helper _run_main_and_capture_full_pipeline(...) to let main() progress and capture the tmux pipeline command.
  - Adds regression test test_retry_passes_max_age_days_one_to_downloader() which asserts the tmux pipeline contains the precise downloader invocation:
    "downloader --max-age-days 1 /home/ec2-user/ingest-wikimedia/retry/smithsonian-download-retry.csv si"
  - Tightens an existing test assertion and added a comment explaining an empty except SystemExit block to satisfy CodeQL guidance.

## Impact / Deployment notes

- Scope: script-only fix; no changes to infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM), environment variables, or AWS Secrets Manager keys.
- No database migrations.
- No public API changes.
- No security-sensitive changes (no auth changes or new credential handling).
- Activation: takes effect when the retry script is invoked by the existing /wikimedia-upload retry Slack workflow; no pipeline trigger or ECS redeploy is required.
- CI: ruff checks passed locally; pytest + ruff on CI pending.
- Post-merge: manual validation in production is recommended to confirm the retry run actually re-downloads previously-failed files as intended.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->