### PR TITLE
uploader: emit per-item upload-result.json (PR 3 of 5)

### DIFF
--- a/ingest_wikimedia/s3.py
+++ b/ingest_wikimedia/s3.py
@@ -12,6 +12,7 @@ IIIF_JSON = "iiif.json"
 FILE_LIST_TXT = "file-list.txt"
 TEXT_PLAIN = "text/plain"
 DPLA_MAP_FILENAME = "dpla-map.json"
+UPLOAD_RESULT_FILENAME = "upload-result.json"
 APPLICATION_JSON = "application/json"
 S3_RETRIES = 3
 S3_BUCKET = "dpla-wikimedia"
@@ -104,6 +105,28 @@ class S3Client:
         Reads the metadata file back from s3.
         """
         return self.get_item_file(partner, dpla_id, DPLA_MAP_FILENAME)
+
+    def write_upload_result(
+        self, partner: str, dpla_id: str, upload_result: dict
+    ) -> None:
+        """
+        Stage the per-item upload result file used by the SDC sync phase to
+        decide which ordinals to attempt structured-data writes on.
+
+        Replaces any existing result file for this item; we only care about
+        the latest uploader pass's verdict.
+        """
+        self.write_item_file(
+            partner,
+            dpla_id,
+            json.dumps(upload_result),
+            UPLOAD_RESULT_FILENAME,
+            APPLICATION_JSON,
+        )
+
+    def get_upload_result(self, partner: str, dpla_id: str) -> str | None:
+        """Read the per-item upload result file written by the uploader."""
+        return self.get_item_file(partner, dpla_id, UPLOAD_RESULT_FILENAME)
 
     def write_file_list(self, partner: str, dpla_id: str, file_urls: list[str]) -> None:
         """

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import datetime
 import json
 import logging
 import mimetypes
@@ -72,6 +73,19 @@ UPLOAD_RETRY_MAX_DELAY_SECS = 60
 # This cap ensures a single hung upload never freezes the whole session.
 UPLOAD_TIMEOUT_SECS = 3600  # 1 hour
 
