### PR TITLE
sdc-sync: stop overwriting foreign qualifiers when stamping references

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1,0 +1,215 @@
+"""Tests for sdc_sync's existing-statement reconciliation logic.
+
+Focused on the bug fix that motivated the helper: foreign statements
+(carrying qualifiers DPLA didn't author) must never be amended via
+wbeditentity-with-id, because Wikibase replaces the entire claim's
+qualifiers + references with what we send.
+
+The full check() flow is hard to unit-test without standing up a fake
+get_entity() return — these tests mock that at module scope and cover
+the four observable outcomes:
+
+  * existing matching statement that is DPLA-shaped → don't add duplicate
+  * existing matching statement that is foreign → add ours alongside,
+    don't capture its id for ref-stamping (the bug case)
+  * existing matching statement with no qualifiers at all → stamp our
+    P459 qualifier onto it
+  * no matching statement → add new
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def _qual_p459(qid):
+    """Build a `qualifiers.P459` snak list with a single entity value."""
+    return [
+        {
+            "snaktype": "value",
+            "property": "P459",
+            "datavalue": {
+                "type": "wikibase-entityid",
+                "value": {
+                    "entity-type": "item",
+                    "numeric-id": int(qid.replace("Q", "")),
+                    "id": qid,
+                },
+            },
+        }
+    ]
+
+
+def _qual_other(prop, qid):
+    """Build a non-P459 entity-valued qualifier snak list."""
+    return [
+        {
+            "snaktype": "value",
+            "property": prop,
+            "datavalue": {
+                "type": "wikibase-entityid",
+                "value": {
+                    "entity-type": "item",
+                    "numeric-id": int(qid.replace("Q", "")),
+                    "id": qid,
+                },
+            },
+        }
+    ]
+
+
+def _item_statement(stmt_id, value_qid, qualifiers=None, references=None):
+    """Construct a Commons MediaInfo statement dict for tests."""
+    stmt = {
+        "id": stmt_id,
+        "mainsnak": {
+            "property": "P6216",
+            "snaktype": "value",
+            "datavalue": {
+                "type": "wikibase-entityid",
+                "value": {
+                    "entity-type": "item",
+                    "numeric-id": int(value_qid.replace("Q", "")),
+                    "id": value_qid,
+                },
+            },
+        },
+    }
+    if qualifiers is not None:
+        stmt["qualifiers"] = qualifiers
+    if references is not None:
+        stmt["references"] = references
+    return stmt
+
+
+def test_is_dpla_shaped_recognises_p459_marker():
+    """_is_dpla_shaped is the sole gate that distinguishes our writes from
+    foreign ones. Confirm it fires on Q61848113 (our marker) and only that."""
+    from tools.sdc_sync import _is_dpla_shaped
+
+    assert _is_dpla_shaped(
+        _item_statement("Z$1", "Q19652", qualifiers={"P459": _qual_p459("Q61848113")})
+    )
+    # Foreign P459 value (e.g. "work of US federal government") must not be
+    # confused for ours — that's exactly the case that caused the bug.
+    assert not _is_dpla_shaped(
+        _item_statement("Z$2", "Q19652", qualifiers={"P459": _qual_p459("Q60671452")})
+    )
+    # No P459 qualifier at all.
+    assert not _is_dpla_shaped(
+        _item_statement(
+            "Z$3", "Q19652", qualifiers={"P1001": _qual_other("P1001", "Q30")}
+        )
+    )
+    # No qualifiers at all.
+    assert not _is_dpla_shaped(_item_statement("Z$4", "Q19652"))
+
+
+def test_check_foreign_match_adds_alongside_not_overwrite():
+    """Reproduces the production bug. Foreign P6216=Q19652 statement with
+    P1001+P459 qualifiers must NOT get its id captured for ref-stamping
+    (which would clobber its qualifiers via wbeditentity-with-id).
+
+    Expected: check returns (True, "") meaning 'add a new DPLA-authored
+    statement alongside'. The foreign statement is left untouched."""
+    from tools import sdc_sync
+
+    foreign_stmt = _item_statement(
+        "M999$abc",
+        "Q19652",
+        qualifiers={
+            "P1001": _qual_other("P1001", "Q30"),
+            "P459": _qual_p459("Q60671452"),
+        },
+    )
+    fake_entity = {
+        "pageid": 999,
+        "statements": {"P6216": [foreign_stmt]},
+    }
+    with patch.object(sdc_sync, "get_entity", return_value=fake_entity):
+        result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
+    # First element True → add new statement. Second element "" → no
+    # ref-stamp candidate; in particular, NOT the foreign statement's id.
+    assert result == (True, "")
+
+
+def test_check_dpla_shaped_match_doesnt_duplicate():
+    """When the existing matching statement is DPLA-shaped, we've already
+    written this claim. Don't add a duplicate. Capture its id for
+    ref-stamping if it lacks references — safe because we own it."""
+    from tools import sdc_sync
+
+    dpla_stmt = _item_statement(
+        "M999$ours",
+        "Q19652",
+        qualifiers={"P459": _qual_p459("Q61848113")},
+    )
+    fake_entity = {
+        "pageid": 999,
+        "statements": {"P6216": [dpla_stmt]},
+    }
+    with patch.object(sdc_sync, "get_entity", return_value=fake_entity):
+        result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
+    # add_new=False (already there), ref="M999$ours" (safe to amend — ours).
+    assert result == (False, "M999$ours")
+
+
+def test_check_no_qualifiers_match_stamps_p459():
+    """An existing statement with matching value and NO qualifiers is the
+    legitimate "stamp our P459 qualifier" case — preserved from the
+    pre-fix behavior. wbsetqualifier is non-destructive."""
+    from tools import sdc_sync
+
+    empty_stmt = _item_statement("M999$empty", "Q19652")
+    fake_entity = {"pageid": 999, "statements": {"P6216": [empty_stmt]}}
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=fake_entity),
+        # The production add_det returns None implicitly; mirror that on the
+        # mock so the (None, ref) tuple comparison below is exact.
+        patch.object(sdc_sync, "add_det", return_value=None) as mock_add_det,
+    ):
+        result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
+    # add_det was called with the matching statement id (stamps the P459
+    # qualifier via wbsetqualifier).
+    mock_add_det.assert_called_once_with("M999", "M999$empty")
+    # First element is add_det's return (None) — the caller's `if checkclaim[0] is True`
+    # is False, so no new statement gets queued. Second element is the
+    # captured ref ("M999$empty" — also DPLA-safe because no qualifiers).
+    assert result == (None, "M999$empty")
+
+
+def test_check_no_matching_statement_adds_new():
+    """No existing P6216 statement at all → add new (True), no ref to amend."""
+    from tools import sdc_sync
+
+    fake_entity = {"pageid": 999, "statements": {}}
+    with patch.object(sdc_sync, "get_entity", return_value=fake_entity):
+        result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
+    assert result == (True, "")
+
+
+@pytest.mark.parametrize(
+    "kind, value, mainsnak_value",
+    [
+        ("string", "abc-123", "abc-123"),
+        ("monolingualtext", "Hello world", {"text": "Hello world", "language": "en"}),
+    ],
+)
+def test_check_foreign_match_other_value_types(kind, value, mainsnak_value):
+    """Same foreign-match-don't-overwrite behavior for string and
+    monolingualtext mainsnaks (P760, P1476 etc.)."""
+    from tools import sdc_sync
+
+    foreign_stmt = {
+        "id": "M999$str",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": kind, "value": mainsnak_value},
+        },
+        "qualifiers": {"P1001": _qual_other("P1001", "Q30")},
+    }
+    fake_entity = {"pageid": 999, "statements": {"P760": [foreign_stmt]}}
+    with patch.object(sdc_sync, "get_entity", return_value=fake_entity):
+        result = sdc_sync.check("M999", (kind, value), "P760")
+    assert result == (True, "")

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -348,6 +348,28 @@ def invalidate_entity(mediaid):
     _entity_cache.pop(mediaid, None)
 
 
