### PR TITLE
sdc-sync: per-ordinal exception boundary + log traceback on abort

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -434,6 +434,7 @@ def notify_sdc_complete(
             f"REMOVALS:             {tracker.count(Result.SDC_REMOVALS):,}",
             f"SKIPPED (no sidecar): {tracker.count(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR):,}",
             f"SKIPPED (mapping):    {tracker.count(Result.SDC_ITEMS_SKIPPED_MAPPING):,}",
+            f"ORDINAL ERRORS:       {tracker.count(Result.SDC_ORDINALS_SKIPPED_ERROR):,}",
             f"Runtime:              {runtime}",
         ],
     )

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -434,6 +434,7 @@ def notify_sdc_complete(
             f"REMOVALS:             {tracker.count(Result.SDC_REMOVALS):,}",
             f"SKIPPED (no sidecar): {tracker.count(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR):,}",
             f"SKIPPED (mapping):    {tracker.count(Result.SDC_ITEMS_SKIPPED_MAPPING):,}",
+            f"SKIPPED (error):      {tracker.count(Result.SDC_ITEMS_SKIPPED_ERROR):,}",
             f"ORDINAL ERRORS:       {tracker.count(Result.SDC_ORDINALS_SKIPPED_ERROR):,}",
             f"Runtime:              {runtime}",
         ],

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -22,6 +22,12 @@ class Result(Enum):
     SDC_REMOVALS = auto()
     SDC_ITEMS_SKIPPED_NO_SIDECAR = auto()
     SDC_ITEMS_SKIPPED_MAPPING = auto()
+    # Ordinals whose SDC sync raised an unexpected exception
+    # (pywikibot APIError, network timeout, deep KeyError, etc.).
+    # Per-ordinal granularity so transient failures don't abort the
+    # whole partner batch — the matching try/except is in
+    # tools/sdc_sync.py::_run_partner_mode.
+    SDC_ORDINALS_SKIPPED_ERROR = auto()
 
 
 class Tracker:

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -28,6 +28,12 @@ class Result(Enum):
     # whole partner batch — the matching try/except is in
     # tools/sdc_sync.py::_run_partner_mode.
     SDC_ORDINALS_SKIPPED_ERROR = auto()
+    # Items where every eligible ordinal hit the per-ordinal exception
+    # path — i.e., the item didn't fail due to malformed data
+    # (MAPPING) or missing sidecars (NO_SIDECAR), but because all of
+    # its SDC writes raised at runtime. Without this counter such items
+    # would be misclassified as MAPPING skips.
+    SDC_ITEMS_SKIPPED_ERROR = auto()
 
 
 class Tracker:

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -440,6 +440,7 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
             Result.SDC_REMOVALS: 4,
             Result.SDC_ITEMS_SKIPPED_NO_SIDECAR: 2,
             Result.SDC_ITEMS_SKIPPED_MAPPING: 1,
+            Result.SDC_ORDINALS_SKIPPED_ERROR: 7,
         },
     )
     stats = captured["stats_lines"]
@@ -449,6 +450,7 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
     assert any(s.startswith("REMOVALS:") and "4" in s for s in stats)
     assert any("SKIPPED (no sidecar)" in s and "2" in s for s in stats)
     assert any("SKIPPED (mapping)" in s and "1" in s for s in stats)
+    assert any("ORDINAL ERRORS:" in s and "7" in s for s in stats)
     assert any("Runtime:" in s and "42s" in s for s in stats)
 
 

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -440,6 +440,7 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
             Result.SDC_REMOVALS: 4,
             Result.SDC_ITEMS_SKIPPED_NO_SIDECAR: 2,
             Result.SDC_ITEMS_SKIPPED_MAPPING: 1,
+            Result.SDC_ITEMS_SKIPPED_ERROR: 3,
             Result.SDC_ORDINALS_SKIPPED_ERROR: 7,
         },
     )
