### PR TITLE
partners: drive upload eligibility off institutions_v2.json, drop DPLA_PARTNERS

### DIFF
--- a/ingest_wikimedia/dpla.py
+++ b/ingest_wikimedia/dpla.py
@@ -8,6 +8,7 @@ from requests import Session
 from .banlist import Banlist
 from .common import null_safe, get_str, get_list, get_dict
 from .iiif import IIIF
+from .partners import PARTNER_HUBS, is_upload_eligible
 from .s3 import S3Client
 from .tracker import Tracker, Result
 
@@ -34,11 +35,22 @@ class DPLA:
 
     @staticmethod
     def check_partner(partner: str) -> None:
+        """Raise ValueError if `partner` is not an upload-eligible DPLA hub.
+
+        Eligibility is driven entirely by institutions_v2.json — the file
+        DPLA maintainers edit to opt hubs and institutions in or out. Any
+        hub slug recognised in PARTNER_HUBS whose entry in
+        institutions_v2.json marks it (or any of its institutions) as
+        `upload: True` is accepted here. No code change is required to
+        add a new partner.
         """
-        Blows up if we're working on a partner we shouldn't.
-        """
-        if partner not in DPLA_PARTNERS.keys():
+        if partner not in PARTNER_HUBS:
             raise ValueError(f"Unrecognized partner: {partner}")
+        if not is_upload_eligible(partner):
+            raise ValueError(
+                f"Hub {partner!r} has no upload-eligible institutions in "
+                f"institutions_v2.json — edit that file to opt in"
+            )
 
     def get_nara_ids(self):
         def build_collections_params(http_session: Session, api_key: str) -> list[str]:
@@ -152,7 +164,7 @@ class DPLA:
                     ) from e
 
     def get_ids(self, partner: str, add_query: str | None, no_shard: bool):
-        partner_full = DPLA_PARTNERS[partner]
+        partner_full = PARTNER_HUBS[partner]
         partner_string = partner_full.replace(" ", "+")
 
         api_query_base = (
@@ -200,7 +212,7 @@ class DPLA:
 
     @staticmethod
     def check_record_partner(partner: str, item_metadata: dict) -> bool:
-        partner_long_name = DPLA_PARTNERS.get(partner, "")
+        partner_long_name = PARTNER_HUBS.get(partner, "")
         record_partner_long_name = get_str(
             get_dict(item_metadata, PROVIDER_FIELD_NAME), EDM_AGENT_NAME
         )
@@ -385,20 +397,3 @@ DC_TITLE_FIELD_NAME = "title"
 DC_IDENTIFIER_FIELD_NAME = "identifier"
 WIKIDATA_FIELD_NAME = "Wikidata"
 AUTHORIZATION_HEADER = "Authorization"
-
-DPLA_PARTNERS = {
-    "bpl": "Digital Commonwealth",
-    "georgia": "Digital Library of Georgia",
-    # hold off on illinois "il": "Illinois Digital Heritage Hub",
-    "indiana": "Indiana Memory",
-    "nara": "National Archives and Records Administration",
-    "northwest-heritage": "Northwest Digital Heritage",
-    "ohio": "Ohio Digital Network",
-    "p2p": "Plains to Peaks Collective",
-    "pa": "PA Digital",
-    "si": "Smithsonian Institution",
-    "texas": "The Portal to Texas History",
-    "minnesota": "Minnesota Digital Library",
-    "mwdl": "Mountain West Digital Library",
-    "heartland": "Heartland Hub",
-}

--- a/tests/test_dpla.py
+++ b/tests/test_dpla.py
@@ -64,12 +64,29 @@ def good_dpla_id():
     return "12345"
 
 
-def test_check_partner(dpla: DPLA):
-    with pytest.raises(Exception, match="Unrecognized partner."):
+def test_check_partner_rejects_unknown_slug(dpla: DPLA):
+    """A slug not in PARTNER_HUBS is rejected before any network call."""
+    with pytest.raises(ValueError, match="Unrecognized partner"):
         dpla.check_partner("invalid_partner")
 
-    # Assuming "bpl" is a valid partner
-    dpla.check_partner("bpl")
+
+def test_check_partner_accepts_upload_eligible_hub(dpla: DPLA):
+    """A recognised hub that's marked upload-eligible in institutions_v2.json
+    passes the check. Mocked to avoid hitting GitHub from the test suite."""
+    with patch("ingest_wikimedia.dpla.is_upload_eligible", return_value=True):
+        dpla.check_partner("bpl")
+
+
+def test_check_partner_rejects_hub_with_no_upload_eligible_institutions(
+    dpla: DPLA,
+):
+    """A recognised hub slug whose institutions_v2.json entry has nothing
+    upload-eligible is rejected with an actionable message pointing at the
+    JSON file — making it obvious that the fix is a data edit, not a code
+    change."""
+    with patch("ingest_wikimedia.dpla.is_upload_eligible", return_value=False):
+        with pytest.raises(ValueError, match="institutions_v2.json"):
+            dpla.check_partner("bpl")
 
 
 def test_check_record_partner_valid(dpla: DPLA):

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -37,7 +37,8 @@ import click
 import requests
 
 from ingest_wikimedia.banlist import Banlist
-from ingest_wikimedia.dpla import DPLA, DPLA_PARTNERS, INSTITUTIONS_URL
+from ingest_wikimedia.dpla import DPLA, INSTITUTIONS_URL
+from ingest_wikimedia.partners import PARTNER_HUBS
 from ingest_wikimedia.es import check_es_response, post_es
 from ingest_wikimedia.iiif import IIIF
 from ingest_wikimedia.s3 import S3Client
@@ -73,7 +74,7 @@ def load_eligible_dp_names(partner: str) -> list[str]:
     Name strings are used rather than Wikidata URIs so that two provider name
     variants mapping to the same Wikidata ID can carry independent upload flags.
     """
