### PR TITLE
sdc-sync: null-edit file pages after SDC changes to refresh categories

### DIFF
--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2118,6 +2118,7 @@ def _run_partner_mode(partner, ids_file):
                 if writes_after > writes_before and title and title != "?":
                     try:
                         pywikibot.FilePage(site, title).touch()
+                        logging.info(f" -- Touched '{title}' (category refresh).")
                     except Exception as e:
                         logging.warning(
                             f" -- Failed to touch '{title}' for category refresh: {e!r}"

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2088,10 +2088,40 @@ def _run_partner_mode(partner, ids_file):
                     logging.warning(f" -- Ordinal {ord_str}: no pageid; skipping.")
                     continue
                 mediaid = f"M{pageid}"
-                logging.info(
-                    f" -- Ordinal {ord_str}: {mediaid} ({data.get('title', '?')})"
+                title = data.get("title", "?")
+                logging.info(f" -- Ordinal {ord_str}: {mediaid} ({title})")
+
+                # Snapshot write counters so we can detect whether this
+                # ordinal's sync actually changed anything on Commons.
+                writes_before = (
+                    tracker.count(Result.SDC_CLAIMS_ADDED)
+                    + tracker.count(Result.SDC_REFS_ADDED)
+                    + tracker.count(Result.SDC_REMOVALS)
                 )
                 process_one_from_sdc(mediaid, dpla_id, sdc_payload)
+                writes_after = (
+                    tracker.count(Result.SDC_CLAIMS_ADDED)
+                    + tracker.count(Result.SDC_REFS_ADDED)
+                    + tracker.count(Result.SDC_REMOVALS)
+                )
+
+                # If SDC actually changed for this ordinal, force a
+                # category re-render on the file page via a null edit.
+                # MediaWiki caches categories at render time; SDC writes
+                # don't propagate to the page's category list until the
+                # wikitext is re-evaluated. Without this the maintenance
+                # categories like "Digital Public Library of America
+                # files missing required SDC statements" cling on long
+                # after the SDC was added. Mirrors the touch pattern in
+                # ingest_wikimedia/categories.py's
+                # touch_files_for_institution().
+                if writes_after > writes_before and title and title != "?":
+                    try:
+                        pywikibot.FilePage(site, title).touch()
+                    except Exception as e:
+                        logging.warning(
+                            f" -- Failed to touch '{title}' for category refresh: {e!r}"
+                        )
                 synced_this_item = True
             # Only count an item as synced if at least one ordinal actually
             # made it past the pageid guard. An item whose every eligible


### PR DESCRIPTION
## Summary

Adds a null-edit (`pywikibot.FilePage.touch()`) on each file page whose SDC was actually modified during a sync run, so MediaWiki re-renders the page and the maintenance categories refresh.

## Why

Categories on a file page are computed at render time. When sdc-sync adds a missing P760 / P170 / P1476 / etc., the corresponding `{{#invoke:SDC_tracking|SDC_statement_exist}}` invocations in `{{DPLA metadata}}` (or `{{DPLA}}`) will *next time the page renders* output the positive_category instead of the "missing required SDC statements" negative_category. But without a re-render, the previously-cached negative category sticks around. A null edit forces re-evaluation and clears the maintenance category.

This was reproducible: on a file where SDC was just synced, hidden categories included `Digital Public Library of America files missing required SDC statements` and `Digital Public Library of America files missing creator`. A manual null edit cleared them.

## What changes

`tools/sdc_sync.py` — inside `_run_partner_mode`'s per-ordinal loop:

1. Snapshot the write counters (`SDC_CLAIMS_ADDED + SDC_REFS_ADDED + SDC_REMOVALS`) before calling `process_one_from_sdc()`.
2. Snapshot again after.
3. If the diff is > 0 — meaning the sync actually wrote something to this file's SDC — call `pywikibot.FilePage(site, title).touch()` on the file page. Per-page errors logged + swallowed so one bad page doesn't abort the batch.
4. If diff is 0 (the common idempotent re-sync path), no touch — saves API calls.

Mirrors the pattern in `ingest_wikimedia/categories.py`'s `touch_files_for_institution()`, which already uses null edits to clear the "unknown institution" category after `CategoryEnsurer` adds P8464 on a partner's Wikidata item.

## Test plan

- [x] `ruff check` + `ruff format` clean on `tools/sdc_sync.py`
- [x] Idempotent re-sync on the Grant County baseline (`0850fba9…` Minnesota) — no writes, no touch fired, log clean
- [x] Validated `pywikibot.FilePage(site, title).touch()` works with the title format `upload-result.json` stores (no "File:" prefix needed; pywikibot adds it via the FilePage class)
- [ ] Reviewer: run sdc-sync on a partner with stale/missing SDC and confirm the maintenance categories clear from refreshed file pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR modifies the SDC synchronization logic to perform null-edits (page touches) on file pages whenever their Structured Data on Commons metadata is modified, enabling MediaWiki to re-render the page and refresh associated maintenance categories.

No pipeline redeploys, environment variable changes, database migrations, shared infrastructure changes, or API response changes are required for this change to take effect. There are no new secrets or IAM changes. There are no security-sensitive credential-handling changes introduced.

## Changes

**tools/sdc_sync.py**
- In `_run_partner_mode`, the per-ordinal loop now snapshots tracker counters (SDC_CLAIMS_ADDED, SDC_REFS_ADDED, SDC_REMOVALS) before calling `process_one_from_sdc()`.
- After the call completes, it recalculates the totals and compares against the snapshot.
- If any SDC writes occurred (counter difference > 0) and the file title is known, it calls `pywikibot.FilePage(site, title).touch()` to trigger a page re-render.
- If no writes occurred (counter difference = 0), the page is not touched, avoiding unnecessary API calls.
- Per-page errors during the touch operation are logged at warning level and swallowed so a touch failure does not abort the batch.
- Adds INFO-level logging for successful null-edits to improve operator observability.

## Rationale

Maintenance categories are computed at MediaWiki render time. When SDC statements are added to correct missing data, a page re-render is required to clear previously cached "missing" maintenance categories. This mirrors an existing pattern used elsewhere in the codebase (ingest_wikimedia/categories.py).

## Testing

- ruff check/format passes.
- Idempotent re-sync on Grant County produced no writes and no touches, confirming the optimization avoids unnecessary API calls.
- Verified `FilePage.touch()` works with the stored title format.
- Reviewer requested an sdc-sync run on a partner with stale/missing SDC for final verification that maintenance categories clear.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->