### PR TITLE
retry: discover download log via session label, not via outer-bash $PWD

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -62,16 +62,19 @@ def _decode_exit_code(rc_str: str | None) -> str:
     return f" (exit {rc}" + (f" — {hint})" if hint else ")")
 
 
-def _find_latest_log(partner_dir: str, label: str) -> str | None:
+def _find_latest_log(partner_dir: str, label: str, phase: str = "*") -> str | None:
     """Return the most recently modified log file matching this label, or None.
 
     Logs are named `{timestamp}-{label}-{phase}.log` under `<partner_dir>/logs/`.
+    Pass `phase` (e.g. "download", "upload") to restrict the match to a single
+    phase; the default matches any phase.
+
     Tolerates the rare race where a candidate disappears between glob and stat —
     raising OSError here would suppress the Slack failure notification entirely.
     """
     if not partner_dir or not os.path.isdir(partner_dir):
         return None
-    pattern = os.path.join(partner_dir, "logs", f"*-{label}-*.log")
+    pattern = os.path.join(partner_dir, "logs", f"*-{label}-{phase}.log")
     newest: tuple[float, str] | None = None
     for path in glob.glob(pattern):
         try:
@@ -324,6 +327,21 @@ def _read_download_failed_count(log_path: str | None) -> int | None:
     return int(match.group(1))
 
 