+def _is_dpla_shaped(statement):
+    """Return True when `statement` carries the P459=Q61848113 marker that
+    DPLA stamps on every claim it writes (determination method = "determined
+    by GLAM institution and stated at its website").
+
+    Used by check() to decide whether an existing matching statement is one
+    we wrote (safe to amend in place via wbeditentity-with-id) or one
+    someone else wrote (must not be touched — wbeditentity-with-id replaces
+    the whole claim's qualifiers + references with what we send, so
+    capturing such a statement's id for ref-stamping would silently erase
+    qualifiers we don't know about).
+    """
+    qualifiers = statement.get("qualifiers") or {}
+    for snak in qualifiers.get("P459") or []:
+        try:
+            if snak["datavalue"]["value"]["id"] == "Q61848113":
+                return True
+        except (KeyError, TypeError):
+            continue
+    return False
+
+
 def check(mediaid, qid, prop):
     ref = ""
     existing_data = get_entity(mediaid)
@@ -361,125 +383,160 @@ def check(mediaid, qid, prop):
     except Exception:
         return True, ""
 
-    # The following code is used to check the existing statements that match the prop. If any statement matches the prop and qid but has no qualifiers, the statement id is returned. If there is a matching statement with qualifiers, return False. Otherwise (statements with matching prop have no matching qid) return True. This logic is not complete: it will return a statement id for a statement with no qualifier, even if another statement already has the desired qualifier. Also, it would return False even in cases where the qualifier value is different from the desired qualifier, in cases where there there is a matching qid and prop with qualifiers.
+    # Inspect existing statements that match `prop` and decide what to do:
+    #
+    #   * Capture `ref` from a matching statement only when amending it is
+    #     SAFE — either the statement has no qualifiers or it carries the
+    #     P459=Q61848113 marker (DPLA-shaped, written by us). Otherwise
+    #     wbeditentity-with-id would clobber qualifiers we didn't author.
+    #   * If a matching statement has no qualifiers at all, stamp our
+    #     P459=Q61848113 qualifier onto it (wbsetqualifier is non-destructive).
+    #   * If a matching statement carries qualifiers AND it's DPLA-shaped,
+    #     we've already written this claim — don't add a duplicate.
+    #   * If a matching statement carries qualifiers AND it's FOREIGN
+    #     (no P459=Q61848113), leave it alone and add the DPLA-authored
+    #     statement alongside as a separate claim. The two coexist with
+    #     different rationales.
     if qid[0] == "item":
