### PR TITLE
retry: combine download + upload FAILED into a single Slack summary

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -282,8 +282,19 @@ _COUNTS_FAILED_RE = re.compile(r"^FAILED:\s*(\d+)\s*$", re.MULTILINE)
 def _read_download_failed_count(log_path: str | None) -> int | None:
     """Read the FAILED count from a downloader log's terminal COUNTS section.
 
-    Returns the int FAILED count, or None if the path is unset, the file
-    can't be read, or the COUNTS section doesn't include a FAILED line.
+    Returns:
+      * the int FAILED count when the COUNTS section names FAILED explicitly
+      * 0 when the COUNTS section exists but omits FAILED — a clean run.
+        `Tracker.__str__` only emits counter lines whose value is > 0, so
+        zero-failure downloads legitimately have no FAILED line at all.
+        Treating that as the unambiguous 0 it is (rather than as a parse
+        failure) keeps clean retries titled "Retry Complete" instead of
+        misleadingly falling back to "Upload Complete".
+      * None when the path is unset, the file can't be read, or there is
+        no COUNTS section at all — the downloader bombed before printing
+        the terminal tracker dump, so we don't have a usable count to
+        combine.
+
     Used by `notify_upload_complete` to roll the download phase's failures
     into a single retry-session Slack summary (see the retry pipeline in
     scripts/wikimedia_retry.py).
@@ -296,13 +307,20 @@ def _read_download_failed_count(log_path: str | None) -> int | None:
     except OSError as e:
         logging.warning(f"Could not read retry download log {log_path}: {e}")
         return None
-    match = _COUNTS_FAILED_RE.search(content)
-    if not match:
+    # Anchor the FAILED lookup to the COUNTS section so we don't accidentally
+    # pick up a stray "FAILED:" earlier in the log (e.g. an [ERROR] line).
+    # rfind because the tracker dump is the last thing the downloader writes.
+    counts_idx = content.rfind("COUNTS:")
+    if counts_idx < 0:
         logging.warning(
-            f"No FAILED count found in retry download log {log_path}; "
+            f"No COUNTS section found in retry download log {log_path}; "
             f"download-phase failures will not be reflected in the Slack summary"
         )
         return None
+    counts_block = content[counts_idx:]
+    match = _COUNTS_FAILED_RE.search(counts_block)
+    if not match:
+        return 0
     return int(match.group(1))
 
 

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -276,6 +276,36 @@ def notify_download_complete(
     )
 
 
+_COUNTS_FAILED_RE = re.compile(r"^FAILED:\s*(\d+)\s*$", re.MULTILINE)
+
+
+def _read_download_failed_count(log_path: str | None) -> int | None:
+    """Read the FAILED count from a downloader log's terminal COUNTS section.
+
+    Returns the int FAILED count, or None if the path is unset, the file
+    can't be read, or the COUNTS section doesn't include a FAILED line.
+    Used by `notify_upload_complete` to roll the download phase's failures
+    into a single retry-session Slack summary (see the retry pipeline in
+    scripts/wikimedia_retry.py).
+    """
+    if not log_path:
+        return None
+    try:
+        with open(log_path, encoding="utf-8", errors="replace") as f:
+            content = f.read()
+    except OSError as e:
+        logging.warning(f"Could not read retry download log {log_path}: {e}")
+        return None
+    match = _COUNTS_FAILED_RE.search(content)
+    if not match:
+        logging.warning(
+            f"No FAILED count found in retry download log {log_path}; "
+            f"download-phase failures will not be reflected in the Slack summary"
+        )
+        return None
+    return int(match.group(1))
+
+
 def notify_upload_complete(
     tracker: Tracker,
     partner_label: str,
@@ -293,14 +323,35 @@ def notify_upload_complete(
     runtime = _format_runtime(elapsed_seconds)
     dry_run_note = " _(dry run)_" if dry_run else ""
 
+    # In a retry session the user cares about whether *anything* failed in
+    # the whole download+upload round-trip — not which phase produced the
+    # failure. When the retry tmux pipeline points us at the prior phase's
+    # download log via `WIKIMEDIA_RETRY_DOWNLOAD_LOG`, fold that phase's
+    # FAILED count into this summary and re-title the message as a retry
+    # complete so the user gets a single combined notification instead of
+    # the misleading "Upload Complete: 0 failed" when downloads bombed.
+    #
+    # SKIPPED/UPLOADED/BYTES are not combined: each phase has its own
+    # semantics for "skipped" (download = "already in S3"; upload =
+    # "already on Commons") and conflating them would only obscure the
+    # picture. FAILED, by contrast, is universally a failure regardless of
+    # where it happened.
+    download_log = os.environ.get("WIKIMEDIA_RETRY_DOWNLOAD_LOG") or None
+    download_failed = _read_download_failed_count(download_log)
+    is_retry_summary = download_failed is not None
+    total_failed = tracker.count(Result.FAILED) + (download_failed or 0)
+
+    header_phrase = "Retry Complete" if is_retry_summary else "Upload Complete"
+    plain_phrase = "retry complete" if is_retry_summary else "upload complete"
+
     _post_completion_notice(
         token=token,
-        header=f"*Wikimedia Upload Complete: {effective_label}*{dry_run_note}",
-        plain_text=f"Wikimedia upload complete: {effective_label}",
+        header=f"*Wikimedia {header_phrase}: {effective_label}*{dry_run_note}",
+        plain_text=f"Wikimedia {plain_phrase}: {effective_label}",
         stats_lines=[
             f"UPLOADED: {tracker.count(Result.UPLOADED):,}",
             f"SKIPPED:  {tracker.count(Result.SKIPPED):,}",
-            f"FAILED:   {tracker.count(Result.FAILED):,}",
+            f"FAILED:   {total_failed:,}",
             f"BYTES:    {_format_bytes(tracker.count(Result.BYTES))}",
             f"Runtime:  {runtime}",
         ],

--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -289,6 +289,22 @@ def main() -> None:
             steps.append(
                 f"downloader --max-age-days 1 {shlex.quote(download_csv)} {slug}"
             )
+            # Roll the download phase's FAILED count into the upload phase's
+            # final Slack summary. After the downloader finishes, capture the
+            # most-recent log it just wrote (matches the
+            # `{timestamp}-{session_label}-download.log` naming convention
+            # produced by ingest_wikimedia.logs.setup_logging) and pass its
+            # absolute path to the uploader via WIKIMEDIA_RETRY_DOWNLOAD_LOG.
+            # notify_upload_complete reads that env var, parses the COUNTS
+            # FAILED line, and adds it to its own tracker's FAILED so the
+            # user sees one combined Retry Complete summary instead of an
+            # Upload Complete summary that misleadingly reports 0 failures
+            # when downloads bombed.
+            steps.append(
+                "export WIKIMEDIA_RETRY_DOWNLOAD_LOG="
+                '"$PWD/$(ls -t logs/*-${WIKIMEDIA_SESSION_LABEL}-download.log '
+                '2>/dev/null | head -1)"'
+            )
             steps.append(f"uploader {shlex.quote(download_csv)} {slug}")
         if upload_csv:
             steps.append(f"uploader {shlex.quote(upload_csv)} {slug}")

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -202,10 +202,54 @@ def test_read_download_failed_count_missing_file_returns_none(tmp_path):
 
 
 def test_read_download_failed_count_no_counts_section_returns_none(tmp_path):
-    """Log file without a COUNTS section → None (downloader bombed early)."""
+    """Log file without a COUNTS section → None (downloader bombed early).
+
+    No usable counts to combine; the upper layer falls back to the
+    upload-only header and logs a warning so the missing data is visible.
+    """
     log = tmp_path / "partial.log"
     log.write_text("[INFO] 20:15:58: Starting download for si\n")
     assert _read_download_failed_count(str(log)) is None
+
+
+def test_read_download_failed_count_counts_without_failed_returns_zero(tmp_path):
+    """COUNTS section present but no FAILED line → returns 0 (clean run).
+
+    Tracker.__str__ only emits counter lines whose value > 0, so a clean
+    download (no failures) writes a COUNTS section with no FAILED line at
+    all. Returning 0 here (rather than None) is what keeps the retry
+    summary titled "Retry Complete" instead of falling back to
+    "Upload Complete" on a clean run.
+    """
+    log = tmp_path / "20260524-220233-retry-si-download.log"
+    log.write_text(
+        "[INFO] 22:02:33: Starting download for si\n"
+        "[INFO] 22:02:36: \n"
+        "COUNTS:\n"
+        "DOWNLOADED: 50\n"
+        "SKIPPED: 30\n"
+        "BYTES: 5000\n"
+        "\n"
+        "[INFO] 22:02:36: 3.0 seconds.\n"
+    )
+    assert _read_download_failed_count(str(log)) == 0
+
+
+def test_read_download_failed_count_ignores_failed_outside_counts_section(tmp_path):
+    """A stray "FAILED:" earlier in the log (e.g. inside an [ERROR] line)
+    must NOT be picked up as the tracker's FAILED count. The COUNTS dump
+    is the last thing the downloader writes; anchor the lookup there."""
+    log = tmp_path / "noisy.log"
+    log.write_text(
+        "[INFO] 22:02:33: Starting download for si\n"
+        "[ERROR] 22:02:34: HTTPError 500; FAILED: 999 retries exhausted\n"
+        "[INFO] 22:02:36: \n"
+        "COUNTS:\n"
+        "DOWNLOADED: 50\n"
+        "SKIPPED: 30\n"
+    )
+    # Only the COUNTS section's FAILED line counts. Absent → 0.
+    assert _read_download_failed_count(str(log)) == 0
 
 
 def _capture_completion_message(env: dict, tracker_counts: dict) -> dict:
@@ -290,5 +334,36 @@ def test_notify_upload_complete_with_retry_env_but_no_log_file(tmp_path):
     )
     # Falls back gracefully — upload-only header, FAILED unchanged.
     assert "Wikimedia Upload Complete" in captured["header"]
+    failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
+    assert failed_lines == ["FAILED:   0"]
+
+
+def test_notify_upload_complete_clean_retry_still_titled_retry_complete(tmp_path):
+    """A retry session with ZERO failures must still be titled
+    "Retry Complete" — not fall back to "Upload Complete" just because
+    the download log's COUNTS section omitted the FAILED line.
+
+    Tracker.__str__ only emits counter lines whose value > 0, so clean
+    download runs legitimately have no FAILED line in their COUNTS
+    section. `_read_download_failed_count` returns 0 (not None) in that
+    case so the retry-aware code path still fires."""
+    download_log = tmp_path / "20260524-220233-retry-si-download.log"
+    download_log.write_text(
+        "[INFO] 22:02:33: Starting download for si\n"
+        "COUNTS:\n"
+        "DOWNLOADED: 80\n"
+        "SKIPPED: 0\n"
+        "BYTES: 8000\n"
+    )
+    captured = _capture_completion_message(
+        env={
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": "retry-si",
+            "WIKIMEDIA_RETRY_DOWNLOAD_LOG": str(download_log),
+        },
+        tracker_counts={Result.UPLOADED: 0, Result.SKIPPED: 80, Result.FAILED: 0},
+    )
+    assert "Wikimedia Retry Complete" in captured["header"]
+    assert "Upload Complete" not in captured["header"]
     failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
     assert failed_lines == ["FAILED:   0"]

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -8,16 +8,19 @@ log-summary logic that produces the message body.
 import os
 import tempfile
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from ingest_wikimedia.slack import (
     _decode_exit_code,
     _find_latest_log,
+    _read_download_failed_count,
     _summarize_log,
     notify_pipeline_fail,
+    notify_upload_complete,
 )
+from ingest_wikimedia.tracker import Result, Tracker
 
 
 @pytest.mark.parametrize(
@@ -163,3 +166,129 @@ def test_notify_pipeline_fail_treats_any_value_other_than_1_as_not_last():
         assert "skipping to next target" in msg, (
             f"value {value!r} should be treated as not-last"
         )
+
+
+# ---------------------------------------------------------------------------
+# notify_upload_complete: combined retry summary
+# ---------------------------------------------------------------------------
+
+
+def test_read_download_failed_count_parses_counts_section(tmp_path):
+    """Reads `FAILED: N` out of a downloader log's terminal COUNTS section."""
+    log = tmp_path / "20260524-201558-si-download.log"
+    log.write_text(
+        "[INFO] 20:15:58: Starting download for si\n"
+        "[INFO] 20:46:51: \n"
+        "COUNTS:\n"
+        "DOWNLOADED: 6937\n"
+        "FAILED: 12\n"
+        "SKIPPED: 6\n"
+        "BYTES: 6785972036\n"
+        "\n"
+        "[INFO] 20:46:51: 1852.87 seconds.\n"
+    )
+    assert _read_download_failed_count(str(log)) == 12
+
+
+def test_read_download_failed_count_none_path_returns_none():
+    """Unset env var → None (no combination)."""
+    assert _read_download_failed_count(None) is None
+    assert _read_download_failed_count("") is None
+
+
+def test_read_download_failed_count_missing_file_returns_none(tmp_path):
+    """Path that doesn't exist → None, no crash."""
+    assert _read_download_failed_count(str(tmp_path / "does-not-exist.log")) is None
+
+
+def test_read_download_failed_count_no_counts_section_returns_none(tmp_path):
+    """Log file without a COUNTS section → None (downloader bombed early)."""
+    log = tmp_path / "partial.log"
+    log.write_text("[INFO] 20:15:58: Starting download for si\n")
+    assert _read_download_failed_count(str(log)) is None
+
+
+def _capture_completion_message(env: dict, tracker_counts: dict) -> dict:
+    """Run notify_upload_complete with a mocked Tracker + env, return the
+    keyword arguments passed to `_post_completion_notice` (header,
+    plain_text, stats_lines) so the test can assert on them."""
+    tracker = MagicMock(spec=Tracker)
+    tracker.count.side_effect = lambda result: tracker_counts.get(result, 0)
+    captured: dict = {}
+
+    with (
+        patch.dict(os.environ, env, clear=True),
+        patch("ingest_wikimedia.slack._post_completion_notice") as mock_post,
+    ):
+        mock_post.side_effect = lambda **kwargs: captured.update(kwargs)
+        notify_upload_complete(
+            tracker=tracker,
+            partner_label="si",
+            elapsed_seconds=16.0,
+            dry_run=False,
+        )
+    return captured
+
+
+def test_notify_upload_complete_no_retry_env_keeps_upload_only_header(tmp_path):
+    """Without WIKIMEDIA_RETRY_DOWNLOAD_LOG set, the existing
+    "Wikimedia Upload Complete" header is preserved and FAILED is the
+    uploader tracker's count alone."""
+    captured = _capture_completion_message(
+        env={
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": "si",
+        },
+        tracker_counts={Result.UPLOADED: 5, Result.SKIPPED: 10, Result.FAILED: 2},
+    )
+    assert "Wikimedia Upload Complete" in captured["header"]
+    assert "Retry Complete" not in captured["header"]
+    failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
+    assert failed_lines == ["FAILED:   2"]
+
+
+def test_notify_upload_complete_with_retry_env_combines_failed_count(tmp_path):
+    """With WIKIMEDIA_RETRY_DOWNLOAD_LOG pointing at a download log that
+    recorded 1 failure, FAILED in the Slack summary is the *sum* of the
+    upload tracker's failures and the download log's failures, and the
+    header is re-titled to "Retry Complete"."""
+    download_log = tmp_path / "20260524-220233-retry-si-download.log"
+    download_log.write_text("[INFO] foo\nCOUNTS:\nFAILED: 1\nSKIPPED: 79\n")
+    captured = _capture_completion_message(
+        env={
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": "retry-si",
+            "WIKIMEDIA_RETRY_DOWNLOAD_LOG": str(download_log),
+        },
+        # Upload tracker: 0 uploaded, 80 skipped (already on Commons), 0 failed.
+        # The retry summary must surface the download-phase FAILED=1.
+        tracker_counts={Result.UPLOADED: 0, Result.SKIPPED: 80, Result.FAILED: 0},
+    )
+    assert "Wikimedia Retry Complete" in captured["header"]
+    assert "Upload Complete" not in captured["header"]
+    failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
+    assert failed_lines == ["FAILED:   1"]
+    # SKIPPED and UPLOADED stay as upload-phase only — each phase's SKIPPED
+    # means a different thing (download = "already in S3"; upload = "already
+    # on Commons") and conflating them would obscure the picture.
+    skipped_lines = [s for s in captured["stats_lines"] if s.startswith("SKIPPED:")]
+    assert skipped_lines == ["SKIPPED:  80"]
+
+
+def test_notify_upload_complete_with_retry_env_but_no_log_file(tmp_path):
+    """If WIKIMEDIA_RETRY_DOWNLOAD_LOG is set but the file is unreadable
+    (e.g. the `ls -t | head -1` substitution returned empty and got
+    concatenated with $PWD/ to yield a directory path), gracefully fall
+    back to the upload-only header rather than crashing the notification."""
+    captured = _capture_completion_message(
+        env={
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": "retry-si",
+            "WIKIMEDIA_RETRY_DOWNLOAD_LOG": str(tmp_path),  # a directory, not a file
+        },
+        tracker_counts={Result.UPLOADED: 0, Result.SKIPPED: 80, Result.FAILED: 0},
+    )
+    # Falls back gracefully — upload-only header, FAILED unchanged.
+    assert "Wikimedia Upload Complete" in captured["header"]
+    failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
+    assert failed_lines == ["FAILED:   0"]

