### PR TITLE
wikimedia-launch: add --sdc-only mode for SDC backfills (PR 5b+5c of 5)

### DIFF
--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -30,6 +30,10 @@ on:
         description: "Download-only refresh run — skip upload phase"
         type: boolean
         default: false
+      sdc_only:
+        description: "SDC-only backfill — skip download + upload phases, just re-enumerate IDs and run sdc-sync"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -66,10 +70,12 @@ jobs:
           INPUT_RESPONSE_URL: ${{ github.event.inputs.response_url }}
           INPUT_MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days }}
           INPUT_REFRESH_ONLY: ${{ github.event.inputs.refresh_only }}
+          INPUT_SDC_ONLY: ${{ github.event.inputs.sdc_only }}
         run: |
           python scripts/wikimedia_launch.py \
             --partner "$INPUT_PARTNER" \
             --force "$INPUT_FORCE" \
             --response-url "$INPUT_RESPONSE_URL" \
             --max-age-days "$INPUT_MAX_AGE_DAYS" \
-            --refresh-only "$INPUT_REFRESH_ONLY"
+            --refresh-only "$INPUT_REFRESH_ONLY" \
+            --sdc-only "$INPUT_SDC_ONLY"

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Pre-commit hooks use [ruff](https://docs.astral.sh/ruff/) for linting and format
 
 ## Running the pipeline
 
-The pipeline has three sequential phases, each invoked as a CLI command:
+The pipeline has four sequential phases, each invoked as a CLI command:
 
 ```bash
-# 1. Generate IDs and stage metadata (writes <partner>.csv)
+# 1. Generate IDs and stage metadata (writes <partner>.csv + per-item sdc.json sidecars)
 get-ids-es <partner>
 get-ids-es <partner> --institution "Institution Name"   # institution-level run
 
@@ -29,9 +29,12 @@ downloader <partner>.csv <partner>
 
 # 3. Upload from S3 to Wikimedia Commons
 uploader <partner>.csv <partner>
+
+# 4. Reconcile SDC (MediaInfo statements) on Commons against the staged sdc.json
+sdc-sync --partner <partner> --ids-file <partner>.csv
 ```
 
-All three must run from the partner's working directory on EC2 (e.g. `/home/ec2-user/ingest-wikimedia/bpl/`), where `config.toml` is resolved from CWD.
+All four must run from the partner's working directory on EC2 (e.g. `/home/ec2-user/ingest-wikimedia/bpl/`), where `config.toml` is resolved from CWD.
 
 **In practice, pipelines are launched via Slack or GitHub Actions** — see [docs/operations.md](docs/operations.md) for the full operations guide.
 
@@ -51,6 +54,7 @@ All three must run from the partner's working directory on EC2 (e.g. `/home/ec2-
 get-ids-es <partner> [--institution NAME] [--dry-run]
 downloader <partner>.csv <partner> [--dry-run] [--verbose]
 uploader   <partner>.csv <partner> [--dry-run] [--verbose]
+sdc-sync   --partner <partner> [--ids-file PATH]
 ```
 
 Pass `--help` to any command for full option details.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All three must run from the partner's working directory on EC2 (e.g. `/home/ec2-
 | Path | Purpose |
 |------|---------|
 | `ingest_wikimedia/` | Shared library (partner registry, S3, Slack, SSM, Wikimedia API) |
-| `tools/` | CLI entry points (`get-ids-es`, `downloader`, `uploader`) |
+| `tools/` | CLI entry points (`get-ids-es`, `downloader`, `uploader`, `sdc-sync`) |
 | `scripts/` | GitHub Actions step scripts (`wikimedia_launch.py`, `wikimedia_kill.py`, `wikimedia_upload_status.py`) |
 | `lambda/wikimedia-slack-dispatch/` | Lambda handler for Slack slash commands |
 | `.github/workflows/` | Workflow definitions for launch, kill, and status checks |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -264,6 +264,8 @@ The `wikimedia-launch.yml` workflow accepts two boolean inputs that swap the def
 
 - **`refresh_only=true`** — runs `get-ids-es → downloader` only (no uploader, no SDC). For re-downloading aged media files in S3 without re-uploading. The downloader is invoked with `--notify-complete` so its own Slack summary fires at the end. `max_age_days=N` controls the re-download threshold (default: > 365 days).
 - **`sdc_only=true`** — runs `get-ids-es → sdc-sync` only (no downloader, no uploader). For backfilling or refreshing SDC on items that were uploaded in a prior session, including picking up changes to ingestion3's `institutions_v2.json` / `subjects.json` mappings. The `get-ids-es` step re-stages each item's `sdc.json` from current ingestion3 data; `sdc-sync` then reconciles Commons against that.
+  - **Targets without sdc.json re-staging**: single-item DPLA IDs (which use `resolve-dpla-ids` + `printf`) and NARA hub-level targets (which use `get-ids-nara`) do **not** re-stage `sdc.json`. For these, `sdc-sync` replays whatever sidecar the original upload run wrote. The launcher prints a stderr warning when this combination is detected. Useful for re-running fixed sdc-sync logic against a specific item; not useful for picking up upstream mapping changes.
+  - `max_age_days` is ignored in `sdc_only` mode (no download phase runs).
 
 ---
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -41,10 +41,11 @@ GitHub Actions (wikimedia-launch.yml)
     ▼
 EC2 (i-033eff6c8c168f999) via AWS SSM
     │  tmux session: wikimedia-bpl+pa
-    │  Runs three phases per target (sequentially):
-    │    1. get-ids-es → <partner>.csv
+    │  Runs four phases per target (sequentially):
+    │    1. get-ids-es → <partner>.csv  (also stages per-item sdc.json)
     │    2. downloader <partner>.csv <partner>
-    │    3. uploader   <partner>.csv <partner>
+    │    3. uploader   <partner>.csv <partner>  (writes per-item upload-result.json)
+    │    4. sdc-sync   --partner <partner> --ids-file <partner>.csv
     ▼
 S3 (s3://dpla-wikimedia/)     Wikimedia Commons
 ```
@@ -57,7 +58,7 @@ Results (success or failure) post to **#tech-alerts** via the `DPLA_SLACK_BOT_TO
 
 ### `/wikimedia-upload <target> [<target> ...]`
 
-Launches the full upload pipeline (ID generation → download → upload) for one or more targets. All targets run sequentially in a single tmux session. If any step fails, the chain stops.
+Launches the full upload pipeline (ID generation → download → upload → SDC sync) for one or more targets. All targets run sequentially in a single tmux session. If any step fails, the chain stops.
 
 ```text
 /wikimedia-upload bpl
@@ -220,11 +221,11 @@ Hub-level eligibility does not imply every institution within it is eligible —
 
 ## Pipeline phases
 
-Each target runs three sequential phases within the tmux session. The `&&` chain ensures a later phase only starts if the previous one succeeded.
+Each target runs four sequential phases within the tmux session. The `&&` chain ensures a later phase only starts if the previous one succeeded.
 
 ### Phase 1: ID generation (`get-ids-es`)
 
-Queries DPLA's Elasticsearch index for items belonging to the partner hub (or a specific institution). Writes a CSV of DPLA IDs and associated metadata to `<partner>.csv` in the partner's working directory.
+Queries DPLA's Elasticsearch index for items belonging to the partner hub (or a specific institution). Writes a CSV of DPLA IDs to `<partner>.csv` in the partner's working directory and stages each item's `dpla-map.json` plus a precomputed `sdc.json` claim envelope to S3 under `<partner>/images/<sharded-prefix>/<dpla-id>/`.
 
 ```bash
 get-ids-es <partner>                              # full hub
@@ -241,13 +242,28 @@ downloader <partner>.csv <partner>
 
 ### Phase 3: Upload (`uploader`)
 
-Reads `<partner>.csv`, retrieves media from S3, and uploads each file to Wikimedia Commons with structured SDC (Structured Data on Commons) metadata. Skips files already present on Commons.
+Reads `<partner>.csv`, retrieves media from S3, and uploads each file to Wikimedia Commons with structured SDC (Structured Data on Commons) metadata. Skips files already present on Commons. Writes a per-item `upload-result.json` sidecar to S3 with each ordinal's outcome (status / page title / pageid), which the SDC phase consumes.
 
 ```bash
 uploader <partner>.csv <partner>
 ```
 
-All three phases are idempotent — re-running is safe and picks up where it left off.
+### Phase 4: SDC sync (`sdc-sync`)
+
+Reads each item's precomputed `sdc.json` and `upload-result.json` from S3, and for every ordinal whose upload status is `UPLOADED` or `SKIPPED`, posts MediaInfo statements (and references) to the corresponding Commons file via the wbeditentity API. Idempotent — re-syncing a fully-synced item produces zero writes.
+
+```bash
+sdc-sync --partner <partner> --ids-file <partner>.csv
+```
+
+All phases are idempotent — re-running is safe and picks up where it left off.
+
+### Alternate run modes
+
+The `wikimedia-launch.yml` workflow accepts two boolean inputs that swap the default 4-phase chain for a shorter variant. They are mutually exclusive — pick at most one.
+
+- **`refresh_only=true`** — runs `get-ids-es → downloader` only (no uploader, no SDC). For re-downloading aged media files in S3 without re-uploading. The downloader is invoked with `--notify-complete` so its own Slack summary fires at the end. `max_age_days=N` controls the re-download threshold (default: > 365 days).
+- **`sdc_only=true`** — runs `get-ids-es → sdc-sync` only (no downloader, no uploader). For backfilling or refreshing SDC on items that were uploaded in a prior session, including picking up changes to ingestion3's `institutions_v2.json` / `subjects.json` mappings. The `get-ids-es` step re-stages each item's `sdc.json` from current ingestion3 data; `sdc-sync` then reconciles Commons against that.
 
 ---
 
@@ -287,6 +303,10 @@ Inputs:
 - `partner` (required): shlex-encoded target list, e.g. `bpl` or `bpl pa` or `bpl "indiana|Indiana State Library"` or `Q72380652`
 - `force` (boolean, default `false`): kill any conflicting sessions before launching
 - `response_url` (optional): Slack response URL for ephemeral error feedback
+- `concurrency_key` (optional): short SHA256 prefix of the partner string, used by the GitHub Actions concurrency group to keep the key under the 400-char limit; set by the Slack dispatcher
+- `max_age_days` (optional integer): for `refresh_only` runs, re-download files older than N days in S3 (default: 365)
+- `refresh_only` (boolean, default `false`): run `get-ids-es → downloader` only — skip the upload and SDC phases (see "Alternate run modes" above)
+- `sdc_only` (boolean, default `false`): run `get-ids-es → sdc-sync` only — skip the download and upload phases (see "Alternate run modes" above). Mutually exclusive with `refresh_only`.
 
 Steps:
 1. Installs `boto3` and `requests`
@@ -460,7 +480,7 @@ Common crash causes:
 
 ### Re-running after a crash
 
-All phases are idempotent — re-launching is safe. The downloader skips already-staged S3 objects; the uploader skips files already on Commons. Just trigger `/wikimedia-upload <hub>` again.
+All phases are idempotent — re-launching is safe. The downloader skips already-staged S3 objects; the uploader skips files already on Commons; sdc-sync re-syncs each item but writes nothing when the Commons-side state already matches the precomputed sdc.json. Just trigger `/wikimedia-upload <hub>` again.
 
 If the ID file (`<partner>.csv`) is partial or empty, delete it before re-running — the launch script will regenerate it from scratch.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -58,7 +58,7 @@ Results (success or failure) post to **#tech-alerts** via the `DPLA_SLACK_BOT_TO
 
 ### `/wikimedia-upload <target> [<target> ...]`
 
-Launches the full upload pipeline (ID generation → download → upload → SDC sync) for one or more targets. All targets run sequentially in a single tmux session. If any step fails, the chain stops.
+Launches the full upload pipeline (ID generation → download → upload → SDC sync) for one or more targets. Targets run sequentially in a single tmux session. If a step fails for a given target, that target's pipeline stops and a Slack failure notification posts — the launcher then continues with the next target in the batch.
 
 ```text
 /wikimedia-upload bpl

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -381,6 +381,40 @@ def main() -> None:
         detail = ("\n• " + "\n• ".join(skipped_warnings)) if skipped_warnings else ""
         _slack_fail(response_url, f"No valid targets to launch.{detail}")
 
+    # `--sdc-only` is meaningful only for targets whose ID-generation step
+    # re-stages sdc.json. Two target types use a different path:
+    #   * Single-item DPLA IDs — the launcher writes the one ID via `printf`
+    #     to skip the enumeration phase; `resolve-dpla-ids` (run at startup)
+    #     stages `dpla-map.json` but NOT `sdc.json`.
+    #   * NARA hub-level — uses `get-ids-nara` (NARA catalog enumeration,
+    #     not ingestion3 ES), which also doesn't write `sdc.json`.
+    # For these, sdc-sync will replay whatever sidecar the *original* upload
+    # run wrote. That's fine for re-running PR-#251-style code changes
+    # against a known item, but operators backfilling for upstream mapping
+    # changes need to know they won't pick up. Warn loudly rather than
+    # silently using stale data.
+    if sdc_only:
+        stale_sdc_target_labels = [
+            lbl
+            for canonical, institution, lbl, dpla_id, _ in targets
+            if dpla_id is not None or (canonical == "nara" and institution is None)
+        ]
+        if stale_sdc_target_labels:
+            print(
+                "Warning: --sdc-only with single-item DPLA IDs or NARA"
+                " hub-level targets will use the existing sdc.json sidecars"
+                " (last written by get-ids-es during the original upload"
+                " run). These targets cannot re-stage sdc.json. Affected:"
+                f" {', '.join(stale_sdc_target_labels)}.",
+                file=sys.stderr,
+            )
+        if max_age_days is not None:
+            print(
+                "Warning: --max-age-days is ignored in --sdc-only mode"
+                " (no download phase runs).",
+                file=sys.stderr,
+            )
+
     # Session name uses + as separator (unambiguous since slugs/institution names use -).
     # Institution-level targets include the hub slug as a prefix so the status script
     # can derive the EC2 directory: "indiana|Indiana State Library" → wikimedia-indiana+indiana-state-library.

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -58,6 +58,18 @@ def _slugify(name: str) -> str:
     return _SLUG_RE.sub("", name.lower().replace(" ", "-"))
 
 
+def _parse_bool(value: str) -> bool:
+    """Parse a GitHub Actions boolean-string input into a real bool.
+
+    GH Actions passes ``workflow_dispatch`` boolean inputs as the literal
+    strings ``"true"`` / ``"false"`` (case-insensitive). Anything else
+    (including empty, ``"yes"``, ``"1"``) is treated as falsy. Used for
+    ``--force``, ``--refresh-only``, and ``--sdc-only`` so the polarity
+    stays consistent across all three flags.
+    """
+    return value.lower() == "true"
+
+
 def _slack_fail(response_url: str, msg: str) -> NoReturn:
     """Print msg to stderr, post ephemeral reply to response_url if set, then exit 1."""
     print(msg, file=sys.stderr)
@@ -84,10 +96,9 @@ def main() -> None:
     parser.add_argument("--sdc-only", default="false")
     args = parser.parse_args()
 
-    force = args.force.lower() == "true"
-    # GitHub Actions passes boolean inputs as the strings "true"/"false" — same as --force.
-    refresh_only = args.refresh_only.lower() == "true"
-    sdc_only = args.sdc_only.lower() == "true"
+    force = _parse_bool(args.force)
+    refresh_only = _parse_bool(args.refresh_only)
+    sdc_only = _parse_bool(args.sdc_only)
 
     # Normalize the response_url first so the mutual-exclusion check below
     # can use the validated value rather than re-implementing the same

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -81,11 +81,26 @@ def main() -> None:
     parser.add_argument("--response-url", default="")
     parser.add_argument("--max-age-days", default="")
     parser.add_argument("--refresh-only", default="false")
+    parser.add_argument("--sdc-only", default="false")
     args = parser.parse_args()
 
     force = args.force.lower() == "true"
     # GitHub Actions passes boolean inputs as the strings "true"/"false" — same as --force.
     refresh_only = args.refresh_only.lower() == "true"
+    sdc_only = args.sdc_only.lower() == "true"
+    if refresh_only and sdc_only:
+        raw_url_for_err = args.response_url.strip()
+        err_url = (
+            raw_url_for_err
+            if raw_url_for_err.startswith("https://hooks.slack.com/commands/")
+            else ""
+        )
+        _slack_fail(
+            err_url,
+            "Cannot combine --refresh-only and --sdc-only — they're mutually"
+            " exclusive run modes (refresh skips upload + SDC; sdc-only skips"
+            " download + upload).",
+        )
     raw_url = args.response_url.strip()
     # Only accept genuine Slack response_url values — reject arbitrary POST targets.
     response_url = (
@@ -644,25 +659,38 @@ def main() -> None:
             f"{is_last_env}; "
             f"{single_item_env}"
         )
-        dl_age_opt = (
-            f"--max-age-days {max_age_days} " if max_age_days is not None else ""
-        )
-        dl_notify_opt = "--notify-complete " if refresh_only else ""
-        pipeline_steps = [
-            f"cd {base}",
-            get_ids_cmd,
-            f"downloader {dl_age_opt}{dl_notify_opt}{csv_file} {canonical}",
-        ]
-        if not refresh_only:
-            pipeline_steps.append(f"uploader {csv_file} {canonical}")
-            # SDC sync is the final step of every upload run: it reads the
-            # per-item sdc.json (staged by get-ids-es) and upload-result.json
-            # (written by uploader) sidecars and posts MediaInfo statements
-            # to Commons. Skipped for refresh_only because no upload phase
-            # ran — there's no upload-result.json to drive from.
-            pipeline_steps.append(
-                f"sdc-sync --partner {canonical} --ids-file {csv_file}"
+        if sdc_only:
+            # SDC-only backfill: re-enumerate the partner's items (which
+            # also refreshes sdc.json sidecars from the latest ingestion3
+            # data) then run sdc-sync. No downloader, no uploader — the
+            # caller is reconciling SDC for items the uploader already
+            # processed in a prior session.
+            pipeline_steps = [
+                f"cd {base}",
+                get_ids_cmd,
+                f"sdc-sync --partner {canonical} --ids-file {csv_file}",
+            ]
+        else:
+            dl_age_opt = (
+                f"--max-age-days {max_age_days} " if max_age_days is not None else ""
             )
+            dl_notify_opt = "--notify-complete " if refresh_only else ""
+            pipeline_steps = [
+                f"cd {base}",
+                get_ids_cmd,
+                f"downloader {dl_age_opt}{dl_notify_opt}{csv_file} {canonical}",
+            ]
+            if not refresh_only:
+                pipeline_steps.append(f"uploader {csv_file} {canonical}")
+                # SDC sync is the final step of every upload run: it reads
+                # the per-item sdc.json (staged by get-ids-es) and
+                # upload-result.json (written by uploader) sidecars and
+                # posts MediaInfo statements to Commons. Skipped for
+                # refresh_only because no upload phase ran — there's no
+                # upload-result.json to drive from.
+                pipeline_steps.append(
+                    f"sdc-sync --partner {canonical} --ids-file {csv_file}"
+                )
         target_steps = " && ".join(pipeline_steps)
         target_blocks.append(
             f"{label_export}; {{ {target_steps}; }}"
@@ -695,6 +723,11 @@ def main() -> None:
             item_descs = [f"`{did}` ({c})" for c, _, did in single_item_targets]
             if refresh_only:
                 msg = f"✅ {', '.join(item_descs)} — eligible, download refresh starting{refresh_suffix}."
+            elif sdc_only:
+                msg = (
+                    f"✅ {', '.join(item_descs)} — eligible,"
+                    " SDC-only backfill starting."
+                )
             else:
                 msg = (
                     f"✅ {', '.join(item_descs)} — eligible,"
@@ -705,6 +738,11 @@ def main() -> None:
             batch_labels = [_target_label(c, i, col) for c, i, _, col in batch_targets]
             if refresh_only:
                 msg = f"▶ Launching `{session_name}` refresh: {', '.join(batch_labels)}{refresh_suffix}."
+            elif sdc_only:
+                msg = (
+                    f"▶ Launching `{session_name}` SDC backfill:"
+                    f" {', '.join(batch_labels)} (ID generation → SDC)."
+                )
             else:
                 msg = (
                     f"▶ Launching `{session_name}` pipeline: {', '.join(batch_labels)}"
@@ -720,6 +758,11 @@ def main() -> None:
                     all_descs.append(_target_label(c, i, col))
             if refresh_only:
                 msg = f"▶ Launching `{session_name}` refresh: {', '.join(all_descs)}{refresh_suffix}."
+            elif sdc_only:
+                msg = (
+                    f"▶ Launching `{session_name}` SDC backfill:"
+                    f" {', '.join(all_descs)} (ID generation → SDC)."
+                )
             else:
                 msg = (
                     f"▶ Launching `{session_name}` pipeline: {', '.join(all_descs)}"

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -88,19 +88,10 @@ def main() -> None:
     # GitHub Actions passes boolean inputs as the strings "true"/"false" — same as --force.
     refresh_only = args.refresh_only.lower() == "true"
     sdc_only = args.sdc_only.lower() == "true"
-    if refresh_only and sdc_only:
-        raw_url_for_err = args.response_url.strip()
-        err_url = (
-            raw_url_for_err
-            if raw_url_for_err.startswith("https://hooks.slack.com/commands/")
-            else ""
-        )
-        _slack_fail(
-            err_url,
-            "Cannot combine --refresh-only and --sdc-only — they're mutually"
-            " exclusive run modes (refresh skips upload + SDC; sdc-only skips"
-            " download + upload).",
-        )
+
+    # Normalize the response_url first so the mutual-exclusion check below
+    # can use the validated value rather than re-implementing the same
+    # `startswith("https://hooks.slack.com/commands/")` guard inline.
     raw_url = args.response_url.strip()
     # Only accept genuine Slack response_url values — reject arbitrary POST targets.
     response_url = (
@@ -108,6 +99,14 @@ def main() -> None:
     )
     if raw_url and not response_url:
         print(f"Ignoring invalid response_url: {raw_url!r}", file=sys.stderr)
+
+    if refresh_only and sdc_only:
+        _slack_fail(
+            response_url,
+            "Cannot combine --refresh-only and --sdc-only — they're mutually"
+            " exclusive run modes (refresh skips upload + SDC; sdc-only skips"
+            " download + upload).",
+        )
     max_age_days: int | None = None
     if args.max_age_days.strip():
         try:

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -1,0 +1,95 @@
+"""Focused tests for scripts/wikimedia_launch.py.
+
+The launcher is a thin orchestrator over boto3 + SSM + Slack — most of its
+behavior is exercised end-to-end by the GH Action that fires it. These
+tests cover the argument-validation surface added in PR 5b/5c so a typo
+in `--sdc-only` handling can't ship silently.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def _run_main(argv: list[str]) -> SystemExit | None:
+    """Invoke `wikimedia_launch.main()` with a synthetic argv and return
+    the SystemExit raised by `_slack_fail` (or None if main exited cleanly).
+
+    `_slack_fail` exits 1 after stderr + optional Slack notification; the
+    test asserts on the SystemExit instance's `.code`.
+    """
+    import scripts.wikimedia_launch as launch_mod
+
+    with patch("sys.argv", ["wikimedia_launch.py", *argv]):
+        try:
+            launch_mod.main()
+        except SystemExit as e:
+            return e
+    return None
+
+
+def test_refresh_only_and_sdc_only_are_mutually_exclusive():
+    """Passing both --refresh-only and --sdc-only must fail fast with a
+    clear error — they're distinct run modes and combining them silently
+    would pick whichever branch the launcher tested first."""
+    exit_info = _run_main(
+        [
+            "--partner",
+            "minnesota",
+            "--refresh-only",
+            "true",
+            "--sdc-only",
+            "true",
+        ]
+    )
+    assert exit_info is not None, "Expected SystemExit on conflicting flags"
+    assert exit_info.code == 1
+
+
+def test_sdc_only_alone_is_accepted_at_parse_time(monkeypatch, capsys):
+    """`--sdc-only true` on its own must parse without error. We can't
+    exercise the full launch chain in a unit test (it shells to EC2), so
+    we just confirm parse_args + the mutual-exclusion gate let it
+    through to the next step.
+
+    We do this by passing an unresolvable target so the launcher errors
+    out *after* the flag-parsing step rather than at it. SystemExit from
+    `_slack_fail("No valid targets to launch...")` confirms parsing
+    succeeded.
+    """
+    exit_info = _run_main(
+        [
+            "--partner",
+            "this-is-not-a-real-hub-slug",
+            "--sdc-only",
+            "true",
+        ]
+    )
+    assert exit_info is not None
+    # Anything that exits with code 1 is fine — the assertion that matters
+    # is that the SystemExit is NOT the mutual-exclusion message (which
+    # would mean we hit the wrong gate).
+    captured = capsys.readouterr()
+    assert "Cannot combine --refresh-only and --sdc-only" not in captured.err
+
+
+@pytest.mark.parametrize(
+    "sdc_only_value,expected",
+    [
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        ("false", False),
+        ("", False),
+        # Anything that isn't a lowercase-"true" match falls through to False.
+        # This matches the existing `--force` / `--refresh-only` handling.
+        ("yes", False),
+        ("1", False),
+    ],
+)
+def test_sdc_only_boolean_parsing(sdc_only_value, expected):
+    """The `args.sdc_only.lower() == "true"` test treats GH Actions'
+    "true"/"false" string inputs case-insensitively; everything else is
+    falsy. Lock this in so a future stringly-typed input change can't
+    quietly flip the polarity."""
+    assert (sdc_only_value.lower() == "true") is expected

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -74,22 +74,26 @@ def test_sdc_only_alone_is_accepted_at_parse_time(monkeypatch, capsys):
 
 
 @pytest.mark.parametrize(
-    "sdc_only_value,expected",
+    "value,expected",
     [
         ("true", True),
         ("True", True),
         ("TRUE", True),
         ("false", False),
         ("", False),
-        # Anything that isn't a lowercase-"true" match falls through to False.
-        # This matches the existing `--force` / `--refresh-only` handling.
+        # Anything that isn't a case-insensitive "true" match falls
+        # through to False. Same convention for --force, --refresh-only,
+        # and --sdc-only.
         ("yes", False),
         ("1", False),
     ],
 )
-def test_sdc_only_boolean_parsing(sdc_only_value, expected):
-    """The `args.sdc_only.lower() == "true"` test treats GH Actions'
-    "true"/"false" string inputs case-insensitively; everything else is
-    falsy. Lock this in so a future stringly-typed input change can't
-    quietly flip the polarity."""
-    assert (sdc_only_value.lower() == "true") is expected
+def test_parse_bool(value, expected):
+    """Exercise the launcher's actual boolean-string parser (the same
+    helper that converts `args.sdc_only`, `args.refresh_only`, and
+    `args.force` into bools). This locks in the case-insensitive "true"
+    contract so a refactor of the parsing code can't silently flip the
+    polarity."""
+    from scripts.wikimedia_launch import _parse_bool
+
+    assert _parse_bool(value) is expected

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -52,11 +52,21 @@ def test_sdc_only_alone_is_accepted_at_parse_time(monkeypatch, capsys):
     we just confirm parse_args + the mutual-exclusion gate let it
     through to the next step.
 
-    We do this by passing an unresolvable target so the launcher errors
-    out *after* the flag-parsing step rather than at it. SystemExit from
-    `_slack_fail("No valid targets to launch...")` confirms parsing
-    succeeded.
+    Stub `ssm_run` so the SystemExit comes from a deterministic post-parse
+    point (`_slack_fail("Failed to heal EC2 file ownership: …")`), not
+    from an implicit AWS-credential failure that depends on whether the
+    test runner happens to have creds. The assertion that matters is just
+    that the exit is NOT the mutual-exclusion message — any post-parse
+    exit point satisfies it.
     """
+    monkeypatch.setattr(
+        "scripts.wikimedia_launch.boto3.client",
+        lambda *a, **kw: object(),
+    )
+    monkeypatch.setattr(
+        "scripts.wikimedia_launch.ssm_run",
+        lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("ssm stubbed")),
+    )
     exit_info = _run_main(
         [
             "--partner",

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1991,6 +1991,11 @@ def _run_partner_mode(partner, ids_file):
     setup_logging(partner, "sdc", logging.INFO)
     start_time = time.time()
 
+    # Reset the module-level tracker so per-partner counts don't carry
+    # over across invocations of `_run_partner_mode` within a single
+    # process (e.g. tests, future multi-partner runs).
+    tracker.reset()
+
     s3 = S3Client()
 
     with open(ids_file) as f:


### PR DESCRIPTION
## Summary

Adds a workflow-dispatchable SDC-only run mode so the `/wikimedia-upload` slash command can trigger SDC backfills without re-uploading anything.

> ⚠️ **Stacked on #248.** Base branch is `sdc-sync/pipeline-integration`, not `main`. Will be rebased onto main once #248 merges (once #248 is in, this will be the final PR in the 5-PR sdc-sync integration sequence).

## Why

After #248 lands, every regular Wikimedia upload run will end with SDC. But sometimes we want to **re-sync SDC** without re-uploading — e.g. when ingestion3's `institutions_v2.json` or `subjects.json` changes and we want existing Commons files to pick up the new mappings, or when a prior session uploaded files but couldn't run SDC at the time.

## What changes

- **`.github/workflows/wikimedia-launch.yml`**: new `sdc_only` boolean workflow input, threaded through to `wikimedia_launch.py` as `--sdc-only`. Slack-side dispatcher (the Lambda that parses `/wikimedia-upload sdc <target>`) just passes this flag through to the existing workflow.
- **`scripts/wikimedia_launch.py`**:
  - New `--sdc-only` arg + mutual-exclusion check against `--refresh-only` (the two modes skip different phases — the caller must pick one).
  - New target-block branch: pipeline is `cd \$base && get-ids-es ... > csv && sdc-sync --partner \$hub --ids-file csv`. No downloader, no uploader. The get-ids-es step is preserved on purpose — it also re-stages each item's `sdc.json` from the latest ingestion3 data, so backfills automatically propagate upstream changes.
  - Slack launch copy gets new variants for sdc-only mode (single-item / batch / mixed) so the announcement message accurately reflects what's running (\"SDC-only backfill starting\" / \"ID generation → SDC\").
- **`tests/test_wikimedia_launch.py`** *(new file)*: covers the mutual-exclusion gate, sdc-only-alone parsing, and the boolean-string parsing contract (matching the existing `--refresh-only` / `--force` string-vs-bool convention). 9 tests, all passing.

## Test plan

- [x] `ruff check` + `ruff format` clean
- [x] 9 new tests pass on EC2 venv (`pytest tests/test_wikimedia_launch.py`)
- [ ] Reviewer: after #248 merges and this is rebased, smoke-test from Slack by running `/wikimedia-upload sdc minnesota` (or by invoking the workflow with `sdc_only=true` from the Actions tab) and confirm the chain logs `[INFO] Partner mode: minnesota — N items` then `Wikimedia SDC Complete:` in Slack with no downloader/uploader phase in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR introduces a `--sdc-only` workflow dispatch mode for the Wikimedia upload pipeline, enabling SDC (Structured Data Commons) backfills without running downloader/uploader phases. The feature is workflow-dispatchable and allows re-applying SDC synchronization fixes to existing sidecars.

## Key Changes

**Workflow Changes**
- `.github/workflows/wikimedia-launch.yml`: Added `sdc_only` boolean workflow input (default `false`) passed to the launcher script via `--sdc-only` flag.

**Script Implementation**
- `scripts/wikimedia_launch.py`: 
  - Introduces `--sdc-only` argument with mutual-exclusion validation against `--refresh-only` (exits with `SystemExit(1)` if both specified).
  - Implements SDC-only pipeline: runs ID generation (`get-ids-es`/`get-ids-*`/`printf`) followed by `sdc-sync` only, skipping downloader/uploader phases.
  - Adds `_parse_bool()` helper for GitHub Actions boolean-string parsing.
  - Emits stderr warnings when `--sdc-only` is used with targets that cannot re-stage `sdc.json` (single-item DPLA IDs and NARA hub-level targets).
  - Warns when `--sdc-only` is paired with `--max-age-days` (which is ignored in this mode).
  - Updates Slack launch message variants to reflect SDC-only workflow (no download/upload references).

**Testing**
- `tests/test_wikimedia_launch.py`: Added 9 tests covering mutual-exclusion validation, `--sdc-only` parsing, and boolean-string parsing; all tests stub AWS interactions for deterministic local execution.

**Documentation Updates**
- `README.md`: Documents `sdc-sync` as the fourth pipeline phase; clarifies that `get-ids-es` writes per-item `sdc.json` sidecars.
- `docs/operations.md`: Describes the 4-phase pipeline (get-ids-es → downloader → uploader → sdc-sync); documents workflow inputs including `sdc_only` and `max_age_days` with mutual-exclusivity notes; clarifies that uploader writes per-item `upload-result.json` sidecars for SDC phase consumption; notes that re-launching after crashes is safe and produces no additional writes when Commons state matches.

**Sidecar Management**
- `tools/sdc_sync.py`: Calls `tracker.reset()` at the start of partner-mode runs to prevent SDC counter carryover across separate invocations within the same process.

## Deployment Notes
- No manual ECS redeployment required; changes take effect once merged as the workflow invocation is self-contained.
- No new environment variables or AWS Secrets Manager keys added.
- No database migrations or infrastructure configuration changes.
- The feature is backward-compatible; existing workflows continue to function unchanged (default `sdc_only=false`).

## Known Limitations & Trade-offs
- Single-item DPLA ID targets and NARA hub-level targets will use potentially stale `sdc.json` in `--sdc-only` mode (design decision to warn rather than block, allowing fixes to be re-applied against existing sidecars).
- When using `--sdc-only`, `--max-age-days` is parsed but ignored (warning emitted).
- Branch stacked on PR `#248` (sdc-sync/pipeline-integration) and will be rebased onto main after that merges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->