+def _find_retry_download_log() -> str | None:
+    """Locate this retry session's download log, if any.
+
+    Only fires for retry sessions (label prefixed `retry-`); normal upload
+    and refresh-only runs have their own Slack messaging and must not be
+    combined. Returns None when not in a retry session or no matching log
+    exists yet.
+    """
+    label = (os.environ.get("WIKIMEDIA_SESSION_LABEL") or "").strip()
+    partner_dir = (os.environ.get("WIKIMEDIA_PARTNER_DIR") or "").strip()
+    if not label.startswith("retry-"):
+        return None
+    return _find_latest_log(partner_dir, label, phase="download")
+
+
 def notify_upload_complete(
     tracker: Tracker,
     partner_label: str,
@@ -343,18 +361,15 @@ def notify_upload_complete(
 
     # In a retry session the user cares about whether *anything* failed in
     # the whole download+upload round-trip — not which phase produced the
-    # failure. When the retry tmux pipeline points us at the prior phase's
-    # download log via `WIKIMEDIA_RETRY_DOWNLOAD_LOG`, fold that phase's
-    # FAILED count into this summary and re-title the message as a retry
-    # complete so the user gets a single combined notification instead of
-    # the misleading "Upload Complete: 0 failed" when downloads bombed.
+    # failure. Fold the download phase's FAILED count into this summary so
+    # the user sees one combined notification instead of the misleading
+    # "Upload Complete: 0 failed" when downloads bombed.
     #
-    # SKIPPED/UPLOADED/BYTES are not combined: each phase has its own
-    # semantics for "skipped" (download = "already in S3"; upload =
-    # "already on Commons") and conflating them would only obscure the
-    # picture. FAILED, by contrast, is universally a failure regardless of
-    # where it happened.
-    download_log = os.environ.get("WIKIMEDIA_RETRY_DOWNLOAD_LOG") or None
+    # SKIPPED/UPLOADED/BYTES are not combined: each phase's "skipped" means
+    # a different thing (download = "already in S3"; upload = "already on
+    # Commons") and conflating them would obscure the picture. FAILED, by
+    # contrast, is universally a failure regardless of where it happened.
+    download_log = _find_retry_download_log()
     download_failed = _read_download_failed_count(download_log)
     is_retry_summary = download_failed is not None
     total_failed = tracker.count(Result.FAILED) + (download_failed or 0)

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -330,14 +330,20 @@ def _read_download_failed_count(log_path: str | None) -> int | None:
 def _find_retry_download_log() -> str | None:
     """Locate this retry session's download log, if any.
 
-    Only fires for retry sessions (label prefixed `retry-`); normal upload
-    and refresh-only runs have their own Slack messaging and must not be
-    combined. Returns None when not in a retry session or no matching log
-    exists yet.
+    Only fires for retry sessions (label prefixed `retry-`) that actually
+    ran a download phase this run (WIKIMEDIA_RETRY_HAS_DOWNLOAD=1, set by
+    the retry pipeline iff a download CSV is present for the target).
+
+    The HAS_DOWNLOAD gate is important: retry session labels are reused
+    across runs, so without it an upload-only retry would happily pick
+    up a stale `*-retry-<slug>-download.log` from a prior run and inflate
+    FAILED with counts that already shipped in an earlier message.
     """
     label = (os.environ.get("WIKIMEDIA_SESSION_LABEL") or "").strip()
     partner_dir = (os.environ.get("WIKIMEDIA_PARTNER_DIR") or "").strip()
     if not label.startswith("retry-"):
+        return None
+    if os.environ.get("WIKIMEDIA_RETRY_HAS_DOWNLOAD") != "1":
         return None
     return _find_latest_log(partner_dir, label, phase="download")
 

--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -289,22 +289,12 @@ def main() -> None:
             steps.append(
                 f"downloader --max-age-days 1 {shlex.quote(download_csv)} {slug}"
             )
-            # Roll the download phase's FAILED count into the upload phase's
-            # final Slack summary. After the downloader finishes, capture the
-            # most-recent log it just wrote (matches the
-            # `{timestamp}-{session_label}-download.log` naming convention
-            # produced by ingest_wikimedia.logs.setup_logging) and pass its
-            # absolute path to the uploader via WIKIMEDIA_RETRY_DOWNLOAD_LOG.
-            # notify_upload_complete reads that env var, parses the COUNTS
-            # FAILED line, and adds it to its own tracker's FAILED so the
-            # user sees one combined Retry Complete summary instead of an
-            # Upload Complete summary that misleadingly reports 0 failures
-            # when downloads bombed.
-            steps.append(
-                "export WIKIMEDIA_RETRY_DOWNLOAD_LOG="
-                '"$PWD/$(ls -t logs/*-${WIKIMEDIA_SESSION_LABEL}-download.log '
-                '2>/dev/null | head -1)"'
-            )
+            # The uploader's notify_upload_complete folds the download
+            # phase's FAILED count into the final Slack summary by
+            # discovering this session's download log itself, via
+            # WIKIMEDIA_SESSION_LABEL + WIKIMEDIA_PARTNER_DIR (both
+            # exported with literal values by label_export above). See
+            # slack._find_retry_download_log.
             steps.append(f"uploader {shlex.quote(download_csv)} {slug}")
         if upload_csv:
             steps.append(f"uploader {shlex.quote(upload_csv)} {slug}")

--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -258,14 +258,28 @@ def main() -> None:
             if idx == last_idx
             else "unset WIKIMEDIA_TARGET_IS_LAST"
         )
+        download_csv = type_csvs.get("download")
+        upload_csv = type_csvs.get("upload")
+        # WIKIMEDIA_RETRY_HAS_DOWNLOAD gates the combined-summary log
+        # discovery in notify_upload_complete. Retry session labels are
+        # reused across runs, so an upload-only retry would otherwise
+        # find a stale *-retry-<slug>-download.log from a prior session
+        # and inflate FAILED with already-shipped counts. Set the flag
+        # only when this target actually runs the download phase; unset
+        # it otherwise so the env doesn't leak across targets in the
+        # same tmux session.
+        has_download_env = (
+            "export WIKIMEDIA_RETRY_HAS_DOWNLOAD=1"
+            if download_csv
+            else "unset WIKIMEDIA_RETRY_HAS_DOWNLOAD"
+        )
         label_export = (
             f"export WIKIMEDIA_SESSION_LABEL={shlex.quote(session_label)}; "
             f"export WIKIMEDIA_PARTNER_DIR={base}; "
             f"{is_last_env}; "
+            f"{has_download_env}; "
             "unset WIKIMEDIA_SINGLE_ITEM"
         )
-        download_csv = type_csvs.get("download")
-        upload_csv = type_csvs.get("upload")
         steps = [f"cd {base}"]
         if download_csv:
             # `--max-age-days 1` forces the downloader to actually re-attempt

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -320,6 +320,7 @@ def test_notify_upload_complete_with_retry_label_combines_failed_count(tmp_path)
             "DPLA_SLACK_BOT_TOKEN": "x",
             "WIKIMEDIA_SESSION_LABEL": "retry-si",
             "WIKIMEDIA_PARTNER_DIR": str(tmp_path),
+            "WIKIMEDIA_RETRY_HAS_DOWNLOAD": "1",
         },
         # Upload tracker: 0 uploaded, 80 skipped (already on Commons), 0 failed.
         # The retry summary must surface the download-phase FAILED=1.
