### PR TITLE
uploader: fix wikimedia-wikimedia- double-prefix in upload-complete Slack

### DIFF
--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1047,8 +1047,13 @@ def main(ids_file, partner: str, dry_run: bool, verbose: bool) -> None:
         # calls — for typical runs replication has settled long before this.
         _post_upload_touch_new_institutions(commons_site, category_ensurer, dry_run)
         notify_upload_complete(
+            # Bare partner slug, not "wikimedia-<partner>" — notify_upload_complete
+            # always prepends "wikimedia-" itself (matching the bare-label
+            # convention notify_phase_start and notify_download_complete use).
+            # Passing the pre-prefixed form yielded "wikimedia-wikimedia-<partner>"
+            # in standalone runs after PR #199 refactored these helpers.
             tracker=tracker,
-            partner_label=f"wikimedia-{partner}",
+            partner_label=partner,
             elapsed_seconds=elapsed,
             dry_run=dry_run,
         )


### PR DESCRIPTION
## Summary

One-line fix for a Slack-label regression that's been present since PR #199 (May 13). Standalone uploader runs (where `WIKIMEDIA_SESSION_LABEL` is unset in the environment) have been posting the upload-complete message with `wikimedia-wikimedia-<partner>` as the label.

## Cause

PR #199 refactored `notify_upload_complete` to do the `wikimedia-` prefixing itself, on the implicit contract that callers pass a **bare** partner slug — the same contract `notify_phase_start` and `notify_download_complete` already use. The uploader caller wasn't updated to match: it still passed `partner_label=f"wikimedia-{partner}"`, which the function then wrapped again into `wikimedia-wikimedia-<partner>`.

Why it slipped: when `WIKIMEDIA_SESSION_LABEL` *is* set (the wikimedia-launch pipeline path), the env value supplies the label and the function's prepending works correctly — so the bug only surfaces in standalone runs.

## Fix

Drop the redundant wrapping at the one offending call site:

```diff
 notify_upload_complete(
     tracker=tracker,
-    partner_label=f"wikimedia-{partner}",
+    partner_label=partner,
     elapsed_seconds=elapsed,
     dry_run=dry_run,
 )
```

The downloader-side call (`notify_download_complete(... partner_label=partner ...)`) is already correct and unchanged.

## Test plan

- [x] `ruff check` clean.
- [ ] Next standalone uploader run will produce `Wikimedia Upload Complete: wikimedia-<partner>` (no double prefix). The Grant County one-off I just ran produced `wikimedia-wikimedia-minnesota`; this fix makes it `wikimedia-minnesota`.
- [ ] Normal wikimedia-launch pipeline runs are unaffected (they use `WIKIMEDIA_SESSION_LABEL` and ignore `partner_label`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes a Slack-label regression in the uploader where standalone runs produced messages like `wikimedia-wikimedia-<partner>` by passing a pre-prefixed partner label to notify_upload_complete. The uploader now passes the bare partner slug so notify_upload_complete's internal `wikimedia-` prefix produces the correct `wikimedia-<partner>` label.

## Changes

- tools/uploader.py
  - Changed notify_upload_complete(..., partner_label=f"wikimedia-{partner}", ...) → partner_label=partner
  - Added inline comment clarifying the bare-partner-label convention
  - Lines changed: +6 / -1

## Technical details

- Root cause: PR `#199` refactored notify_upload_complete to prepend `wikimedia-` itself, so callers must supply a bare partner slug. The uploader call site was still supplying a prefixed label, resulting in double-prefixing; downloader call site already passed a bare slug and required no change.
- The bug only appeared in standalone uploader runs when WIKIMEDIA_SESSION_LABEL is unset. When that environment variable is set (normal wikimedia-launch pipeline), its value masked the issue.
- Lint: ruff check clean.
- Tests: existing unit tests for slack helpers cover related behavior; manual verification planned (next standalone uploader run should show: "Wikimedia Upload Complete: wikimedia-<partner>").

## Deployment / infra / security notes

- No pipeline trigger, ECS redeploy, or other deployment special action required — change is code-only and takes effect when the updated code runs.
- No environment variables, AWS Secrets Manager keys, database migrations, shared infrastructure configuration, or public API changes were added/removed/renamed.
- No security implications introduced (no credential handling or new external inputs).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->