### PR TITLE
wikimedia: use appendtext/prependtext for atomic shared-page edits

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -504,6 +504,27 @@ def post_commonsdelinker_request(
     Both filenames should be bare (without the 'File:' namespace prefix).
     Each call makes one edit, matching the one-request-per-edit convention
     used by other editors on that page.
+
+    Uses the MediaWiki `appendtext` API parameter rather than the naive
+    read-modify-write (`page.text = page.text + template; page.save()`).
+    The naive form races itself on this page in particular: a single
+    uploader run can post hundreds of requests in rapid succession, and
+    the GET that pywikibot issues to populate `page.text` is load-balanced
+    across MediaWiki replica databases that may be lagged behind the
+    primary by the time we POST. The resulting basetimestamp is older
+    than the primary's current revision (the one OUR previous successful
+    edit just produced), and the primary rejects with `editconflict` —
+    a self-inflicted conflict despite our bot being the only editor.
+
+    `appendtext` sidesteps both halves of that race:
+
+      * No GET — pywikibot skips reading `page.text`, so there is no
+        ~230 KB-and-growing payload pulled into the process on every
+        call (a major memory accumulator that contributed to a recent
+        OOM kill of the uploader).
+      * No basetimestamp — MediaWiki concatenates atomically on the
+        primary; conflicting concurrent edits can no longer cause
+        spurious rejections.
     """
     page = pywikibot.Page(site, COMMONSDELINKER_PAGE)
     template = (
@@ -513,8 +534,9 @@ def post_commonsdelinker_request(
         f"|reason={_COMMONSDELINKER_REASON}}}}}"
     )
     summary = f"universal replace: [[File:{old_filename}]] → [[File:{new_filename}]]"
-    page.text = page.text.rstrip("\n") + "\n" + template
-    page.save(summary=summary, minor=False)
+    # Leading newline so the new request lands on its own line regardless
+    # of whether the existing page ends with one.
+    site.editpage(page, summary=summary, minor=False, appendtext="\n" + template)
 
 
 def wiki_file_exists(site: BaseSite, sha1: str) -> bool:
@@ -645,11 +667,21 @@ def tag_as_duplicate(
 
     correct_filename should be bare (no 'File:' prefix).
     reason is the free-text reason shown in the template.
+
+    Uses the MediaWiki `prependtext` API parameter so the existing page
+    text doesn't need to be fetched into the process just to be re-saved
+    unchanged. Each call writes a different file page (so self-conflicts
+    of the kind that hit `post_commonsdelinker_request` aren't possible
+    here), but the read-modify-write form still costs an extra GET per
+    call and is vulnerable to rare external edit conflicts on the same
+    page. `prependtext` skips the GET, skips the basetimestamp check,
+    and lets MediaWiki concatenate atomically on the primary.
     """
     tag = f"{{{{Duplicate|{correct_filename}|{reason}}}}}"
     summary = f"Tagging as duplicate: correct title is [[File:{correct_filename}]]"
