### PR TITLE
launch/retry: escape $? and $rc in notify_fail_cmd so exit code survives

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -573,10 +573,20 @@ def main() -> None:
     # notify_fail_cmd uses single-quoted Python inside a double-quoted tmux argument.
     # Single quotes are literal characters inside double-quoted bash strings, so the
     # inner Python code reaches the interpreter verbatim without needing any escaping.
-    # `rc=$?` captures the failing step's exit code so the Slack message can decode
-    # signals like 137 (SIGKILL / probable OOM) and 143 (SIGTERM).
+    #
+    # The `$?` and `$rc` references DO need backslash-escaping. pipeline_cmd is
+    # embedded as `"{pipeline_cmd}"` in tmux_cmd below — a double-quoted argument
+    # — and the outer bash on EC2 expands unescaped `$` references inside double
+    # quotes BEFORE tmux ever sees the command string. Without the escapes the
+    # inner shell ends up with `rc=0; WIKIMEDIA_LAST_EXIT= python3 -c '...'`
+    # (outer $? = 0 from the previous tmux launch, outer $rc undefined), so
+    # WIKIMEDIA_LAST_EXIT is always empty in the Slack message — losing the
+    # exit-code suffix that decodes signals like 137 (SIGKILL / probable OOM)
+    # and 143 (SIGTERM). With `\$?` and `\$rc`, the outer bash leaves the `$`
+    # literal and the inner shell evaluates the references against the actual
+    # failing step's exit status.
     notify_fail_cmd = (
-        "rc=$?; WIKIMEDIA_LAST_EXIT=$rc python3 -c "
+        r"rc=\$?; WIKIMEDIA_LAST_EXIT=\$rc python3 -c "
         "'from ingest_wikimedia.slack import notify_pipeline_fail; notify_pipeline_fail()'"
     )
     setup = " && ".join(

--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -225,8 +225,18 @@ def main() -> None:
 
     # `rc=$?` captures the failing step's exit code so the Slack message can
     # decode signals like 137 (SIGKILL / probable OOM) and 143 (SIGTERM).
+    #
+    # The `$?` and `$rc` references MUST be backslash-escaped. notify_fail_cmd
+    # is embedded inside a `"{pipeline_cmd}"` double-quoted argument when the
+    # tmux command is built (see the launch path below), and the outer bash on
+    # EC2 expands unescaped `$` references inside double quotes before tmux
+    # sees the command. Without the escapes the inner shell ends up with
+    # `rc=0; WIKIMEDIA_LAST_EXIT= python3 -c '...'` and Slack failure
+    # notifications silently lose their exit-code suffix. With `\$?` and
+    # `\$rc` the outer bash leaves the `$` literal and the inner shell
+    # evaluates the references against the actual failing step's status.
     notify_fail_cmd = (
-        "rc=$?; WIKIMEDIA_LAST_EXIT=$rc python3 -c "
+        r"rc=\$?; WIKIMEDIA_LAST_EXIT=\$rc python3 -c "
         "'from ingest_wikimedia.slack import notify_pipeline_fail; notify_pipeline_fail()'"
     )
     setup = " && ".join(

--- a/tests/test_wikimedia_retry.py
+++ b/tests/test_wikimedia_retry.py
@@ -231,6 +231,42 @@ def test_retry_pipeline_does_not_export_download_log_via_pwd_subshell():
     )
 
 
+def test_retry_pipeline_escapes_dollar_in_notify_fail_cmd():
+    r"""Regression guard: the failure handler must use `\$?` and `\$rc`, not
+    `$?` and `$rc`, when capturing the failing step's exit code.
+
+    The whole pipeline_cmd is sent to tmux as a `"{pipeline_cmd}"`
+    double-quoted argument. Inside double quotes the outer bash on EC2
+    expands `$?` and `$rc` *before* tmux ever sees the command — using
+    its own (unrelated) last-command status and undefined `$rc`. Without
+    the backslashes the inner shell ends up with literal
+    `rc=0; WIKIMEDIA_LAST_EXIT= python3 -c '...'`, so every Slack failure
+    notification silently loses the exit-code suffix that decodes signals
+    like 137 (SIGKILL / probable OOM).
+    """
+    commands = _run_main_and_capture_full_pipeline(
+        ["wikimedia_retry.py", "--days", "30", "--partner", "si"]
+    )
+    pipeline_cmd = next(c for c in commands if "tmux new-session" in c)
+
+    assert r"rc=\$?" in pipeline_cmd, (
+        "notify_fail_cmd must use `rc=\\$?` (backslash-escaped) so the outer "
+        "bash leaves the `$` literal and the inner shell evaluates `$?` "
+        f"against the failing step; got: {pipeline_cmd!r}"
+    )
+    assert r"WIKIMEDIA_LAST_EXIT=\$rc" in pipeline_cmd, (
+        "notify_fail_cmd must use `WIKIMEDIA_LAST_EXIT=\\$rc` (backslash-"
+        "escaped) so $rc is read by the inner shell, not the outer one; "
+        f"got: {pipeline_cmd!r}"
+    )
+    # Defence: make sure the UNESCAPED form isn't hiding somewhere else in
+    # the command. If it ever reappears the silent-loss bug returns.
+    assert "rc=$?" not in pipeline_cmd, (
+        "found unescaped `rc=$?` in pipeline_cmd; outer bash will expand "
+        f"$? prematurely. Use `rc=\\$?`. Got: {pipeline_cmd!r}"
+    )
+
+
 def test_retry_clears_stale_csvs_even_when_no_partner_given():
     """When the user runs `/wikimedia-upload retry 30` (no partner), the
     scan still needs to clear stale CSVs so that hubs which legitimately


### PR DESCRIPTION
## Summary

Slack pipeline-failure messages have been silently losing their exit-code suffix on every failure since the suffix was introduced. The `(exit 137 — SIGKILL — likely OOM)` decoder in `_decode_exit_code` exists specifically to surface causes like OOM kills directly in Slack — but it has never actually been seen, because the `WIKIMEDIA_LAST_EXIT` env var passed to `notify_pipeline_fail` was always empty.

## Root cause

`pipeline_cmd` is embedded as `"{pipeline_cmd}"` in `tmux_cmd` — a double-quoted argument. Inside double quotes, the outer bash on EC2 expands `$?` and `$rc` BEFORE tmux ever sees the command:

- `$?` evaluates to the outer bash's last-command status (0, from the prior step in the SSM launcher)
- `$rc` is undefined → empty

So by the time tmux's inner shell runs the `||` failure branch, the handler has already been rewritten to:
```
rc=0; WIKIMEDIA_LAST_EXIT= python3 -c '...'
```

Python receives `WIKIMEDIA_LAST_EXIT=""`, `_decode_exit_code("")` returns `""`, the suffix is empty.

## Concrete impact

When `nara+center-for-legislative-archives` uploader was OOM-killed (confirmed by `journalctl`: `Out of memory: Killed process 1510845 (uploader) total-vm:7943152kB, anon-rss:6849708kB`), the Slack message read:

> ❌ wikimedia-nara+center-for-legislative-archives: pipeline step failed — no further targets in batch

instead of:

> ❌ wikimedia-nara+center-for-legislative-archives: pipeline step failed (exit 137 — SIGKILL — likely OOM) — no further targets in batch

— forcing a dmesg dive to discover what the exit-code suffix exists specifically to surface.

## Fix

Backslash-escape the `$` in `notify_fail_cmd`. Inside double quotes, `\$` emits a literal `$`, leaving `$?` and `$rc` intact for the inner shell to evaluate against the actual failing step.

End-to-end verified: with the fix, `WIKIMEDIA_LAST_EXIT='1'` for a `false` step. Without the fix, `WIKIMEDIA_LAST_EXIT=''`.

Same fix applied to `wikimedia_launch.py` and `wikimedia_retry.py` (both share the pattern).

## Same class of bug as PR #239

PR #239's `$PWD` retry-log-discovery bug was the same trap (`\$` inside double quotes expands too early). This is the exit-code-suffix variant.

## Test plan

- [x] Added `test_retry_pipeline_escapes_dollar_in_notify_fail_cmd` — asserts both that the escaped form is present AND that the unescaped `rc=$?` form does not reappear.
- [x] ruff check / format clean.
- [ ] Next pipeline failure that produces a non-zero exit should show `(exit N — …)` in the Slack header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Bug Fix: Preserve Exit Codes in Slack Pipeline-Failure Messages

This PR fixes a bug where Slack notifications for failed pipeline steps were losing their exit-code suffix (e.g., exit 137) because shell variable expansion occurred in the outer EC2 shell instead of the inner tmux shell.

### Root Cause
The pipeline command string passed to tmux used double quotes so the outer EC2 bash expanded `$?` and `$rc` before tmux’s inner shell ran the failure handler. That made WIKIMEDIA_LAST_EXIT empty and `_decode_exit_code` returned no suffix.

### Solution
Backslash-escape the dollar signs in the notify-failure handler so the outer shell emits literal `$` characters (use `\$?` and `\$rc`). This allows the inner tmux shell to evaluate them against the actual failing step’s exit status, preserving the exit-code suffix in Slack messages.

### Changes
- scripts/wikimedia_launch.py (+13/-3): Escaped `$?`/`$rc` in notify_fail_cmd and expanded comments documenting the quoting/expansion behavior.
- scripts/wikimedia_retry.py (+11/-1): Same escaping fix and updated inline comments.
- tests/test_wikimedia_retry.py (+36/-0): Added regression test test_retry_pipeline_escapes_dollar_in_notify_fail_cmd which asserts the escaped forms (rc=\$? and WIKIMEDIA_LAST_EXIT=\$rc) appear and the unescaped rc=$? does not.

### Verification
- End-to-end verification: a failing `false` step set WIKIMEDIA_LAST_EXIT='1' with the fix (it was empty before).
- Automated regression test added to prevent reintroduction.
- Manual verification item remaining: observe the next real pipeline failure to confirm the exit-code suffix appears in Slack.

### Impact Analysis (explicit checks)
- Requires manual pipeline trigger or ECS redeployment to take effect: No — change is in scripts used on EC2; deploying the updated code to the host that runs the retry/launch scripts is required for the fix to be active in production.
- Adds/removes/renames environment variables or AWS Secrets Manager keys: No.
- Includes a database migration: No.
- Changes shared infra configuration (CodePipeline/CodeBuild/ECS/IAM): No.
- Modifies public-facing API responses or endpoints: No.
- Security implications: None apparent — the change only adjusts quoting to preserve exit-code reporting; no new credentials or external inputs are introduced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->