@@ -346,11 +347,40 @@ def test_notify_upload_complete_with_retry_label_but_no_log_file(tmp_path):
             "DPLA_SLACK_BOT_TOKEN": "x",
             "WIKIMEDIA_SESSION_LABEL": "retry-si",
             "WIKIMEDIA_PARTNER_DIR": str(tmp_path),
+            "WIKIMEDIA_RETRY_HAS_DOWNLOAD": "1",
         },
         tracker_counts={Result.UPLOADED: 0, Result.SKIPPED: 80, Result.FAILED: 0},
     )
     # Falls back gracefully — upload-only header, FAILED unchanged.
     assert "Wikimedia Upload Complete" in captured["header"]
+    failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
+    assert failed_lines == ["FAILED:   0"]
+
+
+def test_notify_upload_complete_upload_only_retry_ignores_stale_download_log(
+    tmp_path,
+):
+    """An upload-only retry (WIKIMEDIA_RETRY_HAS_DOWNLOAD unset) must NOT
+    pick up a stale `*-retry-<slug>-download.log` from a prior retry run.
+
+    Retry session labels are reused across runs, so without the gate the
+    most-recent matching download log on disk — from a previous session
+    that already shipped its own Slack summary — would be folded in,
+    inflating FAILED and incorrectly switching to "Retry Complete"."""
+    _write_retry_download_log(
+        tmp_path, "retry-si", "[INFO] stale\nCOUNTS:\nFAILED: 999\nSKIPPED: 1\n"
+    )
+    captured = _capture_completion_message(
+        env={
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": "retry-si",
+            "WIKIMEDIA_PARTNER_DIR": str(tmp_path),
+            # WIKIMEDIA_RETRY_HAS_DOWNLOAD intentionally unset.
+        },
+        tracker_counts={Result.UPLOADED: 0, Result.SKIPPED: 80, Result.FAILED: 0},
+    )
+    assert "Wikimedia Upload Complete" in captured["header"]
+    assert "Retry Complete" not in captured["header"]
     failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
     assert failed_lines == ["FAILED:   0"]
 
@@ -378,6 +408,7 @@ def test_notify_upload_complete_clean_retry_still_titled_retry_complete(tmp_path
             "DPLA_SLACK_BOT_TOKEN": "x",
             "WIKIMEDIA_SESSION_LABEL": "retry-si",
             "WIKIMEDIA_PARTNER_DIR": str(tmp_path),
+            "WIKIMEDIA_RETRY_HAS_DOWNLOAD": "1",
         },
         tracker_counts={Result.UPLOADED: 0, Result.SKIPPED: 80, Result.FAILED: 0},
     )

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -274,14 +274,29 @@ def _capture_completion_message(env: dict, tracker_counts: dict) -> dict:
     return captured
 
 