-    file_page.text = tag + "\n" + file_page.text
-    file_page.save(summary=summary, minor=False)
+    # Trailing newline so the tag sits on its own line above whatever
+    # wikitext currently starts the page.
+    site.editpage(file_page, summary=summary, minor=False, prependtext=tag + "\n")
 
 
 INVALID_CONTENT_TYPES = frozenset(

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch, MagicMock
 from ingest_wikimedia.wikimedia import (
+    COMMONSDELINKER_PAGE,
     MAX_COMMENT_BYTES,
     build_title_drift_move_reason,
     get_site,
@@ -16,6 +17,8 @@ from ingest_wikimedia.wikimedia import (
     extract_strings_dict,
     is_same_item_redirect_relic,
     merge_preserved_wikitext,
+    post_commonsdelinker_request,
+    tag_as_duplicate,
     wiki_file_exists,
     check_content_type,
 )
@@ -712,3 +715,108 @@ def test_move_reason_extreme_filenames_falls_back_to_minimum():
     new = "y" * 240
     reason = build_title_drift_move_reason(old, new, _DPLA_ID, _USERNAME)
     assert reason == "Title drift correction"
+
+
+# ---------------------------------------------------------------------------
+# post_commonsdelinker_request / tag_as_duplicate — atomic-append behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_post_commonsdelinker_request_uses_appendtext_not_read_modify_write():
+    """post_commonsdelinker_request must call site.editpage(...) with the
+    `appendtext` kwarg, not the read-modify-write `page.text = page.text +
+    template; page.save()` form.
+
+    The naive form pulls the entire (~230 KB and growing) filemovers page
+    into the process on every call AND races itself when our bot is the
+    only editor: pywikibot's GET is load-balanced across MediaWiki replica
+    databases that may lag the primary, so the basetimestamp pywikibot
+    sends with the POST is older than the revision OUR previous successful
+    edit just produced. The primary rejects with EditConflictError — a
+    self-inflicted conflict from the perspective of the only editor.
+
+    `appendtext` is server-side atomic: no read, no basetimestamp, no
+    race. This test pins both halves of that contract.
+    """
+    site = MagicMock()
+    # If anything tries to read page.text the test fails loudly: that
+    # would mean we slipped back into the naive form.
+    page_text_accessed = MagicMock(
+        side_effect=AssertionError("page.text must not be accessed — use appendtext")
+    )
+    with (
+        patch("ingest_wikimedia.wikimedia.pywikibot.Page") as PageCtor,
+    ):
+        page = PageCtor.return_value
+        type(page).text = property(page_text_accessed)
+        post_commonsdelinker_request(
+            site, old_filename="Old.jpg", new_filename="New.jpg"
+        )
+
+    # Page constructed for the right target.
+    PageCtor.assert_called_once_with(site, COMMONSDELINKER_PAGE)
+    # editpage called on the *site* (the API surface that accepts appendtext),
+    # not via page.save (which would re-introduce the read).
+    assert site.editpage.call_count == 1, (
+        f"expected exactly one site.editpage() call, got {site.editpage.call_count}"
+    )
+    _, kwargs = site.editpage.call_args
+    assert "appendtext" in kwargs, (
+        f"editpage call must use appendtext; got kwargs={kwargs!r}"
+    )
+    # The leading newline matters: it guarantees the new request lands on
+    # its own line regardless of whether the existing page ends with one.
+    assert kwargs["appendtext"].startswith("\n"), (
+        "appendtext must begin with a newline so the new request is "
+        f"line-separated from the existing content; got {kwargs['appendtext']!r}"
+    )
+    # The request template carries the universal-replace shape.
+    assert "{{universal replace" in kwargs["appendtext"]
+    assert "|Old.jpg" in kwargs["appendtext"]
+    assert "|New.jpg" in kwargs["appendtext"]
+    # page.save must not be called — that path re-introduces the read.
+    page.save.assert_not_called()
+
+
+def test_tag_as_duplicate_uses_prependtext_not_read_modify_write():
+    """tag_as_duplicate must use site.editpage(prependtext=...) rather
+    than `file_page.text = tag + file_page.text; file_page.save()`.
+
+    Unlike post_commonsdelinker_request this isn't a self-conflict
+    hotspot (each call edits a different file page), but the same
+    arguments apply: skip the unnecessary GET of the existing page text,
+    let MediaWiki concatenate atomically on the primary, and keep the
+    pattern consistent with the other shared-page edits.
+    """
+    site = MagicMock()
+    file_page = MagicMock()
+    text_accessed = MagicMock(
+        side_effect=AssertionError(
+            "file_page.text must not be accessed — use prependtext"
+        )
+    )
+    type(file_page).text = property(text_accessed)
+
+    tag_as_duplicate(
+        site,
+        file_page,
+        correct_filename="Correct.jpg",
+        reason="Other file has the correct title.",
+    )
+
+    assert site.editpage.call_count == 1
+    _, kwargs = site.editpage.call_args
+    assert "prependtext" in kwargs, (
+        f"editpage call must use prependtext; got kwargs={kwargs!r}"
+    )
+    # Tag goes first, followed by a newline so the existing page wikitext
+    # starts on its own line.
+    assert kwargs["prependtext"].startswith("{{Duplicate|Correct.jpg|"), (
+        f"prependtext must begin with the Duplicate template; got "
+        f"{kwargs['prependtext']!r}"
+    )
+    assert kwargs["prependtext"].endswith("\n"), (
+        "prependtext must end with a newline so the original wikitext is "
+        f"line-separated; got {kwargs['prependtext']!r}"
+    )
+    file_page.save.assert_not_called()


### PR DESCRIPTION
## Summary

Switch the two shared-page edits in `ingest_wikimedia/wikimedia.py` from naive read-modify-write to MediaWiki's atomic `appendtext`/`prependtext` parameters. Eliminates a self-inflicted edit-conflict storm and a per-call memory accumulator that together OOM-killed the uploader during the recent NARA `center-for-legislative-archives` run.

## Two call sites changed

| Site | Before | After |
|---|---|---|
| `post_commonsdelinker_request` | `page.text = page.text + template; page.save()` | `site.editpage(page, appendtext="\n" + template, …)` |
| `tag_as_duplicate` | `file_page.text = tag + file_page.text; file_page.save()` | `site.editpage(file_page, prependtext=tag + "\n", …)` |

The other three `.text = ...` sites in the codebase (`_resolve_redirect_overwrite`, the post-move description update in `_move_to_correct_title`, and the category-page bootstrap in `categories.py`) are intentionally left alone — they either compute the new text via `merge_preserved_wikitext` (so they genuinely need the existing wikitext and the `basetimestamp` guard is the desired behavior) or write the entire page fresh (so there's no read to skip).

## Why this matters

The naive form has two compounding failure modes when the bot edits the same page in rapid sequence:

1. **Self-conflict via replica lag.** MediaWiki's API farm load-balances reads across replica databases that may lag the primary by seconds. After our successful POST produces revision Rn+1 on the primary, our next call's GET can hit a replica that still serves Rn. pywikibot records `basetimestamp = Rn`'s timestamp, the subsequent POST hits the primary which sees `basetimestamp < current` (because our previous edit created Rn+1), and the primary rejects with `EditConflictError` — a self-inflicted conflict despite our bot being the only editor.

2. **Per-call memory accumulator.** Each GET pulls the full page text into the process. For a hot shared page like `User:CommonsDelinker/commands/filemovers` (~230 KB and growing), several hundred calls retain tens of MB of page text in pywikibot's Page object and HTTP response buffers.

Both were observed in the recent NARA failure: **168 `EditConflictError` instances on `commons:User:CommonsDelinker/commands/filemovers`** (against 50 successful revisions in the same window — confirmed by Commons API revision history showing only "DPLA bot" as the editor), and an OOM kill at 6.8 GB resident on the 7.6 GB instance.

`appendtext`/`prependtext` sidestep both halves:

- **No GET** — pywikibot's `editpage` sets `text = None` and skips the read when these kwargs are present (`pywikibot/site/_apisite.py:2080-2095`).
- **No basetimestamp** — same code path sets `basetimestamp = False`; MediaWiki concatenates atomically on the primary, no race possible.

## Test plan

- [x] Two new unit tests pin the contract for both functions: must call `site.editpage(...)` with `appendtext`/`prependtext`, must NOT access `page.text` (the tests fail loudly if anything tries to read it), must NOT call `page.save()`.
- [x] `ruff check` / `ruff format --check` clean.
- [ ] Next upload run that triggers title-drift moves should land all CommonsDelinker requests on the queue with no `EditConflictError` entries in the log.

## Side-effect of the bug worth knowing

The 168 dropped filemover requests from the NARA run are a real (separate) cleanup item: the underlying files WERE renamed on Commons, but the universal-replace requests never made it onto the CommonsDelinker queue. Any wiki links pointing at the old filenames currently still point at redirects rather than being updated to the new titles. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR replaces two read-modify-write patterns in `ingest_wikimedia/wikimedia.py` with MediaWiki's atomic `appendtext` and `prependtext` API parameters to eliminate edit conflicts and reduce memory consumption.

**Changes:**
- `post_commonsdelinker_request()`: Now uses `site.editpage(..., appendtext=...)` instead of loading the full page text, appending to it, and saving
- `tag_as_duplicate()`: Now uses `site.editpage(..., prependtext=...)` instead of prepending to loaded page text and saving
- Updated docstrings to describe the concurrency and memory implications of the new approaches

**Rationale:**
The previous pattern caused self-inflicted `EditConflictError` due to replica lag and basetimestamp checks, as well as memory growth because each GET request loaded the full page text. Observed failures during a NARA run included 168 EditConflictError instances and an OOM kill at 6.8 GB.

The atomic API parameters cause pywikibot to skip the GET and basetimestamp, allowing MediaWiki to perform server-side concatenation atomically.

**Testing:**
Two new unit tests verify that:
- `post_commonsdelinker_request()` calls `site.editpage()` with `appendtext` and does not access `page.text` or call `page.save()`
- `tag_as_duplicate()` calls `site.editpage()` with `prependtext` and does not access `page.text` or call `page.save()`

**No deployment, infrastructure, or configuration changes required.** This is a code-only change to the Wikimedia ingestion utility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->