### PR TITLE
uploader: refresh FilePage after new upload to record real pageid

### DIFF
--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -550,10 +550,59 @@ class Uploader:
                     self._tag_drift_duplicate(drift_old_filename, page_title, dpla_id)
                 self.tracker.increment(Result.UPLOADED)
                 self.tracker.increment(Result.BYTES, file_size)
+                # `wiki_file_page.pageid` is stale for net-new uploads:
+                # the pre-upload existence check populated the cached
+                # `_pageid = 0` (definitively, since the file did not
+                # exist), and `site.upload()` does not invalidate that
+                # cache. Reading it here records `pageid: 0` in
+                # upload-result.json even though the file is now on
+                # Commons with a real pageid — which downstream
+                # sdc-sync resolves to the bogus mediaid "M0" and
+                # raises. Construct a fresh FilePage (no cached
+                # pageid) and force a populated load via .exists() so
+                # the recorded pageid matches the API's assigned
+                # value.
+                #
+                # Fail closed on the sidecar contract: if the refresh
+                # throws or still returns a falsy pageid, record
+                # `pageid: None` rather than the malformed `0`. The
+                # upload itself genuinely succeeded — keep
+                # ORDINAL_UPLOADED so future runs see the file as
+                # already uploaded (returning ORDINAL_FAILED would
+                # trigger a retry against a file that's already on
+                # Commons, hitting the "file linked to another page"
+                # drift detection). sdc-sync's `if not pageid` guard
+                # (added in #252) cleanly skips None as a mapping
+                # malformed record without raising.
+                resolved_pageid = None
+                try:
+                    fresh_page = get_page(self.site, page_title)
+                    fresh_page.exists()
+                    resolved_pageid = fresh_page.pageid
+                except Exception as refresh_ex:
+                    logging.warning(
+                        f"Uploaded {page_title} but post-upload pageid"
+                        f" refresh raised: {refresh_ex!r}. Recording"
+                        " pageid=None; sdc-sync will skip this ordinal"
+                        " as malformed."
+                    )
+                if not resolved_pageid:
+                    if resolved_pageid is not None:
+                        # Refresh returned but produced a falsy value
+                        # (typically 0). Normalize to None so the
+                        # sidecar shape is uniformly "missing" rather
+                        # than the legacy bug shape.
+                        logging.warning(
+                            f"Uploaded {page_title} but resolved pageid"
+                            f" is {resolved_pageid!r}; recording"
+                            " pageid=None, sdc-sync will skip this"
+                            " ordinal as malformed."
+                        )
+                    resolved_pageid = None
                 return {
                     "status": ORDINAL_UPLOADED,
                     "title": page_title,
-                    "pageid": wiki_file_page.pageid,
+                    "pageid": resolved_pageid,
                 }
 
             # dry_run path falls through without uploading — flag as INELIGIBLE


### PR DESCRIPTION
## The bug

`upload-result.json` sidecars for **net-new** uploads have been recording `"pageid": 0` despite `"status": "UPLOADED"`. The file IS on Commons with a real pageid — but `tools/uploader.py` reads `wiki_file_page.pageid` from a stale pywikibot cache:

1. `wiki_file_page = get_page(site, title)` — FilePage constructed with `_pageid = 0` (pywikibot default).
2. Pre-upload existence check finds the page doesn't exist; pywikibot **definitively** caches `_pageid = 0`.
3. `site.upload(...)` succeeds — Commons creates a page with a real id.
4. Code reads `wiki_file_page.pageid` → still cached `0`. `site.upload()` doesn't auto-invalidate.

## Real-world impact

Downstream `sdc-sync` reads the sidecar, builds the bogus mediaid `M0`, and the resulting pywikibot APIError aborts the whole partner batch (pre-#252) or churns ordinal errors across every freshly-uploaded item (post-#252).

Concrete example: file `Cliff Palace, Mesa Verde - DPLA - 0034db749eabed986395f6fe1b7439db.gif`
- Real pageid on Commons: **192836790**
- Recorded in upload-result.json: **0**

Aborted the NARA still-pictures+photographic-negatives SDC phase on 2026-05-26 on the first ordinal.

## Fix

After a successful upload, construct a fresh FilePage and force a populated load via `.exists()`. The fresh object has no cached `_pageid`, so `.exists()` does a real loadpageinfo API call and `.pageid` returns the assigned id:

```python
fresh_page = get_page(self.site, page_title)
fresh_page.exists()
resolved_pageid = fresh_page.pageid
```

Plus a defensive `if not resolved_pageid` warning that catches any surprise case where a freshly-loaded FilePage still returns 0 — we'd rather see the warning in the log than silently write another bad sidecar.

## Backfill

Existing sidecars from pre-fix runs need their `pageid: 0` records repaired. That's tracked as a separate one-off script (not in this PR) — it'll scan affected `upload-result.json` files on S3, look up the real pageids via the Commons API, and rewrite.

## Test plan

- [x] `pytest tests/` — **270 passed** on EC2 (Python 3.13.2).
- [x] `ruff check` + `ruff format` clean.
- [ ] Smoke test: re-run a small NARA sub-collection through the pipeline; verify the new upload-result.json sidecars carry real pageids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Bug Fix: FilePage Cache Invalidation After Upload

### What Changed
Updated tools/uploader.py (process_file) so upload-result.json records the true Commons pageid for net-new uploads by constructing a fresh pywikibot.FilePage for the uploaded title after site.upload(), forcing a server lookup via .exists(), and reading .pageid from that fresh object. If the refreshed pageid is falsy (e.g., 0) or the refresh raises, the code logs a defensive warning, records pageid: None, and still returns ORDINAL_UPLOADED so downstream logic can skip malformed mappings.

### The Problem
Net-new uploads were being recorded with "pageid": 0 despite successful uploads. Root cause: the pre-upload FilePage object cached _pageid = 0 during an existence check, and that cached object was not invalidated after site.upload(), so subsequent reads returned 0 and produced invalid media IDs (M0).

### The Fix
- After a successful upload, instantiate a fresh FilePage for the title.
- Call .exists() to force loadpageinfo from Commons and then read fresh_page.pageid.
- Log a warning and set pageid: None if refresh fails or yields 0.

### Impact
- Prevents downstream sdc-sync errors caused by invalid media IDs (M0) and pywikibot APIError failures that aborted partner batch runs (example: NARA SDC failure on 2026-05-26 where a file with real pageid 192836790 was recorded as 0).
- No operational changes required: no manual pipeline trigger or ECS redeployment is necessary.
- No environment variable or AWS Secrets Manager key additions/removals/renames.
- No database migrations.
- No shared infrastructure changes (CodePipeline/CodeBuild/ECS/IAM).
- No changes to public API shapes or endpoints.
- No security-sensitive credential or auth changes introduced.

### Backfill
A separate one-off script (not included) will repair existing upload-result.json sidecars that currently have pageid: 0 by querying Commons and rewriting those sidecars.

### Testing
- Unit tests: pytest (270 passed on Python 3.13.2)
- Static checks: ruff passed
- Smoke test: pending

### Other Notes
- Change is localized to uploader logic and is defensive: when the post-upload refresh cannot resolve a pageid, the code records None and logs a warning rather than producing an invalid mediaid.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->