-    hub_name = DPLA_PARTNERS[partner]
+    hub_name = PARTNER_HUBS[partner]
     resp = requests.get(INSTITUTIONS_URL, timeout=15)
     resp.raise_for_status()
     institutions = resp.json()
@@ -175,7 +176,7 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
         raise click.BadParameter(str(e)) from e
 
     notify_phase_start(partner, "id-generation")
-    provider_name = DPLA_PARTNERS[partner]
+    provider_name = PARTNER_HUBS[partner]
 
     eligible_dp_names = load_eligible_dp_names(partner)
     if not eligible_dp_names:


### PR DESCRIPTION
## Summary

Eliminates the duplicate partner registry that was causing tmux-only failures for any hub recognised by the launch script but not in the legacy `DPLA_PARTNERS` whitelist in `dpla.py` (e.g. `bhl|Phillips Academy, Oliver Wendell Holmes Library (archive.org)`, `ia|Phillips Academy`, etc.). The launcher accepts the target, dispatches the tmux session, and `get-ids-es` crashes with `Error: Invalid value: Unrecognized partner: bhl` before any log file is created — leaving an empty `*.csv`, no `logs/` dir, and a Slack failure notice with no log tail to point at the cause.

## What changed

- `ingest_wikimedia/dpla.py`:
  - `Partner.check_partner(slug)` now accepts any slug in `PARTNER_HUBS` whose institutions_v2.json entry marks the hub or any of its institutions `upload: True`. Rejection messages now point at `institutions_v2.json` so the next person sees that the fix is a data edit, not a code change.
  - `DPLA.get_ids` and `DPLA.check_record_partner` switched from `DPLA_PARTNERS[slug]` to `PARTNER_HUBS[slug]` (same mapping, single source).
  - `DPLA_PARTNERS = {...}` dict deleted.
- `tools/get_ids_es.py`: imports `PARTNER_HUBS` from `partners.py` instead of `DPLA_PARTNERS` from `dpla.py`; two lookups updated.
- `tests/test_dpla.py`: `test_check_partner` split into three covering the new behavior (unknown slug, upload-eligible hub, recognised hub with no upload-eligible institutions).

`PARTNER_HUBS` itself stays — it's the slug↔hub-display-name routing table, edited only when a brand-new DPLA hub joins the network. It is no longer pretending to be an authorization list.

## Why this matters

`institutions_v2.json` is the editor-friendly source of truth for which hubs and institutions are upload-eligible. The previous setup required a code edit (adding the slug to `DPLA_PARTNERS`) in addition to the JSON edit, so the two registries drifted. After this PR, opting in a new institution or hub is exactly the edit to institutions_v2.json — the next pipeline run picks it up automatically.

## Test plan

- [x] ruff check / format clean.
- [x] Unit tests in tests/test_dpla.py updated and patched to avoid hitting GitHub.
- [ ] Real run of bhl|Phillips Academy and ia|Phillips Academy targets after merge succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR consolidates partner upload eligibility checking by making `institutions_v2.json` (fetched from GitHub at runtime) the single source of truth, eliminating a redundant code-based partner whitelist that required synchronized code and JSON edits.

### Changes

**ingest_wikimedia/dpla.py**
- Removed module-level `DPLA_PARTNERS` constant
- Updated `check_partner(slug)` to validate against `PARTNER_HUBS` from `.partners` and enforce `is_upload_eligible()` check based on `institutions_v2.json`
- Updated error messages to reference `institutions_v2.json` as the source of eligibility truth
- Updated `get_ids()` and `check_record_partner()` to use `PARTNER_HUBS[slug]` for provider name lookups instead of `DPLA_PARTNERS`
- Added imports: `PARTNER_HUBS` and `is_upload_eligible` from `.partners`

**tools/get_ids_es.py**
- Updated to import `PARTNER_HUBS` from `ingest_wikimedia.partners` instead of importing `DPLA_PARTNERS` from `dpla`
- Updated two provider name resolutions to use `PARTNER_HUBS[partner]`

**tests/test_dpla.py**
- Refactored `test_check_partner` into three focused tests:
  - `test_check_partner_rejects_unknown_slug`: Validates rejection of unrecognized partner slugs
  - `test_check_partner_accepts_upload_eligible_hub`: Validates acceptance of upload-eligible hubs
  - `test_check_partner_rejects_hub_with_no_upload_eligible_institutions`: Validates rejection with actionable error message pointing to `institutions_v2.json`

### Impact

**Operational Benefit**: Adding a new partner now requires only editing `institutions_v2.json`; no code changes to `DPLA_PARTNERS` are needed. This eliminates drift between code and config that previously caused tmux-only failures when launcher accepted a slug that had not yet been added to `DPLA_PARTNERS`, resulting in "Unrecognized partner" errors before logs were created.

**No Deployment Required**: The `is_upload_eligible()` function fetches `institutions_v2.json` fresh from GitHub's main branch on each invocation, so eligibility changes are picked up dynamically without requiring pipeline trigger or redeployment.

**No Infrastructure Changes**: No environment variables, AWS Secrets Manager keys, database migrations, or infrastructure configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->