### PR TITLE
wikimedia-kill: accept the same target formats as wikimedia-launch

### DIFF
--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -23,6 +23,11 @@ _QID_RE = re.compile(r"^Q\d+$")
 # IDs pasted in uppercase or mixed-case are recognised correctly.
 _DPLA_ID_RE = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)
 
+# Pattern that strips any character not allowed in a tmux-safe session-label
+# slug.  Anything outside [a-z0-9-] is removed; whitespace is converted to
+# hyphens first.  See slugify_session_label_component().
+_SLUG_STRIP_RE = re.compile(r"[^a-z0-9-]")
+
 # All DPLA partner hubs: canonical slug → hub display name (as used in institutions_v2.json)
 PARTNER_HUBS: dict[str, str] = {
     "artstor": "Artstor",
@@ -174,6 +179,21 @@ def is_item_upload_eligible(
     if not inst_data.get("Wikidata", ""):
         return False
     return hub.get("upload", False) or inst_data.get("upload", False)
+
+
+def slugify_session_label_component(name: str) -> str:
+    """Normalize a display name to the tmux-safe slug used in session labels.
+
+    Session-label components are lowercase alphanumeric + hyphens.  Whitespace
+    becomes hyphens; everything else (apostrophes, ampersands, commas, slashes,
+    accents, etc.) is stripped.
+
+    Both wikimedia_launch (which produces session names) and wikimedia_kill
+    (which matches them) MUST use this same function — otherwise an institution
+    name like ``AT&T Archives`` would launch as ``att-archives`` but never
+    match when ``kill`` derives its target slug from a different rule.
+    """
+    return _SLUG_STRIP_RE.sub("", name.lower().replace(" ", "-"))
 
 
 def is_wikidata_id(s: str) -> bool:

--- a/scripts/wikimedia_kill.py
+++ b/scripts/wikimedia_kill.py
@@ -1,12 +1,22 @@
 #!/usr/bin/env python3
 """Kill a running Wikimedia upload pipeline session on EC2.
 
-Finds all tmux sessions whose name contains any of the given label components
-(e.g. "indiana-state-library" matches "wikimedia-indiana-state-library" and
-"wikimedia-bpl+indiana-state-library"), kills them, and posts a Slack notification.
+Accepts the SAME target formats as wikimedia_launch.py so that any string
+a user gave to ``/wikimedia-upload`` can be re-used verbatim with
+``/wikimedia-upload kill``:
 
-Targets are the session label suffix shown by /wikimedia-status (e.g. "bpl",
-"indiana-state-library"). Wikidata QIDs are also accepted and resolved to labels.
+  * Hub slug              — ``bpl``
+  * Hub|institution        — ``"indiana|Indiana State Library"``
+  * Hub|institution|coll  — ``"nara|Center for Legislative Archives|RG46"``
+  * Wikidata QID          — ``Q12345`` (resolves to hub or institution)
+  * DPLA item ID          — 32-hex-char single-item launch label
+  * Bare component slug   — ``indiana-state-library`` (kept for back-compat
+                            with the prior matcher; matches any session
+                            whose name contains it as a +-separated part)
+
+Each token is normalized to the same session-label suffix that
+wikimedia_launch.py would produce, then matched against running
+``wikimedia-*`` tmux sessions and killed.
 
 Environment variables:
   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY  — IAM credentials with ssm:SendCommand
@@ -22,7 +32,13 @@ import sys
 import boto3
 import requests
 
-from ingest_wikimedia.partners import is_wikidata_id, resolve_slug, resolve_wikidata_id
+from ingest_wikimedia.partners import (
+    is_dpla_id,
+    is_wikidata_id,
+    resolve_slug,
+    resolve_wikidata_id,
+    slugify_session_label_component,
+)
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run
 
@@ -41,6 +57,134 @@ def _slack_fail(response_url: str, msg: str) -> None:
         except Exception as e:
             logging.warning("Failed to post to Slack response_url: %s", e)
     sys.exit(1)
+
+
+class _UnknownHub(ValueError):
+    """Raised by resolve_kill_components when a hub|institution token names an unknown hub."""
+
+
+def resolve_kill_components(target_tokens: list[str]) -> list[frozenset[str]]:
+    """Translate a list of user-supplied target tokens into session-label
+    component GROUPS for kill-matching.
+
+    Each token produces ONE group (a frozenset of session-label slugs).  A
+    session is killed only if at least one group is a SUBSET of the
+    session's component set (the part after ``wikimedia-``, split by ``+``).
+    This scopes the kill to exactly the launch-time session label that
+    produced it:
+
+      * ``bpl`` → ``{bpl}`` — matches any wikimedia-bpl[+…] session
+        (full-hub kill).
+      * ``nara|Lyndon Baines Johnson Library`` →
+        ``{nara, lyndon-baines-johnson-library}`` — matches
+        wikimedia-nara+lyndon-baines-johnson-library[+…] and nothing
+        else (NOT bare wikimedia-nara, NOT a different hub that happens
+        to share an institution slug).
+      * ``nara|Center for Legislative Archives|RG46`` →
+        ``{nara, center-for-legislative-archives, rg-46}`` — matches
+        ONLY the specific collection sub-session.  In particular, this
+        is what fixes the original bug: a flat component list would
+        kill the parent institution session (because
+        ``center-for-legislative-archives`` alone intersected) AND any
+        unrelated ``*+rg-46`` session.
+      * Wikidata QID → one group per (canonical, institution_or_None)
+        match, shaped the same way as the hub|institution form.
+      * DPLA item ID → ``{first_8_hex}``; single-item launch labels
+        carry that 8-hex string in the institution position.
+      * Bare component slug (back-compat) → ``{slug}``, single-element
+        group matching any session containing that component.
+
+    Accepts the same token shapes as wikimedia_launch.  Groups are
+    deduplicated in first-seen order.  Raises :class:`_UnknownHub` for
+    ``hub|…`` tokens whose hub prefix doesn't resolve; raises
+    :class:`ValueError` for unknown Wikidata QIDs — both so the caller
+    can produce a user-facing Slack error.
+    """
+    groups: list[frozenset[str]] = []
+    seen: set[frozenset[str]] = set()
+
+    def _add(group: frozenset[str]) -> None:
+        if group and group not in seen:
+            seen.add(group)
+            groups.append(group)
+
+    def _slug_or_raise(name: str, role: str, token: str) -> str:
+        """Slugify or raise with a user-facing error if the result is empty.
+
+        slugify_session_label_component returns "" when the input is purely
+        punctuation (e.g. "&&&", "..."), which would otherwise produce a
+        group containing the empty string — impossible to match against any
+        real tmux session label, so the kill would silently no-op rather
+        than tell the user their input is malformed.
+        """
+        slug = slugify_session_label_component(name)
+        if not slug:
+            raise ValueError(
+                f"{role} {name!r} in token {token!r} normalizes to an empty slug "
+                f"(input is punctuation-only after slugifying); cannot match a session."
+            )
+        return slug
+
+    for raw_token in target_tokens:
+        # Strip once at the top so classification predicates (is_wikidata_id,
+        # is_dpla_id) and slug lookups all see the same normalized form. Without
+        # this, a token like " 405714D9... " or " indiana-state-library " would
+        # silently fall through to the bare-slug branch (or fail entirely),
+        # never matching anything in main()'s subset check.
+        token = raw_token.strip()
+        if not token:
+            continue
+        if is_wikidata_id(token):
+            resolved = resolve_wikidata_id(token)
+            if not resolved:
+                raise ValueError(
+                    f"No hub or institution found for Wikidata ID {token!r} in institutions_v2.json."
+                )
+            for canonical, institution in resolved:
+                if institution:
+                    _add(
+                        frozenset(
+                            {
+                                canonical,
+                                _slug_or_raise(institution, "Institution", token),
+                            }
+                        )
+                    )
+                else:
+                    _add(frozenset({canonical}))
+        elif is_dpla_id(token):
+            # Single-item launch labels carry the first 8 hex chars of the
+            # DPLA ID as their institution-position slug (see
+            # wikimedia_launch._add_target); match that.  An 8-hex string
+            # is unique enough that a single-component group is safe.
+            _add(frozenset({token.lower()[:8]}))
+        elif "|" in token:
+            # hub | institution [| collection]: build a group containing
+            # the canonical hub plus the institution/collection slugs.
+            # main()'s subset check then requires ALL of them be present
+            # together — so a collection token can't kill the parent
+            # institution session, and an institution slug can't cross
+            # to a different hub that happens to share it.
+            parts = token.split("|", 2)
+            hub_part = parts[0].strip()
+            canonical = resolve_slug(hub_part)
+            if canonical is None:
+                raise _UnknownHub(f"Unknown hub {hub_part!r} in target {token!r}.")
+            group: set[str] = {canonical}
+            if len(parts) >= 2:
+                inst = parts[1].strip()
+                if inst:
+                    group.add(_slug_or_raise(inst, "Institution", token))
+            if len(parts) == 3:
+                coll = parts[2].strip()
+                if coll:
+                    group.add(_slug_or_raise(coll, "Collection", token))
+            _add(frozenset(group))
+        else:
+            # Bare hub slug or already-a-component slug — single-component
+            # group matching any session containing that component.
+            _add(frozenset({resolve_slug(token) or token}))
+    return groups
 
 
 def main() -> None:
@@ -62,33 +206,12 @@ def main() -> None:
     except ValueError as e:
         _slack_fail(response_url, f"Could not parse --partner: {e}")
 
-    # Each token is a session label component to match exactly (e.g. "bpl",
-    # "indiana-state-library"). QIDs are resolved to the appropriate component.
-    kill_components: list[str] = []
-    seen: set[str] = set()
+    try:
+        kill_groups = resolve_kill_components(target_tokens)
+    except (ValueError, _UnknownHub) as e:
+        _slack_fail(response_url, str(e))
 
-    for token in target_tokens:
-        if is_wikidata_id(token):
-            resolved = resolve_wikidata_id(token)
-            if not resolved:
-                _slack_fail(
-                    response_url,
-                    f"No hub or institution found for Wikidata ID {token!r} in institutions_v2.json.",
-                )
-            for canonical, institution in resolved:
-                component = (
-                    institution.lower().replace(" ", "-") if institution else canonical
-                )
-                if component not in seen:
-                    seen.add(component)
-                    kill_components.append(component)
-        else:
-            component = resolve_slug(token) or token
-            if component not in seen:
-                seen.add(component)
-                kill_components.append(component)
-
-    if not kill_components:
+    if not kill_groups:
         _slack_fail(response_url, "No targets specified.")
 
     ssm = boto3.client("ssm", region_name=REGION)
@@ -99,15 +222,18 @@ def main() -> None:
     except Exception as e:
         _slack_fail(response_url, f"⚠️ Failed to list tmux sessions: {e}")
 
-    component_set = set(kill_components)
     killed: list[str] = []
     failed: list[str] = []
     for line in tmux_list.splitlines():
         session_name = line.split(":")[0].strip()
         if not session_name.startswith("wikimedia-"):
             continue
+        # Subset, not intersection: every component in at least one group
+        # must be present in the session's label.  Intersection would let
+        # a collection token kill the parent institution session, and an
+        # institution slug bleed across hubs — see resolve_kill_components.
         components = set(session_name[len("wikimedia-") :].split("+"))
-        if component_set & components:
+        if any(group <= components for group in kill_groups):
             print(f"Killing session {session_name}...")
             try:
                 ssm_run(ssm, f"tmux kill-session -t {shlex.quote(session_name)}")
@@ -128,7 +254,11 @@ def main() -> None:
     elif killed:
         msg = f"🛑 Killed Wikimedia pipeline session(s): {', '.join(f'`{s}`' for s in killed)}"
     else:
-        msg = f"No running Wikimedia sessions found matching: {', '.join(f'`{c}`' for c in kill_components)}"
+        # Render each group as the '+'-joined component list a matching
+        # tmux session would carry; that's the most readable form for the
+        # user and mirrors how the session names actually look.
+        group_strs = ["+".join(sorted(g)) for g in kill_groups]
+        msg = f"No running Wikimedia sessions found matching: {', '.join(f'`{s}`' for s in group_strs)}"
 
     print(msg)
     if slack_token:

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -26,7 +26,6 @@ Environment variables:
 import argparse
 import logging
 import os
-import re
 import shlex
 import sys
 from typing import NoReturn
@@ -42,6 +41,7 @@ from ingest_wikimedia.partners import (
     parse_session_labels,
     resolve_slug,
     resolve_wikidata_id,
+    slugify_session_label_component,
 )
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run
@@ -49,13 +49,13 @@ from ingest_wikimedia.ssm import REGION, ssm_run
 # Each ingest session peaks at ~300–500 MB; 30% of 7.6 GB leaves headroom for 4–5 concurrent sessions.
 MEMORY_HEADROOM_PCT = 30
 
-# Pre-compiled pattern for normalizing display names to tmux-safe label slugs.
-_SLUG_RE = re.compile(r"[^a-z0-9-]")
-
-
-def _slugify(name: str) -> str:
-    """Normalize a display name to a tmux-safe slug (lowercase alphanumeric + hyphens)."""
-    return _SLUG_RE.sub("", name.lower().replace(" ", "-"))
+# Tmux-safe session-label slugifier (lowercase alphanumeric + hyphens) lives in
+# ingest_wikimedia.partners as slugify_session_label_component so that
+# wikimedia_kill.py uses the IDENTICAL function — otherwise institutions whose
+# names contain stripped characters (e.g. ``AT&T``) would launch under one
+# slug and never match on kill.  Keep a short local alias for readability of
+# the call sites below.
+_slugify = slugify_session_label_component
 
 
 def _slack_fail(response_url: str, msg: str) -> NoReturn:

--- a/tests/test_wikimedia_kill.py
+++ b/tests/test_wikimedia_kill.py
@@ -1,0 +1,307 @@
+"""Tests for scripts/wikimedia_kill.py — the input-format parsing that makes
+``/wikimedia-upload kill <target>`` accept the same target strings as
+``/wikimedia-upload <target>``, AND the group-subset matching contract that
+keeps a collection-scoped kill from also killing the parent institution
+session (or vice-versa, or across hubs that share an institution slug).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from scripts.wikimedia_kill import resolve_kill_components, _UnknownHub
+
+
+def test_bare_hub_slug_resolves_to_single_element_group():
+    """``bpl`` → group ``{bpl}``; matches any wikimedia-bpl[+…] session."""
+    assert resolve_kill_components(["bpl"]) == [frozenset({"bpl"})]
+
+
+def test_bare_component_slug_passes_through_as_single_element_group():
+    """A pre-slugified institution component without a hub prefix is kept as-is
+    in a single-element group, preserving the back-compat 'kill by component
+    slug' behavior."""
+    assert resolve_kill_components(["indiana-state-library"]) == [
+        frozenset({"indiana-state-library"})
+    ]
+
+
+def test_hub_pipe_institution_builds_canonical_plus_institution_group():
+    """``nara|Lyndon Baines Johnson Library`` → group {nara,
+    lyndon-baines-johnson-library}. The group requires BOTH components
+    together: matches wikimedia-nara+lyndon-baines-johnson-library[+…]
+    but NOT bare wikimedia-nara, and NOT a different hub that happens
+    to share the institution slug."""
+    components = resolve_kill_components(["nara|Lyndon Baines Johnson Library"])
+    assert components == [frozenset({"nara", "lyndon-baines-johnson-library"})]
+
+
+def test_hub_pipe_institution_strips_non_alphanumeric():
+    """Institutions with punctuation (e.g. ``AT&T``) must slug identically on
+    launch and kill — the shared slugify strips ``&``, commas, etc.  The
+    canonical hub is still part of the group."""
+    components = resolve_kill_components(["nara|AT&T Archives, Inc."])
+    assert components == [frozenset({"nara", "att-archives-inc"})]
+
+
+def test_hub_pipe_institution_pipe_collection_includes_all_three():
+    """Three-part target → group {canonical, institution_slug, collection_slug}.
+    THE BUG FIX: a flat component list let `nara|Center for Legislative
+    Archives|RG46` also kill the parent institution session (because the
+    institution slug alone intersected) and any unrelated `*+rg-46`
+    session. Now the kill only fires when ALL THREE components are
+    present together in the session label."""
+    components = resolve_kill_components(["nara|Center for Legislative Archives|RG 46"])
+    assert components == [
+        frozenset({"nara", "center-for-legislative-archives", "rg-46"})
+    ]
+
+
+def test_dpla_id_resolves_to_first_8_hex_group():
+    """Single-item launch labels use the first 8 hex chars of the DPLA ID
+    as their tmux-label suffix; kill must mirror that. The 8-hex string
+    is unique enough that a single-component group is safe."""
+    components = resolve_kill_components(["405714d95f606141d383ccc3ef22908b"])
+    assert components == [frozenset({"405714d9"})]
+
+
+def test_dpla_id_case_insensitive():
+    """DPLA IDs from URLs are sometimes uppercase; normalize before slicing."""
+    components = resolve_kill_components(["405714D95F606141D383CCC3EF22908B"])
+    assert components == [frozenset({"405714d9"})]
+
+
+def test_unknown_hub_in_pipe_token_raises_unknown_hub():
+    """Hub prefix must resolve; otherwise raise _UnknownHub so the caller
+    can produce a user-facing Slack error referencing the bad token."""
+    with pytest.raises(_UnknownHub) as exc:
+        resolve_kill_components(["not-a-hub|Some Institution"])
+    assert "not-a-hub" in str(exc.value)
+
+
+def test_wikidata_qid_resolves_to_canonical_plus_institution_group():
+    """QID that matches an institution → group {canonical, institution_slug}
+    — same shape as the hub|institution form, for the same subset-match
+    safety reasons."""
+    with patch(
+        "scripts.wikimedia_kill.resolve_wikidata_id",
+        return_value=[("nara", "Herbert Hoover Library")],
+    ):
+        assert resolve_kill_components(["Q12345"]) == [
+            frozenset({"nara", "herbert-hoover-library"})
+        ]
+
+
+def test_wikidata_qid_resolves_to_canonical_only_when_no_institution():
+    """QID that matches a hub itself (no institution) → group {canonical}."""
+    with patch(
+        "scripts.wikimedia_kill.resolve_wikidata_id",
+        return_value=[("indiana", None)],
+    ):
+        assert resolve_kill_components(["Q67890"]) == [frozenset({"indiana"})]
+
+
+def test_wikidata_qid_unknown_raises_value_error():
+    with patch("scripts.wikimedia_kill.resolve_wikidata_id", return_value=[]):
+        with pytest.raises(ValueError) as exc:
+            resolve_kill_components(["Q99999"])
+    assert "Q99999" in str(exc.value)
+
+
+def test_deduplicates_identical_groups_first_seen_order():
+    """If two tokens produce the IDENTICAL group, only one is kept.
+    Different token shapes that produce different groups (e.g.
+    bare 'indiana-state-library' vs 'indiana|Indiana State Library')
+    are NOT duplicates — they have different match semantics (the
+    former matches any session containing the slug; the latter
+    requires the canonical hub to also be present)."""
+    components = resolve_kill_components(
+        [
+            "bpl",
+            "bpl",  # identical → deduped
+            "nara|Lyndon Baines Johnson Library",
+            "nara|Lyndon Baines Johnson Library",  # identical → deduped
+        ]
+    )
+    assert components == [
+        frozenset({"bpl"}),
+        frozenset({"nara", "lyndon-baines-johnson-library"}),
+    ]
+
+
+def test_bare_slug_and_hub_pipe_institution_produce_different_groups():
+    """The bare slug ``indiana-state-library`` produces a single-element
+    group (matches any session with that component, any hub).  The
+    ``indiana|Indiana State Library`` token produces a two-element group
+    requiring the indiana canonical too.  They are NOT duplicates — the
+    second form is strictly narrower."""
+    components = resolve_kill_components(
+        [
+            "indiana-state-library",
+            "indiana|Indiana State Library",
+        ]
+    )
+    assert components == [
+        frozenset({"indiana-state-library"}),
+        frozenset({"indiana", "indiana-state-library"}),
+    ]
+
+
+def test_handles_mixed_token_types():
+    """A realistic /wikimedia-upload kill call might mix several forms."""
+    components = resolve_kill_components(["bpl", "nara|Lyndon Baines Johnson Library"])
+    assert components == [
+        frozenset({"bpl"}),
+        frozenset({"nara", "lyndon-baines-johnson-library"}),
+    ]
+
+
+def test_empty_input_returns_empty():
+    assert resolve_kill_components([]) == []
+
+
+def test_whitespace_around_tokens_is_stripped_before_classification():
+    """Tokens arriving via shlex.split sometimes still carry whitespace from
+    upstream Slack payload parsing. Without an explicit strip, an input like
+    `' 405714D9... '` would fail is_dpla_id() and fall through to the bare-
+    slug branch, producing a group containing the un-normalized literal that
+    never matches any tmux session."""
+    dpla_id_padded = "  405714D95F606141D383CCC3EF22908B  "
+    bare_padded = "\tindiana-state-library\n"
+    qid_padded = " Q12345 "
+    hub_pipe_padded = " nara|Lyndon Baines Johnson Library "
+    with patch(
+        "scripts.wikimedia_kill.resolve_wikidata_id",
+        return_value=[("nara", "Herbert Hoover Library")],
+    ):
+        groups = resolve_kill_components(
+            [dpla_id_padded, bare_padded, qid_padded, hub_pipe_padded]
+        )
+    assert groups == [
+        frozenset({"405714d9"}),
+        frozenset({"indiana-state-library"}),
+        frozenset({"nara", "herbert-hoover-library"}),
+        frozenset({"nara", "lyndon-baines-johnson-library"}),
+    ]
+
+
+def test_whitespace_only_tokens_are_skipped():
+    """A token that's purely whitespace produces no group — no empty-string
+    'slug' silently appears in the kill list."""
+    assert resolve_kill_components(["   ", "\t", ""]) == []
+
+
+def test_hub_pipe_institution_with_punctuation_only_institution_raises():
+    """If the institution part normalizes to an empty slug (e.g. all punctuation
+    like '&&&' or '...'), raise a user-facing ValueError instead of silently
+    producing an unmatchable group. The same protection covers the collection
+    position of the three-part form."""
+    with pytest.raises(ValueError) as exc:
+        resolve_kill_components(["nara|&&&"])
+    assert "&&&" in str(exc.value)
+    assert "empty slug" in str(exc.value).lower()
+
+
+def test_hub_pipe_institution_pipe_punctuation_only_collection_raises():
+    """Collection slug that normalizes to empty should fail loudly, same as
+    the institution case."""
+    with pytest.raises(ValueError) as exc:
+        resolve_kill_components(["nara|Center for Legislative Archives|..."])
+    assert "..." in str(exc.value)
+    assert "empty slug" in str(exc.value).lower()
+
+
+def test_wikidata_qid_institution_normalizing_to_empty_raises():
+    """If a QID resolves to an institution whose name normalizes to empty
+    (rare but possible if institutions_v2.json ever stores punctuation-only
+    names), surface that as a ValueError rather than a silently-broken group."""
+    with patch(
+        "scripts.wikimedia_kill.resolve_wikidata_id",
+        return_value=[("nara", "&&&")],
+    ):
+        with pytest.raises(ValueError) as exc:
+            resolve_kill_components(["Q12345"])
+    assert "empty slug" in str(exc.value).lower()
+
+
+def test_empty_institution_part_falls_back_to_hub_only_group():
+    """``nara|`` — hub with empty institution — produces a single-element
+    {canonical} group, identical to the bare ``nara`` form. This is a
+    behavior tightening from the previous 'silently skip' result: with
+    the group model the two forms are now functionally equivalent,
+    which is what most users would intuitively expect."""
+    components = resolve_kill_components(["nara|"])
+    assert components == [frozenset({"nara"})]
+
+
+# --------------------------------------------------------------------------
+# Subset-matching semantics — the contract main() relies on
+#
+# main() iterates tmux sessions and kills any whose '+'-split component set
+# is a SUPERSET of at least one group. These scenario tests directly
+# exercise the bug CodeRabbit caught on the original PR: a collection-
+# scoped token must NOT also kill the parent institution session, and an
+# institution slug must NOT bleed across to a different hub.
+# --------------------------------------------------------------------------
+
+
+def _session_components(session_label_suffix: str) -> set[str]:
+    """Mirror what main() does: split the part after 'wikimedia-' on '+'."""
+    return set(session_label_suffix.split("+"))
+
+
+def test_collection_scoped_kill_spares_parent_institution_session():
+    """The original CodeRabbit-flagged bug, pinned: a token like
+    ``nara|Center for Legislative Archives|RG46`` must kill only the
+    specific collection sub-session, not the parent institution session."""
+    [group] = resolve_kill_components(["nara|Center for Legislative Archives|RG 46"])
+    parent = _session_components("nara+center-for-legislative-archives")
+    child = _session_components("nara+center-for-legislative-archives+rg-46")
+    sibling_collection = _session_components(
+        "nara+center-for-legislative-archives+rg-99"
+    )
+    assert not group <= parent  # parent must NOT be killed
+    assert group <= child  # exact target IS killed
+    assert not group <= sibling_collection  # different collection NOT killed
+
+
+def test_institution_scoped_kill_does_not_cross_hubs():
+    """A token like ``nara|Lyndon Baines Johnson Library`` must not kill
+    a session that happens to have the same institution slug under a
+    different hub (cross-hub bleed)."""
+    [group] = resolve_kill_components(["nara|Lyndon Baines Johnson Library"])
+    intended = _session_components("nara+lyndon-baines-johnson-library")
+    cross_hub_collision = _session_components(
+        "some-other-hub+lyndon-baines-johnson-library"
+    )
+    bare_hub = _session_components("nara")
+    assert group <= intended
+    assert not group <= cross_hub_collision
+    assert not group <= bare_hub
+
+
+def test_institution_scoped_kill_includes_collection_sub_sessions():
+    """An institution-scoped token DOES kill the institution's collection
+    sub-sessions — narrowing further requires the collection form.
+    Killing the parent + all its children when targeting the parent is
+    the expected behavior."""
+    [group] = resolve_kill_components(["nara|Lyndon Baines Johnson Library"])
+    institution_only = _session_components("nara+lyndon-baines-johnson-library")
+    with_collection = _session_components(
+        "nara+lyndon-baines-johnson-library+some-collection"
+    )
+    assert group <= institution_only
+    assert group <= with_collection
+
+
+def test_bare_hub_kill_kills_all_sessions_for_that_hub():
+    """``bpl`` kills any wikimedia-bpl[+…] session — full-hub kill."""
+    [group] = resolve_kill_components(["bpl"])
+    bare = _session_components("bpl")
+    with_inst = _session_components("bpl+some-institution")
+    with_inst_and_coll = _session_components("bpl+some-institution+some-collection")
+    other_hub = _session_components("nara+something")
+    assert group <= bare
+    assert group <= with_inst
+    assert group <= with_inst_and_coll
+    assert not group <= other_hub


### PR DESCRIPTION
## Summary

The \`/wikimedia-upload kill <target>\` Slack command previously only recognized bare canonical hub slugs (e.g. \`bpl\`) and pre-slugified component names. If a user launched with \`'nara|Lyndon Baines Johnson Library'\`, a Wikidata QID, or a DPLA item ID, the matching kill invocation silently matched no sessions.

This PR makes kill accept every input shape that launch accepts, and shares the session-label slugifier between the two scripts so they can never drift.

## What changed

- **\`ingest_wikimedia/partners.py\`** — extracts \`slugify_session_label_component()\` (lowercase, spaces→hyphens, strip everything outside \`[a-z0-9-]\`) as the single source of truth for tmux-safe label components. Both launch and kill import it.
- **\`scripts/wikimedia_launch.py\`** — drops its local \`_slugify\` regex helper in favour of the shared one.
- **\`scripts/wikimedia_kill.py\`** — new \`resolve_kill_components()\` normalizes every launch-accepted token shape to the session-label components launch would emit:
  - bare hub slug / alias → canonical (\`bpl\`)
  - \`hub|institution[|collection]\` → institution + collection slugs (NOT the hub canonical, so the kill is scoped to that institution session)
  - Wikidata QID → institution slug if matched, otherwise canonical hub
  - DPLA item ID (32 hex) → first 8 hex chars (matches the single-item launch label)
  - bare already-a-component slug → pass-through (back-compat with the previous matcher)
- A new \`_UnknownHub\` exception so unknown hub prefixes inside \`hub|…\` tokens raise a user-facing Slack error referencing the bad token.
- **\`tests/test_wikimedia_kill.py\`** — 15 tests covering every input shape, deduplication ordering, mixed token types, unknown-hub / unknown-QID errors, and edge cases like empty institution part.

## Test plan

- [x] \`pytest tests/test_wikimedia_kill.py\` — 15/15 pass
- [x] \`ruff check\` + \`ruff format --check\` — clean
- [ ] After merge: re-run a known launch (e.g. \`/wikimedia-upload nara|Lyndon Baines Johnson Library\`), then kill with the same string and confirm the right session is matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR makes /wikimedia-upload kill accept the same target token formats as wikimedia_launch so kill reliably matches sessions launched with those inputs. It tightens matching semantics (per-token groups + subset matching) to prevent cross-hub or parent-session accidental kills and fixes a three-token collection bug that could previously kill parent institution sessions.

Notable behavioral changes:
- resolve_kill_components() now returns one frozenset[str] per input token (first-seen order). main() matches sessions using subset semantics: a session is killed only if every component in at least one group is present in the session label. This prevents collection-scoped kills from matching parent institution sessions and avoids cross-hub bleed.
- Canonical hub slug is now included where appropriate (e.g., hub|institution → {hub, institution-slug}); hub| with empty institution falls back to hub-only. Bare component slugs remain supported for back-compat.
- Centralized slug validation via _slug_or_raise() surfaces punctuation-only or empty institution/collection parts as user-facing ValueError. Unknown hub prefixes raise _UnknownHub to produce explicit Slack errors.

## Changes

ingest_wikimedia/partners.py
- Added slugify_session_label_component(name: str) — canonical tmux-safe slugifier (lowercase, spaces→hyphens, strip to [a-z0-9-]) used by both launch and kill. Ensures identical slug normalization for session creation and matching.

scripts/wikimedia_launch.py
- Replaced the script-local slugifier with the shared slugify_session_label_component to ensure consistent session-label normalization and avoid mismatches.

scripts/wikimedia_kill.py
- Added resolve_kill_components(target_tokens: list[str]) -> list[frozenset[str]] to normalize tokens into deduplicated component groups supporting:
  - bare hub slug/alias → canonical hub slug
  - hub|institution[|collection] → hub + institution [+ collection] slugs (scoped to hub; canonical hub included)
  - Wikidata QID → resolved into (canonical[, institution]) group(s) where found; unknown QIDs raise ValueError
  - DPLA item ID (32 hex) → first 8 hex chars (normalized)
  - bare component slugs → pass-through
- Added _UnknownHub(ValueError) to produce user-facing Slack errors for invalid hub prefixes.
- Centralized _slug_or_raise() to validate non-empty, non-punctuation-only slugs and produce descriptive ValueError messages routed to Slack handling.
- main() updated to:
  - call resolve_kill_components()
  - convert ValueError/_UnknownHub into Slack ephemeral failures
  - error early on empty target list
  - deduplicate groups while preserving first-seen order
  - render normalized groups in the “no sessions found” message
- Matching logic changed from intersection to per-group subset semantics (group <= session_components) to scope kills precisely.
- Trims tokens at top of processing loop to ensure whitespace handling is consistent.

tests/test_wikimedia_kill.py
- New/expanded test module (25 tests) covering:
  - Group construction for every input shape (bare hub, bare component slug, hub|institution, hub|institution|collection, DPLA ID, Wikidata QID).
  - Deduplication and first-seen ordering.
  - Mixed-token handling, empty-input and whitespace-only token behaviors.
  - Unknown-hub (_UnknownHub) and unknown-QID (ValueError) error cases.
  - Subset/superset matching scenarios verifying collection-scoped kills spare parent institution sessions, institution-scoped kills don’t cross hubs, institution-scoped kills include their collections, and bare-hub kills cover all hub sessions.
  - Tests for _slug_or_raise() behavior on empty/punctuation-only institution/collection parts.

## Testing

- Local: pytest — author reports 25/25 tests passing after updates; ruff checks clean.
- Post-merge: recommended to re-run a known launch then confirm kill matches the same session(s).
- CI note: author observed unrelated GitHub Actions infrastructure failures (ruff-action 404, git-fetch account suspension) during runs; these are expected to clear with retries/pushes.

## Deployment / Infra / Security Notes

- No manual pipeline trigger or ECS redeployment required.
- No environment variables, AWS Secrets Manager keys, database migrations, or shared infrastructure (CodePipeline/CodeBuild/ECS/IAM) changes.
- No public API response shape or endpoint changes.
- Security: accepts additional external identifier token formats (Wikidata QIDs, DPLA IDs) for matching but does not introduce authentication/credential changes or new secret handling. Unknown-hub/QID errors are surfaced to avoid silent failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->