### PR TITLE
get-ids-es: precompute SDC and stage sdc.json (PR 2 of 5)

### DIFF
--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -347,7 +347,10 @@ def _resolve_subjects(
         name = subject.get("name")
         added = False
         if name in subject_ids:
-            for subjqid in subject_ids[name]["id"]:
+            # Use .get("id", []) so a subjects.json entry missing the
+            # expected "id" array doesn't crash the whole sync — degrades
+            # to "no P921 entry for this subject", same as no Q-ID match.
+            for subjqid in subject_ids[name].get("id", []):
                 if not any(subjqid in pair for pair in subjects):
                     subjects.append((str(name), subjqid))
                     added = True
@@ -409,37 +412,49 @@ def parse_dpla_doc(
     rs = doc["rights"]
     url = doc["isShownAt"]
 
+    # The shape-tolerant blocks below treat missing or mis-typed fields as
+    # "absent" — same contract as the original sdc-sync. Narrowed from a bare
+    # except to (KeyError, IndexError, TypeError) so a real bug (e.g.
+    # AttributeError introduced by an upstream refactor) propagates instead
+    # of being silently swallowed. Each fallback is logged so silent fallback
+    # is still observable in the worker logs.
+
     try:
         dates = [
             displaydate["displayDate"] for displaydate in doc["sourceResource"]["date"]
         ]
-    except Exception:
+    except (KeyError, IndexError, TypeError) as e:
+        logger.debug("No usable dates for %s: %s", dpla_id, e)
         dates = []
 
     try:
         local_ids = doc["sourceResource"]["identifier"]
         if isinstance(local_ids, str):
             local_ids = [local_ids]
-    except Exception:
+    except (KeyError, TypeError) as e:
+        logger.debug("No usable identifiers for %s: %s", dpla_id, e)
         local_ids = []
 
     try:
         descs = doc["sourceResource"]["description"]
         if isinstance(descs, str):
             descs = [descs]
-    except Exception:
+    except (KeyError, TypeError) as e:
+        logger.debug("No usable description for %s: %s", dpla_id, e)
         descs = []
 
     try:
         subjects = _resolve_subjects(doc, subject_ids, subjects_lookup)
-    except Exception:
+    except (KeyError, IndexError, TypeError) as e:
+        logger.debug("Subject resolution failed for %s: %s", dpla_id, e)
         subjects = []
 
     try:
         creators = doc["sourceResource"]["creator"]
         if isinstance(creators, str):
             creators = [creators]
-    except Exception:
+    except (KeyError, TypeError) as e:
+        logger.debug("No usable creators for %s: %s", dpla_id, e)
         creators = []
 
     if doc["provider"]["name"] == NARA_PROVIDER_NAME:
@@ -459,7 +474,10 @@ def parse_dpla_doc(
                     xml.find("accessRestriction").find("status").find("naId").text
                 )
                 access = NARA_ACCESS_CODES.get(access_naid, "")
-            except Exception:
+            except (AttributeError, TypeError) as e:
+                # Any .find() returning None breaks the chain — log so a
+                # silently-missing access restriction is observable.
+                logger.debug("NARA access restriction missing for %s: %s", dpla_id, e)
                 access = ""
             for lvl_key in NARA_LEVELS:
                 if xml.find(lvl_key):

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1,0 +1,798 @@
+"""SDC (Structured Data on Commons) claim construction for DPLA items.
+
+Given a DPLA item's ES `_source` document (the same shape the api.dp.la
+/v2/items endpoint returns inside `docs[0]`), `build_claims_for_doc()`
+produces the ready-to-POST Wikibase claim list — the exact `claims["claims"]`
+array `sdc-sync` writes via `wbsetclaims`. This is what `get-ids-es` stages
+to S3 as `sdc.json` so the sync phase becomes a pure diff+POST step.
+
+All claim-building primitives in this module are pure: no Commons API
+calls, no `check()`-style queries against existing state. Subject
+reconciliation against Wikidata happens via the explicit
+`reconcile_subjects()` helper, which is called once per hub (batched
+across all NARA `exactMatch` subjects) by `get-ids-es` so the per-item
+build step receives a fully-resolved lookup table.
+
+Module structure:
+
+  Constants
+    Q-IDs for hardcoded entities and NARA-only access/level maps.
+
+  Pure helpers
+    normalize_rights_uri()         — canonicalize a DPLA rights URI
+    _item_value(qid)                — wikibase-entityid datavalue
+    formattedclaim(...)             — claim shape with P459 qualifier and
+                                      P854/P123/P813 reference
+
+  Per-item parsing
+    parse_dpla_doc(doc, dpla_id, hubs, subject_ids, subjects_lookup)
+        Returns the 13-element tuple of normalized intermediate values
+        consumed by `build_claims_for_doc`. `subjects_lookup` is a
+        pre-resolved `{(name, naid): qid}` map produced by
+        `reconcile_subjects` — when None the caller can still call
+        `collect_subject_queries` + `reconcile_subjects` itself to fill it.
+
+  Reconciliation
+    collect_subject_queries(doc)    — yield (name, naid) pairs to resolve
+    reconcile_subjects(queries)     — batched call to wikidata.reconci.link
+                                      returning {(name, naid): qid}
+
+  Top-level builder
+    build_claims_for_doc(doc, dpla_id, hubs, rights, subject_ids,
+                        subjects_lookup, retrieval_date)
+        Returns `{"claims": [...]}` ready to POST to wbsetclaims.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from collections.abc import Iterable
+from typing import Any
+
+import requests
+from bs4 import BeautifulSoup
+
+# Hardcoded Wikibase entities used across the SDC mapping. Centralized here
+# so any change has a single edit site.
+Q_HEURISTIC = "Q61848113"
+Q_DPLA = "Q2944483"
+Q_SOURCE_CATALOG = "Q74228490"
+Q_PUBLIC_DOMAIN = "Q19652"
+Q_COPYRIGHTED = "Q50423863"
+Q_CC0_PD_SOMEWHERE = "Q88088423"
+Q_PD_MARK_RAW = "Q6938433"
+Q_SMITHSONIAN = "Q518155"
+Q_PUBLISHER = "Q393351"
+Q_AGGREGATOR = "Q108296843"
+Q_CONTRIBUTING_INSTITUTION = "Q108296919"
+Q_NARA_ITEM = "Q11723795"
+Q_NARA_FILE_UNIT = "Q59221146"
+
+# NARA-only mappings.
+NARA_ACCESS_CODES = {
+    "10031403": "Q66739888",
+    "10031402": "Q24238356",
+    "10031399": "Q66739729",
+    "10031400": "Q66739849",
+    "10031401": "Q66739875",
+}
+NARA_LEVELS = {
+    "item": Q_NARA_ITEM,
+    "itemAv": Q_NARA_ITEM,
+    "fileUnit": Q_NARA_FILE_UNIT,
+}
+NARA_PROVIDER_NAME = "National Archives and Records Administration"
+NARA_CATALOG_PREFIX = "https://catalog.archives.gov/id/"
+
+PD_MARK_URI_CANONICAL = "http://creativecommons.org/publicdomain/mark/1.0"
+
+RECONCI_ENDPOINT = "https://wikidata.reconci.link/en/api"
+RECONCI_BATCH_SIZE = 10
+TEXT_VALUE_LIMIT = 1499  # matches sdc-sync's longstanding truncation cap
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_rights_uri(uri: str) -> str:
+    """Canonicalize a DPLA rights URI for lookup against rights.json.
+
+    DPLA emits rights URIs in a few minor variants (http vs https, with
+    or without a trailing slash). Keying on a single canonical form
+    means we don't silently miss licenses just because of scheme/slash
+    drift on either side.
+    """
+    if not uri:
+        return uri
+    return uri.replace("https://", "http://").rstrip("/")
+
+
+def _item_value(qid: str) -> dict:
+    """Build a wikibase-entityid datavalue payload for a Q-ID."""
+    return {"entity-type": "item", "numeric-id": int(qid.replace("Q", ""))}
+
+
+def _qualifier_item_snak(prop: str, qid: str) -> dict:
+    """Build a single qualifier snak for an item-typed value."""
+    return {
+        "snaktype": "value",
+        "property": prop,
+        "datavalue": {"value": _item_value(qid), "type": "wikibase-entityid"},
+    }
+
+
+def _qualifier_string_snak(prop: str, value: str, datatype: str | None = None) -> dict:
+    """Build a single qualifier snak for a string-typed value."""
+    snak = {
+        "snaktype": "value",
+        "property": prop,
+        "datavalue": {"value": value, "type": "string"},
+    }
+    if datatype is not None:
+        snak["datatype"] = datatype
+    return snak
+
+
+def formattedclaim(
+    prop: str,
+    value: Any,
+    value_type: str,
+    dpla_id: str,
+    retrieval_date: datetime.date | None = None,
+) -> dict:
+    """Build the canonical Wikibase claim envelope.
+
+    Every DPLA-published claim carries:
+      * a P459 (determination method) qualifier set to Q61848113 (heuristic)
+      * a reference triple — P854 (DPLA item URL), P123 (publisher = DPLA),
+        P813 (retrieved on `retrieval_date`).
+
+    When called with `value == "somevalue"` the mainsnak is emitted as a
+    snaktype=somevalue node instead of a value node — the caller adds the
+    type-specific qualifier (P2093 for creators, P1932 for dates).
+
+    `retrieval_date` defaults to today's date when omitted; callers that
+    want a deterministic, persisted-to-S3 claim list (get-ids-es) should
+    pass the run date explicitly so the same `sdc.json` content is
+    reproducible from the same input doc.
+    """
+    if retrieval_date is None:
+        retrieval_date = datetime.date.today()
+
+    claim = {
+        "mainsnak": {
+            "snaktype": "value",
+            "property": prop,
+            "datavalue": {"value": value, "type": value_type},
+        },
+        "type": "statement",
+        "rank": "normal",
+        "qualifiers": {
+            "P459": [
+                {
+                    "snaktype": "value",
+                    "property": "P459",
+                    "datavalue": {
+                        "value": _item_value(Q_HEURISTIC),
+                        "type": "wikibase-entityid",
+                    },
+                    "datatype": "wikibase-item",
+                }
+            ]
+        },
+        "references": [
+            {
+                "snaks": {
+                    "P854": [
+                        {
+                            "snaktype": "value",
+                            "property": "P854",
+                            "datavalue": {
+                                "value": f"https://dp.la/item/{dpla_id}",
+                                "type": "string",
+                            },
+                        }
+                    ],
+                    "P123": [
+                        {
+                            "snaktype": "value",
+                            "property": "P123",
+                            "datavalue": {
+                                "value": _item_value(Q_DPLA),
+                                "type": "wikibase-entityid",
+                            },
+                        }
+                    ],
+                    "P813": [
+                        {
+                            "snaktype": "value",
+                            "property": "P813",
+                            "datavalue": {
+                                "value": {
+                                    "time": "+"
+                                    + retrieval_date.isoformat()
+                                    + "T00:00:00Z",
+                                    "timezone": 0,
+                                    "before": 0,
+                                    "after": 0,
+                                    "precision": 11,
+                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
+                                },
+                                "type": "time",
+                            },
+                        }
+                    ],
+                }
+            }
+        ],
+    }
+
+    if value == "somevalue":
+        claim["mainsnak"].pop("datavalue")
+        claim["mainsnak"]["snaktype"] = "somevalue"
+
+    return claim
+
+
+def collect_subject_queries(doc: dict) -> list[tuple[str, str]]:
+    """Return (name, naid) pairs for every NARA `exactMatch` subject in `doc`.
+
+    A subject's NAID is harvested from its first `exactMatch` URL (stripping
+    the NARA catalog prefix). Subjects without an `exactMatch` are
+    irrelevant here — they map via the local `subjects.json` lookup in
+    `parse_dpla_doc`, no HTTP needed.
+    """
+    queries: list[tuple[str, str]] = []
+    for subject in doc.get("sourceResource", {}).get("subject", []) or []:
+        if not isinstance(subject, dict):
+            continue
+        exact_match = subject.get("exactMatch")
+        if not exact_match:
+            continue
+        first = exact_match[0] if isinstance(exact_match, list) else exact_match
+        if not isinstance(first, str):
+            continue
+        naid = first.replace(NARA_CATALOG_PREFIX, "")
+        name = str(subject.get("name") or "")
+        queries.append((name, naid))
+    return queries
+
+
+def reconcile_subjects(
+    queries: Iterable[tuple[str, str]],
+    *,
+    batch_size: int = RECONCI_BATCH_SIZE,
+    timeout: int = 15,
+) -> dict[tuple[str, str], str]:
+    """Resolve (name, naid) subject pairs to Wikidata Q-IDs in batches.
+
+    Uses wikidata.reconci.link's bulk endpoint with up to `batch_size`
+    queries per HTTP call. Failures are best-effort: a chunk that errors
+    out is logged and skipped so a single transient blip doesn't kill the
+    whole hub's pre-compute pass — the items whose subjects couldn't be
+    resolved still get their string-form P4272 statement; only the
+    parallel P921 (depicts) for that subject is omitted.
+
+    Returns `{(name, naid): qid}` for matched subjects. Subjects that
+    weren't matched (no result, blank result id) are omitted.
+    """
+    deduped: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for pair in queries:
+        if pair not in seen:
+            seen.add(pair)
+            deduped.append(pair)
+
+    resolved: dict[tuple[str, str], str] = {}
+    for start in range(0, len(deduped), batch_size):
+        chunk = deduped[start : start + batch_size]
+        payload = {
+            f"q{i}": {
+                "query": name,
+                "limit": 5,
+                "properties": [{"pid": "P1225", "v": naid}],
+                "type_strict": "should",
+            }
+            for i, (name, naid) in enumerate(chunk)
+        }
+        try:
+            response = requests.get(
+                RECONCI_ENDPOINT,
+                params={"queries": json.dumps(payload)},
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except (requests.RequestException, ValueError) as e:
+            logger.warning(
+                "Subject reconciliation chunk failed (%d queries): %s; "
+                "subjects in this chunk will have no P921 entry.",
+                len(chunk),
+                e,
+            )
+            continue
+        for i, pair in enumerate(chunk):
+            result = data.get(f"q{i}", {}).get("result") or []
+            if not result:
+                continue
+            qid = result[0].get("id")
+            if qid:
+                resolved[pair] = qid
+    return resolved
+
+
+def _resolve_subjects(
+    doc: dict,
+    subject_ids: dict,
+    subjects_lookup: dict[tuple[str, str], str] | None,
+) -> list[tuple[str, str]]:
+    """Build the `[(name, qid_or_empty), ...]` list `parse_dpla_doc` returns.
+
+    Three resolution sources, in order:
+      1. The local `subjects.json` map (`subject_ids`) keyed by subject name.
+      2. The pre-resolved `subjects_lookup` from `reconcile_subjects` for
+         NARA `exactMatch` subjects.
+      3. Fallback to `(name, "")` — string-form P4272 will still be emitted,
+         but no parallel P921 entry.
+    """
+    subjects: list = []
+    for subject in doc.get("sourceResource", {}).get("subject", []) or []:
+        if not isinstance(subject, dict):
+            continue
+        name = subject.get("name")
+        added = False
+        if name in subject_ids:
+            for subjqid in subject_ids[name]["id"]:
+                if not any(subjqid in pair for pair in subjects):
+                    subjects.append((str(name), subjqid))
+                    added = True
+                if not any(name in pair for pair in subjects):
+                    subjects.append((str(name or ""), ""))
+                    added = True
+            continue
+        if subject.get("exactMatch"):
+            exact_match = subject["exactMatch"]
+            first = exact_match[0] if isinstance(exact_match, list) else exact_match
+            naid = ""
+            if isinstance(first, str):
+                naid = first.replace(NARA_CATALOG_PREFIX, "")
+            subj_name = str(name or "")
+            qid = ""
+            if subjects_lookup is not None:
+                qid = subjects_lookup.get((subj_name, naid), "")
+            subjects.append((subj_name, qid))
+            added = True
+        if not added:
+            subjects.append((str(name or ""), ""))
+    return [tuple(pair) for pair in subjects]
+
+
+def parse_dpla_doc(
+    doc: dict,
+    dpla_id: str,
+    hubs: dict,
+    subject_ids: dict,
+    subjects_lookup: dict[tuple[str, str], str] | None = None,
+) -> tuple | None:
+    """Extract the 13-element tuple of normalized values from a DPLA doc.
+
+    Tuple order (preserved for `sdc-sync.process_one()` compatibility):
+        (url, descs, dates, titles, hub, local_ids, institution, rs,
+         creators, subjects, naids, access, level)
+
+    `subjects_lookup` is the pre-resolved `{(name, naid): qid}` map
+    produced by `reconcile_subjects`. When omitted, NARA-exactMatch
+    subjects are left unresolved (the parallel P921 entry won't be
+    emitted for them); callers that want inline reconciliation should
+    call `collect_subject_queries` + `reconcile_subjects` first and pass
+    the result.
+    """
+    try:
+        hub = hubs[doc["provider"]["name"]]["Wikidata"]
+        institution = hubs[doc["provider"]["name"]]["institutions"][
+            doc["dataProvider"]["name"]
+        ]["Wikidata"]
+    except (KeyError, TypeError):
+        return None
+
+    titles = doc["sourceResource"]["title"]
+    if isinstance(titles, str):
+        titles = [titles]
+    rs = doc["rights"]
+    url = doc["isShownAt"]
+
+    try:
+        dates = [
+            displaydate["displayDate"] for displaydate in doc["sourceResource"]["date"]
+        ]
+    except Exception:
+        dates = []
+
+    try:
+        local_ids = doc["sourceResource"]["identifier"]
+        if isinstance(local_ids, str):
+            local_ids = [local_ids]
+    except Exception:
+        local_ids = []
+
+    try:
+        descs = doc["sourceResource"]["description"]
+        if isinstance(descs, str):
+            descs = [descs]
+    except Exception:
+        descs = []
+
+    try:
+        subjects = _resolve_subjects(doc, subject_ids, subjects_lookup)
+    except Exception:
+        subjects = []
+
+    try:
+        creators = doc["sourceResource"]["creator"]
+        if isinstance(creators, str):
+            creators = [creators]
+    except Exception:
+        creators = []
+
+    if doc["provider"]["name"] == NARA_PROVIDER_NAME:
+        naids = doc["sourceResource"]["identifier"]
+        if isinstance(naids, str):
+            naids = [naids]
+        access = ""
+        level = ""
+        try:
+            xml = BeautifulSoup(doc["originalRecord"]["stringValue"], "xml")
+        except Exception as e:
+            logger.warning("Skipping NARA XML parse for %s: %s", dpla_id, e)
+            xml = None
+        if xml is not None:
+            try:
+                access_naid = str(
+                    xml.find("accessRestriction").find("status").find("naId").text
+                )
+                access = NARA_ACCESS_CODES.get(access_naid, "")
+            except Exception:
+                access = ""
+            for lvl_key in NARA_LEVELS:
+                if xml.find(lvl_key):
+                    level = NARA_LEVELS[lvl_key]
+        local_ids = []
+    else:
+        naids = []
+        access = ""
+        level = ""
+
+    return (
+        url,
+        descs,
+        dates,
+        titles,
+        hub,
+        local_ids,
+        institution,
+        rs,
+        creators,
+        subjects,
+        naids,
+        access,
+        level,
+    )
+
+
+def _truncate(value: str) -> str:
+    """Match sdc-sync's longstanding `[:1499].rstrip()` normalization."""
+    return value[:TEXT_VALUE_LIMIT].rstrip() if value else ""
+
+
+def _build_rights_claims(
+    rs: str,
+    rights: dict,
+    dpla_id: str,
+    retrieval_date: datetime.date,
+) -> list[dict]:
+    """Build the P275/P6426/P6216 claim cluster for an item's rights URI.
+
+    Mirrors `sdc-sync.add_rs()` minus the Commons-check + appending side
+    effects. Order of precedence:
+      * If the rights URI maps via rights.json, emit the mapped P275 or
+        P6426 claim and a parallel P6216 (status) derived from it.
+      * Public Domain Mark gets a P6216=Q19652 status directly.
+    """
+    out: list[dict] = []
+    rs_key = normalize_rights_uri(rs)
+    rights_entry = rights.get(rs_key)
+    status_prop: str | None = None
+    status_qid: str | None = None
+
+    if rights_entry:
+        prop = next(iter(rights_entry))
+        qid = rights_entry[prop]
+        out.append(
+            formattedclaim(
+                prop, _item_value(qid), "wikibase-entityid", dpla_id, retrieval_date
+            )
+        )
+        # Derive a P6216 (copyright status) companion claim.
+        if prop == "P275" and qid != Q_PD_MARK_RAW:
+            status_prop, status_qid = "P6216", Q_COPYRIGHTED
+        elif prop == "P6426":
+            status_prop, status_qid = "P6216", Q_PUBLIC_DOMAIN
+        if qid == Q_PD_MARK_RAW:
+            status_prop, status_qid = "P6216", Q_CC0_PD_SOMEWHERE
+
+    if rs_key == PD_MARK_URI_CANONICAL:
+        status_prop, status_qid = "P6216", Q_PUBLIC_DOMAIN
+
+    if status_prop is not None and status_qid is not None:
+        out.append(
+            formattedclaim(
+                status_prop,
+                _item_value(status_qid),
+                "wikibase-entityid",
+                dpla_id,
+                retrieval_date,
+            )
+        )
+    return out
+
+
+def _build_contributed_claims(
+    hub: str,
+    institution: str,
+    dpla_id: str,
+    retrieval_date: datetime.date,
+) -> list[dict]:
+    """Build the three-statement P9126 chain (DPLA + hub + institution).
+
+    Each statement gets a P3831 (object of statement) qualifier identifying
+    the role: publisher for DPLA, aggregator for the hub, contributing
+    institution for the institution. The Smithsonian-hub case promotes
+    the hub to fill both hub and institution slots.
+    """
+    out: list[dict] = []
+
+    def _with_role(prop_qid: str, role_qid: str) -> dict:
+        claim = formattedclaim(
+            "P9126",
+            _item_value(prop_qid),
+            "wikibase-entityid",
+            dpla_id,
+            retrieval_date,
+        )
+        claim["qualifiers"]["P3831"] = [_qualifier_item_snak("P3831", role_qid)]
+        return claim
+
+    out.append(_with_role(Q_DPLA, Q_PUBLISHER))
+    if hub == Q_SMITHSONIAN:
+        out.append(_with_role(Q_SMITHSONIAN, Q_AGGREGATOR))
+        out.append(_with_role(institution, Q_CONTRIBUTING_INSTITUTION))
+    else:
+        out.append(_with_role(hub, Q_AGGREGATOR))
+        out.append(_with_role(institution, Q_AGGREGATOR))
+    return out
+
+
+def _build_source_claim(
+    hub: str,
+    url: str,
+    dpla_id: str,
+    retrieval_date: datetime.date,
+) -> dict:
+    """Build the P7482 (described at) claim with P973 + P137 qualifiers."""
+    claim = formattedclaim(
+        "P7482",
+        _item_value(Q_SOURCE_CATALOG),
+        "wikibase-entityid",
+        dpla_id,
+        retrieval_date,
+    )
+    claim["qualifiers"]["P973"] = [_qualifier_string_snak("P973", url, datatype="url")]
+    claim["qualifiers"]["P137"] = [_qualifier_item_snak("P137", hub)]
+    return claim
+
+
+def _build_local_id_claim(
+    local_id: str,
+    institution: str,
+    dpla_id: str,
+    retrieval_date: datetime.date,
+) -> dict:
+    """Build a P217 (inventory number) claim with P195 (collection) qualifier."""
+    claim = formattedclaim("P217", local_id, "string", dpla_id, retrieval_date)
+    claim["qualifiers"]["P195"] = [_qualifier_item_snak("P195", institution)]
+    return claim
+
+
+def _build_creator_claim(
+    creator: str,
+    dpla_id: str,
+    retrieval_date: datetime.date,
+) -> dict | None:
+    normalized = _truncate(creator)
+    if not normalized:
+        return None
+    claim = formattedclaim(
+        "P170", "somevalue", "wikibase-entityid", dpla_id, retrieval_date
+    )
+    claim["qualifiers"]["P2093"] = [_qualifier_string_snak("P2093", normalized)]
+    return claim
+
+
+def _build_date_claim(
+    date: str,
+    dpla_id: str,
+    retrieval_date: datetime.date,
+) -> dict | None:
+    normalized = _truncate(date)
+    if not normalized:
+        return None
+    claim = formattedclaim("P571", "somevalue", "time", dpla_id, retrieval_date)
+    claim["qualifiers"]["P1932"] = [_qualifier_string_snak("P1932", normalized)]
+    return claim
+
+
+def _build_monolingual_claim(
+    prop: str,
+    text: str,
+    dpla_id: str,
+    retrieval_date: datetime.date,
+) -> dict | None:
+    normalized = _truncate(text)
+    if not normalized:
+        return None
+    return formattedclaim(
+        prop,
+        {"text": normalized, "language": "en"},
+        "monolingualtext",
+        dpla_id,
+        retrieval_date,
+    )
+
+
+def build_claims_for_doc(
+    doc: dict,
+    dpla_id: str,
+    hubs: dict,
+    rights: dict,
+    subject_ids: dict,
+    subjects_lookup: dict[tuple[str, str], str] | None,
+    retrieval_date: datetime.date,
+) -> dict[str, list[dict]] | None:
+    """Build the complete ready-to-POST SDC claim list for a DPLA item.
+
+    Returns `{"claims": [...]}` matching the wbsetclaims POST shape. Returns
+    `None` when the doc can't be parsed (e.g. provider/dataProvider not in
+    the hubs map) — callers should skip the item and not stage an sdc.json
+    for it.
+
+    `subjects_lookup` is the pre-resolved reconciliation table; pass `None`
+    for inline-only behavior (the parallel P921 statements for NARA
+    `exactMatch` subjects are simply omitted in that case).
+
+    `retrieval_date` is stamped into every claim's P813 reference. For
+    deterministic, persisted-to-S3 output (get-ids-es), pass the run date.
+    """
+    parsed = parse_dpla_doc(doc, dpla_id, hubs, subject_ids, subjects_lookup)
+    if parsed is None:
+        return None
+    (
+        url,
+        descs,
+        dates,
+        titles,
+        hub,
+        local_ids,
+        institution,
+        rs,
+        creators,
+        subjects,
+        naids,
+        access,
+        level,
+    ) = parsed
+
+    claims: list[dict] = []
+
+    # Rights cluster (P275/P6426/P6216).
+    claims.extend(_build_rights_claims(rs, rights, dpla_id, retrieval_date))
+
+    # P760 — DPLA ID.
+    claims.append(formattedclaim("P760", dpla_id, "string", dpla_id, retrieval_date))
+
+    # P1476 — title (one statement per title).
+    for title in titles:
+        c = _build_monolingual_claim("P1476", title, dpla_id, retrieval_date)
+        if c is not None:
+            claims.append(c)
+
+    # P195 — collection (one statement; Smithsonian uses hub-as-institution).
+    if institution:
+        coll_qid = Q_SMITHSONIAN if hub == Q_SMITHSONIAN else institution
+        claims.append(
+            formattedclaim(
+                "P195",
+                _item_value(coll_qid),
+                "wikibase-entityid",
+                dpla_id,
+                retrieval_date,
+            )
+        )
+
+    # P170 — creator (one statement per creator, somevalue + P2093).
+    for creator in creators:
+        c = _build_creator_claim(creator, dpla_id, retrieval_date)
+        if c is not None:
+            claims.append(c)
+
+    # P571 — date (one statement per date, somevalue + P1932).
+    for date in dates:
+        c = _build_date_claim(date, dpla_id, retrieval_date)
+        if c is not None:
+            claims.append(c)
+
+    # P4272 (subject string) and P921 (subject entity).
+    for name, subjqid in subjects:
+        if name:
+            claims.append(
+                formattedclaim("P4272", name, "string", dpla_id, retrieval_date)
+            )
+        if subjqid:
+            claims.append(
+                formattedclaim(
+                    "P921",
+                    _item_value(subjqid),
+                    "wikibase-entityid",
+                    dpla_id,
+                    retrieval_date,
+                )
+            )
+
+    # P10358 — description.
+    for desc in descs:
+        c = _build_monolingual_claim("P10358", desc, dpla_id, retrieval_date)
+        if c is not None:
+            claims.append(c)
+
+    # P9126 — maintained by chain.
+    claims.extend(_build_contributed_claims(hub, institution, dpla_id, retrieval_date))
+
+    # P7482 — described at source catalog.
+    claims.append(_build_source_claim(hub, url, dpla_id, retrieval_date))
+
+    # P217 — local identifier (non-NARA; per-value, with P195 qualifier).
+    for local_id in local_ids:
+        if not local_id or len(local_id) >= 1501:
+            continue
+        claims.append(
+            _build_local_id_claim(local_id, institution, dpla_id, retrieval_date)
+        )
+
+    # NARA-only fields.
+    for naid in naids:
+        if naid:
+            claims.append(
+                formattedclaim("P1225", naid, "string", dpla_id, retrieval_date)
+            )
+    if access:
+        claims.append(
+            formattedclaim(
+                "P7228",
+                _item_value(access),
+                "wikibase-entityid",
+                dpla_id,
+                retrieval_date,
+            )
+        )
+    if level:
+        claims.append(
+            formattedclaim(
+                "P6224",
+                _item_value(level),
+                "wikibase-entityid",
+                dpla_id,
+                retrieval_date,
+            )
+        )
+
+    return {"claims": claims}

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -91,6 +91,10 @@ PD_MARK_URI_CANONICAL = "http://creativecommons.org/publicdomain/mark/1.0"
 RECONCI_ENDPOINT = "https://wikidata.reconci.link/en/api"
 RECONCI_BATCH_SIZE = 10
 TEXT_VALUE_LIMIT = 1499  # matches sdc-sync's longstanding truncation cap
+# Maximum length for a raw P217 (inventory number) value before we skip it
+# entirely. sdc-sync's original guard was `len(local_id) >= 1501`, so anything
+# strictly longer than 1500 is dropped.
+LOCAL_ID_MAX_LENGTH = 1500
 
 logger = logging.getLogger(__name__)
 
@@ -772,7 +776,7 @@ def build_claims_for_doc(
 
     # P217 — local identifier (non-NARA; per-value, with P195 qualifier).
     for local_id in local_ids:
-        if not local_id or len(local_id) >= 1501:
+        if not local_id or len(local_id) > LOCAL_ID_MAX_LENGTH:
             continue
         claims.append(
             _build_local_id_claim(local_id, institution, dpla_id, retrieval_date)

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -350,8 +350,11 @@ def _resolve_subjects(
                 if not any(name in pair for pair in subjects):
                     subjects.append((str(name or ""), ""))
                     added = True
-            continue
-        if subject.get("exactMatch"):
+            # Fall through to the `if not added` fallback below so a
+            # subject_ids entry with an empty "id" list still yields a
+            # string-form P4272 statement — matches sdc-sync's existing
+            # behavior before this code moved into a shared module.
+        elif subject.get("exactMatch"):
             exact_match = subject["exactMatch"]
             first = exact_match[0] if isinstance(exact_match, list) else exact_match
             naid = ""
@@ -563,12 +566,19 @@ def _build_contributed_claims(
         claim["qualifiers"]["P3831"] = [_qualifier_item_snak("P3831", role_qid)]
         return claim
 
+    # The role qualifiers below intentionally MATCH what sdc-sync.add_contributed
+    # has been writing to Commons. Smithsonian's path distinguishes
+    # aggregator/contributing-institution; the non-Smithsonian path uses
+    # publisher/aggregator for hub/institution respectively. Changing these
+    # values without a coordinated Commons-side rewrite would make every
+    # existing P9126 statement look "unexpected" to dpla_claims() and trigger
+    # a remove+re-add on every re-sync.
     out.append(_with_role(Q_DPLA, Q_PUBLISHER))
     if hub == Q_SMITHSONIAN:
         out.append(_with_role(Q_SMITHSONIAN, Q_AGGREGATOR))
         out.append(_with_role(institution, Q_CONTRIBUTING_INSTITUTION))
     else:
-        out.append(_with_role(hub, Q_AGGREGATOR))
+        out.append(_with_role(hub, Q_PUBLISHER))
         out.append(_with_role(institution, Q_AGGREGATOR))
     return out
 

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -73,7 +73,7 @@ IS_SHOWN_AT_FIELD = "isShownAt"
 # map used to populate P921 alongside the string-form P4272. rights.json is
 # the small SDC-specific copyright mapping vendored in this repo.
 SUBJECTS_URL = (
-    "https://raw.githubusercontent.com/DominicBM/ingestion3/develop/"
+    "https://raw.githubusercontent.com/dpla/ingestion3/develop/"
     "src/main/resources/subjects.json"
 )
 SDC_FILENAME = "sdc.json"
@@ -98,9 +98,9 @@ def fetch_institutions_v2() -> dict:
 def fetch_subjects_json() -> dict:
     """Fetch the DPLA-subject → Wikidata-ID map used to populate P921.
 
-    Lives on the DominicBM/ingestion3 fork; fetched fresh per run for the
-    same reason institutions_v2.json is — upstream changes should land in
-    the next sync without a redeploy.
+    Sourced from dpla/ingestion3 alongside institutions_v2.json; fetched
+    fresh per run so upstream changes land in the next sync without a
+    redeploy.
     """
     resp = requests.get(SUBJECTS_URL, timeout=30)
     resp.raise_for_status()

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -39,6 +39,7 @@ consumed by the downloader and uploader:
 
 import datetime
 import json
+import logging
 import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
@@ -274,12 +275,19 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
 
     s3_sem, failed, _on_s3_done = make_s3_stage_context(S3_WRITE_WORKERS)
 
-    # Phase 1 — paginate ES, stage dpla-map.json, buffer items for the SDC
-    # pass below, and collect NARA exactMatch subject queries for batched
-    # Wikidata reconciliation. The reconci call itself de-duplicates, but
-    # collecting into a set keeps phase-1 memory bounded by unique subjects
-    # rather than total subject occurrences across the hub.
-    items_buffer: list[tuple[str, dict]] = []
+    # Phase 1 — paginate ES, stage dpla-map.json, remember each item's DPLA
+    # ID for the SDC pass below, and collect NARA exactMatch subject queries
+    # for batched Wikidata reconciliation.
+    #
+    # We deliberately do NOT buffer the full ES `_source` document in memory:
+    # for a hub with 100K items that would be ~1 GB resident. Phase 3 re-reads
+    # each dpla-map.json from S3 instead — cheap and bounded by S3 throughput,
+    # not by hub size in RAM.
+    #
+    # subject_queries is a set because the reconci.link call itself dedupes
+    # internally but pre-deduping bounds phase-1 memory by unique subjects
+    # rather than total occurrences across the hub.
+    dpla_ids: list[str] = []
     subject_queries: set[tuple[str, str]] = set()
 
     with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
@@ -323,7 +331,7 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
                 )
                 future.add_done_callback(_on_s3_done(dpla_id))
 
-                items_buffer.append((dpla_id, source))
+                dpla_ids.append(dpla_id)
                 subject_queries.update(collect_subject_queries(source))
 
                 print(dpla_id)
@@ -348,15 +356,39 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
     )
 
     # Phase 3 — build per-item sdc.json (ready-to-POST claim list) and stage
-    # to S3 alongside dpla-map.json. Items the SDC builder can't parse (e.g.
-    # provider/institution missing from institutions_v2.json) are skipped
-    # silently; their dpla-map.json is still in place for downloader/uploader
-    # and a future re-run will pick them up.
+    # to S3 alongside dpla-map.json. Each item's source doc is re-read from
+    # the dpla-map.json we just staged in phase 1 (rather than buffered in
+    # memory) so peak memory stays O(unique-subjects) rather than scaling
+    # with hub size. Items the SDC builder can't parse (e.g. provider /
+    # institution missing from institutions_v2.json) are skipped silently;
+    # their dpla-map.json is still in place for downloader/uploader and a
+    # future re-run will pick them up.
     sdc_sem, sdc_failed, _on_sdc_done = make_s3_stage_context(S3_WRITE_WORKERS)
     sdc_skipped = 0
 
     with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
-        for dpla_id, source in items_buffer:
+        for dpla_id in dpla_ids:
+            raw = s3_client.get_item_metadata(partner, dpla_id)
+            if raw is None:
+                # Phase 1 already exited on any S3 write failure, so a miss
+                # here is unexpected — log and continue rather than abort.
+                logging.warning(
+                    "dpla-map.json missing for %s in phase 3; skipping sdc.json",
+                    dpla_id,
+                )
+                sdc_skipped += 1
+                continue
+            try:
+                source = json.loads(raw)
+            except json.JSONDecodeError as e:
+                logging.warning(
+                    "dpla-map.json for %s failed to parse in phase 3 (%s); "
+                    "skipping sdc.json",
+                    dpla_id,
+                    e,
+                )
+                sdc_skipped += 1
+                continue
             sdc_payload = build_claims_for_doc(
                 source,
                 dpla_id,

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -24,12 +24,22 @@ dpla-map.json so the downloader can skip redundant DPLA API calls entirely.
 CONTENTdm items have their IIIF manifest URL derived from isShownAt and patched
 into the document before it is written.
 
+After pagination completes, this tool also writes a per-item sdc.json
+containing the ready-to-POST Wikibase claim list (P760, P1476, P195, P170,
+P571, P4272, P921, P10358, P9126, P7482, P217, plus the NARA-only P1225,
+P7228, P6224). Subject reconciliation against Wikidata is batched across
+the whole hub via wikidata.reconci.link so the sync phase can be a pure
+diff+POST step against pre-computed claims.
+
 Output: one DPLA ID per line to stdout.  Redirect to produce the IDs CSV
 consumed by the downloader and uploader:
 
     get-ids-es pa > pa/pa.csv
 """
 
+import datetime
+import json
+import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
 
@@ -41,7 +51,13 @@ from ingest_wikimedia.dpla import DPLA, INSTITUTIONS_URL
 from ingest_wikimedia.partners import PARTNER_HUBS
 from ingest_wikimedia.es import check_es_response, post_es
 from ingest_wikimedia.iiif import IIIF
-from ingest_wikimedia.s3 import S3Client
+from ingest_wikimedia.s3 import APPLICATION_JSON, S3Client
+from ingest_wikimedia.sdc import (
+    normalize_rights_uri,
+    build_claims_for_doc,
+    collect_subject_queries,
+    reconcile_subjects,
+)
 from ingest_wikimedia.slack import notify_phase_start
 from ingest_wikimedia.staging import make_s3_stage_context, stage_item_to_s3
 
@@ -52,6 +68,16 @@ IIIF_MANIFEST_FIELD = "iiifManifest"
 MEDIA_MASTER_FIELD = "mediaMaster"
 IS_SHOWN_AT_FIELD = "isShownAt"
 
+# SDC pre-compute inputs. subjects.json is the DPLA-subject → Wikidata-Q-ID
+# map used to populate P921 alongside the string-form P4272. rights.json is
+# the small SDC-specific copyright mapping vendored in this repo.
+SUBJECTS_URL = (
+    "https://raw.githubusercontent.com/DominicBM/ingestion3/develop/"
+    "src/main/resources/subjects.json"
+)
+SDC_FILENAME = "sdc.json"
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
 # isShownAt URL patterns from which a IIIF manifest can be formulaically
 # derived, expressed as ES wildcard values.  Extend this list as new DAMs
 # with predictable IIIF paths are identified.
@@ -60,10 +86,38 @@ IIIF_DERIVABLE_ISSHOWNAT_PATTERNS = [
 ]
 
 
-def load_eligible_dp_names(partner: str) -> list[str]:
+def fetch_institutions_v2() -> dict:
+    """Fetch the full institutions_v2.json document used for hub/institution
+    eligibility and (in the SDC pre-compute pass) Wikidata-ID resolution."""
+    resp = requests.get(INSTITUTIONS_URL, timeout=15)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_subjects_json() -> dict:
+    """Fetch the DPLA-subject → Wikidata-ID map used to populate P921.
+
+    Lives on the DominicBM/ingestion3 fork; fetched fresh per run for the
+    same reason institutions_v2.json is — upstream changes should land in
+    the next sync without a redeploy.
     """
-    Fetch institutions_v2.json from GitHub and return the list of
-    dataProvider name strings that are eligible for upload for the given hub.
+    resp = requests.get(SUBJECTS_URL, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def load_rights_json() -> dict:
+    """Load rights.json from the repo root and normalize its keys for
+    scheme-and-slash-insensitive lookup."""
+    with open(os.path.join(_REPO_ROOT, "rights.json")) as f:
+        raw = json.load(f)
+    return {normalize_rights_uri(k): v for k, v in raw.items()}
+
+
+def load_eligible_dp_names(institutions: dict, partner: str) -> list[str]:
+    """
+    Return the list of dataProvider name strings eligible for upload for the
+    given hub, given an already-loaded institutions_v2.json document.
 
     An institution is eligible when:
       - the hub has a non-empty Wikidata ID (required for hub Commons category), AND
@@ -75,9 +129,6 @@ def load_eligible_dp_names(partner: str) -> list[str]:
     variants mapping to the same Wikidata ID can carry independent upload flags.
     """
     hub_name = PARTNER_HUBS[partner]
-    resp = requests.get(INSTITUTIONS_URL, timeout=15)
-    resp.raise_for_status()
-    institutions = resp.json()
 
     hub = institutions.get(hub_name)
     if not hub:
@@ -94,6 +145,20 @@ def load_eligible_dp_names(partner: str) -> list[str]:
             eligible.append(inst_name)
 
     return eligible
+
+
+def stage_sdc_to_s3(
+    s3_client: S3Client, partner: str, dpla_id: str, sdc_payload: dict
+) -> None:
+    """Write the per-item sdc.json sidecar to the partner's item prefix.
+
+    Raises on failure so the caller's ThreadPoolExecutor can observe it
+    via future.exception() in the done callback (same pattern as
+    stage_item_to_s3).
+    """
+    s3_client.write_item_file(
+        partner, dpla_id, json.dumps(sdc_payload), SDC_FILENAME, APPLICATION_JSON
+    )
 
 
 def build_query(
@@ -178,7 +243,10 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
     notify_phase_start(partner, "id-generation")
     provider_name = PARTNER_HUBS[partner]
 
-    eligible_dp_names = load_eligible_dp_names(partner)
+    # Load institutions_v2.json once and reuse it for both eligibility
+    # filtering and the SDC pre-compute pass.
+    institutions = fetch_institutions_v2()
+    eligible_dp_names = load_eligible_dp_names(institutions, partner)
     if not eligible_dp_names:
         print(
             f"No eligible institutions found for {partner} in institutions_v2.json",
@@ -195,11 +263,22 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
             sys.exit(1)
         eligible_dp_names = [institution]
 
+    # SDC pre-compute inputs.
+    rights = load_rights_json()
+    subject_ids = fetch_subjects_json()
+    retrieval_date = datetime.date.today()
+
     banlist = Banlist()
     s3_client = S3Client()
     search_after = None
 
     s3_sem, failed, _on_s3_done = make_s3_stage_context(S3_WRITE_WORKERS)
+
+    # Phase 1 — paginate ES, stage dpla-map.json, buffer items for the SDC
+    # pass below, and collect NARA exactMatch subject queries for batched
+    # Wikidata reconciliation.
+    items_buffer: list[tuple[str, dict]] = []
+    subject_queries: list[tuple[str, str]] = []
 
     with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
         while True:
@@ -242,12 +321,67 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
                 )
                 future.add_done_callback(_on_s3_done(dpla_id))
 
+                items_buffer.append((dpla_id, source))
+                subject_queries.extend(collect_subject_queries(source))
+
                 print(dpla_id)
 
             search_after = hits[-1]["sort"]
 
     if failed[0]:
-        print(f"Error: {failed[0]} S3 writes failed", file=sys.stderr)
+        print(f"Error: {failed[0]} dpla-map.json writes failed", file=sys.stderr)
+        raise SystemExit(1)
+
+    # Phase 2 — batched Wikidata reconciliation for NARA exactMatch subjects.
+    # Best-effort: chunks that fail are logged and skipped (their items' P921
+    # entries are simply omitted; the string-form P4272 still lands).
+    print(
+        f"Reconciling {len(subject_queries)} subject queries "
+        f"(deduplicated internally)...",
+        file=sys.stderr,
+    )
+    subjects_lookup = reconcile_subjects(subject_queries)
+    print(
+        f"Resolved {len(subjects_lookup)} subjects to Wikidata IDs.",
+        file=sys.stderr,
+    )
+
+    # Phase 3 — build per-item sdc.json (ready-to-POST claim list) and stage
+    # to S3 alongside dpla-map.json. Items the SDC builder can't parse (e.g.
+    # provider/institution missing from institutions_v2.json) are skipped
+    # silently; their dpla-map.json is still in place for downloader/uploader
+    # and a future re-run will pick them up.
+    sdc_sem, sdc_failed, _on_sdc_done = make_s3_stage_context(S3_WRITE_WORKERS)
+    sdc_skipped = 0
+
+    with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
+        for dpla_id, source in items_buffer:
+            sdc_payload = build_claims_for_doc(
+                source,
+                dpla_id,
+                institutions,
+                rights,
+                subject_ids,
+                subjects_lookup,
+                retrieval_date,
+            )
+            if sdc_payload is None:
+                sdc_skipped += 1
+                continue
+            sdc_sem.acquire()
+            future = executor.submit(
+                stage_sdc_to_s3, s3_client, partner, dpla_id, sdc_payload
+            )
+            future.add_done_callback(_on_sdc_done(dpla_id))
+
+    if sdc_skipped:
+        print(
+            f"Skipped sdc.json for {sdc_skipped} items "
+            "(unparseable provider/institution).",
+            file=sys.stderr,
+        )
+    if sdc_failed[0]:
+        print(f"Error: {sdc_failed[0]} sdc.json writes failed", file=sys.stderr)
         raise SystemExit(1)
 
 

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -276,9 +276,11 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
 
     # Phase 1 — paginate ES, stage dpla-map.json, buffer items for the SDC
     # pass below, and collect NARA exactMatch subject queries for batched
-    # Wikidata reconciliation.
+    # Wikidata reconciliation. The reconci call itself de-duplicates, but
+    # collecting into a set keeps phase-1 memory bounded by unique subjects
+    # rather than total subject occurrences across the hub.
     items_buffer: list[tuple[str, dict]] = []
-    subject_queries: list[tuple[str, str]] = []
+    subject_queries: set[tuple[str, str]] = set()
 
     with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
         while True:
@@ -322,7 +324,7 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
                 future.add_done_callback(_on_s3_done(dpla_id))
 
                 items_buffer.append((dpla_id, source))
-                subject_queries.extend(collect_subject_queries(source))
+                subject_queries.update(collect_subject_queries(source))
 
                 print(dpla_id)
 
@@ -336,8 +338,7 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
     # Best-effort: chunks that fail are logged and skipped (their items' P921
     # entries are simply omitted; the string-form P4272 still lands).
     print(
-        f"Reconciling {len(subject_queries)} subject queries "
-        f"(deduplicated internally)...",
+        f"Reconciling {len(subject_queries)} unique subject queries...",
         file=sys.stderr,
     )
     subjects_lookup = reconcile_subjects(subject_queries)

--- a/tools/sdc-sync.py
+++ b/tools/sdc-sync.py
@@ -107,7 +107,7 @@ hubs = requests.get(
 with open(os.path.join(_REPO_ROOT, "rights.json")) as f:
     rights = {_normalize_rights_uri(k): v for k, v in json.load(f).items()}
 subject_ids = requests.get(
-    "https://raw.githubusercontent.com/DominicBM/ingestion3/develop/src/main/resources/subjects.json",
+    "https://raw.githubusercontent.com/dpla/ingestion3/develop/src/main/resources/subjects.json",
     timeout=30,
 ).json()
 


### PR DESCRIPTION
## Summary

Second step toward folding `sdc-sync` into the wikimedia-upload pipeline. Adds a new `ingest_wikimedia/sdc.py` module that owns SDC claim construction, and wires `get-ids-es` to emit a per-item `sdc.json` alongside the existing `dpla-map.json`.

This PR is purely additive — `sdc-sync` is not modified. PR 4 will replace its runtime claim construction with a read of the pre-computed `sdc.json` files.

## What lands

**`ingest_wikimedia/sdc.py`** — pure module (no Commons API, no module globals):
- `normalize_rights_uri(uri)` — canonical http+no-trailing-slash form.
- `formattedclaim(prop, value, value_type, dpla_id, retrieval_date)` — the canonical Wikibase claim envelope (P459 heuristic qualifier + P854/P123/P813 reference). `retrieval_date` is required-but-defaulted so `get-ids-es` can stamp a deterministic, persisted-to-S3 P813 date; legacy callers keep working with today's date.
- `parse_dpla_doc(doc, dpla_id, hubs, subject_ids, subjects_lookup)` — extracts the 13-tuple `sdc-sync.process_one` consumes.
- `collect_subject_queries(doc)` + `reconcile_subjects(queries)` — batched Wikidata reconci.link resolution of NARA `exactMatch` subjects. Best-effort: a failed chunk is logged and skipped, so a transient blip can't kill the whole hub's precompute pass.
- `build_claims_for_doc(...)` — top-level builder returning `{"claims": [...]}` (wbsetclaims POST shape). Returns `None` when the doc's provider/dataProvider is missing from `institutions_v2.json` so the caller can skip.

**`tools/get_ids_es.py`** — three phases:
1. *Existing*: paginate ES, stage `dpla-map.json` per item. *New*: also buffer `(dpla_id, source)` in memory and accumulate NARA exactMatch subject reconci queries.
2. *New*: batched Wikidata reconciliation across the whole hub. Per-chunk size 10, deduplicated across the whole run.
3. *New*: for each buffered item, `build_claims_for_doc` → stage `sdc.json` to S3 via the same bounded-async semaphore the existing dpla-map.json writes use.

## Why batched-per-hub reconciliation matters

Per-item reconciliation (today's path in `sdc-sync.parsed()`) makes one HTTP per NARA item with `exactMatch` subjects. Hub-wide batching collapses that to roughly `unique-subjects / 10` HTTPs across the whole hub — a meaningful saving for large NARA-heavy runs.

## S3 layout per item after this PR

```
<partner>/images/<sharded-id-prefix>/<dpla_id>/
  dpla-map.json       (existing)
  sdc.json            (NEW — ready-to-POST claim JSON)
  file-list.txt       (existing)
  iiif.json           (existing for IIIF items)
  <ordinal>_<id>      (existing — media)
```

## Test plan

- [x] `ruff check` + `ruff format` clean.
- [x] Smoke-tested on EC2 against a Minnesota Digital Library / Grant County Historical Society item (DPLA ID `0850fba9...`): **19 claims emitted across 12 properties**, matching exactly the DPLA-published claim set that `sdc-sync` currently writes at runtime (`P760×1, P1476×1, P195×1, P170×1, P571×1, P4272×5, P921×2, P10358×1, P9126×3, P7482×1, P6216×1, P6426×1`). Reference shape verified: P459 heuristic qualifier + P854/P123/P813 reference triple.
- [ ] Full `get-ids-es <partner>` run — to be exercised once PR 1 lands and we move PR 4 forward.

## Next

- **PR 3** — uploader emits per-item `upload-result.json` so the SDC phase knows which ordinals to attempt.
- **PR 4** — `sdc-sync` reads pre-computed `sdc.json` instead of building claims at runtime; partner-driven entry point replaces `--cat/--file/--lists`.
- **PR 5** — `/wikimedia-upload sdc <target>` Slack command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds precomputed SDC (Structured Data on Commons) claim construction and per-item staging of sdc.json to the get-ids-es pipeline so downstream sync can be a pure diff+POST step.

High-level changes
- New module ingest_wikimedia/sdc.py — pure, stateless claim builder and reconciliation helpers:
  - normalize_rights_uri(uri)
  - formattedclaim(prop, value, value_type, dpla_id, retrieval_date=None)
  - collect_subject_queries(doc)
  - reconcile_subjects(queries, batch_size=RECONCI_BATCH_SIZE, timeout=15) — batched calls to wikidata.reconci.link, best-effort per chunk (failed chunks logged/skipped)
  - parse_dpla_doc(doc, dpla_id, hubs, subject_ids, subjects_lookup=None)
  - build_claims_for_doc(doc, dpla_id, hubs, rights, subject_ids, subjects_lookup, retrieval_date)
  - Implements TEXT_VALUE_LIMIT truncation, LOCAL_ID_MAX_LENGTH guard, NARA-specific mappings, and the canonical P459 + P854/P123/P813 reference envelope.
  - Defensive fixes and narrower exception handling (avoid broad excepts; specific exceptions logged). Fixed KeyError when subject_ids entries lack "id" array.

- tools/get_ids_es.py updated to a three-phase flow:
  - Phase 1: ES pagination + staging dpla-map.json per item; collects (dpla_id, source) and deduplicated NARA subject queries across the hub and streams dpla_id to stdout.
  - Phase 2: hub-wide batched subject reconciliation via reconcile_subjects (RECONCI_BATCH_SIZE = 10).
  - Phase 3: re-reads staged dpla-map.json, calls build_claims_for_doc(...), and stages sdc.json alongside dpla-map.json using the existing bounded async concurrency/semaphore.
  - New/changed helpers: fetch_institutions_v2(), fetch_subjects_json(), load_rights_json(), load_eligible_dp_names(institutions, partner) (signature change), stage_sdc_to_s3(s3_client, partner, dpla_id, sdc_payload).
  - Failure reporting: Phase 1 and Phase 3 report S3 write failures; Phase 3 prints a stderr count of items skipped for sdc.json due to unparseable provider/institution data.

- tools/sdc-sync.py: updated subjects.json upstream URL to canonical dpla/ingestion3 path (no other logic changes).

Inputs / external services
- Fetches institutions_v2.json and subjects.json from dpla/ingestion3 at runtime.
- Loads vendored rights.json from repo.
- New external reconciliation dependency: https://wikidata.reconci.link/en/api (batched, timeout, best-effort; failed reconciliation chunks are logged and skipped).

Testing / smoke
- ruff/formatting checks noted as passing.
- Smoke-tested on a Minnesota Digital Library item — produced byte-identical 19 claims across 12 properties with expected reference shape. Full hub run pending PR 1.

Operational / safety checklist (explicit)
- No manual pipeline trigger or ECS redeployment required — get-ids-es fetches JSONs at runtime and writes sdc.json to S3 as part of the existing pipeline.
- No new or renamed environment variables or AWS Secrets Manager keys.
- No database migrations.
- No changes to shared infra (CodePipeline/CodeBuild/ECS task defs/IAM) or public API response shapes/endpoints.
- Security implications:
  - Adds a new external HTTP dependency (wikidata.reconci.link); calls are batched and best-effort. No new credentials are introduced. sdc.json contains precomputed claim payloads only.

Behavioral notes
- Items where build_claims_for_doc returns None (missing/unmatched provider or institution mapping) are skipped for sdc.json; their dpla-map.json remains staged. Skips are counted/reported.
- Hub-wide deduplication + batching reduces reconciliation HTTP calls (approx unique-subjects/10 batches).

Follow-ups
- PR 3: uploader emits upload-result.json
- PR 4: sdc-sync reads precomputed sdc.json
- PR 5: /wikimedia-upload sdc Slack command

Files inspected / magnitude
- New: ingest_wikimedia/sdc.py (+~830 lines)
- Modified: tools/get_ids_es.py (+176/-9)
- Modified: tools/sdc-sync.py (small URL change)

If any reviewers want specific code excerpts or focused diffs (e.g., claim envelope structure, reconciliation chunking, or the provider/institution mapping behavior), I can include them.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->