### PR TITLE
sdc-sync: wire into wikimedia upload pipeline (PR 5a of 5)

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -395,3 +395,45 @@ def notify_upload_complete(
             f"Runtime:  {runtime}",
         ],
     )
+
+
+def notify_sdc_complete(
+    tracker: Tracker,
+    partner_label: str,
+    elapsed_seconds: float,
+    dry_run: bool = False,
+) -> None:
+    """Post the SDC phase's completion summary to #tech-alerts.
+
+    Same channel and block shape as `notify_upload_complete` — the user
+    sees one message per phase. Counter set differs because SDC writes
+    statements + references to existing MediaInfo entities rather than
+    uploading new files; "items synced" is the per-DPLA-ID count, and the
+    SKIPPED_* lines surface items the partner-mode loop bailed on because
+    their sidecars were missing or malformed.
+    """
+    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
+    if not token:
+        logging.warning("DPLA_SLACK_BOT_TOKEN not set — skipping Slack notification")
+        return
+
+    effective_label = (
+        f"wikimedia-{os.environ.get('WIKIMEDIA_SESSION_LABEL') or partner_label}"
+    )
+    runtime = _format_runtime(elapsed_seconds)
+    dry_run_note = " _(dry run)_" if dry_run else ""
+
+    _post_completion_notice(
+        token=token,
+        header=f"*Wikimedia SDC Complete: {effective_label}*{dry_run_note}",
+        plain_text=f"Wikimedia SDC complete: {effective_label}",
+        stats_lines=[
+            f"ITEMS SYNCED:         {tracker.count(Result.SDC_ITEMS_SYNCED):,}",
+            f"CLAIMS ADDED:         {tracker.count(Result.SDC_CLAIMS_ADDED):,}",
+            f"REFS ADDED:           {tracker.count(Result.SDC_REFS_ADDED):,}",
+            f"REMOVALS:             {tracker.count(Result.SDC_REMOVALS):,}",
+            f"SKIPPED (no sidecar): {tracker.count(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR):,}",
+            f"SKIPPED (mapping):    {tracker.count(Result.SDC_ITEMS_SKIPPED_MAPPING):,}",
+            f"Runtime:              {runtime}",
+        ],
+    )

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -14,6 +14,14 @@ class Result(Enum):
     RETIRED = auto()
     ORPHANS_TAGGED = auto()
     ORPHANS_FLAGGED = auto()
+    # SDC phase counters. `Tracker.__str__` already prints only non-zero
+    # values, so adding these here doesn't affect downloader/uploader output.
+    SDC_ITEMS_SYNCED = auto()
+    SDC_CLAIMS_ADDED = auto()
+    SDC_REFS_ADDED = auto()
+    SDC_REMOVALS = auto()
+    SDC_ITEMS_SKIPPED_NO_SIDECAR = auto()
+    SDC_ITEMS_SKIPPED_MAPPING = auto()
 
 
 class Tracker:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,5 @@ get-ids-nara = "tools.get_ids_nara:main"
 resolve-dpla-ids = "tools.resolve_dpla_ids:main"
 fix-unknown-categories = "tools.fix_unknown_categories:main"
 get-ids-retry = "tools.get_ids_retry:main"
+sdc-sync = "tools.sdc_sync:main"
 

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -645,6 +645,14 @@ def main() -> None:
         ]
         if not refresh_only:
             pipeline_steps.append(f"uploader {csv_file} {canonical}")