-def test_notify_upload_complete_no_retry_env_keeps_upload_only_header(tmp_path):
-    """Without WIKIMEDIA_RETRY_DOWNLOAD_LOG set, the existing
-    "Wikimedia Upload Complete" header is preserved and FAILED is the
-    uploader tracker's count alone."""
+def _write_retry_download_log(partner_dir, label: str, body: str):
+    """Write a download log into `{partner_dir}/logs/` with the filename
+    pattern produced by ingest_wikimedia.logs.setup_logging — that's what
+    `_find_retry_download_log` globs for."""
+    logs_dir = partner_dir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log = logs_dir / f"20260524-220233-{label}-download.log"
+    log.write_text(body)
+    return log
+
+
+def test_notify_upload_complete_non_retry_label_keeps_upload_only_header(tmp_path):
+    """A non-retry session label (no `retry-` prefix) keeps the existing
+    "Wikimedia Upload Complete" header and FAILED is the uploader
+    tracker's count alone, even if a download log happens to be present
+    in the partner dir — non-retry runs have their own download Slack
+    message and must not be combined."""
+    _write_retry_download_log(tmp_path, "si", "[INFO] foo\nCOUNTS:\nFAILED: 999\n")
     captured = _capture_completion_message(
         env={
             "DPLA_SLACK_BOT_TOKEN": "x",
             "WIKIMEDIA_SESSION_LABEL": "si",
+            "WIKIMEDIA_PARTNER_DIR": str(tmp_path),
         },
         tracker_counts={Result.UPLOADED: 5, Result.SKIPPED: 10, Result.FAILED: 2},
     )
@@ -291,18 +306,20 @@ def test_notify_upload_complete_no_retry_env_keeps_upload_only_header(tmp_path):
     assert failed_lines == ["FAILED:   2"]
 
 
