### PR TITLE
uploader: skip duplicate-tagging when 'old title' is another current ordinal

### DIFF
--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -675,3 +675,110 @@ def test_orphan_check_skips_redirect_but_continues_probing():
     assert candidate_arg.title() == real_orphan_title
     assert tracker.count(Result.ORPHANS_TAGGED) == 1
     assert tracker.count(Result.ORPHANS_FLAGGED) == 0
+
+
+# --------------------------------------------------------------------------
+# Uploader._resolve_hash_drift — Case 2 skips tag when title is in asset list
+# --------------------------------------------------------------------------
+
+
+def _build_uploader_with_dpla(other_item_exists: bool = True) -> "object":
+    from tools.uploader import Uploader
+
+    dpla = MagicMock()
+    dpla.get_item_metadata.return_value = (
+        {"sourceResource": {}} if other_item_exists else None
+    )
+    return Uploader(
+        tracker=Tracker(),
+        local_fs=MagicMock(),
+        s3_client=MagicMock(),
+        dpla=dpla,
+        site=MagicMock(),
+        category_ensurer=None,
+    )
+
+
+def _drift_existing_file(title: str) -> MagicMock:
+    f = MagicMock()
+    f.title.return_value = title
+    return f
+
+
+def test_resolve_hash_drift_case2_skips_tag_when_existing_in_expected_titles():
+    """The bug fix: when existing file's title is one of THIS item's other
+    current asset positions, it's a sibling, not an orphan. The duplicate tag
+    would be wasted (the sibling's content will be overwritten by its own
+    ordinal in this same run), so route to upload_only."""
+    uploader = _build_uploader_with_dpla()
+    # Existing file: page N+1 of the SAME item, will be processed soon.
+    existing_title = "Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page 5).jpg"
+    intended_title = "Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page 4).jpg"
+    expected_titles = {
+        f"Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page {n}).jpg"
+        for n in range(1, 10)
+    }
+    # intended_page: exists with different content (Case 2 territory).
+    intended_page = MagicMock()
+    intended_page.exists.return_value = True
+    intended_page.isRedirectPage.return_value = False
+    intended_page.title.return_value = intended_title
+    with patch("tools.uploader.get_page", return_value=intended_page):
+        action = uploader._resolve_hash_drift(
+            existing_file=_drift_existing_file(existing_title),
+            page_title=intended_title,
+            dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ordinal=4,
+            wiki_markup="",
+            expected_item_titles=expected_titles,
+        )
+    assert action == "upload_only"
+
+
+def test_resolve_hash_drift_case2_still_tags_when_existing_is_true_orphan():
+    """When the existing file's title is NOT in the current asset list (i.e.
+    it's a trailing orphan beyond what the source authorizes), the tag is
+    still correct and Case 2 should fire as before."""
+    uploader = _build_uploader_with_dpla()
+    # Existing file at (page 99) — way beyond our asset list of pages 1..9.
+    existing_title = "Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page 99).jpg"
+    intended_title = "Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page 4).jpg"
+    expected_titles = {
+        f"Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page {n}).jpg"
+        for n in range(1, 10)
+    }
+    intended_page = MagicMock()
+    intended_page.exists.return_value = True
+    intended_page.isRedirectPage.return_value = False
+    intended_page.title.return_value = intended_title
+    with patch("tools.uploader.get_page", return_value=intended_page):
+        action = uploader._resolve_hash_drift(
+            existing_file=_drift_existing_file(existing_title),
+            page_title=intended_title,
+            dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ordinal=4,
+            wiki_markup="",
+            expected_item_titles=expected_titles,
+        )
+    assert action == "upload_and_tag"
+
+
+def test_resolve_hash_drift_case2_tags_when_expected_titles_is_none():
+    """Backward-compat: callers that don't pass expected_item_titles see
+    Case 2 firing as before (no behavior change in that path)."""
+    uploader = _build_uploader_with_dpla()
+    existing_title = "Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page 5).jpg"
+    intended_title = "Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page 4).jpg"
+    intended_page = MagicMock()
+    intended_page.exists.return_value = True
+    intended_page.isRedirectPage.return_value = False
+    intended_page.title.return_value = intended_title
+    with patch("tools.uploader.get_page", return_value=intended_page):
+        action = uploader._resolve_hash_drift(
+            existing_file=_drift_existing_file(existing_title),
+            page_title=intended_title,
+            dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ordinal=4,
+            wiki_markup="",
+        )
+    assert action == "upload_and_tag"

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -126,6 +126,7 @@ class Uploader:
         verbose: bool,
         dry_run: bool,
         duplicate_source_sha1s: set[str] | None = None,