@@ -450,6 +451,7 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
     assert any(s.startswith("REMOVALS:") and "4" in s for s in stats)
     assert any("SKIPPED (no sidecar)" in s and "2" in s for s in stats)
     assert any("SKIPPED (mapping)" in s and "1" in s for s in stats)
+    assert any("SKIPPED (error)" in s and "3" in s for s in stats)
     assert any("ORDINAL ERRORS:" in s and "7" in s for s in stats)
     assert any("Runtime:" in s and "42s" in s for s in stats)
 

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2075,6 +2075,13 @@ def _run_partner_mode(partner, ids_file):
                 continue
 
             synced_this_item = False
+            # Tracks whether any ordinal hit the per-ordinal exception
+            # path (runtime failure) so an item with all-failed ordinals
+            # is classified under SDC_ITEMS_SKIPPED_ERROR rather than
+            # SDC_ITEMS_SKIPPED_MAPPING — they mean different things and
+            # operators read the Slack summary to distinguish bad data
+            # from bad network/API.
+            had_ordinal_error = False
             # int(ord_str) on a malformed ordinal key (e.g. "abc" instead
             # of "3") would otherwise raise out of the whole loop and
             # abort the partner batch. Skip the item, log, and account
@@ -2124,6 +2131,7 @@ def _run_partner_mode(partner, ids_file):
                         " SDC sync failed; skipping ordinal."
                     )
                     tracker.increment(Result.SDC_ORDINALS_SKIPPED_ERROR)
+                    had_ordinal_error = True
                     continue
                 writes_after = (
                     tracker.count(Result.SDC_CLAIMS_ADDED)
@@ -2156,6 +2164,13 @@ def _run_partner_mode(partner, ids_file):
             # counter and underreport mapping skips.
             if synced_this_item:
                 tracker.increment(Result.SDC_ITEMS_SYNCED)
+            elif had_ordinal_error:
+                # Every eligible ordinal raised at runtime — classify
+                # under the error bucket, not MAPPING. (Mixed-result
+                # items where some ordinals succeed go to SYNCED; the
+                # per-ordinal failures are still visible under
+                # SDC_ORDINALS_SKIPPED_ERROR.)
+                tracker.increment(Result.SDC_ITEMS_SKIPPED_ERROR)
             else:
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
         completed = True

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2103,7 +2103,28 @@ def _run_partner_mode(partner, ids_file):
                     + tracker.count(Result.SDC_REFS_ADDED)
                     + tracker.count(Result.SDC_REMOVALS)
                 )