-        if any(
-            statement["mainsnak"]["datavalue"]["value"]["id"] == qid[1]
-            and not statement.get("references")
-            for statement in statements
-        ):
-            for statement in statements:
-                if statement["mainsnak"]["datavalue"]["value"]["id"] == qid[
-                    1
-                ] and not statement.get("references"):
-                    ref = statement["id"]
-        if any(
-            statement["mainsnak"]["datavalue"]["value"]["id"] == qid[1]
-            and not statement.get("qualifiers")
-            for statement in statements
-        ):
-            for statement in statements:
-                if statement["mainsnak"]["datavalue"]["value"]["id"] == qid[
-                    1
-                ] and not statement.get("qualifiers"):
-                    return add_det(mediaid, statement["id"]), ref
+        for statement in statements:
+            if (
+                statement["mainsnak"]["datavalue"]["value"]["id"] == qid[1]
+                and not statement.get("references")
+                and (not statement.get("qualifiers") or _is_dpla_shaped(statement))
+            ):
+                ref = statement["id"]
+                break
+        for statement in statements:
+            if statement["mainsnak"]["datavalue"]["value"]["id"] == qid[
+                1
+            ] and not statement.get("qualifiers"):
+                return add_det(mediaid, statement["id"]), ref
 
-        elif any(
+        if any(
+            statement["mainsnak"]["datavalue"]["value"]["id"] == qid[1]
+            and _is_dpla_shaped(statement)
+            for statement in statements
+        ):
+            print(
+                f" -- There already exists a DPLA-authored statement with a {prop} > {qid[1]} claim for {mediaid}."
+            )
+            return False, ref
+
+        if any(
             statement["mainsnak"]["datavalue"]["value"]["id"] == qid[1]
             for statement in statements
         ):
             print(
-                f" -- There already exists a statement with a {prop} > {qid[1]} claim for {mediaid}."
+                f" -- A foreign {prop} > {qid[1]} statement exists for {mediaid}; adding the DPLA-authored statement alongside."
             )
-            return False, ref
+            return True, ""
 
-        else:
-            return True, ref
+        return True, ref
     if qid[0] == "string":
-        if any(
-            statement["mainsnak"]["datavalue"]["value"] == qid[1]
-            and not statement.get("references")
-            for statement in statements
-        ):
-            for statement in statements:
-                if statement["mainsnak"]["datavalue"]["value"] == qid[
-                    1
-                ] and not statement.get("references"):
-                    ref = statement["id"]
-        if any(
-            statement["mainsnak"]["datavalue"]["value"] == qid[1]
-            and not statement.get("qualifiers")
-            for statement in statements
-        ):
-            for statement in statements:
-                if statement["mainsnak"]["datavalue"]["value"] == qid[
-                    1
-                ] and not statement.get("qualifiers"):
-                    return add_det(mediaid, statement["id"]), ref
+        for statement in statements:
+            if (
+                statement["mainsnak"]["datavalue"]["value"] == qid[1]
+                and not statement.get("references")
+                and (not statement.get("qualifiers") or _is_dpla_shaped(statement))
+            ):
+                ref = statement["id"]
+                break
+        for statement in statements:
+            if statement["mainsnak"]["datavalue"]["value"] == qid[
+                1
+            ] and not statement.get("qualifiers"):
+                return add_det(mediaid, statement["id"]), ref
 
-        elif any(
+        if any(
+            statement["mainsnak"]["datavalue"]["value"] == qid[1]
+            and _is_dpla_shaped(statement)
+            for statement in statements
+        ):
+            print(
+                f" -- There already exists a DPLA-authored statement with a {prop} > {qid[1]} claim for {mediaid}."
+            )
+            return False, ref
+
+        if any(
             statement["mainsnak"]["datavalue"]["value"] == qid[1]
             for statement in statements
         ):
             print(
-                f" -- There already exists a statement with a {prop} > {qid[1]} claim for {mediaid}."
+                f" -- A foreign {prop} > {qid[1]} statement exists for {mediaid}; adding the DPLA-authored statement alongside."
             )
-            return False, ref
+            return True, ""
 
-        else:
-            return True, ref
+        return True, ref
     if qid[0] == "monolingualtext":
-        if any(
-            statement["mainsnak"]["datavalue"]["value"]["text"] == qid[1]
-            and not statement.get("references")
-            for statement in statements
-        ):
-            for statement in statements:
-                if statement["mainsnak"]["datavalue"]["value"]["text"] == qid[
-                    1
-                ] and not statement.get("references"):
-                    ref = statement["id"]
-        if any(
-            statement["mainsnak"]["datavalue"]["value"]["text"] == qid[1]
-            and not statement.get("qualifiers")
-            for statement in statements
-        ):
-            for statement in statements:
-                if statement["mainsnak"]["datavalue"]["value"]["text"] == qid[
-                    1
-                ] and not statement.get("qualifiers"):
-                    return add_det(mediaid, statement["id"]), ref
+        for statement in statements:
+            if (
+                statement["mainsnak"]["datavalue"]["value"]["text"] == qid[1]
+                and not statement.get("references")
+                and (not statement.get("qualifiers") or _is_dpla_shaped(statement))
+            ):
+                ref = statement["id"]
+                break
+        for statement in statements:
+            if statement["mainsnak"]["datavalue"]["value"]["text"] == qid[
+                1
+            ] and not statement.get("qualifiers"):
+                return add_det(mediaid, statement["id"]), ref
 
-        elif any(
+        if any(
+            statement["mainsnak"]["datavalue"]["value"]["text"] == qid[1]
+            and _is_dpla_shaped(statement)
+            for statement in statements
+        ):
+            print(
+                f" -- There already exists a DPLA-authored statement with a {prop} > {qid[1]} claim for {mediaid}."
+            )
+            return False, ref
+
+        if any(
             statement["mainsnak"]["datavalue"]["value"]["text"] == qid[1]
             for statement in statements
         ):
             print(
-                f" -- There already exists a statement with a {prop} > {qid[1]} claim for {mediaid}."
+                f" -- A foreign {prop} > {qid[1]} statement exists for {mediaid}; adding the DPLA-authored statement alongside."
             )
-            return False, ref
+            return True, ""
 
-        else:
-            return True, ref
+        return True, ref
     if qid[0] == "somevalue":
         p = "P1932" if prop == "P571" else "P2093"
         try:
             if any(statement.get("qualifiers", {}).get(p) for statement in statements):
+                # Capture ref only from DPLA-shaped matching statements.
+                # somevalue claims always have at least the P1932/P2093
+                # qualifier we matched on, so "no qualifiers" is impossible;
+                # the DPLA-shaped check is the only safe gate.
                 for statement in statements:
                     qualifiers = statement.get("qualifiers", {}).get(p) or []
-                    # Scan every qualifier entry, not just the first. Wikibase
-                    # qualifier props may carry multiple values.
+                    if (
+                        any(
+                            q.get("datavalue", {}).get("value") == qid[1]
+                            for q in qualifiers
+                        )
+                        and _is_dpla_shaped(statement)
+                        and not statement.get("references")
+                    ):
+                        ref = statement["id"]
+                        break
+                # Already-our-write check: a DPLA-shaped statement with the
+                # matching qualifier value means we wrote this claim before.
+                # Don't add a duplicate.
+                for statement in statements:
+                    qualifiers = statement.get("qualifiers", {}).get(p) or []
                     if any(
                         q.get("datavalue", {}).get("value") == qid[1]
                         for q in qualifiers
-                    ) and not statement.get("references"):
-                        ref = statement["id"]
-                # Walk every statement looking for a qualifier match. Only
-                # return False on an actual match; otherwise fall through and
-                # return True once we've exhausted all statements. Returning
-                # early on a non-match would skip later statements that DO
-                # match and cause duplicate writes on multi-value properties
-                # (creators, dates, etc.).
+                    ) and _is_dpla_shaped(statement):
+                        print(
+                            f" -- There already exists a DPLA-authored statement with a {prop} > {qid[1]} claim for {mediaid}."
+                        )
+                        return False, ref
+                # Foreign matching statement: leave alone, add ours as a
+                # separate claim.
                 for statement in statements:
                     qualifiers = statement.get("qualifiers", {}).get(p) or []
                     if any(
@@ -487,9 +544,9 @@ def check(mediaid, qid, prop):
                         for q in qualifiers
                     ):
                         print(
-                            f" -- There already exists a statement with a {prop} > {qid[1]} claim for {mediaid}."
+                            f" -- A foreign {prop} > {qid[1]} statement exists for {mediaid}; adding the DPLA-authored statement alongside."
                         )
-                        return False, ref
+                        return True, ""
                 return True, ref
             else:
                 return True, ref
@@ -500,15 +557,34 @@ def check(mediaid, qid, prop):
             if any(
                 statement.get("qualifiers", {}).get("P973") for statement in statements
             ):
+                # Same logic as the somevalue branch: P7482 source claims
+                # always have at least the P973 qualifier we matched on,
+                # so amend-safety hinges on whether the statement is
+                # DPLA-shaped (carries P459=Q61848113).
+                for statement in statements:
+                    qualifiers = statement.get("qualifiers", {}).get("P973") or []
+                    if (
+                        any(
+                            q.get("datavalue", {}).get("value") == qid[1]
+                            for q in qualifiers
+                        )
+                        and _is_dpla_shaped(statement)
+                        and not statement.get("references")
+                    ):
+                        ref = statement["id"]
+                        break
+                # Already-our-write check.
                 for statement in statements:
                     qualifiers = statement.get("qualifiers", {}).get("P973") or []
                     if any(
                         q.get("datavalue", {}).get("value") == qid[1]
                         for q in qualifiers
-                    ) and not statement.get("references"):
-                        ref = statement["id"]
-                # See the somevalue branch above: scan every statement before
-                # concluding the claim is missing.
+                    ) and _is_dpla_shaped(statement):
+                        print(
+                            f" -- There already exists a DPLA-authored statement with a {prop} > {qid[1]} claim for {mediaid}."
+                        )
+                        return False, ref
+                # Foreign matching statement: leave alone, add ours alongside.
                 for statement in statements:
                     qualifiers = statement.get("qualifiers", {}).get("P973") or []
                     if any(
@@ -516,9 +592,9 @@ def check(mediaid, qid, prop):
                         for q in qualifiers
                     ):
                         print(
-                            f" -- There already exists a statement with a {prop} > {qid[1]} claim for {mediaid}."
+                            f" -- A foreign {prop} > {qid[1]} statement exists for {mediaid}; adding the DPLA-authored statement alongside."
                         )
-                        return False, ref
+                        return True, ""
                 return True, ref
             else:
                 return True, ref


### PR DESCRIPTION
## The bug — real damage observed

Live diff: https://commons.wikimedia.org/w/index.php?title=File:Masked_%22Mudheads%22_Prepared_to_Dance,_Zuni_Pueblo,_New_Mexico_-_DPLA_-_bbdde594f597ad0b6eb1a7bbaa1752ae.gif&diff=prev&oldid=1220976609

A pre-existing P6216 (copyright status) = Q19652 (public domain) statement on that file carried two qualifiers it didn't author:
- `P1001` = `Q30` (applies to jurisdiction: United States)
- `P459` = `Q60671452` (work of the federal government of the United States)

The bot's reconciliation pass:
1. Found the matching `P6216 = Q19652` mainsnak.
2. Captured its claim id into `ref` because the statement had no reference.
3. Queued a `wbeditentity` POST with `id=<that claim guid>` and our own claim shape — only `P459 = Q61848113` qualifier, our DPLA-publisher reference.
4. Wikibase's `wbeditentity`-with-`id` is a **wholesale replace** of mainsnak + qualifiers + references with what you send. So:
   - `P1001 = Q30` → erased
   - `P459 = Q60671452` → replaced with `P459 = Q61848113`
   - Reference added (intended)

We had no right to touch the foreign qualifiers.

## Root cause

`check()` had no notion of whether a matching existing statement was DPLA-authored or foreign. Any matching statement without a reference was eligible for ref-stamping, and the stamping mechanism (wbeditentity-with-id) destructively replaces the rest of the claim.

## Fix

New `_is_dpla_shaped(statement)` helper recognises our writes by their `P459 = Q61848113` marker (the determination-method qualifier sdc-sync stamps on every claim).

All five type branches in `check()` (`item`, `string`, `monolingualtext`, `somevalue`, `source`) now:

1. **Capture `ref` only from amend-safe statements** — either (a) no qualifiers at all, or (b) DPLA-shaped. Foreign qualifiers can no longer be round-tripped through wbeditentity-with-id.
2. **Split the "matching mainsnak with qualifiers exists" decision**:
   - **DPLA-shaped match** → `(False, ref)`: we already wrote this; don't duplicate.
   - **Foreign match** → `(True, "")`: add the DPLA-authored statement *alongside* as a separate claim, with our own qualifier and reference. The foreign statement is left untouched.

The non-destructive `add_det` (`wbsetqualifier`) path for "matching statement with no qualifiers" is preserved unchanged.

## Damage from prior runs

This change prevents future damage. It does **not** undo overwrites already in revision history — that requires a separate backfill (scan affected files, restore the qualifiers from pre-bot revisions). Not in scope here.

## Tests

`tests/test_sdc_sync.py` (new) covers:
- `_is_dpla_shaped` — recognises the `P459 = Q61848113` marker and rejects everything else
- Foreign match → adds alongside, does NOT capture id for ref-stamping (the production bug)
- DPLA-shaped match → no duplicate, captures id for ref-stamping (safe)
- No-qualifier match → stamps our P459 via `add_det`
- No match → adds new statement
- Same foreign-match behavior for string and monolingualtext mainsnak types

**277/277 tests pass** on EC2 (Python 3.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->