+        expected_item_titles: set[str] | None = None,
     ) -> dict:
         """Process one ordinal's source asset and return a per-ordinal result dict.
 
@@ -286,6 +287,7 @@ class Uploader:
                             dpla_id=dpla_id,
                             ordinal=ordinal,
                             wiki_markup=wiki_markup,
+                            expected_item_titles=expected_item_titles,
                         )
                         if drift_action == "moved":
                             self.tracker.increment(Result.UPLOADED)
@@ -643,6 +645,7 @@ class Uploader:
         dpla_id: str,
         ordinal: int,
         wiki_markup: str | None = None,
+        expected_item_titles: set[str] | None = None,
     ) -> str:
         """
         Determine and where possible resolve the case where our file's SHA1
@@ -724,10 +727,33 @@ class Uploader:
             )
             return "upload_only"
 
-        # Case 2: intended title has real content with a different hash, and the
-        # file found at the wrong title belongs to a different item (or has no
-        # recognisable DPLA ID). Upload the correct hash and tag the orphaned
-        # old title as a duplicate so it can be cleaned up.
+        # Case 2: intended title has real content with a different hash, and
+        # the file found at the wrong title belongs to a different item (or
+        # has no recognisable DPLA ID). Normally we upload the correct hash
+        # to the intended title AND tag the orphaned old title as a duplicate
+        # so it can be cleaned up.
+        #
+        # BUT: if the "old title" is itself an expected title for one of THIS
+        # item's other current asset positions, it is not an orphan — it's a
+        # legitimate ordinal that will be (or has been) processed by its own
+        # iteration of process_file in this same run, and will get its own
+        # correct content written there.  Tagging it as a duplicate at the
+        # current instant produces a tag pointing at a page whose content is
+        # about to change, which makes the tag wrong (and triggers admin
+        # deletion of a still-valid Commons file).  Skip the tag in that case
+        # and just upload our content to the intended title.
+        if expected_item_titles and actual_filename in expected_item_titles:
+            logging.info(
+                f"Title drift (Case 2 → upload_only): "
+                f"[[File:{intended_page.title(with_ns=False)}]] has a different "
+                f"hash and our SHA1 currently lives at "
+                f"[[File:{actual_filename}]], but that title is one of this "
+                f"item's current asset positions — it will be overwritten by "
+                f"its own ordinal's iteration. Uploading to "
+                f"[[File:{page_title}]] without tagging."
+            )
+            return "upload_only"
+
         logging.info(
             f"Title drift (Case 2): [[File:{intended_page.title(with_ns=False)}]] "
             f"has a different hash; will upload correct hash and tag "
@@ -881,6 +907,26 @@ class Uploader:
                 self.s3_client, dpla_id, partner, len(files)
             )
 
+            # Build the set of Commons titles this item's current asset list
+            # will produce.  _resolve_hash_drift uses this to recognise when
+            # an "old title" found via SHA1 lookup is actually one of THIS
+            # run's other ordinals (a soon-to-be-overwritten sibling, not a
+            # trailing orphan) and skip the duplicate-tagging in that case.
+            # Without this, Case 2 produces a cascade of wrong tags whenever
+            # source content has shifted within a multi-page item.
+            expected_item_titles: set[str] = set()
+            for ord_n, ext in ordinal_exts.items():
+                if not ext:
+                    continue
+                expected_item_titles.add(
+                    get_page_title(
+                        item_title=title,
+                        dpla_identifier=dpla_id,
+                        suffix=ext,
+                        page=page_labels.get(ord_n, ""),
+                    )
+                )
+
             # Per-ordinal results collected here are written to
             # <partner>/<dpla_id>/upload-result.json at the end of this method,
             # and read by the SDC sync phase to decide which ordinals are
@@ -909,6 +955,7 @@ class Uploader:
                         verbose,
                         dry_run,
                         duplicate_source_sha1s=duplicate_source_sha1s,
+                        expected_item_titles=expected_item_titles,
                     )
                     ordinal_results[str(ordinal)] = result
                 except UploadTimeoutError as ex:


### PR DESCRIPTION
## Summary

Fixes the multi-page tagging cascade bug observed today on `405714d95f606141d383ccc3ef22908b` (Petition Against the Annexation of Hawaii): **143 correct uploads, each paired with a wrong `{{Duplicate}}` tag** on the next page in the series.

## What happened

When a multi-page item's source content shifts — e.g. an interior page is removed and everything after it renumbers down by one (or, in this case, a PDF in the middle moved from `(page 369).pdf` to no-suffix `.pdf`, shifting all later JPGs by -1) — every ord N in `process_item` finds its SHA1 already on Commons at `(page N+1)`. That's where the prior session put what is now ord N's content.