-def test_notify_upload_complete_with_retry_env_combines_failed_count(tmp_path):
-    """With WIKIMEDIA_RETRY_DOWNLOAD_LOG pointing at a download log that
-    recorded 1 failure, FAILED in the Slack summary is the *sum* of the
-    upload tracker's failures and the download log's failures, and the
-    header is re-titled to "Retry Complete"."""
-    download_log = tmp_path / "20260524-220233-retry-si-download.log"
-    download_log.write_text("[INFO] foo\nCOUNTS:\nFAILED: 1\nSKIPPED: 79\n")
+def test_notify_upload_complete_with_retry_label_combines_failed_count(tmp_path):
+    """With WIKIMEDIA_SESSION_LABEL=retry-* and a matching download log
+    in WIKIMEDIA_PARTNER_DIR/logs/ that recorded 1 failure, FAILED in
+    the Slack summary is the *sum* of the upload tracker's failures and
+    the download log's failures, and the header is re-titled to
+    "Retry Complete"."""
+    _write_retry_download_log(
+        tmp_path, "retry-si", "[INFO] foo\nCOUNTS:\nFAILED: 1\nSKIPPED: 79\n"
+    )
     captured = _capture_completion_message(
         env={
             "DPLA_SLACK_BOT_TOKEN": "x",
             "WIKIMEDIA_SESSION_LABEL": "retry-si",
-            "WIKIMEDIA_RETRY_DOWNLOAD_LOG": str(download_log),
+            "WIKIMEDIA_PARTNER_DIR": str(tmp_path),
         },
         # Upload tracker: 0 uploaded, 80 skipped (already on Commons), 0 failed.
         # The retry summary must surface the download-phase FAILED=1.
@@ -319,16 +336,16 @@ def test_notify_upload_complete_with_retry_env_combines_failed_count(tmp_path):
     assert skipped_lines == ["SKIPPED:  80"]
 
 
-def test_notify_upload_complete_with_retry_env_but_no_log_file(tmp_path):
-    """If WIKIMEDIA_RETRY_DOWNLOAD_LOG is set but the file is unreadable
-    (e.g. the `ls -t | head -1` substitution returned empty and got
-    concatenated with $PWD/ to yield a directory path), gracefully fall
-    back to the upload-only header rather than crashing the notification."""
+def test_notify_upload_complete_with_retry_label_but_no_log_file(tmp_path):
+    """If the retry label is set but no matching download log exists in
+    the partner dir's logs/, gracefully fall back to the upload-only
+    header rather than crashing the notification."""
+    (tmp_path / "logs").mkdir()  # empty logs dir, no matching file
     captured = _capture_completion_message(
         env={
             "DPLA_SLACK_BOT_TOKEN": "x",
             "WIKIMEDIA_SESSION_LABEL": "retry-si",
-            "WIKIMEDIA_RETRY_DOWNLOAD_LOG": str(tmp_path),  # a directory, not a file
+            "WIKIMEDIA_PARTNER_DIR": str(tmp_path),
         },
         tracker_counts={Result.UPLOADED: 0, Result.SKIPPED: 80, Result.FAILED: 0},
     )
@@ -347,19 +364,20 @@ def test_notify_upload_complete_clean_retry_still_titled_retry_complete(tmp_path
     download runs legitimately have no FAILED line in their COUNTS
     section. `_read_download_failed_count` returns 0 (not None) in that
     case so the retry-aware code path still fires."""
-    download_log = tmp_path / "20260524-220233-retry-si-download.log"
-    download_log.write_text(
+    _write_retry_download_log(
+        tmp_path,
+        "retry-si",
         "[INFO] 22:02:33: Starting download for si\n"
         "COUNTS:\n"
         "DOWNLOADED: 80\n"
         "SKIPPED: 0\n"
-        "BYTES: 8000\n"
+        "BYTES: 8000\n",
     )
     captured = _capture_completion_message(
         env={
             "DPLA_SLACK_BOT_TOKEN": "x",
             "WIKIMEDIA_SESSION_LABEL": "retry-si",
-            "WIKIMEDIA_RETRY_DOWNLOAD_LOG": str(download_log),
+            "WIKIMEDIA_PARTNER_DIR": str(tmp_path),
         },
         tracker_counts={Result.UPLOADED: 0, Result.SKIPPED: 80, Result.FAILED: 0},
     )

--- a/tests/test_wikimedia_retry.py
+++ b/tests/test_wikimedia_retry.py
@@ -220,6 +220,15 @@ def test_retry_pipeline_does_not_export_download_log_via_pwd_subshell():
     # on must still be present and must precede the uploader.
     assert "export WIKIMEDIA_SESSION_LABEL=" in pipeline_cmd
     assert "export WIKIMEDIA_PARTNER_DIR=" in pipeline_cmd
+    # WIKIMEDIA_RETRY_HAS_DOWNLOAD must be set to 1 when a download CSV is
+    # present, so notify_upload_complete knows the discovered download log
+    # belongs to this run rather than a prior retry session that reused
+    # the same label.
+    assert "export WIKIMEDIA_RETRY_HAS_DOWNLOAD=1" in pipeline_cmd, (
+        "pipeline must opt into combined-summary log discovery via "
+        "WIKIMEDIA_RETRY_HAS_DOWNLOAD=1 when the target has a download "
+        f"phase; got: {pipeline_cmd!r}"
+    )
 
 
 def test_retry_clears_stale_csvs_even_when_no_partner_given():

--- a/tests/test_wikimedia_retry.py
+++ b/tests/test_wikimedia_retry.py
@@ -188,40 +188,38 @@ def test_retry_passes_max_age_days_one_to_downloader():
     )
 
 
-def test_retry_pipeline_exports_download_log_for_combined_summary():
-    """The pipeline must export `WIKIMEDIA_RETRY_DOWNLOAD_LOG` after the
-    downloader runs and before the uploader runs, so notify_upload_complete
-    can fold the download-phase FAILED count into the final Slack summary.
+def test_retry_pipeline_does_not_export_download_log_via_pwd_subshell():
+    """Regression guard: the pipeline must NOT try to capture the download
+    log via `export WIKIMEDIA_RETRY_DOWNLOAD_LOG="$PWD/$(ls -t ...)"`.
 
-    Without this, a retry session that produces download failures (the
-    common case for the persistent-source-error class of bug) would post
-    a "Wikimedia Upload Complete: …" message with FAILED: 0 — silently
-    hiding the failures from the user, even though the download log
-    correctly recorded them.
+    That form was the original implementation of the combined-summary
+    feature and it looked correct — but the outer bash that constructs
+    the tmux session argument eagerly expanded `$PWD` (the SSM agent's
+    cwd, typically `/usr/bin/`) before the inner shell ever ran
+    `cd {partner_dir}`. The exported value was `/usr/bin/` on every
+    real run, and notify_upload_complete dutifully tried to read it as a
+    log file, failed, and silently degraded to upload-only "0 failed"
+    summaries even when downloads had bombed.
+
+    The replacement design: notify_upload_complete discovers its own
+    download log from WIKIMEDIA_SESSION_LABEL + WIKIMEDIA_PARTNER_DIR
+    (both exported as literal shlex.quote-d values that survive the
+    outer-bash parse intact). See slack._find_retry_download_log.
     """
     commands = _run_main_and_capture_full_pipeline(
         ["wikimedia_retry.py", "--days", "30", "--partner", "si"]
     )
     pipeline_cmd = next(c for c in commands if "tmux new-session" in c)
 
-    export_idx = pipeline_cmd.find("export WIKIMEDIA_RETRY_DOWNLOAD_LOG=")
-    downloader_idx = pipeline_cmd.find("downloader --max-age-days 1")
-    uploader_idx = pipeline_cmd.find("uploader ")
-
-    assert export_idx >= 0, (
-        f"pipeline must export WIKIMEDIA_RETRY_DOWNLOAD_LOG; got: {pipeline_cmd!r}"
+    assert "WIKIMEDIA_RETRY_DOWNLOAD_LOG" not in pipeline_cmd, (
+        "pipeline must not export WIKIMEDIA_RETRY_DOWNLOAD_LOG — the "
+        "$PWD-based form is a known footgun (outer-bash expansion timing). "
+        f"got: {pipeline_cmd!r}"
     )
-    assert downloader_idx < export_idx < uploader_idx, (
-        f"export must come after the downloader and before the uploader so "
-        f"the log it references actually exists by the time the uploader "
-        f"reads it; positions were downloader={downloader_idx}, "
-        f"export={export_idx}, uploader={uploader_idx}"
-    )
-    # The captured path must include `$PWD/` so notify_upload_complete gets
-    # an absolute path regardless of any cwd change inside the uploader.
-    assert "$PWD/" in pipeline_cmd, (
-        f"WIKIMEDIA_RETRY_DOWNLOAD_LOG must be an absolute path; got: {pipeline_cmd!r}"
-    )
+    # The label + partner-dir exports that the new discovery flow depends
+    # on must still be present and must precede the uploader.
+    assert "export WIKIMEDIA_SESSION_LABEL=" in pipeline_cmd
+    assert "export WIKIMEDIA_PARTNER_DIR=" in pipeline_cmd
 
 
 def test_retry_clears_stale_csvs_even_when_no_partner_given():


### PR DESCRIPTION
## Summary

Fix the regression from #237. The retry Slack summary still reported "Upload Complete: 0 failed" even when downloads failed, because the env-var bridge it relied on was being broken by bash quoting layers.

PR #237 wired the combined retry Slack summary by exporting between the downloader and uploader:

```bash
export WIKIMEDIA_RETRY_DOWNLOAD_LOG="$PWD/$(ls -t logs/*-${LABEL}-download.log | head -1)"
```

The outer bash that builds the tmux session command eagerly expanded `$PWD` (the SSM agent's cwd — `/usr/bin/`) *before* the inner shell ever ran `cd {partner_dir}`. Every retry session exported `WIKIMEDIA_RETRY_DOWNLOAD_LOG=/usr/bin/`, `notify_upload_complete` failed to open it, logged a `[WARNING] Could not read retry download log /usr/bin/: [Errno 21] Is a directory`, and silently fell back to upload-only "0 failed."

## Fix

Remove the env-var dance. `notify_upload_complete` discovers its own download log via `WIKIMEDIA_SESSION_LABEL` + `WIKIMEDIA_PARTNER_DIR` (both already exported by the retry pipeline as literal `shlex.quote`-d values that survive the outer-bash parse intact), delegating to the existing `_find_latest_log` helper extended with an optional `phase` parameter.

## Test plan

- [x] Updated tests in `tests/test_slack.py` to cover: non-retry label → upload-only header; retry label with matching log → combined; retry label with no log file → graceful fallback; retry label with clean COUNTS → still titled "Retry Complete."
- [x] Replaced the now-obsolete `test_retry_pipeline_exports_download_log_for_combined_summary` with a regression guard (`test_retry_pipeline_does_not_export_download_log_via_pwd_subshell`) asserting the broken export is gone and the label/partner-dir exports are present.
- [ ] Real `wikimedia-retry-si` run on EC2 produces a combined "Retry Complete: …" Slack message with the download-phase FAILED count rolled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a regression from `#237` where retry Slack summaries could report "Upload Complete: 0 failed" despite download failures. The regression was caused by exporting WIKIMEDIA_RETRY_DOWNLOAD_LOG using an outer-shell $PWD expansion (pointing to the SSM agent cwd) so the uploader could not read the intended download log.

## Solution

Remove the brittle WIKIMEDIA_RETRY_DOWNLOAD_LOG export and have the uploader discover the download log itself. notify_upload_complete() now uses WIKIMEDIA_SESSION_LABEL and WIKIMEDIA_PARTNER_DIR together with an enhanced _find_latest_log(phase=...) helper and a new _find_retry_download_log() to locate the correct retry download log (if any) and fold download-phase FAILED counts into the Slack summary.

## Changes

- ingest_wikimedia/slack.py
  - _find_latest_log() accepts optional phase to restrict filename matching (e.g., *-{label}-{phase}.log).
  - Added _find_retry_download_log() to detect retry sessions (labels starting with retry-) and, when WIKIMEDIA_RETRY_HAS_DOWNLOAD=1, locate the latest download-phase log under {WIKIMEDIA_PARTNER_DIR}/logs/.
  - notify_upload_complete() now calls _find_retry_download_log() instead of reading WIKIMEDIA_RETRY_DOWNLOAD_LOG; combined summary logic updated accordingly.

- scripts/wikimedia_retry.py
  - Removed the export of WIKIMEDIA_RETRY_DOWNLOAD_LOG that embedded an outer-shell $PWD subshell.
  - Added per-target flag WIKIMEDIA_RETRY_HAS_DOWNLOAD=1 when the downloader actually ran.
  - Comments updated to document that uploader-side discovery uses session label + partner dir.

- tests/test_slack.py
  - Added helper _write_retry_download_log() and updated tests to cover:
    - non-retry label → upload-only header;
    - retry label + matching download log → combined summary (upload + download FAILED totals);
    - retry label + no log → graceful fallback to upload-only behavior;
    - retry label with clean COUNTS in download log → still titled "Wikimedia Retry Complete" with FAILED: 0;
    - case where WIKIMEDIA_RETRY_HAS_DOWNLOAD unset → ignores stale logs and remains upload-only.

- tests/test_wikimedia_retry.py
  - Removed the old test that asserted the pipeline exported WIKIMEDIA_RETRY_DOWNLOAD_LOG via a $PWD/ sub-shell.
  - Added regression guard test asserting the tmux pipeline does NOT export download log via $PWD subshell and that it still exports WIKIMEDIA_SESSION_LABEL and WIKIMEDIA_PARTNER_DIR; also verifies WIKIMEDIA_RETRY_HAS_DOWNLOAD is set for download-phase runs.

## Environment variable / secrets / infra impact

- Removed: WIKIMEDIA_RETRY_DOWNLOAD_LOG — the retry script no longer exports this.
- Added/changed behavior:
  - WIKIMEDIA_RETRY_HAS_DOWNLOAD (per-target flag) is set by the retry pipeline when a download phase runs.
  - The uploader now relies on the existing WIKIMEDIA_SESSION_LABEL and WIKIMEDIA_PARTNER_DIR exports to discover logs.
- No AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline/CodeBuild/ECS task defs/IAM) or public API surfaces.

## Deployment / operational notes

- To take effect in production the updated code must be deployed (i.e., merge + normal deployment pipeline). No special infrastructure changes are required.
- Manual verification recommended: run a real wikimedia-retry-si on EC2 to confirm a combined Slack message that includes download-phase FAILED counts alongside upload-phase counts (this verification is pending).

## Security implications

- No auth/credential handling changes or new external inputs introduced by this PR.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->