### PR TITLE
uploader: skip redirect pages in trailing-page orphan check

### DIFF
--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -128,21 +128,35 @@ def _stub_s3_client_for_assets(assets_by_ordinal: dict[int, str]):
     return s3_client
 
 
-def _make_file_page_factory(existing: dict[str, str]):
+def _make_file_page_factory(
+    existing: dict[str, str],
+    redirects: set[str] | None = None,
+):
     """Return a stub for pywikibot.FilePage(site, title).
 
-    `existing` maps Commons title → sha1 of the orphan file at that title.
-    Titles not in the map are treated as nonexistent (exists() == False).
+    `existing` maps Commons title → sha1 of the file at that title. For
+    redirect pages, the value is the redirect *target's* sha1, mirroring
+    pywikibot's `latest_file_info.sha1` behavior of following redirects.
+
+    `redirects` is the set of titles that should be reported as redirect
+    pages (`isRedirectPage()` → True). Titles in `existing` but not in
+    `redirects` are real file pages; titles in both are redirects whose
+    `latest_file_info` would resolve through to a target.
+
+    Titles not in `existing` are nonexistent (`exists()` → False).
     """
+    redirects = redirects or set()
 
     def _factory(site, title):
         page = MagicMock()
         page.title.return_value = title
         if title in existing:
             page.exists.return_value = True
+            page.isRedirectPage.return_value = title in redirects
             page.latest_file_info.sha1 = existing[title]
         else:
             page.exists.return_value = False
+            page.isRedirectPage.return_value = False
             # Accessing latest_file_info on a nonexistent page would raise,
             # but the code-under-test breaks the loop before reading it.
         return page
@@ -551,4 +565,113 @@ def test_orphan_check_skips_extensions_with_no_assets():
         )
     fp.assert_not_called()
     assert tracker.count(Result.ORPHANS_TAGGED) == 0