--- a/tests/test_wikimedia_retry.py
+++ b/tests/test_wikimedia_retry.py
@@ -188,6 +188,42 @@ def test_retry_passes_max_age_days_one_to_downloader():
     )
 
 
+def test_retry_pipeline_exports_download_log_for_combined_summary():
+    """The pipeline must export `WIKIMEDIA_RETRY_DOWNLOAD_LOG` after the
+    downloader runs and before the uploader runs, so notify_upload_complete
+    can fold the download-phase FAILED count into the final Slack summary.
+
+    Without this, a retry session that produces download failures (the
+    common case for the persistent-source-error class of bug) would post
+    a "Wikimedia Upload Complete: …" message with FAILED: 0 — silently
+    hiding the failures from the user, even though the download log
+    correctly recorded them.
+    """
+    commands = _run_main_and_capture_full_pipeline(
+        ["wikimedia_retry.py", "--days", "30", "--partner", "si"]
+    )
+    pipeline_cmd = next(c for c in commands if "tmux new-session" in c)
+
+    export_idx = pipeline_cmd.find("export WIKIMEDIA_RETRY_DOWNLOAD_LOG=")
+    downloader_idx = pipeline_cmd.find("downloader --max-age-days 1")
+    uploader_idx = pipeline_cmd.find("uploader ")
+
+    assert export_idx >= 0, (
+        f"pipeline must export WIKIMEDIA_RETRY_DOWNLOAD_LOG; got: {pipeline_cmd!r}"
+    )
+    assert downloader_idx < export_idx < uploader_idx, (
+        f"export must come after the downloader and before the uploader so "
+        f"the log it references actually exists by the time the uploader "
+        f"reads it; positions were downloader={downloader_idx}, "
+        f"export={export_idx}, uploader={uploader_idx}"
+    )
+    # The captured path must include `$PWD/` so notify_upload_complete gets
+    # an absolute path regardless of any cwd change inside the uploader.
+    assert "$PWD/" in pipeline_cmd, (
+        f"WIKIMEDIA_RETRY_DOWNLOAD_LOG must be an absolute path; got: {pipeline_cmd!r}"
+    )
+
+
 def test_retry_clears_stale_csvs_even_when_no_partner_given():
     """When the user runs `/wikimedia-upload retry 30` (no partner), the
     scan still needs to clear stale CSVs so that hubs which legitimately


### PR DESCRIPTION
## Summary

Make the retry session's Slack notification reflect the *whole* retry — download phase + upload phase — instead of just the upload phase. Today's `/wikimedia-upload retry 30 si` posted `FAILED: 0` even though the download phase recorded one HTTP 404, because the downloader and uploader are separate processes with separate `Tracker` instances and only the uploader notifies Slack.

## Today's misleading message

> *Wikimedia Upload Complete: wikimedia-retry-si*
> UPLOADED: 0
> SKIPPED:  80
> FAILED:   0    ← misleading
> BYTES:    0.0 B
> Runtime:  16s

The download log for the same session:

```
COUNTS:
FAILED: 1
SKIPPED: 79
```

The 404 on `https://airandspace.si.edu/.../AerialAgeWeekly_March18-1918pgs54-56.pdf` was correctly recorded by the downloader's tracker but never made it to the upload phase (the file never reached S3), so the upload tracker's FAILED is 0 — true but not useful for the user, who asked for a *retry* and wants a single number for "did anything fail in this retry session?".

## Fix

Aggregate the download phase's FAILED into the upload phase's notification via a known env var pointing at the freshly-written download log:

### `ingest_wikimedia/slack.py`

- New `_read_download_failed_count(path)` helper parses `FAILED: N` from a downloader log's terminal `COUNTS:` section.
- `notify_upload_complete` checks `WIKIMEDIA_RETRY_DOWNLOAD_LOG`. When set:
  - Reads the pointed-to log, adds its FAILED count to the upload tracker's FAILED.
  - Re-titles the message header from `"Wikimedia Upload Complete"` to `"Wikimedia Retry Complete"`.
- When unset or unreadable: falls back gracefully — upload-only header, FAILED unchanged.

### `scripts/wikimedia_retry.py`

Each retry target block now exports the env var between the downloader and uploader steps:

```bash
downloader --max-age-days 1 {csv} {slug}
export WIKIMEDIA_RETRY_DOWNLOAD_LOG="$PWD/$(ls -t logs/*-${WIKIMEDIA_SESSION_LABEL}-download.log 2>/dev/null | head -1)"
uploader {csv} {slug}
```

`$PWD/` makes the path absolute, so the uploader's notification helper still finds the log even if any pywikibot setup changes cwd internally.

## What's combined and what isn't

| Field | Combined? | Reason |
|---|---|---|
| FAILED | **yes** | A failure is a failure regardless of phase — this is what the user cares about. |
| SKIPPED | no | Different semantics per phase (download = "already in S3"; upload = "already on Commons"). Conflating them would obscure the picture; show upload-phase only. |
| UPLOADED / BYTES / Runtime | no | Inherently phase-specific. |

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] New tests in `tests/test_slack.py` covering:
  - `_read_download_failed_count` parses COUNTS correctly
  - Returns None for unset / empty / missing-file / no-COUNTS-section inputs
  - `notify_upload_complete` without env: keeps "Upload Complete" header, FAILED = upload tracker's count alone
  - `notify_upload_complete` with env + valid log: header becomes "Retry Complete", FAILED = upload + download FAILED, SKIPPED stays as upload-only
  - `notify_upload_complete` with env + unreadable path: graceful fallback to upload-only header, no crash
- [x] New test in `tests/test_wikimedia_retry.py` asserting the pipeline exports the env var between downloader and uploader and uses an absolute (`$PWD/`) path
- [ ] CI: pytest + ruff green
- [ ] After merge: next `/wikimedia-upload retry` run that hits a download failure shows the count in the Slack message, with the header reading "Wikimedia Retry Complete"

## Lesson recorded

> **Multi-phase pipelines: aggregate failure counts into a single user-facing summary**

(Added to `~/.claude/lessons.md`.) Captures the principle: when a pipeline runs N phases and the user's mental model is "this is one session, did anything fail?", the visible failure count must reflect the entire session, not just the last phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR makes Slack completion notifications for Wikimedia retry sessions report combined download+upload failures instead of reporting upload failures only. When the retry pipeline runs both downloader and uploader, the uploader’s Slack message now reads "Wikimedia Retry Complete" and shows FAILED as the sum of download + upload FAILED counts; other counters (SKIPPED, UPLOADED, BYTES, Runtime) remain phase-specific. If the downloader log is missing or unreadable, behavior falls back to the previous upload-only summary.

### Changes Made

- ingest_wikimedia/slack.py
  - Adds _read_download_failed_count(path) which anchors to the terminal COUNTS: section of a downloader log and extracts FAILED: N. Treats absent COUNTS as None, treats COUNTS present without a FAILED line as 0, and ignores stray earlier "FAILED:" entries.
  - notify_upload_complete reads WIKIMEDIA_RETRY_DOWNLOAD_LOG (when set and readable), folds the download FAILED count into the upload FAILED total, and retitles the Slack header to "Wikimedia Retry Complete". If the env var is unset/unreadable, it preserves upload-only behavior.
- scripts/wikimedia_retry.py
  - Exports WIKIMEDIA_RETRY_DOWNLOAD_LOG after the downloader step, pointing at the most recent session-specific download log using an absolute path via $PWD/, so the uploader can find and parse the downloader log.
- tests/test_slack.py
  - Adds tests for _read_download_failed_count (including absent COUNTS, COUNTS-without-FAILED → 0, and ignoring stray FAILED before COUNTS) and for notify_upload_complete in no-retry, valid-retry, unreadable-log, and clean-retry scenarios.
- tests/test_wikimedia_retry.py
  - Adds a regression test ensuring the retry tmux pipeline exports WIKIMEDIA_RETRY_DOWNLOAD_LOG (and that the export appears after downloader and before uploader invocations).

### Environment Variables / Secrets / Infra Impact

- Adds one new internal environment variable: WIKIMEDIA_RETRY_DOWNLOAD_LOG. This is exported by the retry script and consumed only by the uploader process for richer Slack summaries.
- No new AWS Secrets Manager keys, no changes to public API shapes, no database migrations, and no shared infrastructure (CodePipeline/CodeBuild/ECS/IAM) modifications in this PR.

### Backward Compatibility, Deployment & Rollout

- Backward compatible: if WIKIMEDIA_RETRY_DOWNLOAD_LOG is not set or not readable, Slack messaging falls back to the previous upload-only behavior.
- No manual pipeline trigger, redeployment, or configuration change is required to enable the code change itself. (The retry script already exports the env var in the modified flow; simply deploying the updated code is sufficient.)
- No secret or credential changes required.

### Security Notes

- No authentication/authorization changes.
- The uploader reads a log file path provided by an internal env var exported by the retry pipeline; this is an internal operational data flow and does not introduce new external inputs or credential handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->