`_resolve_hash_drift`'s Case 2 then fires: upload new content to `(page N)` AND tag `(page N+1)` as a duplicate.

The tag is **technically truthful at the instant of tagging** — both files briefly share a SHA1, because the new upload to `(page N)` just landed the same content that's been at `(page N+1)`. But ~3 seconds later ord N+1 iterates and overwrites `(page N+1)` with its own actual content. The tag now points at a page whose content no longer matches the page it's claimed-duplicate-of.

Worse, the tag is an active request for an admin to delete a perfectly valid Commons file.

Verified on the Hawaii item: all 142 tags landed on pages that were overwritten 3-5 seconds later.

## The fix

When `process_item` computes the asset list's per-extension page labels, also derive the full set of **expected Commons titles for this item**. Pass it down to `_resolve_hash_drift`.

In Case 2, if `existing_file.title` is in that set, it's a sibling ordinal that will be processed by its own iteration in this same run — not a trailing orphan. Route to `upload_only` (overwrite our intended title, no tag).

True trailing orphans (titles beyond the asset count) still flow through Case 2 normally; PR #227's post-item orphan check picks them up afterward.

## Why this is the right place to fix

The information needed (\"is this an in-the-current-asset-list title\") is already known by `process_item` because it just computed the page labels for every ordinal. Passing the derived title set is a one-time per-item cost. The check itself is a single set-membership lookup per drift event. No new I/O.

The existing PR #231 fix (skip drift when source has the same SHA1 at multiple positions) handles a related-but-distinct case: positions in the *current* source that legitimately share content. This PR handles the case where positions in *prior session's Commons state* will be reprocessed.

## Test plan
- [x] `pytest tests/test_uploader.py` — 21 tests pass (18 existing + 3 new)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- New tests cover: (a) the new short-circuit fires when existing-title is in expected set, (b) Case 2 still fires for true trailing orphans, (c) backward compat when the new parameter is omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a bug in the multi-page item upload process where orphaned "duplicate" tags are left on valid file pages, incorrectly requesting admin deletion.

### The Bug

When a multi-page item's source content shifts (e.g., interior pages are removed and everything after renumbers down by one), every asset ordinal N finds its SHA1 already on Commons at position N+1 (where the prior session left that content). The `_resolve_hash_drift` Case 2 logic then:
1. Uploads new content to page N
2. Tags page N+1 as {{Duplicate}}

However, ~3 seconds later, the iteration for ordinal N+1 overwrites page N+1 with its own correct content, leaving the {{Duplicate}} tag pointing at valid, unrelated content—suggesting the file should be deleted.

Real-world impact: DPLA item 405714d95f606141d383ccc3ef22908b accumulated 142 incorrect duplicate tags on 142 distinct pages, each of which was then overwritten with correct content seconds later.

### The Fix

When `process_item` computes the per-extension page labels, it now also derives the full set of expected Commons titles for all current asset ordinals and passes it to `_resolve_hash_drift`.

In Case 2, when the "wrong-title" page (identified by SHA1 drift) is actually one of this item's own expected titles for another ordinal being processed in the same run, the logic:
- Routes to `"upload_only"` (overwrites the sibling's page, no tag)
- Instead of `"upload_and_tag"` (which would tag a file about to be overwritten)

True trailing orphans (titles beyond the asset count) continue through Case 2's normal path; PR `#227`'s post-item orphan checks handle them afterward.

### Implementation Details

**Method signatures updated**:
- `Uploader.process_file(...)` adds parameter `expected_item_titles: set[str] | None = None`
- `Uploader._resolve_hash_drift(...)` adds parameter `expected_item_titles: set[str] | None = None`

**Logic**: In `_resolve_hash_drift` Case 2, a simple set membership check determines whether the existing file's title is a sibling ordinal or a true orphan. No new I/O; the required information is already available in `process_item`.

**Backward compatibility**: The new parameter defaults to `None`, and callers that omit it see Case 2 firing as before.

### Testing

Three new tests verify:
1. When the existing file's title is in the `expected_item_titles` set, `_resolve_hash_drift` returns `"upload_only"`
2. When that title is not in the set (true orphan), the method returns `"upload_and_tag"` as before
3. When `expected_item_titles` is omitted (backward-compat path), the method returns `"upload_and_tag"`

All 21 tests pass (18 existing + 3 new); ruff checks and formatting are clean.

### Deployment Notes

Code-only changes with no infrastructure, environment variables, API response shape modifications, or database migrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->