+            # SDC sync is the final step of every upload run: it reads the
+            # per-item sdc.json (staged by get-ids-es) and upload-result.json
+            # (written by uploader) sidecars and posts MediaInfo statements
+            # to Commons. Skipped for refresh_only because no upload phase
+            # ran — there's no upload-result.json to drive from.
+            pipeline_steps.append(
+                f"sdc-sync --partner {canonical} --ids-file {csv_file}"
+            )
         target_steps = " && ".join(pipeline_steps)
         target_blocks.append(
             f"{label_export}; {{ {target_steps}; }}"

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -686,7 +686,10 @@ def main() -> None:
             if refresh_only:
                 msg = f"✅ {', '.join(item_descs)} — eligible, download refresh starting{refresh_suffix}."
             else:
-                msg = f"✅ {', '.join(item_descs)} — eligible, download + upload starting."
+                msg = (
+                    f"✅ {', '.join(item_descs)} — eligible,"
+                    " download + upload + SDC starting."
+                )
         elif batch_targets and not single_item_targets:
             # All batch targets (hub, institution, or collection).
             batch_labels = [_target_label(c, i, col) for c, i, _, col in batch_targets]
@@ -695,7 +698,7 @@ def main() -> None:
             else:
                 msg = (
                     f"▶ Launching `{session_name}` pipeline: {', '.join(batch_labels)}"
-                    " (ID generation → download → upload)."
+                    " (ID generation → download → upload → SDC)."
                 )
         else:
             # Mixed: list all targets with a note distinguishing items from batches.
@@ -708,7 +711,10 @@ def main() -> None:
             if refresh_only:
                 msg = f"▶ Launching `{session_name}` refresh: {', '.join(all_descs)}{refresh_suffix}."
             else:
-                msg = f"▶ Launching `{session_name}` pipeline: {', '.join(all_descs)}."
+                msg = (
+                    f"▶ Launching `{session_name}` pipeline: {', '.join(all_descs)}"
+                    " (ID generation → download → upload → SDC)."
+                )
         try:
             post_message(slack_token, msg)
         except Exception as e:

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -308,6 +308,8 @@ def main() -> None:
                     label = log_filename[: -len("-download.log")]
                 elif log_filename.endswith("-upload.log"):
                     label = log_filename[: -len("-upload.log")]
+                elif log_filename.endswith("-sdc.log"):
+                    label = log_filename[: -len("-sdc.log")]
                 else:
                     return session, f"Unknown (unrecognised log: {log_filename!r})"
                 raw_hub = label.removeprefix("retry-")

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -185,11 +185,16 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
         # sdc-sync's _run_partner_mode logs `DPLA ID: <id> (n/total)` per
         # item — same `DPLA ID:` marker the awk pass already counts. Uses
         # the COUNTS: terminal marker as the completion signal, matching
-        # the downloader/uploader convention.
+        # the downloader/uploader convention. The reported figure is
+        # "items processed" (i.e. iterated by the loop) rather than
+        # "items synced" because some processed items may have been
+        # skipped for missing sidecars or mapping issues — the Slack
+        # summary surfaces the real synced count via the tracker's
+        # SDC_ITEMS_SYNCED line.
         if dpla_id_count == 0:
             return "SDC syncing (starting...)"
         if counts_marker > 0:
-            return f"{_SDC_COMPLETE_PREFIX} ({dpla_id_count:,} items synced)"
+            return f"{_SDC_COMPLETE_PREFIX} ({dpla_id_count:,} items processed)"
         return f"SDC syncing ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}"
 
     return "Unknown"

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -20,19 +20,20 @@ from ingest_wikimedia.ssm import REGION, ssm_run
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
 _UPLOAD_COMPLETE_PREFIX = "Upload complete"
+_SDC_COMPLETE_PREFIX = "SDC complete"
 
 
 def log_filename_pattern_for_label(label: str) -> str:
     """Anchored regex matching log filenames for exactly this label.
 
-    Log filenames follow "{YYYYMMDD}-{HHMMSS}-{label}-(download|upload).log".
+    Log filenames follow "{YYYYMMDD}-{HHMMSS}-{label}-(download|upload|sdc).log".
     The pattern must match `…-bpl+phillips-academy-download.log` and NOT
     `…-bpl+phillips-academy-andover-download.log` — otherwise sibling
     labels whose names extend this one steal the log selection and the
     status report sticks on the wrong target. See lessons.md
     "Log filename phase detection".
     """
-    return rf"-{re.escape(label)}-(download|upload)\.log$"
+    return rf"-{re.escape(label)}-(download|upload|sdc)\.log$"
 
 
 _DOWNLOAD_COMPLETE_PREFIX = "Download complete"
@@ -179,6 +180,17 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
         if counts_marker > 0:
             return f"{_UPLOAD_COMPLETE_PREFIX} ({uploaded_count:,} uploaded, {skipped_count:,} already on Commons)"
         return f"Uploading ({dpla_id_count:,} / {total:,}, ~{pct(dpla_id_count)}%){stale_suffix}"
+
+    if log_file.endswith("-sdc.log"):
+        # sdc-sync's _run_partner_mode logs `DPLA ID: <id> (n/total)` per
+        # item — same `DPLA ID:` marker the awk pass already counts. Uses
+        # the COUNTS: terminal marker as the completion signal, matching
+        # the downloader/uploader convention.
+        if dpla_id_count == 0:
+            return "SDC syncing (starting...)"
+        if counts_marker > 0:
+            return f"{_SDC_COMPLETE_PREFIX} ({dpla_id_count:,} items synced)"
+        return f"SDC syncing ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}"
 
     return "Unknown"
 
@@ -343,6 +355,7 @@ def main() -> None:
             if not (
                 phase.startswith(_UPLOAD_COMPLETE_PREFIX)
                 or phase.startswith(_DOWNLOAD_COMPLETE_PREFIX)
+                or phase.startswith(_SDC_COMPLETE_PREFIX)
             ):
                 # Active or stalled label — this is the one to report.
                 return session, f"[{label}] {phase}" if multi else phase

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -18,6 +18,7 @@ from ingest_wikimedia.slack import (
     _read_download_failed_count,
     _summarize_log,
     notify_pipeline_fail,
+    notify_sdc_complete,
     notify_upload_complete,
 )
 from ingest_wikimedia.tracker import Result, Tracker
@@ -383,6 +384,107 @@ def test_notify_upload_complete_upload_only_retry_ignores_stale_download_log(
     assert "Retry Complete" not in captured["header"]
     failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
     assert failed_lines == ["FAILED:   0"]
+
+
+def _capture_sdc_completion_message(env: dict, tracker_counts: dict) -> dict:
+    """Mirror of `_capture_completion_message` for `notify_sdc_complete`."""
+    tracker = MagicMock(spec=Tracker)
+    tracker.count.side_effect = lambda result: tracker_counts.get(result, 0)
+    captured: dict = {}
+
+    with (
+        patch.dict(os.environ, env, clear=True),
+        patch("ingest_wikimedia.slack._post_completion_notice") as mock_post,
+    ):
+        mock_post.side_effect = lambda **kwargs: captured.update(kwargs)
+        notify_sdc_complete(
+            tracker=tracker,
+            partner_label="minnesota",
+            elapsed_seconds=42.0,
+            dry_run=False,
+        )
+    return captured
+
+
+def test_notify_sdc_complete_header_uses_session_label():
+    """Confirms the SDC Slack summary header is "Wikimedia SDC Complete:
+    wikimedia-<session label>", matching the shape of upload-complete."""
+    captured = _capture_sdc_completion_message(
+        env={
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": "minnesota",
+        },
+        tracker_counts={
+            Result.SDC_ITEMS_SYNCED: 3,
+            Result.SDC_CLAIMS_ADDED: 7,
+            Result.SDC_REFS_ADDED: 5,
+        },
+    )
+    assert captured["header"] == "*Wikimedia SDC Complete: wikimedia-minnesota*"
+    assert captured["plain_text"] == "Wikimedia SDC complete: wikimedia-minnesota"
+
+
+def test_notify_sdc_complete_stats_reflect_tracker_counts():
+    """ITEMS SYNCED / CLAIMS ADDED / REFS ADDED / REMOVALS / SKIPPED lines
+    pull from the corresponding Result enum members, and Runtime formats
+    elapsed_seconds."""
+    captured = _capture_sdc_completion_message(
+        env={
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": "minnesota",
+        },
+        tracker_counts={
+            Result.SDC_ITEMS_SYNCED: 100,
+            Result.SDC_CLAIMS_ADDED: 250,
+            Result.SDC_REFS_ADDED: 30,
+            Result.SDC_REMOVALS: 4,
+            Result.SDC_ITEMS_SKIPPED_NO_SIDECAR: 2,
+            Result.SDC_ITEMS_SKIPPED_MAPPING: 1,
+        },
+    )
+    stats = captured["stats_lines"]
+    assert any(s.startswith("ITEMS SYNCED:") and "100" in s for s in stats)
+    assert any(s.startswith("CLAIMS ADDED:") and "250" in s for s in stats)
+    assert any(s.startswith("REFS ADDED:") and "30" in s for s in stats)
+    assert any(s.startswith("REMOVALS:") and "4" in s for s in stats)
+    assert any("SKIPPED (no sidecar)" in s and "2" in s for s in stats)
+    assert any("SKIPPED (mapping)" in s and "1" in s for s in stats)
+    assert any("Runtime:" in s and "42s" in s for s in stats)
+
+
+def test_notify_sdc_complete_dry_run_adds_suffix():
+    """`dry_run=True` appends the same italicized note as upload-complete."""
+    tracker = MagicMock(spec=Tracker)
+    tracker.count.return_value = 0
+    captured: dict = {}
+    with (
+        patch.dict(
+            os.environ,
+            {"DPLA_SLACK_BOT_TOKEN": "x", "WIKIMEDIA_SESSION_LABEL": "minnesota"},
+            clear=True,
+        ),
+        patch("ingest_wikimedia.slack._post_completion_notice") as mock_post,
+    ):
+        mock_post.side_effect = lambda **kwargs: captured.update(kwargs)
+        notify_sdc_complete(
+            tracker=tracker,
+            partner_label="minnesota",
+            elapsed_seconds=1.0,
+            dry_run=True,
+        )
+    assert captured["header"].endswith("_(dry run)_")
+
+
+def test_notify_sdc_complete_skipped_without_token(monkeypatch, caplog):
+    """Without DPLA_SLACK_BOT_TOKEN we must skip silently (just warn)."""
+    monkeypatch.delenv("DPLA_SLACK_BOT_TOKEN", raising=False)
+    tracker = MagicMock(spec=Tracker)
+    tracker.count.return_value = 0
+    with patch("ingest_wikimedia.slack._post_completion_notice") as mock_post:
+        notify_sdc_complete(
+            tracker=tracker, partner_label="minnesota", elapsed_seconds=1.0
+        )
+        mock_post.assert_not_called()
 
 
 def test_notify_upload_complete_clean_retry_still_titled_retry_complete(tmp_path):

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -35,12 +35,13 @@ def test_log_filename_pattern_matches_only_exact_label():
 
 
 def test_log_filename_pattern_matches_only_phase_suffixes():
-    """Only -download.log and -upload.log are valid phase logs."""
+    """Only -download.log, -upload.log, and -sdc.log are valid phase logs."""
     from scripts.wikimedia_upload_status import log_filename_pattern_for_label
 
     pattern = re.compile(log_filename_pattern_for_label("nara"))
     assert pattern.search("20260522-100000-nara-download.log")
     assert pattern.search("20260522-100000-nara-upload.log")
+    assert pattern.search("20260522-100000-nara-sdc.log")
     # Other phases (e.g. legacy retirer logs) must NOT match
     assert not pattern.search("20251220-012010-nara-retirer.log")
     assert not pattern.search("20260522-100000-nara-fix.log")
@@ -118,3 +119,99 @@ def test_log_filename_pattern_always_starts_with_dash():
             f"Pattern for {label!r} must lead with `-` so the anchor before "
             "the label binds; callers must compensate with `grep -E --`."
         )
+
+
+def _fake_ssm_for_phase(log_filename: str, awk_counts: list[int], csv_total: int):
+    """Build a fake `ssm_run` that returns the precheck + counts payload
+    `get_phase_and_progress` expects, with the named log file and counts.
+
+    Sequence (matches the real two-call flow):
+      1. precheck — `session_created\nlog_filename`
+      2. main — `now\nmtime\nSEP\ntail\nSEP\n<5 lines of awk + wc>`
+    """
+    call_count = [0]
+    sep = "__WM_SEP__"
+
+    def fake_ssm_run(_client, _command, **_kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return f"1700000000\n{log_filename}\n"
+        # now=mtime so no staleness suffix; counts payload then csv_total
+        body = f"1700000000\n1700000000\n{sep}\nlast log line\n{sep}\n"
+        body += "\n".join(str(n) for n in awk_counts) + "\n"
+        body += f"{csv_total}\n"
+        return body
+
+    return fake_ssm_run
+
+
+def test_get_phase_and_progress_reports_sdc_syncing_in_progress():
+    """An -sdc.log with DPLA IDs logged but no terminal COUNTS marker
+    surfaces as "SDC syncing (N / total items, ~pct%)".
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    # awk_counts layout: [dpla_id_count, uploaded, skipping, counts_marker]
+    fake = _fake_ssm_for_phase(
+        log_filename="20260525-200000-minnesota-sdc.log",
+        awk_counts=[3, 0, 0, 0],
+        csv_total=10,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase = get_phase_and_progress(
+            client=None,
+            session="wikimedia-minnesota",
+            hub="minnesota",
+            label="minnesota",
+        )
+    assert phase.startswith("SDC syncing")
+    assert "3" in phase
+    assert "10" in phase
+
+
+def test_get_phase_and_progress_reports_sdc_complete():
+    """An -sdc.log whose awk pass found a COUNTS: terminal marker surfaces
+    as "SDC complete (N items synced)" so the walker can mark it done.
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_phase(
+        log_filename="20260525-200000-minnesota-sdc.log",
+        awk_counts=[10, 0, 0, 1],  # 10 items, COUNTS marker present
+        csv_total=10,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase = get_phase_and_progress(
+            client=None,
+            session="wikimedia-minnesota",
+            hub="minnesota",
+            label="minnesota",
+        )
+    assert phase.startswith("SDC complete"), phase
+    assert "10" in phase
+
+
+def test_get_phase_and_progress_reports_sdc_starting_with_no_items():
+    """An -sdc.log that exists but hasn't logged any `DPLA ID:` lines yet
+    surfaces as "SDC syncing (starting...)" — no false staleness."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_phase(
+        log_filename="20260525-200000-minnesota-sdc.log",
+        awk_counts=[0, 0, 0, 0],
+        csv_total=10,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase = get_phase_and_progress(
+            client=None,
+            session="wikimedia-minnesota",
+            hub="minnesota",
+            label="minnesota",
+        )
+    assert phase == "SDC syncing (starting...)"

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -40,6 +40,7 @@ site: pywikibot.site.BaseSite
 hubs: dict
 rights: dict
 subject_ids: dict
+token: str
 _s3_partner: str | None = None
 _s3_client = None
 
@@ -143,7 +144,7 @@ def _initialize() -> None:
     time. Kept out of import-time so `import tools.sdc_sync` (e.g. by the
     console-script entry point) does no I/O.
     """
-    global parser, args, method, dpla_api, site, hubs, rights, subject_ids
+    global parser, args, method, dpla_api, site, hubs, rights, subject_ids, token
     global _s3_partner, _s3_client
 
     parser = _build_parser()
@@ -156,6 +157,11 @@ def _initialize() -> None:
 
     site = pywikibot.Site()
     site.login()
+    # Fetch the wbeditentity CSRF token here so importing the module
+    # remains side-effect free — the helper post functions (_post_new_refs,
+    # _post_new_claims) read `token` at call time and refresh it
+    # themselves via `login()` on save failure.
+    token = login()
 
     # Hubs and subject mappings are fetched live from ingestion3 on every run,
     # by design: this sync exists precisely to propagate upstream changes to
@@ -1752,9 +1758,6 @@ def login():
     return token
 
 
-token = login()
-
-
 def _resolve_dpla_id(title, dpla_api):
     """Return the DPLA item ID for a Commons file title.
 
@@ -2039,6 +2042,7 @@ def _run_partner_mode(partner, ids_file):
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
                 continue
 
+            synced_this_item = False
             for ord_str, data in sorted(eligible.items(), key=lambda kv: int(kv[0])):
                 pageid = data.get("pageid")
                 if pageid is None:
@@ -2049,7 +2053,15 @@ def _run_partner_mode(partner, ids_file):
                     f" -- Ordinal {ord_str}: {mediaid} ({data.get('title', '?')})"
                 )
                 process_one_from_sdc(mediaid, dpla_id, sdc_payload)
-            tracker.increment(Result.SDC_ITEMS_SYNCED)
+                synced_this_item = True
+            # Only count an item as synced if at least one ordinal actually
+            # made it past the pageid guard. An item whose every eligible
+            # ordinal lacked a pageid would otherwise inflate the synced
+            # counter and underreport mapping skips.
+            if synced_this_item:
+                tracker.increment(Result.SDC_ITEMS_SYNCED)
+            else:
+                tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
     finally:
         elapsed = time.time() - start_time
         # Terminal "COUNTS:" marker — the status script keys on it to detect

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1,6 +1,7 @@
 # TODO caption, date, page, iiif manifest, url
 
 import copy
+import logging
 import pywikibot
 import requests
 import re
@@ -16,83 +17,104 @@ import urllib.parse
 from bs4 import BeautifulSoup
 from pywikibot.comms import http
 from pywikibot import pagegenerators
+from ingest_wikimedia.logs import setup_logging
+from ingest_wikimedia.slack import notify_sdc_complete
+from ingest_wikimedia.tracker import Result, Tracker
 from ingest_wikimedia.wikimedia import extract_dpla_id_from_commons_title
 
-# When running manually, sometimes it is helpful to specify the category to work on in the command line, using --cat "<category>".
+# Module-level SDC tracker. Counters accumulate across one invocation of
+# main() — the helpers (`_post_new_refs`, `_post_new_claims`,
+# `_reconcile_existing_claims`) increment as their POSTs succeed, and
+# `_run_partner_mode` increments the per-item skip / sync counters.
+tracker = Tracker()
 
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--cat",
-    dest="cat",
-    metavar="CAT",
-    action="store",
-    help="Commons category name (without 'Category:' prefix) to enumerate File: pages from",
-)
-parser.add_argument(
-    "--recurse",
-    dest="recurse",
-    action="store_true",
-    help="When using --cat, also walk subcategories",
-)
-parser.add_argument("--method", dest="method", metavar="METHOD", action="store")
-parser.add_argument("--lists", dest="lists", metavar="LISTS", action="store")
-parser.add_argument(
-    "--file",
-    dest="files",
-    metavar="FILE",
-    action="append",
-    help="Commons file title to process directly (repeatable)",
-)
-parser.add_argument(
-    "--limit",
-    dest="limit",
-    type=int,
-    default=0,
-    help="When using --cat, stop after this many files (0 = no limit)",
-)
-parser.add_argument(
-    "--from-s3",
-    dest="from_s3",
-    metavar="PARTNER",
-    action="store",
-    default=None,
-    help=(
-        "Read each DPLA item's metadata from the dpla-map.json staged in S3 "
-        "by get-ids-es (under the partner's sharded item prefix; resolved by "
-        "S3Client.get_item_metadata) instead of calling api.dp.la. Falls back "
-        "to api.dp.la when an item's dpla-map.json is missing."
-    ),
-)
-parser.add_argument(
-    "--partner",
-    dest="partner",
-    metavar="PARTNER",
-    action="store",
-    default=None,
-    help=(
-        "Partner-driven SDC sync from precomputed S3 sidecars. Iterates the "
-        "partner's IDs CSV (defaults to <PARTNER>/<PARTNER>.csv) and for each "
-        "DPLA ID reads sdc.json (staged by get-ids-es) and upload-result.json "
-        "(written by uploader). Posts SDC only for ordinals whose uploader "
-        "status is UPLOADED or SKIPPED. No api.dp.la calls."
-    ),
-)
-parser.add_argument(
-    "--ids-file",
-    dest="ids_file",
-    metavar="PATH",
-    action="store",
-    default=None,
-    help=(
-        "When using --partner, the IDs CSV path. Defaults to "
-        "<PARTNER>/<PARTNER>.csv (matching the uploader's input convention)."
-    ),
-)
-args = parser.parse_args()
+# Module-level handles populated by `_initialize()` inside main(). Importing
+# this module does no I/O — only running it (or calling main() from the
+# `sdc-sync` console-script entry point) triggers argparse, config reads,
+# Commons login, and the institutions_v2.json/subjects.json fetches.
+parser: argparse.ArgumentParser
+args: argparse.Namespace
+method: str = "livecat"
+dpla_api: str
+site: pywikibot.site.BaseSite
+hubs: dict
+rights: dict
+subject_ids: dict
+_s3_partner: str | None = None
+_s3_client = None
 
-method = "livecat"
-if args.method:
-    method = args.method
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser. Pure — no side effects."""
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--cat",
+        dest="cat",
+        metavar="CAT",
+        action="store",
+        help="Commons category name (without 'Category:' prefix) to enumerate File: pages from",
+    )
+    p.add_argument(
+        "--recurse",
+        dest="recurse",
+        action="store_true",
+        help="When using --cat, also walk subcategories",
+    )
+    p.add_argument("--method", dest="method", metavar="METHOD", action="store")
+    p.add_argument("--lists", dest="lists", metavar="LISTS", action="store")
+    p.add_argument(
+        "--file",
+        dest="files",
+        metavar="FILE",
+        action="append",
+        help="Commons file title to process directly (repeatable)",
+    )
+    p.add_argument(
+        "--limit",
+        dest="limit",
+        type=int,
+        default=0,
+        help="When using --cat, stop after this many files (0 = no limit)",
+    )
+    p.add_argument(
+        "--from-s3",
+        dest="from_s3",
+        metavar="PARTNER",
+        action="store",
+        default=None,
+        help=(
+            "Read each DPLA item's metadata from the dpla-map.json staged in S3 "
+            "by get-ids-es (under the partner's sharded item prefix; resolved by "
+            "S3Client.get_item_metadata) instead of calling api.dp.la. Falls back "
+            "to api.dp.la when an item's dpla-map.json is missing."
+        ),
+    )
+    p.add_argument(
+        "--partner",
+        dest="partner",
+        metavar="PARTNER",
+        action="store",
+        default=None,
+        help=(
+            "Partner-driven SDC sync from precomputed S3 sidecars. Iterates the "
+            "partner's IDs CSV (defaults to <PARTNER>/<PARTNER>.csv) and for each "
+            "DPLA ID reads sdc.json (staged by get-ids-es) and upload-result.json "
+            "(written by uploader). Posts SDC only for ordinals whose uploader "
+            "status is UPLOADED or SKIPPED. No api.dp.la calls."
+        ),
+    )
+    p.add_argument(
+        "--ids-file",
+        dest="ids_file",
+        metavar="PATH",
+        action="store",
+        default=None,
+        help=(
+            "When using --partner, the IDs CSV path. Defaults to "
+            "<PARTNER>/<PARTNER>.csv (matching the uploader's input convention)."
+        ),
+    )
+    return p
 
 
 def _normalize_rights_uri(uri):
@@ -113,39 +135,54 @@ def _normalize_rights_uri(uri):
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.dirname(_HERE)
 
-# Config + Commons login happen after argparse so that `--help` doesn't trigger
-# file I/O or network/auth on this module's import.
-with open(os.path.join(_REPO_ROOT, "config.toml"), "rb") as _f:
-    dpla_api = tomllib.load(_f)["dpla_api_key"]
 
-site = pywikibot.Site()
-site.login()
+def _initialize() -> None:
+    """Parse args, load config, log in to Commons, fetch live ingestion3 JSONs.
 
-# Hubs and subject mappings are fetched live from ingestion3 on every run, by
-# design: this sync exists precisely to propagate upstream changes to that
-# data, and a vendored snapshot would defeat the point. rights.json is the
-# exception — it lives here because it's a small, slow-moving SDC-specific
-# mapping not maintained in ingestion3.
-hubs = requests.get(
-    "https://raw.githubusercontent.com/dpla/ingestion3/develop/src/main/resources/wiki/institutions_v2.json",
-    timeout=30,
-).json()
-with open(os.path.join(_REPO_ROOT, "rights.json")) as f:
-    rights = {_normalize_rights_uri(k): v for k, v in json.load(f).items()}
-subject_ids = requests.get(
-    "https://raw.githubusercontent.com/dpla/ingestion3/develop/src/main/resources/subjects.json",
-    timeout=30,
-).json()
+    Populates the module-level globals the helper functions read at call
+    time. Kept out of import-time so `import tools.sdc_sync` (e.g. by the
+    console-script entry point) does no I/O.
+    """
+    global parser, args, method, dpla_api, site, hubs, rights, subject_ids
+    global _s3_partner, _s3_client
 
-# When --from-s3 <partner> is set, parsed() reads each item's dpla-map.json
-# from S3 instead of calling api.dp.la. Imported lazily so that --help doesn't
-# pay the boto3 import cost.
-_s3_partner = args.from_s3
-_s3_client = None
-if _s3_partner is not None:
-    from ingest_wikimedia.s3 import S3Client
+    parser = _build_parser()
+    args = parser.parse_args()
+    if args.method:
+        method = args.method
 
-    _s3_client = S3Client()
+    with open(os.path.join(_REPO_ROOT, "config.toml"), "rb") as f:
+        dpla_api = tomllib.load(f)["dpla_api_key"]
+
+    site = pywikibot.Site()
+    site.login()
+
+    # Hubs and subject mappings are fetched live from ingestion3 on every run,
+    # by design: this sync exists precisely to propagate upstream changes to
+    # that data, and a vendored snapshot would defeat the point. rights.json
+    # is the exception — it lives here because it's a small, slow-moving
+    # SDC-specific mapping not maintained in ingestion3.
+    hubs = requests.get(
+        "https://raw.githubusercontent.com/dpla/ingestion3/develop/src/main/resources/wiki/institutions_v2.json",
+        timeout=30,
+    ).json()
+    with open(os.path.join(_REPO_ROOT, "rights.json")) as f:
+        rights = {_normalize_rights_uri(k): v for k, v in json.load(f).items()}
+    subject_ids = requests.get(
+        "https://raw.githubusercontent.com/dpla/ingestion3/develop/src/main/resources/subjects.json",
+        timeout=30,
+    ).json()
+
+    # When --from-s3 <partner> is set, parsed() reads each item's dpla-map.json
+    # from S3 instead of calling api.dp.la. Imported lazily so this module
+    # doesn't pay the boto3 import cost when nothing needs S3.
+    _s3_partner = args.from_s3
+    _s3_client = None
+    if _s3_partner is not None:
+        from ingest_wikimedia.s3 import S3Client
+
+        _s3_client = S3Client()
+
 
 # This is the JSON used for formatting a claim. The P459 -> Q61848113 (determination method) qualifier is hardcoded in for everything DPLA adds. Not all data types have the same format for value, so this is formatted in the function for each property added.
 
@@ -1062,6 +1099,7 @@ def _post_new_refs(mediaid, dpla_id):
     global token
     if not refclaims["claims"]:
         return
+    refs_to_post = len(refclaims["claims"])
     postrefs = {
         "action": "wbeditentity",
         "format": "json",
@@ -1096,6 +1134,7 @@ def _post_new_refs(mediaid, dpla_id):
         post = json.loads(save.text)
         if post["success"] == 1:
             print(" --- Saved new refs!")
+            tracker.increment(Result.SDC_REFS_ADDED, refs_to_post)
         else:
             print(post)
             print(" --- Error encountered on save.")
@@ -1112,6 +1151,7 @@ def _post_new_refs(mediaid, dpla_id):
             post = json.loads(save.text)
             if post["success"] == 1:
                 print(" --- Saved new refs!")
+                tracker.increment(Result.SDC_REFS_ADDED, refs_to_post)
             else:
                 print(post)
                 print(" --- Error encountered on save.")
@@ -1132,6 +1172,7 @@ def _post_new_claims(mediaid, dpla_id):
     global token
     if not claims["claims"]:
         return
+    claims_to_post = len(claims["claims"])
     postdata = {
         "action": "wbeditentity",
         "format": "json",
@@ -1166,6 +1207,7 @@ def _post_new_claims(mediaid, dpla_id):
         post = json.loads(save.text)
         if post["success"] == 1:
             print(" --- Saved new claims!")
+            tracker.increment(Result.SDC_CLAIMS_ADDED, claims_to_post)
         else:
             print(post)
             print(" --- Error encountered on save.")
@@ -1182,6 +1224,7 @@ def _post_new_claims(mediaid, dpla_id):
             post = json.loads(save.text)
             if post["success"] == 1:
                 print(" --- Saved new claims!")
+                tracker.increment(Result.SDC_CLAIMS_ADDED, claims_to_post)
             else:
                 print(post)
                 print(" --- Error encountered on save.")
@@ -1216,6 +1259,7 @@ def dpla_claims(
 ):
     """Legacy entry point: build `expected` from the 13-tuple, then reconcile."""
     expected = _build_expected_from_parsed(
+        dpla_id,
         url,
         descs,
         dates,
@@ -1234,6 +1278,7 @@ def dpla_claims(
 
 
 def _build_expected_from_parsed(
+    dpla_id,
     url,
     descs,
     dates,
@@ -1446,6 +1491,7 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
             "https://commons.wikimedia.org/w/api.php", method="POST", data=rmdata
         )
         print(" --- Saved removals!")
+        tracker.increment(Result.SDC_REMOVALS, len(removals))
 
 
 def _fetch_dpla_doc_from_api(dpla_id, dpla_api):
@@ -1915,152 +1961,199 @@ def _run_partner_mode(partner, ids_file):
 
     Items where the metadata isn't yet on S3 are skipped silently and
     will be picked up the next time the full pipeline runs.
+
+    Logs to `{partner}/logs/{timestamp}-{label}-sdc.log` (matching the
+    downloader/uploader pattern) so `wikimedia-upload-status` can detect
+    progress; final summary posted via `notify_sdc_complete`.
     """
     from botocore.exceptions import ClientError
 
     from ingest_wikimedia.s3 import S3Client
+
+    setup_logging(partner, "sdc", logging.INFO)
+    start_time = time.time()
 
     s3 = S3Client()
 
     with open(ids_file) as f:
         dpla_ids = [line.strip() for line in f if line.strip()]
 
-    print(f"Partner mode: {partner} — {len(dpla_ids)} items from {ids_file}")
-    local_count = 0
-    for dpla_id in dpla_ids:
-        local_count += 1
-        print(f"\n{local_count}: {dpla_id}")
+    logging.info(f"Partner mode: {partner} — {len(dpla_ids)} items from {ids_file}")
+    try:
+        for local_count, dpla_id in enumerate(dpla_ids, start=1):
+            # Item-start marker — `wikimedia_upload_status._sdc_progress`
+            # greps for this to surface SDC progress.
+            logging.info(f"DPLA ID: {dpla_id} ({local_count}/{len(dpla_ids)})")
 
-        # S3Client.get_item_file returns None on 404/NoSuchKey but re-raises
-        # any other ClientError. Catch those per-item so one transient S3
-        # failure doesn't abort the whole partner batch.
-        try:
-            sdc_raw = s3.get_sdc_json(partner, dpla_id)
-        except ClientError as e:
-            print(f" -- S3 error reading sdc.json for {dpla_id}: {e!r}; skipping.")
-            continue
-        if sdc_raw is None:
-            print(" -- No sdc.json on S3; skipping.")
-            continue
-        try:
-            sdc_payload = json.loads(sdc_raw)
-        except json.JSONDecodeError as e:
-            print(f" -- sdc.json failed to parse: {e}; skipping.")
-            continue
-
-        try:
-            upload_raw = s3.get_upload_result(partner, dpla_id)
-        except ClientError as e:
-            print(
-                f" -- S3 error reading upload-result.json for {dpla_id}: {e!r}; skipping."
-            )
-            continue
-        if upload_raw is None:
-            print(" -- No upload-result.json on S3; skipping.")
-            continue
-        try:
-            upload_result = json.loads(upload_raw)
-        except json.JSONDecodeError as e:
-            print(f" -- upload-result.json failed to parse: {e}; skipping.")
-            continue
-
-        ordinals = upload_result.get("ordinals", {})
-        eligible = {
-            ord_str: data
-            for ord_str, data in ordinals.items()
-            if data.get("status") in ("UPLOADED", "SKIPPED")
-        }
-        if not eligible:
-            print(" -- No SDC-eligible ordinals; skipping.")
-            continue
-
-        for ord_str, data in sorted(eligible.items(), key=lambda kv: int(kv[0])):
-            pageid = data.get("pageid")
-            if pageid is None:
-                print(f" -- Ordinal {ord_str}: no pageid; skipping.")
+            # S3Client.get_item_file returns None on 404/NoSuchKey but
+            # re-raises any other ClientError. Catch those per-item so one
+            # transient S3 failure doesn't abort the whole partner batch.
+            try:
+                sdc_raw = s3.get_sdc_json(partner, dpla_id)
+            except ClientError as e:
+                logging.warning(
+                    f" -- S3 error reading sdc.json for {dpla_id}: {e!r}; skipping."
+                )
+                tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
                 continue
-            mediaid = f"M{pageid}"
-            print(f" -- Ordinal {ord_str}: {mediaid} ({data.get('title', '?')})")
-            process_one_from_sdc(mediaid, dpla_id, sdc_payload)
+            if sdc_raw is None:
+                logging.info(" -- No sdc.json on S3; skipping.")
+                tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
+                continue
+            try:
+                sdc_payload = json.loads(sdc_raw)
+            except json.JSONDecodeError as e:
+                logging.warning(f" -- sdc.json failed to parse: {e}; skipping.")
+                tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
+                continue
+
+            try:
+                upload_raw = s3.get_upload_result(partner, dpla_id)
+            except ClientError as e:
+                logging.warning(
+                    f" -- S3 error reading upload-result.json for {dpla_id}: {e!r}; skipping."
+                )
+                tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
+                continue
+            if upload_raw is None:
+                logging.info(" -- No upload-result.json on S3; skipping.")
+                tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
+                continue
+            try:
+                upload_result = json.loads(upload_raw)
+            except json.JSONDecodeError as e:
+                logging.warning(
+                    f" -- upload-result.json failed to parse: {e}; skipping."
+                )
+                tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
+                continue
+
+            ordinals = upload_result.get("ordinals", {})
+            eligible = {
+                ord_str: data
+                for ord_str, data in ordinals.items()
+                if data.get("status") in ("UPLOADED", "SKIPPED")
+            }
+            if not eligible:
+                logging.info(" -- No SDC-eligible ordinals; skipping.")
+                tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
+                continue
+
+            for ord_str, data in sorted(eligible.items(), key=lambda kv: int(kv[0])):
+                pageid = data.get("pageid")
+                if pageid is None:
+                    logging.warning(f" -- Ordinal {ord_str}: no pageid; skipping.")
+                    continue
+                mediaid = f"M{pageid}"
+                logging.info(
+                    f" -- Ordinal {ord_str}: {mediaid} ({data.get('title', '?')})"
+                )
+                process_one_from_sdc(mediaid, dpla_id, sdc_payload)
+            tracker.increment(Result.SDC_ITEMS_SYNCED)
+    finally:
+        elapsed = time.time() - start_time
+        # Terminal "COUNTS:" marker — the status script keys on it to detect
+        # SDC completion, mirroring downloader/uploader.
+        logging.info("\n" + str(tracker))
+        logging.info(f"{elapsed} seconds.")
+        notify_sdc_complete(
+            tracker=tracker,
+            partner_label=partner,
+            elapsed_seconds=elapsed,
+        )
 
 
 # We can use a PWB generator to programatically make the list of files we are working on based on a set of criteria. Here, we are generating the page titles from a Wikimedia Commons search and categories. For other types of available page generators, see <https://doc.wikimedia.org/pywikibot/master/api_ref/pywikibot.html#module-pywikibot.pagegenerators>. As an additional step, we take the pageid provided by the generator and prepend "M" for the mediaid needed for posting SDC statements.
 
-count = 0
 
-if method == "list":
-    ltotal = [i for i in os.listdir(args.lists) if ".txt" in i]
-    lists = [i for i in ltotal if "COMPLETE" not in i and "WORKING" not in i]
-    percent = 100 * (len(ltotal) - len(lists)) / len(ltotal) if ltotal else 0
-    while lists:
-        # range(0, len(lists)-1) is exclusive on the upper bound, so the
-        # previous expression never selected the last index — fixed.
-        x = random.randrange(len(lists))
-        working_file = os.path.join(args.lists, "WORKING-" + lists[x])
-        print(working_file)
-        os.rename(os.path.join(args.lists, lists[x]), working_file)
+def main() -> None:
+    """Entry point for the `sdc-sync` console script.
 
-        files = pagegenerators.TextIOPageGenerator(working_file)
+    Dispatches to the legacy livecat/list/file/cat modes or the PR-4 partner
+    mode based on the parsed CLI flags. Initialization (argparse, Commons
+    login, ingestion3 JSON fetch) lives in `_initialize()`.
+    """
+    _initialize()
 
-        for file in files:
-            count += 1
-            print(f"{count}:\n - {args.lists}/{lists[x]} ({percent:.2f}% done)")
-            print("\n" + str(file).replace('""', '"'))
-            mediaid = "M" + str(file.pageid)
-            dpla_id = _resolve_dpla_id(str(file), dpla_api)
-            process_one(mediaid, dpla_id)
+    count = 0
 
-        os.rename(working_file, os.path.join(args.lists, "COMPLETE-" + lists[x]))
-
+    if method == "list":
         ltotal = [i for i in os.listdir(args.lists) if ".txt" in i]
         lists = [i for i in ltotal if "COMPLETE" not in i and "WORKING" not in i]
         percent = 100 * (len(ltotal) - len(lists)) / len(ltotal) if ltotal else 0
+        while lists:
+            # range(0, len(lists)-1) is exclusive on the upper bound, so the
+            # previous expression never selected the last index — fixed.
+            x = random.randrange(len(lists))
+            working_file = os.path.join(args.lists, "WORKING-" + lists[x])
+            print(working_file)
+            os.rename(os.path.join(args.lists, lists[x]), working_file)
 
-        duduped = set()
-        try:
-            with open("Missing ids.txt", "r") as f:
-                for line in f:
-                    duduped.add(line.strip())
-            with open("Missing ids.txt", "w") as f:
-                f.write("\n".join(duduped) + "\n")
-        except FileNotFoundError:
-            # No missing IDs recorded this batch; nothing to dedupe.
-            pass
+            files = pagegenerators.TextIOPageGenerator(working_file)
 
-elif args.files:
-    for title in args.files:
-        print("\n" + title)
-        page = pywikibot.Page(site, title)
-        if not page.exists():
-            print(f" -- Page not found on Commons: {title}")
-            continue
-        mediaid = "M" + str(page.pageid)
-        dpla_id = _resolve_dpla_id(title, dpla_api)
-        count += 1
-        print(f"{count}: {mediaid}")
-        process_one(mediaid, dpla_id)
+            for file in files:
+                count += 1
+                print(f"{count}:\n - {args.lists}/{lists[x]} ({percent:.2f}% done)")
+                print("\n" + str(file).replace('""', '"'))
+                mediaid = "M" + str(file.pageid)
+                dpla_id = _resolve_dpla_id(str(file), dpla_api)
+                process_one(mediaid, dpla_id)
 
-elif args.cat:
-    category = pywikibot.Category(site, args.cat)
-    generator = pagegenerators.CategorizedPageGenerator(
-        category, namespaces=[6], recurse=args.recurse
-    )
-    for page in generator:
-        title = page.title()
-        print("\n" + title)
-        mediaid = "M" + str(page.pageid)
-        dpla_id = _resolve_dpla_id(title, dpla_api)
-        count += 1
-        print(f"{count}: {mediaid}")
-        process_one(mediaid, dpla_id)
-        if args.limit and count >= args.limit:
-            print(f" -- Reached --limit {args.limit}, stopping.")
-            break
+            os.rename(working_file, os.path.join(args.lists, "COMPLETE-" + lists[x]))
 
-elif args.partner:
-    # Partner-driven SDC phase (PR 4). Iterates the partner's IDs CSV and
-    # syncs each item's precomputed sdc.json against Commons. Designed to be
-    # the last step in a `get-ids-es → downloader → uploader → sdc-sync`
-    # pipeline chain.
-    _ids_file = args.ids_file or os.path.join(args.partner, f"{args.partner}.csv")
-    _run_partner_mode(args.partner, _ids_file)
+            ltotal = [i for i in os.listdir(args.lists) if ".txt" in i]
+            lists = [i for i in ltotal if "COMPLETE" not in i and "WORKING" not in i]
+            percent = 100 * (len(ltotal) - len(lists)) / len(ltotal) if ltotal else 0
+
+            duduped = set()
+            try:
+                with open("Missing ids.txt", "r") as f:
+                    for line in f:
+                        duduped.add(line.strip())
+                with open("Missing ids.txt", "w") as f:
+                    f.write("\n".join(duduped) + "\n")
+            except FileNotFoundError:
+                # No missing IDs recorded this batch; nothing to dedupe.
+                pass
+
+    elif args.files:
+        for title in args.files:
+            print("\n" + title)
+            page = pywikibot.Page(site, title)
+            if not page.exists():
+                print(f" -- Page not found on Commons: {title}")
+                continue
+            mediaid = "M" + str(page.pageid)
+            dpla_id = _resolve_dpla_id(title, dpla_api)
+            count += 1
+            print(f"{count}: {mediaid}")
+            process_one(mediaid, dpla_id)
+
+    elif args.cat:
+        category = pywikibot.Category(site, args.cat)
+        generator = pagegenerators.CategorizedPageGenerator(
+            category, namespaces=[6], recurse=args.recurse
+        )
+        for page in generator:
+            title = page.title()
+            print("\n" + title)
+            mediaid = "M" + str(page.pageid)
+            dpla_id = _resolve_dpla_id(title, dpla_api)
+            count += 1
+            print(f"{count}: {mediaid}")
+            process_one(mediaid, dpla_id)
+            if args.limit and count >= args.limit:
+                print(f" -- Reached --limit {args.limit}, stopping.")
+                break
+
+    elif args.partner:
+        # Partner-driven SDC phase (PR 4). Iterates the partner's IDs CSV and
+        # syncs each item's precomputed sdc.json against Commons. Designed to
+        # be the last step in a `get-ids-es → downloader → uploader → sdc-sync`
+        # pipeline chain.
+        _ids_file = args.ids_file or os.path.join(args.partner, f"{args.partner}.csv")
+        _run_partner_mode(args.partner, _ids_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1997,6 +1997,7 @@ def _run_partner_mode(partner, ids_file):
         dpla_ids = [line.strip() for line in f if line.strip()]
 
     logging.info(f"Partner mode: {partner} — {len(dpla_ids)} items from {ids_file}")
+    completed = False
     try:
         for local_count, dpla_id in enumerate(dpla_ids, start=1):
             # Item-start marker — `wikimedia_upload_status._sdc_progress`
@@ -2047,10 +2048,21 @@ def _run_partner_mode(partner, ids_file):
                 continue
 
             ordinals = upload_result.get("ordinals", {})
+            # Guard the type of `ordinals` before iteration — if the JSON
+            # sidecar is corrupt or its schema drifts (null, list, scalar),
+            # `ordinals.items()` would raise out of the whole loop and abort
+            # the partner batch. Same handling as any other mapping error.
+            if not isinstance(ordinals, dict):
+                logging.warning(
+                    f" -- upload-result.json has non-mapping `ordinals` for {dpla_id}; skipping."
+                )
+                tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
+                continue
             eligible = {
                 ord_str: data
                 for ord_str, data in ordinals.items()
-                if data.get("status") in ("UPLOADED", "SKIPPED")
+                if isinstance(data, dict)
+                and data.get("status") in ("UPLOADED", "SKIPPED")
             }
             if not eligible:
                 logging.info(" -- No SDC-eligible ordinals; skipping.")
@@ -2089,17 +2101,29 @@ def _run_partner_mode(partner, ids_file):
                 tracker.increment(Result.SDC_ITEMS_SYNCED)
             else:
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
+        completed = True
     finally:
         elapsed = time.time() - start_time
-        # Terminal "COUNTS:" marker — the status script keys on it to detect
-        # SDC completion, mirroring downloader/uploader.
-        logging.info("\n" + str(tracker))
-        logging.info(f"{elapsed} seconds.")
-        notify_sdc_complete(
-            tracker=tracker,
-            partner_label=partner,
-            elapsed_seconds=elapsed,
-        )
+        # Emit the terminal "COUNTS:" marker and Slack completion message
+        # only on a successful loop completion. The shell-level failure
+        # handler (`notify_pipeline_fail`) will surface aborted runs via a
+        # separate `❌ pipeline step failed` message, so on the failure
+        # path we'd otherwise double-signal — and worse, the status script
+        # would treat the SDC phase as done based on the spurious COUNTS:
+        # line.
+        if completed:
+            logging.info("\n" + str(tracker))
+            logging.info(f"{elapsed} seconds.")
+            notify_sdc_complete(
+                tracker=tracker,
+                partner_label=partner,
+                elapsed_seconds=elapsed,
+            )
+        else:
+            logging.warning(
+                "SDC sync aborted before completion; suppressing terminal "
+                "COUNTS dump and notify_sdc_complete call."
+            )
 
 
 # We can use a PWB generator to programatically make the list of files we are working on based on a set of criteria. Here, we are generating the page titles from a Wikimedia Commons search and categories. For other types of available page generators, see <https://doc.wikimedia.org/pywikibot/master/api_ref/pywikibot.html#module-pywikibot.pagegenerators>. As an additional step, we take the pageid provided by the generator and prepend "M" for the mediaid needed for posting SDC statements.

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1493,11 +1493,26 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
             "bot": True,
             "summary": f"Changing structured data claims from [[COM:DPLA|DPLA]] item '[[dpla:{dpla_id}|{dpla_id}]]'. [[COM:DPLA/MOD|Leave feedback]]!",
         }
-        http.fetch(
+        # Only count removals once we've seen `success: 1` on the
+        # wbremoveclaims response, matching what `_post_new_refs` and
+        # `_post_new_claims` do for their respective POSTs. Without this
+        # check, a rejected removal batch (bad token, replication lag,
+        # claim already gone, etc.) would silently inflate the counter.
+        rm_resp = http.fetch(
             "https://commons.wikimedia.org/w/api.php", method="POST", data=rmdata
         )
-        print(" --- Saved removals!")
-        tracker.increment(Result.SDC_REMOVALS, len(removals))
+        try:
+            rm_post = json.loads(rm_resp.text)
+        except (ValueError, AttributeError):
+            print(" --- Could not parse removals response.")
+            sys.exit()
+        if rm_post.get("success") == 1:
+            print(" --- Saved removals!")
+            tracker.increment(Result.SDC_REMOVALS, len(removals))
+        else:
+            print(rm_post)
+            print(" --- Error encountered on removals save.")
+            sys.exit()
 
 
 def _fetch_dpla_doc_from_api(dpla_id, dpla_api):
@@ -2043,7 +2058,19 @@ def _run_partner_mode(partner, ids_file):
                 continue
 
             synced_this_item = False
-            for ord_str, data in sorted(eligible.items(), key=lambda kv: int(kv[0])):
+            # int(ord_str) on a malformed ordinal key (e.g. "abc" instead
+            # of "3") would otherwise raise out of the whole loop and
+            # abort the partner batch. Skip the item, log, and account
+            # for it as a mapping skip — same handling as malformed JSON.
+            try:
+                ordinal_items = sorted(eligible.items(), key=lambda kv: int(kv[0]))
+            except (TypeError, ValueError):
+                logging.warning(
+                    f" -- upload-result ordinals malformed for {dpla_id}; skipping."
+                )
+                tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
+                continue
+            for ord_str, data in ordinal_items:
                 pageid = data.get("pageid")
                 if pageid is None:
                     logging.warning(f" -- Ordinal {ord_str}: no pageid; skipping.")


### PR DESCRIPTION
## Summary

Adds SDC as the final step of every regular Wikimedia upload run.

After PR #243, get-ids-es stages `sdc.json` and uploader stages `upload-result.json` for every item, but the partner-mode `sdc-sync` only ran when invoked by hand. Triggered uploads through `wikimedia-upload` never posted MediaInfo statements to Commons. This PR closes that gap.

## What changes

- **Pipeline wiring** (`scripts/wikimedia_launch.py`): each non-refresh target block now ends in `sdc-sync --partner $HUB --ids-file $CSV` after the uploader. Runs for batch + single-item targets; skipped for refresh-only (no upload-result.json to drive from).
- **Console-script entry point** (`tools/sdc_sync.py` + `pyproject.toml`): renamed `tools/sdc-sync.py` → `tools/sdc_sync.py` (Python can't import a hyphenated module), wrapped argparse + Commons login + ingestion3 JSON fetches inside `_initialize()` so importing the module is side-effect free, registered `sdc-sync` alongside `uploader` / `downloader` / `get-ids-es`. Refactor surfaced a latent bug in `_build_expected_from_parsed` (was reading `dpla_id` from a module-level binding set incidentally by the dispatch loop); fixed by threading `dpla_id` through as an explicit parameter.
- **Tracker + logging + Slack** (`ingest_wikimedia/tracker.py`, `ingest_wikimedia/slack.py`, `tools/sdc_sync._run_partner_mode`): new `Result` enum members (`SDC_ITEMS_SYNCED`, `SDC_CLAIMS_ADDED`, `SDC_REFS_ADDED`, `SDC_REMOVALS`, `SDC_ITEMS_SKIPPED_NO_SIDECAR`, `SDC_ITEMS_SKIPPED_MAPPING`). `_post_new_refs` / `_post_new_claims` / `_reconcile_existing_claims` increment on successful POST; `_run_partner_mode` increments skip and synced counters. Calls `setup_logging(partner, "sdc")` so output lands in `{partner}/logs/{timestamp}-{label}-sdc.log`. New `notify_sdc_complete` mirrors `notify_upload_complete` in channel + block shape (counter set differs).
- **Status integration** (`scripts/wikimedia_upload_status.py`): `log_filename_pattern_for_label` regex extended to match `-sdc.log`; new phase decoder branch reports `SDC syncing (...)` and `SDC complete (...)`; multi-label walker treats `SDC complete` as terminal so it doesn't loop on finished targets.
- **Tests**: 4 new `tests/test_slack.py` cases (header shape, counter mapping, dry-run suffix, silent skip without token) + 3 new `tests/test_wikimedia_upload_status.py` cases (sdc filename + phase decoder syncing / complete / starting branches).

## Test plan

- [x] `ruff check` + `ruff format` clean on all changed files
- [x] Full pytest suite passes on EC2 (47 tests in `test_slack.py` + `test_wikimedia_upload_status.py` + `test_tracker.py`, including 7 new SDC tests)
- [x] End-to-end smoke on Grant County (`0850fba9…`): `sdc-sync --partner minnesota` writes the log file with the expected name, logs the per-item `DPLA ID: <id> (n/N)` marker, posts zero edits (idempotent), dumps the terminal `COUNTS:` section with `SDC_ITEMS_SYNCED: 1`, and gracefully no-ops the Slack call when the token is absent
- [ ] Reviewer: run a real triggered upload (e.g. tiny institution slice) to confirm the pipeline chain now ends with `Wikimedia SDC Complete:` Slack message and `/wikimedia-status` walks Download → Upload → SDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR wires SDC (Structured Data on Commons) syncing into the Wikimedia upload pipeline so SDC runs as the final step of non-refresh upload runs and posts MediaInfo/statements to Commons.

Key changes
- Pipeline integration: scripts/wikimedia_launch.py appends a final sdc-sync --partner {canonical} --ids-file {csv_file} step after the uploader for all non--refresh-only targets (omitted for refresh-only runs). Launch messages updated to include SDC in the ID-generation → download → upload → SDC sequence.
- Console script & CLI refactor: pyproject.toml registers sdc-sync = "tools.sdc_sync:main". The tool file was renamed to tools/sdc_sync.py and refactored to avoid import-time I/O by moving parser creation into _build_parser() and runtime setup (argparse, config.toml read, Commons login/CSRF token acquisition, ingestion3 hubs/subjects fetches, optional S3 client) into _initialize(). dpla_id is threaded into _build_expected_from_parsed().
- Tracker, logging, Slack: ingest_wikimedia/tracker.py adds six SDC counters (SDC_ITEMS_SYNCED, SDC_CLAIMS_ADDED, SDC_REFS_ADDED, SDC_REMOVALS, SDC_ITEMS_SKIPPED_NO_SIDECAR, SDC_ITEMS_SKIPPED_MAPPING). tools/sdc_sync._run_partner_mode uses setup_logging(partner, "sdc") to create partner-scoped -sdc.log files, increments tracker counters for syncs/claims/refs/removals/skips (including on retry-success flows), emits a terminal COUNTS: marker (logging.info(str(tracker))), and calls notify_sdc_complete() from ingest_wikimedia.slack in a try/finally. ingest_wikimedia/slack.py adds notify_sdc_complete(...) to post an SDC completion message summarizing tracker counters and elapsed runtime.
- Status monitoring: scripts/wikimedia_upload_status.py adds _SDC_COMPLETE_PREFIX, extends log filename pattern to match *-sdc.log, reports “SDC syncing (…)” and “SDC complete (…)”, and treats SDC complete as a terminal phase for multi-label walks.
- Tests: seven new unit tests (4 in tests/test_slack.py, 3 in tests/test_wikimedia_upload_status.py). Author reports ruff clean, full pytest passed on EC2 (47 tests including 7 new tests), and an end-to-end smoke on a sample partner validated logging, per-item markers, idempotent POST behavior, and Slack no-op when token absent.

Deployment / infra / secrets / security checklist
- Manual pipeline trigger / redeploy required: No shared-infrastructure redeploy is required (no CodePipeline/CodeBuild/ECS task/IAM changes). The change takes effect once this code is deployed; to exercise it you must run a non-refresh Wikimedia upload (the reviewer-recommended test is a real triggered non-refresh upload to confirm the Slack notification and status walk: Download → Upload → SDC).
- Environment variables / Secrets: No new environment variables or AWS Secrets Manager keys added. Existing DPLA_SLACK_BOT_TOKEN is reused for Slack notifications; WIKIMEDIA_SESSION_LABEL continues to identify session labels. tests and code confirm behavior when DPLA_SLACK_BOT_TOKEN is missing (Slack notification is skipped).
- Database migrations: None.
- Shared infrastructure changes (CodePipeline/CodeBuild/ECS/IAM): None; changes are application-level script/CLI behavior that run inside existing EC2/SSM/S3 flows.
- Public API surface: None — no public API responses or endpoints added/changed.
- Security implications: Import-time credential acquisition was removed (Commons login/CSRF token now obtained during _initialize()), reducing unexpected side effects at import. SDC sync adds outward calls to Wikimedia (wbeditentity/wbremoveclaims) and to Slack using existing tokens; reviewers should validate that the Slack and Wikimedia credentials in use have appropriate scopes and are stored/rotated according to org policies.

Testing / reviewer action
- Recommended: run a real non-refresh (triggered) upload to verify the pipeline finishes with a “Wikimedia SDC Complete:” Slack notification and that scripts/wikimedia_upload_status (and /wikimedia-status consumers) report phases Download → Upload → SDC.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->