+    assert tracker.count(Result.ORPHANS_FLAGGED) == 0
+
+
+def test_orphan_check_skips_redirect_pages():
+    """Regression: a (page N+1) title that is already a #REDIRECT to a kept
+    asset must NOT be tagged as a duplicate.
+
+    The bug: pywikibot's `latest_file_info.sha1` on a redirect *follows*
+    the redirect and returns the target file's sha1, so the orphan check's
+    `orphan_sha1 in sha1_to_kept` lookup always matched, and the bot tagged
+    the redirect page with a `{{Duplicate}}` template — producing:
+
+        {{Duplicate|<target>|Trailing-page orphan: ...}}
+        #REDIRECT [[<target>]]
+
+    which is meaningless (the redirect already does what {{Duplicate}}
+    flags) and pollutes the page with a stray template above the redirect.
+
+    Caught from commit 1219698039 on Commons:
+    File:Drift Sight, Italian, Crocco - DPLA - 023de366f0c65bec19d5b61b7e3b42d6 (page 4).jpg
+    """
+    tracker = Tracker()
+    s3_client = _stub_s3_client_for_assets({1: "aaa", 2: "bbb", 3: "ccc"})
+    ordinal_exts = {1: ".jpg", 2: ".jpg", 3: ".jpg"}
+    page_labels = {1: "1", 2: "2", 3: "3"}
+    base = "Some Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
+    redirect_title = f"{base} (page 4).jpg"
+    keep_title = f"{base} (page 3).jpg"
+
+    with (
+        patch("tools.uploader.pywikibot.FilePage") as fp,
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+    ):
+        # (page 4) exists, is a redirect, and pywikibot's latest_file_info
+        # would (mis)report the target's sha1 ("ccc"). (page 3) exists as a
+        # real file with the same sha1.
+        fp.side_effect = _make_file_page_factory(
+            existing={redirect_title: "ccc", keep_title: "ccc"},
+            redirects={redirect_title},
+        )
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="Some Item",
+            partner="nara",
+            ordinal_exts=ordinal_exts,
+            page_labels=page_labels,
+            dry_run=False,
+        )
+
+    # The redirect must NOT have been tagged.
+    tag_mock.assert_not_called()
+    assert tracker.count(Result.ORPHANS_TAGGED) == 0
+    # Nor was it flagged for follow-up — a redirect is already doing what
+    # we'd flag it for; no manual review needed.
+    assert tracker.count(Result.ORPHANS_FLAGGED) == 0
+
+
+def test_orphan_check_skips_redirect_but_continues_probing():
+    """A redirect at (page N+1) doesn't stop the probe — if (page N+2) is
+    a real orphan file, it should still get tagged."""
+    tracker = Tracker()
+    s3_client = _stub_s3_client_for_assets({1: "aaa", 2: "bbb", 3: "ccc"})
+    ordinal_exts = {1: ".jpg", 2: ".jpg", 3: ".jpg"}
+    page_labels = {1: "1", 2: "2", 3: "3"}
+    base = "Some Item - DPLA - abcd1234abcd1234abcd1234abcd1234"
+    redirect_title = f"{base} (page 4).jpg"
+    real_orphan_title = f"{base} (page 5).jpg"
+    keep_title = f"{base} (page 3).jpg"
+
+    with (
+        patch("tools.uploader.pywikibot.FilePage") as fp,
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+    ):
+        # (page 4) is a redirect (will be skipped).
+        # (page 5) is a real file with the matching sha1 — should be tagged.
+        # (page 3) exists as the kept target.
+        fp.side_effect = _make_file_page_factory(
+            existing={
+                redirect_title: "ccc",
+                real_orphan_title: "ccc",
+                keep_title: "ccc",
+            },
+            redirects={redirect_title},
+        )
+        _post_item_orphan_check(
+            site=MagicMock(),
+            s3_client=s3_client,
+            tracker=tracker,
+            dpla_id="abcd1234abcd1234abcd1234abcd1234",
+            item_title="Some Item",
+            partner="nara",
+            ordinal_exts=ordinal_exts,
+            page_labels=page_labels,
+            dry_run=False,
+        )
+
+    # Exactly one orphan should be tagged (the real one at page 5), and it
+    # must point at the kept title.
+    assert tag_mock.call_count == 1
+    kwargs = tag_mock.call_args.kwargs
+    assert kwargs["correct_filename"] == keep_title
+    # The first positional arg is the candidate FilePage; verify it's the
+    # real orphan, not the redirect.
+    candidate_arg = tag_mock.call_args.args[1]
+    assert candidate_arg.title() == real_orphan_title
+    assert tracker.count(Result.ORPHANS_TAGGED) == 1
     assert tracker.count(Result.ORPHANS_FLAGGED) == 0

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1060,6 +1060,25 @@ def _post_item_orphan_check(
                 continue
             consecutive_misses = 0
 
+            # Redirects are not orphan files — they already point at the
+            # correct target and have no file content of their own. Tagging
+            # them as duplicates produces wikitext like
+            #   {{Duplicate|<target>|...}}
+            #   #REDIRECT [[<target>]]
+            # which is meaningless and pollutes the page with a stray
+            # template above the redirect. Worse, the SHA1 match path below
+            # silently approves the tag because pywikibot's
+            # latest_file_info follows the redirect and returns the
+            # *target's* SHA1, so a redirect to a kept asset always passes
+            # the sha1_to_kept check. Skip redirects entirely — they are
+            # already doing what {{Duplicate}} is meant to do.
+            if candidate.isRedirectPage():
+                logging.info(
+                    f"Orphan check: skipping [[File:{candidate_title}]] — "
+                    f"already a redirect to its target."
+                )
+                continue
+
             try:
                 orphan_sha1 = candidate.latest_file_info.sha1
             except Exception as e:


### PR DESCRIPTION
## Summary

The trailing-page orphan check (`_post_item_orphan_check`, from PR #227) tagged a `#REDIRECT` page with `{{Duplicate}}` during today's `/wikimedia-upload retry si` run. Redirects already do what the duplicate template would flag — point at the kept asset — so re-tagging them is meaningless at best and pollutes the page with a stray template above the redirect line at worst.

### The actual page wikitext the bot produced

```wiki
{{Duplicate|Drift Sight, Italian, Crocco - DPLA - 023de366f0c65bec19d5b61b7e3b42d6 (page 3).jpg|Trailing-page orphan: this title has no corresponding asset in the current DPLA source for this item; the matching asset is uploaded at [[:File:Drift Sight, Italian, Crocco - DPLA - 023de366f0c65bec19d5b61b7e3b42d6 (page 3).jpg]].}}
#REDIRECT [[File:Drift Sight, Italian, Crocco - DPLA - 023de366f0c65bec19d5b61b7e3b42d6 (page 3).jpg]]
```

Diff: https://commons.wikimedia.org/w/index.php?title=File:Drift_Sight,_Italian,_Crocco_-_DPLA_-_023de366f0c65bec19d5b61b7e3b42d6_(page_4).jpg&diff=prev&oldid=1219698039

### Root cause

The orphan check verifies an orphan's SHA1 matches a kept asset's SHA1 before tagging:

```python
candidate = pywikibot.FilePage(site, candidate_title)
if not candidate.exists():
    continue
...
orphan_sha1 = candidate.latest_file_info.sha1
if orphan_sha1 in sha1_to_kept:
    tag_as_duplicate(...)
```

For a **redirect page**, pywikibot's `latest_file_info.sha1` *transparently follows the redirect* and returns the target file's SHA1. So when (page 4) is a redirect to (page 3), `candidate.latest_file_info.sha1` returns (page 3)'s SHA1 — which trivially matches `sha1_to_kept[(page 3).sha1]`. The hash-match guard, which is correct as defence-in-depth against unrelated uploads at orphan titles, doesn't protect against redirects.

The user framed this as "the orphan logic checks for existence of the orphan, not that it's an actual hash-duplicate" — really, the hash check IS there, it just gets spoofed by pywikibot's transparent redirect dereferencing.

### Fix

Add a single guard right after the existence check, before any property read:

```python
if candidate.isRedirectPage():
    logging.info(
        f"Orphan check: skipping [[File:{candidate_title}]] — "
        f"already a redirect to its target."
    )
    continue
```

A redirect is neither a real orphan (no file content of its own to tag) nor a missing page (it does exist), so we just skip it and continue probing. `consecutive_misses` is intentionally not bumped — the page exists, just not as something we want to act on, and the gap-tolerance counter is for genuinely-missing pages.

### Audit of related code

`grep -rn "latest_file_info"` across production code returns only one site: the orphan check. All other `FilePage` usages in `tools/uploader.py` that read properties (move, save, save-after-rename) already check `isRedirectPage()` before acting. So this PR is scoped to the single regression site.

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] Two new regression tests in `tests/test_uploader.py`:
  - `test_orphan_check_skips_redirect_pages`: (page 4) is a redirect to (page 3) with sha1="ccc"; (page 3) is the kept asset. Asserts `tag_as_duplicate` is never called and no tracker increments fire.
  - `test_orphan_check_skips_redirect_but_continues_probing`: (page 4) is a redirect, (page 5) is a real orphan with the matching sha1; asserts exactly one tag is written, targeting (page 5), not (page 4).
- [x] `_make_file_page_factory` test helper extended with an optional `redirects` arg so `isRedirectPage()` can be mocked.
- [ ] CI: pytest + ruff green
- [ ] After merge: no future orphan check writes `{{Duplicate}}` to a redirect page.

## What this PR does NOT touch

- The original-tagging on (page 4) that's already on Commons: this PR doesn't undo it. Cleaning up the existing bad tags is a separate (one-off, manual or scripted) task.
- The retry-specific behavior that surfaced this bug: the bug exists for any orphan-check invocation (refresh, retry, or normal upload). The fix applies universally.

## Lesson recorded

> **MediaWiki redirect pages: any property that "follows" the redirect masks the redirect-ness**

(Added to `~/.claude/lessons.md`.) Captures the general hazard: pywikibot's transparent redirect dereferencing is convenient for read-only inspection but silently hides redirect-ness from code that *acts on* the page. Always guard with `isRedirectPage()` before any save/move/edit on a `FilePage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a bug in `_post_item_orphan_check` where redirect pages on MediaWiki were incorrectly tagged with the `{{Duplicate}}` template. The issue occurred because pywikibot transparently follows redirects, causing `latest_file_info.sha1` on a redirect page to return the target file's SHA1, resulting in false-positive hash matches.

## Changes

**tools/uploader.py** (+19 lines)
- Added a guard in `_post_item_orphan_check` to explicitly skip redirect pages before accessing their properties
- When a candidate `FilePage` is detected as a redirect, the code now logs an info message and continues to the next candidate without attempting SHA1 checks or tagging
- Redirects are intentionally not counted against `consecutive_misses` as they are treated as existing but not actionable

**tests/test_uploader.py** (+126 lines, -3 lines)
- Extended `_make_file_page_factory` helper to accept an optional `redirects` parameter for mocking redirect pages
- Added `test_orphan_check_skips_redirect_pages`: verifies that redirect pages are not tagged and tracking counters are not incremented
- Added `test_orphan_check_skips_redirect_but_continues_probing`: verifies that probing continues past redirects to correctly tag subsequent real file orphans

## Notes

- No environment variables, infrastructure changes, database migrations, or API modifications are required
- No security implications
- No manual deployment actions required beyond standard code review and merge
- The PR does not remove existing incorrect tags already applied to Commons

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->