### PR TITLE
uploader: cap retry memory + force chunked upload above 95 MB

### DIFF
--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -8,9 +8,12 @@ category.
 from unittest.mock import MagicMock, patch
 
 from ingest_wikimedia.tracker import Result, Tracker
+from ingest_wikimedia.wikimedia import WMC_UPLOAD_CHUNK_SIZE
 from tools.uploader import (
+    LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES,
     _post_item_orphan_check,
     _post_upload_touch_new_institutions,
+    select_upload_chunk_size,
 )
 
 
@@ -782,3 +785,75 @@ def test_resolve_hash_drift_case2_tags_when_expected_titles_is_none():
             wiki_markup="",
         )
     assert action == "upload_and_tag"
+
+
+# --------------------------------------------------------------------------
+# select_upload_chunk_size — pin the OOM-prevention contract: files above
+# LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES MUST force chunked upload even when
+# caller flags prefer direct, because direct can't physically succeed past
+# Wikimedia's gateway limit (the 211 MB NARA incident at 6.7 GB RSS).
+# --------------------------------------------------------------------------
+
+
+def test_chunk_size_neither_pref_returns_chunked():
+    """Default path (neither file_exists nor force_ignore_warnings): chunked."""
+    assert select_upload_chunk_size(
+        file_exists=False,
+        force_ignore_warnings=False,
+        file_size_bytes=10 * 1024 * 1024,
+    ) == (WMC_UPLOAD_CHUNK_SIZE, False)
+
+
+def test_chunk_size_file_exists_small_returns_direct():
+    """Overwrite of an existing small page → direct upload to bypass warnings."""
+    assert select_upload_chunk_size(
+        file_exists=True,
+        force_ignore_warnings=False,
+        file_size_bytes=10 * 1024 * 1024,
+    ) == (0, True)
+
+
+def test_chunk_size_force_ignore_warnings_small_returns_direct():
+    """Hash-drift upload_only on a small file → direct upload (warning bypass)."""
+    assert select_upload_chunk_size(
+        file_exists=False,
+        force_ignore_warnings=True,
+        file_size_bytes=10 * 1024 * 1024,
+    ) == (0, True)
+
+
+def test_chunk_size_large_file_exists_forces_chunked():
+    """Overwrite of a large file: direct can't succeed at this size, so chunked
+    even though the warning-bypass benefit is lost. Bounded FAILED > OOM."""
+    one_byte_over = LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES + 1
+    assert select_upload_chunk_size(
+        file_exists=True,
+        force_ignore_warnings=False,
+        file_size_bytes=one_byte_over,
+    ) == (WMC_UPLOAD_CHUNK_SIZE, True)
+
+
+def test_chunk_size_large_force_ignore_warnings_forces_chunked():
+    """Hash-drift upload_only on a 211 MB file (the NARA incident): chunked,
+    and prefers_direct still True so the caller logs the size override."""
+    nara_incident_size = 221_583_206  # exact bytes of 2_7d3114...
+    assert select_upload_chunk_size(
+        file_exists=False,
+        force_ignore_warnings=True,
+        file_size_bytes=nara_incident_size,
+    ) == (WMC_UPLOAD_CHUNK_SIZE, True)
+
+
+def test_chunk_size_exactly_at_threshold_stays_direct():
+    """At-threshold is fine for direct upload; only strictly above forces chunked."""
+    assert select_upload_chunk_size(
+        file_exists=True,
+        force_ignore_warnings=False,
+        file_size_bytes=LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES,
+    ) == (0, True)
+
+
+def test_chunk_size_threshold_under_wikimedia_gateway_limit():
+    """The threshold itself must stay safely under Wikimedia's ~100 MB
+    practical direct-upload limit — otherwise we re-introduce the OOM."""
+    assert LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES < 100 * 1024 * 1024

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1,8 +1,10 @@
 import concurrent.futures
 import datetime
+import gc
 import json
 import logging
 import mimetypes
+import os
 import random
 import time
 