-                process_one_from_sdc(mediaid, dpla_id, sdc_payload)
+                # Per-ordinal exception boundary. Without this, any
+                # transient pywikibot APIError (rate limit, maxlag,
+                # transient 503), network timeout, or surprise
+                # KeyError/AssertionError deep in the property-builder
+                # propagates up through both nested loops and aborts
+                # the entire partner batch — losing thousands of items'
+                # worth of work because of one bad page. Other failure
+                # modes in this function (S3 ClientError, JSON parse,
+                # malformed ordinals) already skip-and-continue; this
+                # makes the actual SDC write follow the same pattern.
+                # `logging.exception` writes the full traceback into
+                # the SDC log file so notify_pipeline_fail's
+                # `_summarize_log` can surface it in Slack.
+                try:
+                    process_one_from_sdc(mediaid, dpla_id, sdc_payload)
+                except Exception:
+                    logging.exception(
+                        f" -- Ordinal {ord_str} ({mediaid}) for {dpla_id}:"
+                        " SDC sync failed; skipping ordinal."
+                    )
+                    tracker.increment(Result.SDC_ORDINALS_SKIPPED_ERROR)
+                    continue
                 writes_after = (
                     tracker.count(Result.SDC_CLAIMS_ADDED)
                     + tracker.count(Result.SDC_REFS_ADDED)
@@ -2138,6 +2159,17 @@ def _run_partner_mode(partner, ids_file):
             else:
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
         completed = True
+    except Exception:
+        # The per-ordinal try/except above already swallows every routine
+        # SDC-write failure. Reaching this outer handler means something
+        # truly outside-the-loop went wrong (sidecar enumeration, S3 auth,
+        # logger state, etc.). Log the traceback into the SDC log file so
+        # notify_pipeline_fail's `_summarize_log` can include it in the
+        # Slack failure message — otherwise the traceback only hits stderr
+        # (the file handler doesn't capture it) and the operator sees an
+        # abort warning with no diagnostic.
+        logging.exception("SDC sync aborted with unhandled exception")
+        raise
     finally:
         elapsed = time.time() - start_time
         # Emit the terminal "COUNTS:" marker and Slack completion message

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2096,8 +2096,22 @@ def _run_partner_mode(partner, ids_file):
                 continue
             for ord_str, data in ordinal_items:
                 pageid = data.get("pageid")
-                if pageid is None:
-                    logging.warning(f" -- Ordinal {ord_str}: no pageid; skipping.")
+                # `if not pageid` rather than `is None` — a recorded
+                # pageid of 0 is just as malformed as a missing one
+                # (no Commons MediaInfo entity has ID `M0`) and would
+                # otherwise propagate downstream as a confusing
+                # pywikibot APIError on the bogus mediaid. The
+                # uploader has historically written `pageid: 0` for
+                # successful new uploads when pywikibot's FilePage
+                # cache wasn't invalidated post-upload; treat that
+                # sidecar shape as a mapping skip until the upstream
+                # bug is fixed and the existing sidecars are
+                # backfilled.
+                if not pageid:
+                    logging.warning(
+                        f" -- Ordinal {ord_str}: missing/zero pageid"
+                        f" ({pageid!r}); skipping."
+                    )
                     continue
                 mediaid = f"M{pageid}"
                 title = data.get("title", "?")


### PR DESCRIPTION
## Summary

The LBJ NARA partner run on 2026-05-26 aborted ~12 min in (item 907 of 4,238, ordinal 79), with no traceback in the SDC log and no useful detail in the Slack failure notification. Root cause: two compounding gaps in `tools/sdc_sync.py::_run_partner_mode`.

### Problem 1 — unguarded SDC write call

Every other failure mode in the per-item loop already has a try/except that skips the offending unit and continues:
- S3 `ClientError` on `get_sdc_json` (lines ~2010–2017)
- JSON parse on `sdc.json` (~2022–2027)
- S3 `ClientError` on `get_upload_result` (~2029–2036)
- JSON parse on `upload-result.json` (~2041–2048)
- Non-mapping ordinals type guard (~2055–2060)
- Malformed ordinal keys (~2077–2084)
- Even the new `.touch()` call (~2119–2125)

But the actual SDC write — `process_one_from_sdc(mediaid, dpla_id, sdc_payload)` — was unguarded. Any transient pywikibot `APIError`, network timeout, maxlag, or surprise `KeyError` deep in the property-builder propagated up through both nested loops and aborted the entire partner batch. **One bad ordinal killed 4,238 items' worth of work.**

### Problem 2 — outer try/finally with no `except`

The `finally` ran (which is how we got the `SDC sync aborted before completion` warning), then Python re-raised the exception — printing the traceback to stderr, which the file logger doesn't capture. So:
- The SDC log file ended at the warning with no diagnostic
- `notify_pipeline_fail`'s `_summarize_log` tailed only the routine `INFO` lines into Slack
- Operator got "something failed" with no clue what

## Fix

1. **Wrap `process_one_from_sdc` in try/except.** Log the exception with `logging.exception` (full traceback into the SDC log file) and increment a new `SDC_ORDINALS_SKIPPED_ERROR` counter, then `continue` to the next ordinal. Same skip-and-continue pattern as everywhere else in the loop.
2. **Add an outer `except Exception:`** that `logging.exception`s the traceback before re-raising. Now any truly-fatal-to-the-batch exception (S3 auth, sidecar enumeration, etc.) lands in the log file too, so `_summarize_log` surfaces it in the Slack failure message.
3. **New `Result.SDC_ORDINALS_SKIPPED_ERROR` counter** rendered in `notify_sdc_complete`'s Slack summary as `ORDINAL ERRORS: N`. Test in `test_notify_sdc_complete_stats_reflect_tracker_counts` covers it.

## Test plan

- [x] `python -m pytest tests/` on EC2 (Python 3.13.2) — **261 passed**.
- [x] `pytest tests/test_slack.py -k sdc` — all 4 SDC tests pass with new counter assertion.
- [x] `ruff check` + `ruff format` clean.
- [ ] End-to-end verification: re-run sdc-sync for LBJ (now safe — the same exception will be logged with traceback, that ordinal skipped, and the batch will complete with `ORDINAL ERRORS: N` in the COUNTS/Slack summary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes two failure modes in the SDC sync tool that previously allowed runtime exceptions during per-ordinal SDC writes to abort entire partner runs without diagnostic tracebacks in the SDC log or useful Slack detail. It also improves accounting so items whose eligible ordinals all fail at runtime are classified separately from mapping/no-sidecar skips.

Operational notes:
- No manual pipeline trigger, ECS redeploy, environment variable / Secrets Manager changes, database migrations, or shared infrastructure (CodePipeline/CodeBuild/ECS/IAM) modifications are required.
- No public API changes or endpoint modifications.
- No new credential handling or other security-sensitive configuration introduced (only improved logging of exceptions).
- End-to-end re-run is still pending; unit/test-suite status below.

### Changes

tools/sdc_sync.py
- Per-ordinal protection: Each call to process_one_from_sdc(mediaid, dpla_id, sdc_payload) is wrapped in try/except Exception:
  - On failure, a full traceback is logged via logging.exception (includes DPLA ID, ordinal key, mediaid), Result.SDC_ORDINALS_SKIPPED_ERROR is incremented, a per-item had_ordinal_error flag is set, and processing continues to the next ordinal instead of aborting the partner batch.
- Item-level classification: After ordinals are processed, items are classified into mutually exclusive buckets:
  - SDC_ITEMS_SYNCED (at least one ordinal succeeded, includes partial-success items),
  - SDC_ITEMS_SKIPPED_ERROR (new: all eligible ordinals failed at runtime),
  - SDC_ITEMS_SKIPPED_MAPPING (mapping/no-sidecar/malformed-data skips).
  This preserves accounting invariants (SYNCED + SKIPPED_* == total items).
- Falsy pageid treated as malformed: Expanded pageid validation treats any falsy pageid (e.g., 0) as malformed to avoid constructing bogus mediaids (mitigates real-world uploader sidecar anomalies).
- Outer abort logging: Added an outer except Exception that logging.exception("SDC sync aborted with unhandled exception") before re-raising, ensuring fatal abort tracebacks are captured in the SDC log file.

ingest_wikimedia/tracker.py
- Added two Result counters:
  - SDC_ORDINALS_SKIPPED_ERROR — counts ordinals skipped due to unexpected runtime exceptions during SDC sync.
  - SDC_ITEMS_SKIPPED_ERROR — counts items where all eligible ordinals failed at runtime.
- Tracker formatting updated so these counters appear in printed/Slack summaries when non-zero.

ingest_wikimedia/slack.py
- notify_sdc_complete Slack summary now includes:
  - "SKIPPED (error): N" (Result.SDC_ITEMS_SKIPPED_ERROR)
  - "ORDINAL ERRORS: N" (Result.SDC_ORDINALS_SKIPPED_ERROR)
  making both per-item and per-ordinal runtime-failure counts visible in Slack notifications.

tests/test_slack.py
- Tests extended to assert new "ORDINAL ERRORS" and "SKIPPED (error)" lines appear and reflect tracker counts; test data includes non-zero mocked counts for the new counters.
- New/updated test: test_notify_sdc_complete_stats_reflect_tracker_counts.

### Test Status
- All unit tests pass in CI for the updated branch: 270/270 tests passing on EC2 (per author).
- Local pre-tweak run reported 261 tests passing; after the tweak and fixes the full suite is passing.
- ruff/format checks clean.
- End-to-end run pending.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->