+# Per-ordinal status strings written to <partner>/<dpla_id>/upload-result.json
+# and consumed by the SDC sync phase (PR 4). The SDC phase only attempts
+# wbsetclaims for ordinals whose status is UPLOADED or SKIPPED — the other
+# three mean no canonical Commons file exists at the expected title for this
+# ordinal in this run, so writing structured data would be pointing at the
+# wrong page or none at all.
+ORDINAL_UPLOADED = "UPLOADED"  # file just uploaded (or drift-moved into place)
+ORDINAL_SKIPPED = "SKIPPED"  # existing Commons file matches our SHA1
+ORDINAL_NOT_PRESENT = "NOT_PRESENT"  # no S3 asset to upload (downloader gap)
+ORDINAL_INELIGIBLE = "INELIGIBLE"  # S3 asset present but uploader chose not
+# to upload (bad MIME, download-only, unguessable extension, etc.)
+ORDINAL_FAILED = "FAILED"  # upload attempted, raised, did not land
+
 
 class UploadTimeoutError(RuntimeError):
     """Raised when a single file upload exceeds UPLOAD_TIMEOUT_SECS.
@@ -112,7 +126,19 @@ class Uploader:
         verbose: bool,
         dry_run: bool,
         duplicate_source_sha1s: set[str] | None = None,
-    ):
+    ) -> dict:
+        """Process one ordinal's source asset and return a per-ordinal result dict.
+
+        Return shape (consumed by process_item to assemble upload-result.json):
+          {"status": <ORDINAL_*>, "title": str | None,
+           "pageid": int | None, "error": str | None}
+
+        The status drives the SDC sync phase (PR 4): UPLOADED and SKIPPED
+        ordinals are eligible for wbsetclaims; NOT_PRESENT, INELIGIBLE, and
+        FAILED ordinals are not. `title` and `pageid` are populated only for
+        UPLOADED and SKIPPED; everything else has no canonical Commons page
+        to attach structured data to.
+        """
         temp_file = self.local_fs.get_temp_file()
 
         try:
@@ -122,7 +148,7 @@ class Uploader:
             if not self.s3_client.s3_file_exists(s3_path):
                 logging.info(f"{dpla_id} {ordinal} not present.")
                 self.tracker.increment(Result.SKIPPED)
-                return
+                return {"status": ORDINAL_NOT_PRESENT}
 
             s3_object = self.s3_client.get_s3().Object(S3_BUCKET, s3_path)
             file_size = s3_object.content_length
@@ -130,7 +156,7 @@ class Uploader:
             if file_size == 0:
                 logging.info(f"Skipping {dpla_id} {ordinal}: File size is 0.")
                 self.tracker.increment(Result.SKIPPED)
-                return
+                return {"status": ORDINAL_NOT_PRESENT}
 
             sha1 = s3_object.metadata.get(CHECKSUM, "")
             mime = s3_object.content_type
@@ -164,19 +190,19 @@ class Uploader:
                     if not dry_run:
                         self.s3_client.get_s3().Object(S3_BUCKET, s3_path).delete()
                     self.tracker.increment(Result.SKIPPED)
-                    return
+                    return {"status": ORDINAL_INELIGIBLE}
 
             if not check_content_type(mime):
                 logging.info(f"Skipping {dpla_id} {ordinal}: Bad content type: {mime}")
                 self.tracker.increment(Result.SKIPPED)
-                return
+                return {"status": ORDINAL_INELIGIBLE}
 
             if is_download_only(mime):
                 logging.info(
                     f"Skipping {dpla_id} {ordinal}: {mime} staged for conversion, not uploaded."
                 )
                 self.tracker.increment(Result.SKIPPED)
-                return
+                return {"status": ORDINAL_INELIGIBLE}
 
             ext = mimetypes.guess_extension(mime)
 
@@ -185,7 +211,7 @@ class Uploader:
                     f"Skipping {dpla_id} {ordinal}: Unable to guess extension for {mime}"
                 )
                 self.tracker.increment(Result.SKIPPED)
-                return
+                return {"status": ORDINAL_INELIGIBLE}
 
             page_title = get_page_title(
                 item_title=title,
@@ -219,7 +245,11 @@ class Uploader:
                         f"Skipping {dpla_id} {ordinal}: Already exists on commons."
                     )
                     self.tracker.increment(Result.SKIPPED)
-                    return
+                    return {
+                        "status": ORDINAL_SKIPPED,
+                        "title": page_title,
+                        "pageid": existing_file.pageid,
+                    }
                 logging.info(
                     f"Hash drift detected for {dpla_id} {ordinal}: "
                     f"SHA1 found at [[File:{existing_file.title(with_ns=False)}]]"
@@ -259,7 +289,14 @@ class Uploader:
                         )
                         if drift_action == "moved":
                             self.tracker.increment(Result.UPLOADED)
-                            return
+                            # After a successful move the same file page lives
+                            # at page_title; existing_file.pageid is preserved
+                            # by MediaWiki across moves so we can stamp it here.
+                            return {
+                                "status": ORDINAL_UPLOADED,
+                                "title": page_title,
+                                "pageid": existing_file.pageid,
+                            }
                         elif drift_action == "upload_and_tag":
                             drift_old_filename = existing_file.title(with_ns=False)
                             force_ignore_warnings = True
@@ -447,11 +484,21 @@ class Uploader:
                     self._tag_drift_duplicate(drift_old_filename, page_title, dpla_id)
                 self.tracker.increment(Result.UPLOADED)
                 self.tracker.increment(Result.BYTES, file_size)
+                return {
+                    "status": ORDINAL_UPLOADED,
+                    "title": page_title,
+                    "pageid": wiki_file_page.pageid,
+                }
+
+            # dry_run path falls through without uploading — flag as INELIGIBLE
+            # for SDC purposes (no real Commons file was placed in this run).
+            return {"status": ORDINAL_INELIGIBLE}
 
         except UploadTimeoutError:
             raise
         except Exception as ex:
             self.handle_upload_exception(ex)
+            return {"status": ORDINAL_FAILED, "error": str(ex)}
 
         finally:
             self.local_fs.clean_up_tmp_file(temp_file)
@@ -783,6 +830,13 @@ class Uploader:
                 self.s3_client, dpla_id, partner, len(files)
             )
 
+            # Per-ordinal results collected here are written to
+            # <partner>/<dpla_id>/upload-result.json at the end of this method,
+            # and read by the SDC sync phase to decide which ordinals are
+            # eligible for wbsetclaims. Schema: {ordinal_str: {status, title?,
+            # pageid?, error?}}.
+            ordinal_results: dict[str, dict] = {}
+
             for ordinal, _ in enumerate(
                 tqdm(
                     files, desc="Uploading Files", leave=False, unit="File", ncols=100
@@ -792,7 +846,7 @@ class Uploader:
                 logging.info(f"Page {ordinal}")
                 page_label = page_labels.get(ordinal, "")
                 try:
-                    self.process_file(
+                    result = self.process_file(
                         dpla_id,
                         title,
                         item_metadata,
@@ -805,7 +859,12 @@ class Uploader:
                         dry_run,
                         duplicate_source_sha1s=duplicate_source_sha1s,
                     )
+                    ordinal_results[str(ordinal)] = result
                 except UploadTimeoutError as ex:
+                    ordinal_results[str(ordinal)] = {
+                        "status": ORDINAL_FAILED,
+                        "error": str(ex),
+                    }
                     self.handle_upload_exception(ex)
                     break
 
@@ -832,6 +891,26 @@ class Uploader:
                 )
             except Exception as ex:
                 logging.warning(f"Orphan check failed for {dpla_id}: {ex}; continuing")
+
+            # Persist the per-ordinal results so the SDC sync phase (PR 4)
+            # knows which ordinals to attempt structured-data writes on.
+            # Best-effort: a write failure here is logged but doesn't fail the
+            # upload — the file was already on Commons successfully; SDC will
+            # just skip this item until the next uploader run.
+            if not dry_run and ordinal_results:
+                upload_result = {
+                    "run_at": datetime.datetime.now(datetime.timezone.utc).isoformat(
+                        timespec="seconds"
+                    ),
+                    "ordinals": ordinal_results,
+                }
+                try:
+                    self.s3_client.write_upload_result(partner, dpla_id, upload_result)
+                except Exception as ex:
+                    logging.warning(
+                        f"Failed to write upload-result.json for {dpla_id}: {ex}; "
+                        "continuing"
+                    )
 
         except Exception as ex:
             logging.warning(

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -809,11 +809,14 @@ class Uploader:
 
             item_metadata_result = self.s3_client.get_item_metadata(partner, dpla_id)
             if not item_metadata_result:
-                # The item isn't in S3 at all — it shouldn't be in the IDs CSV
-                # this run. Don't touch any existing upload-result.json; that
-                # state belongs to whatever run last produced it. This is
-                # purely a "we have no idea about this item" branch.
+                # Missing dpla-map.json. The item is in this run's IDs CSV but
+                # there's no metadata to work from — either get-ids-es never
+                # staged it, the object was deleted between phases, or this is
+                # a transient S3 hiccup. Persist an empty result so the SDC
+                # phase doesn't keep treating a prior run's UPLOADED ordinals
+                # as authoritative for an item we now lack metadata for.
                 self.tracker.increment(Result.ITEM_NOT_PRESENT)
+                self._persist_upload_result(partner, dpla_id, {}, dry_run)
                 return
 
             item_metadata = json.loads(item_metadata_result)

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -757,6 +757,45 @@ class Uploader:
         except Exception as ex:
             logging.warning(f"Failed to tag [[File:{old_filename}]] as duplicate: {ex}")
 
+    def _persist_upload_result(
+        self,
+        partner: str,
+        dpla_id: str,
+        ordinal_results: dict[str, dict],
+        dry_run: bool,
+    ) -> None:
+        """Write the per-item upload-result.json sidecar to S3.
+
+        Called at every non-exception exit path through process_item so the
+        sidecar always reflects what this run decided about this item — never
+        a stale verdict from a previous run. An empty ordinal_results dict is
+        the correct signal for "uploader saw the item but produced nothing
+        the SDC phase should write structured data on" (ineligible item,
+        missing institution Wikidata, zero-file manifest, etc.).
+
+        Dry-run path is intentionally a no-op: dry runs shouldn't mutate S3
+        any more than they mutate Commons.
+
+        Best-effort on the write itself: a failure here is logged but doesn't
+        propagate, since the upload work has already succeeded for any
+        ordinals that were processed and the SDC phase can re-derive on a
+        future uploader run.
+        """
+        if dry_run:
+            return
+        upload_result = {
+            "run_at": datetime.datetime.now(datetime.timezone.utc).isoformat(
+                timespec="seconds"
+            ),
+            "ordinals": ordinal_results,
+        }
+        try:
+            self.s3_client.write_upload_result(partner, dpla_id, upload_result)
+        except Exception as ex:
+            logging.warning(
+                f"Failed to write upload-result.json for {dpla_id}: {ex}; continuing"
+            )
+
     def process_item(
         self,
         dpla_id: str,
@@ -770,6 +809,10 @@ class Uploader:
 
             item_metadata_result = self.s3_client.get_item_metadata(partner, dpla_id)
             if not item_metadata_result:
+                # The item isn't in S3 at all — it shouldn't be in the IDs CSV
+                # this run. Don't touch any existing upload-result.json; that
+                # state belongs to whatever run last produced it. This is
+                # purely a "we have no idea about this item" branch.
                 self.tracker.increment(Result.ITEM_NOT_PRESENT)
                 return
 
@@ -784,6 +827,10 @@ class Uploader:
             ):
                 logging.info(f"Skipping {dpla_id}: Not eligible.")
                 self.tracker.increment(Result.SKIPPED)
+                # Persist an empty result so any prior upload-result.json
+                # doesn't keep telling the SDC phase the item is still SDC-able
+                # after eligibility was revoked.
+                self._persist_upload_result(partner, dpla_id, {}, dry_run)
                 return
 
             if self.category_ensurer:
@@ -803,6 +850,7 @@ class Uploader:
                         f"hub_institution_qid={hub_institution_qid!r}"
                     )
                     self.tracker.increment(Result.SKIPPED)
+                    self._persist_upload_result(partner, dpla_id, {}, dry_run)
                     return
 
             titles = get_list(
@@ -893,26 +941,17 @@ class Uploader:
                 logging.warning(f"Orphan check failed for {dpla_id}: {ex}; continuing")
 
             # Persist the per-ordinal results so the SDC sync phase (PR 4)
-            # knows which ordinals to attempt structured-data writes on.
-            # Best-effort: a write failure here is logged but doesn't fail the
-            # upload — the file was already on Commons successfully; SDC will
-            # just skip this item until the next uploader run.
-            if not dry_run and ordinal_results:
-                upload_result = {
-                    "run_at": datetime.datetime.now(datetime.timezone.utc).isoformat(
-                        timespec="seconds"
-                    ),
-                    "ordinals": ordinal_results,
-                }
-                try:
-                    self.s3_client.write_upload_result(partner, dpla_id, upload_result)
-                except Exception as ex:
-                    logging.warning(
-                        f"Failed to write upload-result.json for {dpla_id}: {ex}; "
-                        "continuing"
-                    )
+            # knows which ordinals to attempt structured-data writes on. Fires
+            # even when ordinal_results is empty (e.g. zero files in
+            # file_list.txt) so a previous run's results don't get treated as
+            # the current truth.
+            self._persist_upload_result(partner, dpla_id, ordinal_results, dry_run)
 
         except Exception as ex:
+            # Intentionally NOT writing upload-result.json on the catch-all
+            # exception path. The failure may be transient (S3 hiccup,
+            # pywikibot socket reset) and the previous result file — if any —
+            # is more likely to still be accurate than a fresh empty one.
             logging.warning(
                 f"Caught exception getting item info for {dpla_id}", exc_info=ex
             )


### PR DESCRIPTION
## Summary

Third step toward folding `sdc-sync` into the wikimedia-upload pipeline. The uploader now writes a per-item `upload-result.json` sidecar to `<partner>/<dpla_id>/upload-result.json` after every `process_item` run, recording each ordinal's outcome (status + Commons title + pageid). PR 4's SDC phase reads this file to decide which ordinals are eligible for `wbsetclaims`.

Independent of PRs #234 (already merged) and #236 (in flight). Doesn't touch sdc-sync.py.

## Schema

```json
{
  "run_at": "2026-05-25T03:42:52+00:00",
  "ordinals": {
    "1": {"status": "UPLOADED",   "title": "File:Foo (page 1).jpg", "pageid": 123456},
    "2": {"status": "SKIPPED",    "title": "File:Foo (page 2).jpg", "pageid": 123457},
    "3": {"status": "FAILED",     "error": "ratelimited"}
  }
}
```

| Status | Meaning | Eligible for SDC (PR 4)? |
|---|---|---|
| `UPLOADED` | Fresh upload, or drift-corrected into the expected title | ✅ |
| `SKIPPED` | Existing Commons file already matches our SHA1 | ✅ |
| `NOT_PRESENT` | No S3 asset to upload (downloader gap) | ❌ |
| `INELIGIBLE` | S3 asset present but uploader chose not to upload (bad MIME, download-only, unguessable extension, dry-run) | ❌ |
| `FAILED` | Upload attempted, raised, did not land | ❌ |

The `pageid` stamp on UPLOADED/SKIPPED entries lets the PR 4 SDC phase derive the MediaInfo ID (`M<pageid>`) without an extra `wbgetentities` per ordinal.

## Implementation

- **`tools/uploader.py`**
  - `process_file` returns a per-ordinal result dict (was: `None`). Each return path stamps `status` and — for UPLOADED/SKIPPED — `title` + `pageid`. `pageid` comes straight from the upload response (`wiki_file_page.pageid`) or the matched existing-file lookup (`existing_file.pageid`).
  - `process_item` collects the dicts into `ordinal_results`, wraps with `run_at`, and writes via `s3_client.write_upload_result`. Write failure is logged and ignored — the uploads themselves already succeeded; the SDC phase will simply skip the item until the next uploader pass.
  - `dry_run` path records as `INELIGIBLE` so SDC never tries to attach claims to a never-uploaded file.
- **`ingest_wikimedia/s3.py`**
  - `UPLOAD_RESULT_FILENAME = "upload-result.json"` constant.
  - `write_upload_result(partner, dpla_id, upload_result)` / `get_upload_result(partner, dpla_id)` helpers mirroring the existing `write_item_metadata` pair. Replace-on-write semantics: each uploader run produces a fresh result file (PR 4 needs current truth, not history).

## Test plan

- [x] `ruff check` + `ruff format` clean.
- [x] `pytest tests/test_uploader.py` — 5/5 pass (no test surface changes; just verifying the return-type refactor didn't break anything).
- [x] End-to-end on EC2 against the Grant County aerial-view item (DPLA ID `0850fba9...` / partner `minnesota` / Commons `M180091486`): uploader reports `SKIPPED: 1` (matches existing on Commons), `upload-result.json` lands in S3 with `status=SKIPPED, title=Aerial view…, pageid=180091486`. Exactly what PR 4 needs.
- [ ] Multi-page item — will exercise during PR 4 verification.

## Next

- **PR 4** — `sdc-sync` reads pre-computed `sdc.json` (from PR #236) and `upload-result.json` (from this PR), writes SDC only for ordinals with status in `{UPLOADED, SKIPPED}`. Partner-driven entry point replaces `--cat/--file/--lists`.
- **PR 5** — `/wikimedia-upload sdc <target>` Slack command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR makes the uploader emit a per-item sidecar at <partner>/<dpla_id>/upload-result.json after each successful process_item run. Each sidecar contains a run_at UTC timestamp and an ordinals mapping of ordinal → result objects with a status and, for UPLOADED/SKIPPED, Commons title and pageid. Example schema:

{
  "run_at": "2026-05-25T03:42:52+00:00",
  "ordinals": {
    "1": {"status": "UPLOADED", "title": "File:Foo (page 1).jpg", "pageid": 123456},
    "2": {"status": "SKIPPED", "title": "File:Foo (page 2).jpg", "pageid": 123457},
    "3": {"status": "FAILED", "error": "ratelimited"}
  }
}

High-level changes
- The uploader now returns and collects structured per-ordinal result dicts from process_file and persists them as <partner>/<dpla_id>/upload-result.json at the end of process_item (non-dry runs).
- New ordinal statuses and SDC eligibility:
  - UPLOADED, SKIPPED → eligible for SDC (handled in next PR).
  - NOT_PRESENT, INELIGIBLE, FAILED → not eligible.
- Writes to S3 use replace-on-write semantics (each run publishes current truth). S3 write failures are logged and ignored so they do not abort processing.
- Dry runs record INELIGIBLE for ordinals and do not persist upload-result.json.
- Early-exit cases now persist an explicit empty ordinals mapping {} in upload-result.json where appropriate (notably when item metadata is missing), ensuring the uploader signals "stop SDC for this item" instead of leaving a stale prior result file. The catch-all exception path still intentionally avoids writing upload-result.json.
- Per-ordinal UploadTimeoutError is recorded as ORDINAL_FAILED and does not abort the rest of the item’s ordinals.

Files changed (high-level)
- ingest_wikimedia/s3.py
  - Added UPLOAD_RESULT_FILENAME = "upload-result.json".
  - Added S3Client.write_upload_result(partner, dpla_id, upload_result) to serialize and write per-item JSON (replace-on-write).
  - Added S3Client.get_upload_result(partner, dpla_id) to read the per-item JSON (returns None if absent).

- tools/uploader.py
  - Added ordinal status constants: ORDINAL_UPLOADED, ORDINAL_SKIPPED, ORDINAL_NOT_PRESENT, ORDINAL_INELIGIBLE, ORDINAL_FAILED.
  - process_file(...) now returns a per-ordinal result dict (status + optional title/pageid/error).
  - process_item(...) accumulates ordinal_results keyed by ordinal (strings), attaches run_at (UTC ISO), and persists via s3_client.write_upload_result for non-dry runs; several early-exit paths now persist an explicit empty ordinals payload when appropriate.
  - Added Uploader._persist_upload_result(...) helper. UploadTimeoutError and other per-ordinal failures are recorded per-ordinal instead of aborting the item loop.

Testing & verification
- ruff checks/formatting clean.
- pytest tests/test_uploader.py: 5/5 pass.
- End-to-end EC2 run on a Grant County item produced an expected SKIPPED result and upload-result.json in S3.
- Consumption of multi-page items by the SDC sync will be validated in PR 4.

Deployment & infrastructure impact (explicit)
- No manual pipeline trigger or ECS redeployment required.
- No environment variable or AWS Secrets Manager key additions/removals/renames.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No modifications to public-facing APIs or response shapes.
- No new credential handling; uses existing S3 write semantics and existing S3 permissions are sufficient.

Next steps
- PR 4 will read upload-result.json (and sdc.json) to decide which ordinals receive wbsetclaims.
- PR 5 will add a Slack command to surface/act on upload-result data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->