@@ -72,6 +74,51 @@ UPLOAD_RETRY_MAX_DELAY_SECS = 60
 # pywikibot's async upload polls Commons indefinitely when the job queue is stuck.
 # This cap ensures a single hung upload never freezes the whole session.
 UPLOAD_TIMEOUT_SECS = 3600  # 1 hour
+
+# Wikimedia's MediaWiki API rejects single-request upload bodies above roughly
+# 100 MB (the exact threshold varies with infrastructure; the practical hard
+# limit observed in NARA runs is between 100–200 MB before the gateway closes
+# the connection mid-stream).  Pywikibot's chunk_size=0 path puts the entire
+# file in one HTTP body, and its internal request-retry loop keeps that body
+# alive via exception tracebacks across retries — a single 211 MB upload was
+# observed to grow the process to 6.7 GB resident before OOM.  Above this
+# size we force chunked upload regardless of any other flag: stash chunks are
+# bounded at WMC_UPLOAD_CHUNK_SIZE (20 MB), so peak memory stays well under
+# control even on the same internal retry pattern.
+LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES = 95 * 1024 * 1024  # 95 MB
+
+
+def select_upload_chunk_size(
+    *,
+    file_exists: bool,
+    force_ignore_warnings: bool,
+    file_size_bytes: int,
+) -> tuple[int, bool]:
+    """Pick the pywikibot ``chunk_size`` for an upload attempt.
+
+    Returns ``(chunk_size, prefers_direct)``.  ``chunk_size`` is ``0`` for
+    a direct whole-body POST or :data:`WMC_UPLOAD_CHUNK_SIZE` for the
+    chunked stash-commit path.  ``prefers_direct`` reflects whether the
+    caller's flags would have chosen direct — useful to pick the matching
+    ``ignore_warnings`` value and to log a size-override decision.
+
+    Either ``file_exists`` (target Commons page already has content we
+    want to overwrite) or ``force_ignore_warnings`` (hash-drift path has
+    accepted a duplicate SHA1) makes direct preferred, because direct
+    suppresses MediaWiki warnings the stash-commit path can't.
+
+    Above :data:`LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES` the override fires:
+    Wikimedia's API gateway rejects single-body uploads at that size, so
+    the warning-bypass benefit is moot and we must chunk regardless.  A
+    bounded failure (e.g. fileexists-shared-forbidden at commit) is
+    strictly better than OOM-killing the whole run.
+    """
+    prefers_direct = file_exists or force_ignore_warnings
+    must_chunk_for_size = file_size_bytes > LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES
+    if prefers_direct and not must_chunk_for_size:
+        return 0, prefers_direct
+    return WMC_UPLOAD_CHUNK_SIZE, prefers_direct
+
 
 # Per-ordinal status strings written to <partner>/<dpla_id>/upload-result.json
 # and consumed by the SDC sync phase (PR 4). The SDC phase only attempts
@@ -399,26 +446,29 @@ class Uploader:
                         # valid sibling (same-item relic) or a foreign file
                         # (cross-item) and must not be tagged as a duplicate.
 
-                # Use direct upload (chunk_size=0) + ignore_warnings=True when the
-                # file page already exists, or when the hash already lives elsewhere
-                # on Commons (drift case). The stash-commit path raises
-                # fileexists-shared-forbidden even on valid overwrites; the direct
-                # path with ignorewarnings=1 bypasses it. True (vs IGNORE_WIKIMEDIA_WARNINGS)
-                # is intentional — for an overwrite we want to suppress all warnings,
-                # including 'exists' variants that would fire on the direct path.
+                # Direct vs. chunked upload decision — see
+                # select_upload_chunk_size for the contract. The on-disk
+                # temp-file size is authoritative (S3 content_length may have
+                # been a stale stub before the re-download path fired).
                 file_exists = (
                     wiki_file_page.exists() and not wiki_file_page.isRedirectPage()
                 )
-                chunk_size = (
-                    0
-                    if (file_exists or force_ignore_warnings)
-                    else WMC_UPLOAD_CHUNK_SIZE
+                temp_file_size = os.path.getsize(temp_file.name)
+                chunk_size, prefers_direct = select_upload_chunk_size(
+                    file_exists=file_exists,
+                    force_ignore_warnings=force_ignore_warnings,
+                    file_size_bytes=temp_file_size,
                 )
-                upload_warnings = (
-                    True
-                    if (file_exists or force_ignore_warnings)
-                    else IGNORE_WIKIMEDIA_WARNINGS
-                )
+                if prefers_direct and chunk_size != 0:
+                    logging.info(
+                        f"Forcing chunked upload for {dpla_id} {ordinal}: "
+                        f"file size {temp_file_size:,} B exceeds direct-upload "
+                        f"limit {LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES:,} B "
+                        f"(would have used chunk_size=0 for "
+                        f"file_exists={file_exists}, "
+                        f"force_ignore_warnings={force_ignore_warnings})."
+                    )
+                upload_warnings = True if prefers_direct else IGNORE_WIKIMEDIA_WARNINGS
 
                 result = None
                 # Avoid the `with executor:` context manager — its __exit__ calls
@@ -428,6 +478,7 @@ class Uploader:
                 executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                 try:
                     for attempt in range(1, MAX_UPLOAD_RETRIES + 1):
+                        future = None
                         try:
                             future = executor.submit(
                                 self.site.upload,
@@ -465,6 +516,15 @@ class Uploader:
                                     f"{MAX_UPLOAD_RETRIES}, retrying in "
                                     f"{delay:.1f}s: {ex}"
                                 )
+                                # Release the failed Future before sleeping —
+                                # its retained traceback frame holds pywikibot's
+                                # request body buffer (the entire file for
+                                # chunk_size=0). Without this, body buffers from
+                                # each failed attempt pile up across the retry
+                                # loop's sleep, plus pywikibot's inner retry
+                                # loop's own accumulated allocations.
+                                del future
+                                gc.collect()
                                 time.sleep(delay)
                             else:
                                 if is_backend_fail:
@@ -472,6 +532,10 @@ class Uploader:
                                 raise
                 finally:
                     executor.shutdown(wait=False)
+                    # Final sweep — clears the last attempt's Future and any
+                    # cycle-trapped pywikibot request/response objects so the
+                    # next process_file iteration doesn't inherit them.
+                    gc.collect()
 
                 if not result:
                     # upload() returned None — file exists under a different page


### PR DESCRIPTION
## Summary

A 211 MB NARA PDF (item \`7d3114490517c70ba4135c986c86905e\` page 2) has OOM-killed the uploader three times — May 23, May 25, and again on May 26 *after* PR #247 was deployed — at ~6.7 GB resident on the 7.6 GB instance.

The killed log's last line on each run is identical: \`Hash drift for 7d3114490517c70ba4135c986c86905e 2: ... belongs to valid DPLA item 571083b43c38bfb1a60809548f234f4f; uploading to correct title only.\` Then 8–23 minutes of silence, then OOM. PR #247 fixed a separate CommonsDelinker memory leak (page-text reads via read-modify-write) that was a contributor to overall pressure in earlier runs, but didn't touch what the upload loop itself does with this specific item.

### What's actually happening

- The S3 file is a legitimate 211 MB PDF (\`%PDF-1.6\`, ContentType \`application/pdf\`, SHA1 \`8c3351017f518288febe988f952625d06a37848b\`). The downloader stored exactly what NARA's \`mediaMaster\` URL pointed at.
- NARA put the same PDF (\`11-a2-242-003-001.pdf\`) into two different DPLA items' mediaMaster lists at position 2 — once correctly (in 571083, archive 003-001) and once spuriously (in 7d3114, archive 003-002).
- We uploaded the PDF correctly during the 571083 run. Now when item 7d3114's position 2 comes up, \`_resolve_hash_drift\` finds the same SHA1 already on Commons under 571083's title, correctly classifies it as a cross-item duplicate, and routes to \`upload_only\` — uploading the same byte stream to a *different* Commons title.
- \`process_file\` was setting \`chunk_size=0\` (direct, whole-body POST) on this path to get the warning-bypass behavior. Direct upload of 211 MB exceeds Wikimedia's practical ~100 MB API-gateway limit; the connection closes mid-stream, pywikibot's internal retry loop fires, and each failed attempt's body buffer is retained via the exception's \`__traceback__\` chain. ~6.7 GB later, OOM.

### Fix

Two-part, both in \`tools/uploader.py\`:

1. **\`select_upload_chunk_size()\` helper** — forces chunked upload (\`chunk_size = WMC_UPLOAD_CHUNK_SIZE\` = 20 MB) for any file above \`LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES\` = 95 MB, regardless of caller flags. Above 95 MB direct can't succeed, so the warning-bypass benefit is moot; chunked stash-commit streams chunks and caps per-attempt memory. A duplicate-content large file (the rare case) now fails with a bounded \`FAILED\` instead of OOMing the whole run — strictly better.
2. **Explicit \`del future\` + \`gc.collect()\` between retry attempts**, and a final \`gc.collect()\` after the executor's \`finally\`-shutdown. The retry loop's sleep window was holding the failed Future (with its body-retaining traceback) until the next assignment overwrote it. Now the buffer is released before sleeping.

### What this PR does NOT do

- Doesn't change the underlying NARA data issue (the PDF appearing in two items' mediaMasters). Skipping cross-item-valid duplicates entirely is a separate option (semantically correct, since the SHA1 is by definition already preserved on Commons), but out of scope here. This PR's defense-in-depth fix kicks in regardless.
- Doesn't change the small-file path (the OOM-trigger threshold). Existing behavior for files under 95 MB is identical.

## Test plan

- [x] 7 new unit tests pin \`select_upload_chunk_size()\`'s contract: default path, both prefer-direct flags, large-file overrides for each flag, at-threshold behavior, and a safety assertion that the constant stays under Wikimedia's 100 MB practical limit.
- [x] All 28 \`tests/test_uploader.py\` tests pass.
- [x] \`ruff check\` + \`ruff format --check\` clean.
- [ ] After merge: rerun a NARA \`center-for-legislative-archives\` upload and confirm item 7d3114 page 2 fails fast with a bounded \`FAILED\` rather than OOMing the process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes an out-of-memory (OOM) issue in the file uploader that was triggered when handling large files (211+ MB) during cross-item duplicate detection. When a file was routed to the "upload_only" path with `chunk_size=0` (direct whole-body POST), pywikibot's retry mechanism would accumulate request body buffers in exception tracebacks, exhausting available memory. The fix prevents direct uploads for files larger than 95 MB and introduces explicit garbage collection during retries to release retained buffers.

## Changes

**tools/uploader.py**
- Added module-level constant `LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES` (95 MB threshold) and a new `select_upload_chunk_size()` function that enforces chunked uploads (20 MB chunks) for any file exceeding the threshold, overriding the caller's direct-upload preferences
- Modified the upload retry loop to explicitly delete failed `Future` objects and call `gc.collect()` between transient retry attempts
- Added an additional `gc.collect()` call after executor shutdown to clear retained pywikibot request/response objects before proceeding
- Updated upload code to use the new helper function and log when direct-upload choices are overridden for oversized files

**tests/test_uploader.py**
- Added 7 new unit tests validating `select_upload_chunk_size()` behavior across small files, files at the 95 MB threshold, oversized files, and scenarios with forced warning bypass
- Includes a guard assertion ensuring the threshold remains below 100 MB to prevent reintroducing OOM risk

## Testing & Validation
- 7 new unit tests added; all 28 existing tests pass
- Ruff linter checks clean
- Manual rerun of the problematic NARA item is planned post-merge to confirm bounded FAILED status instead of OOM

## Notes
- Does not alter NARA data (existing duplicate mediaMaster entries remain)
- Does not change behavior for files under 95 MB
- No manual pipeline trigger, environment variables, AWS Secrets, database migrations, infrastructure changes, or API modifications required

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->