### PR TITLE
uploader: dup-SHA1 short-circuit must check title is one of OURS

### DIFF
--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -13,6 +13,7 @@ from tools.uploader import (
     LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES,
     _post_item_orphan_check,
     _post_upload_touch_new_institutions,
+    is_dup_sha1_sibling_at_expected_title,
     select_upload_chunk_size,
 )
 
@@ -857,3 +858,108 @@ def test_chunk_size_threshold_under_wikimedia_gateway_limit():
     """The threshold itself must stay safely under Wikimedia's ~100 MB
     practical direct-upload limit — otherwise we re-introduce the OOM."""
     assert LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES < 100 * 1024 * 1024
+
+
+# --------------------------------------------------------------------------
+# is_dup_sha1_sibling_at_expected_title — the upload_only short-circuit gate
+#
+# Pin the contract that prevents the orphan-duplicate bug observed on item
+# fe6f59a29fddf8e3483e91ad805bf039 (Zuni in costume). NARA's mediaMaster
+# listed the same TIF URL at two positions, so duplicate_source_sha1s
+# contained that SHA1. The pre-fix code unconditionally treated any
+# existing file with a matching SHA1 as a sibling, leaving the 2011 legacy
+# NARA-bot title in place and uploading (page 1).tiff and (page 2).tiff
+# beside it — three Commons files with the same SHA1. The helper must
+# return True only when the existing title is one of THIS item's own
+# expected current titles.
+# --------------------------------------------------------------------------
+
+_SHA1 = "76f6fe0a766e4a664b7d99b9e6c0fb8594bac083"
+_DPLA_PAGE_1 = "Zuni in costume - DPLA - fe6f59a29fddf8e3483e91ad805bf039 (page 1).tiff"
+_DPLA_PAGE_2 = "Zuni in costume - DPLA - fe6f59a29fddf8e3483e91ad805bf039 (page 2).tiff"
+_LEGACY_NARA = "Zuni in costume - NARA - 523667.tif"
+
+
+def test_dup_sha1_sibling_true_when_existing_is_at_expected_title():
+    """SHA1 appears at multiple source positions AND the Commons file lives
+    at one of our (page N).ext titles → true sibling, upload-only is safe."""
+    assert (
+        is_dup_sha1_sibling_at_expected_title(
+            sha1=_SHA1,
+            existing_file_title=_DPLA_PAGE_1,
+            duplicate_source_sha1s={_SHA1},
+            expected_item_titles={_DPLA_PAGE_1, _DPLA_PAGE_2},
+        )
+        is True
+    )
+
+
+def test_dup_sha1_sibling_false_when_existing_is_legacy_title():
+    """THE BUG FIX: SHA1 is in duplicate_source_sha1s, but the existing file
+    is at a legacy title (here the 2011 NARA-bot upload). Returning True
+    would short-circuit drift handling and leave the legacy title in place
+    forever. Must return False so the caller falls through to drift
+    handling, which Case-3-moves the legacy title to (page 1).tiff."""
+    assert (
+        is_dup_sha1_sibling_at_expected_title(
+            sha1=_SHA1,
+            existing_file_title=_LEGACY_NARA,
+            duplicate_source_sha1s={_SHA1},
+            expected_item_titles={_DPLA_PAGE_1, _DPLA_PAGE_2},
+        )
+        is False
+    )
+
+
+def test_dup_sha1_sibling_false_when_sha1_not_in_dup_set():
+    """No multi-position SHA1 case at all → False even if title coincidentally
+    matches an expected title; the caller's normal drift path handles this."""
+    assert (
+        is_dup_sha1_sibling_at_expected_title(
+            sha1="ffffffffffffffffffffffffffffffffffffffff",
+            existing_file_title=_DPLA_PAGE_1,
+            duplicate_source_sha1s={_SHA1},
+            expected_item_titles={_DPLA_PAGE_1, _DPLA_PAGE_2},
+        )
+        is False
+    )
+
+
+def test_dup_sha1_sibling_false_when_duplicate_source_sha1s_is_none():
+    """Defensive: process_file's signature allows None; the gate must
+    not raise and must return False, routing through normal drift."""
+    assert (
+        is_dup_sha1_sibling_at_expected_title(
+            sha1=_SHA1,
+            existing_file_title=_DPLA_PAGE_1,
+            duplicate_source_sha1s=None,
+            expected_item_titles={_DPLA_PAGE_1},
+        )
+        is False
+    )
+
+
+def test_dup_sha1_sibling_false_when_expected_item_titles_is_none():
+    """Defensive: same as above for the other optional parameter."""
+    assert (
+        is_dup_sha1_sibling_at_expected_title(
+            sha1=_SHA1,
+            existing_file_title=_DPLA_PAGE_1,
+            duplicate_source_sha1s={_SHA1},
+            expected_item_titles=None,
+        )
+        is False
+    )
+
+
+def test_dup_sha1_sibling_false_when_duplicate_source_sha1s_is_empty_set():
+    """Empty set is falsy in the early-return; explicit test for clarity."""
+    assert (
+        is_dup_sha1_sibling_at_expected_title(
+            sha1=_SHA1,
+            existing_file_title=_DPLA_PAGE_1,
+            duplicate_source_sha1s=set(),
+            expected_item_titles={_DPLA_PAGE_1},
+        )
+        is False
+    )

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -88,6 +88,36 @@ UPLOAD_TIMEOUT_SECS = 3600  # 1 hour
 LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES = 95 * 1024 * 1024  # 95 MB
 
 
+def is_dup_sha1_sibling_at_expected_title(
+    *,
+    sha1: str,
+    existing_file_title: str,
+    duplicate_source_sha1s: set[str] | None,
+    expected_item_titles: set[str] | None,
+) -> bool:
+    """Return True iff the existing Commons file is a true sibling at one of
+    this item's own expected current titles.
+
+    ``True`` means it's safe to take the upload-only branch — the per-ordinal
+    iteration is preserving that title intentionally and we can upload our
+    own ordinal alongside it.
+
+    ``False`` means the existing file is at a *different* title than any of
+    this item's current asset positions (typically a legacy upload from a
+    previous naming scheme, like a NARA-bot title from 2011).  Even when the
+    SHA1 legitimately appears at multiple source positions, leaving the
+    legacy title alone produces an orphan duplicate on Commons alongside our
+    new ``(page N).ext`` uploads.  The caller should route through normal
+    drift handling instead, which migrates the legacy title via Case 3.
+    """
+    return bool(
+        duplicate_source_sha1s
+        and sha1 in duplicate_source_sha1s
+        and expected_item_titles
+        and existing_file_title in expected_item_titles
+    )
+
+
 def select_upload_chunk_size(
     *,
     file_exists: bool,
@@ -310,18 +340,25 @@ class Uploader:
                 drift_action: str | None = None
                 force_ignore_warnings = False
                 if existing_file is not None:
-                    if duplicate_source_sha1s and sha1 in duplicate_source_sha1s:
-                        # The source data legitimately lists this SHA1 at
-                        # multiple positions within the item.  The existing
-                        # Commons file at another title is a valid sibling,
-                        # not drift to be migrated — both positions should
-                        # exist as separate Commons pages.  Upload to our
-                        # title and leave the other alone.
+                    # The duplicate-source-SHA1 short-circuit only applies
+                    # when the existing Commons file is at one of THIS item's
+                    # own expected titles — see
+                    # is_dup_sha1_sibling_at_expected_title's docstring for
+                    # why a legacy NARA-bot title with the same SHA1 must
+                    # NOT take this branch (it would leave an orphan
+                    # duplicate alongside our (page N) uploads).
+                    existing_title = existing_file.title(with_ns=False)
+                    if is_dup_sha1_sibling_at_expected_title(
+                        sha1=sha1,
+                        existing_file_title=existing_title,
+                        duplicate_source_sha1s=duplicate_source_sha1s,
+                        expected_item_titles=expected_item_titles,
+                    ):
                         logging.info(
                             f"Source asset list contains the same SHA1 at "
                             f"multiple positions for {dpla_id} {ordinal}; "
                             f"existing file at "
-                            f"[[File:{existing_file.title(with_ns=False)}]] "
+                            f"[[File:{existing_title}]] "
                             f"is a legitimate sibling, not drift. Uploading "
                             f"to [[File:{page_title}]] without disturbing it."
                         )


### PR DESCRIPTION
## Summary

When a DPLA item's mediaMaster lists the same source URL at multiple positions, the per-position downloads produce identical bytes with the same SHA1. `collect_duplicate_source_sha1s` adds that SHA1 to the set, and the existing short-circuit in \`process_file\` says \"this is a legitimate sibling, leave the existing Commons file alone, upload to our own (page N).ext title.\"

That logic was correct for *some* meanings of \"the existing Commons file\" but wrong for others. It treats *any* file with the matching SHA1 as a sibling — including legacy uploads at completely unrelated titles. Result: an orphan duplicate alongside our new \`(page N)\` uploads.

## Concrete example

NARA item [\`fe6f59a29fddf8e3483e91ad805bf039\`](https://dp.la/item/fe6f59a29fddf8e3483e91ad805bf039) (\"Zuni in costume\"). Its mediaMaster has 3 URLs; positions 2 and 3 are the **same** TIF URL. After upload, Commons has three files all sharing SHA1 \`76f6fe0a766e4a664b7d99b9e6c0fb8594bac083\`:

| Title | When | By |
|---|---|---|
| \`Zuni_in_costume_-_NARA_-_523667.tif\` | 2011-09-11 | US National Archives bot |
| \`…DPLA - fe6f59a…(page_1).tiff\` | 2026-05-26 21:10:50 | DPLA bot |
| \`…DPLA - fe6f59a…(page_2).tiff\` | 2026-05-26 21:10:53 | DPLA bot |

The log shows the bug firing twice:

\`\`\`
21:10:47: Hash drift detected for fe6f59a…b6080b 2: SHA1 found at
          [[File:Zuni in costume - NARA - 523667.tif]]
21:10:47: Source asset list contains the same SHA1 at multiple positions …
          existing file at [[File:Zuni in costume - NARA - 523667.tif]]
          is a legitimate sibling, not drift. Uploading to … (page 1).tiff
          without disturbing it.
\`\`\`

The legacy NARA title should have been Case-3-moved to \`(page 1).tiff\` here, then position 3's iteration would find the SHA1 at \`(page 1).tiff\` (now in expected_item_titles) and correctly upload \`(page 2).tiff\` fresh. No orphan.

## Fix

Extract the gate into \`is_dup_sha1_sibling_at_expected_title()\` (module-level helper) and add the missing \"existing title is one of our own current titles\" condition:

\`\`\`python
return bool(
    duplicate_source_sha1s
    and sha1 in duplicate_source_sha1s
    and expected_item_titles
    and existing_file_title in expected_item_titles
)
\`\`\`

When False, \`process_file\` falls through to \`_resolve_hash_drift\`, which Case-3-moves the legacy title to its current expected position. The next ordinal with the same SHA1 then finds the file at an expected title and correctly takes upload-only.

## Out of scope (separate cleanup)

This PR is the code fix only. There are existing Commons files in this orphan-duplicate state from recent NARA runs (the Zuni item is one example; there are likely many more from items whose mediaMaster repeats URLs and which had legacy NARA-bot uploads). I'll do a follow-up data audit to scope and clean those up.

## Test plan

- [x] 6 new tests pin every branch of the helper: sibling case, legacy-title case (the bug), SHA1 not in dup set, and the three None/empty defensive forms.
- [x] 34 \`tests/test_uploader.py\` tests pass.
- [x] \`ruff check\` + \`ruff format --check\` clean.
- [ ] After merge: run a NARA institution that triggers \`duplicate_source_sha1s\` (Still Pictures with legacy NARA-bot uploads in scope) and confirm legacy titles get redirected away rather than left as orphan duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a bug in the uploader where identical-source SHA1s produced by DPLA items with duplicate source URLs cause the process_file short-circuit to incorrectly treat legacy Commons files as legitimate siblings, resulting in orphan duplicate files.

**The Problem**: When a DPLA item's mediaMaster lists the same source URL at multiple positions, it generates duplicate SHA1 values. The previous code would unconditionally skip migration for any existing Commons file with a matching SHA1, even legacy uploads with unrelated titles (e.g., older NARA-bot titles from 2011). This left legacy titles in place while uploading new `(page N)` files, creating orphan duplicates with identical SHA1s.

**The Solution**: Extracts the gate logic into a new module-level helper `is_dup_sha1_sibling_at_expected_title()` that validates two conditions: (1) the SHA1 must be in the `duplicate_source_sha1s` set AND (2) the existing file's title must be one of the item's `expected_item_titles`. When the helper returns False (e.g., for legacy titles), process_file falls through to `_resolve_hash_drift()`, enabling Case-3 migration that moves the legacy title into the expected `(page N)` namespace.

**Changes**:
- Added a new helper function `is_dup_sha1_sibling_at_expected_title()` with comprehensive documentation
- Updated the hash-drift resolution logic in `Uploader.process_file()` to use the helper
- Added 6 focused unit tests covering all branches (sibling detection, legacy-title bug scenario, SHA1 not in duplicate set, defensive None/empty cases)

**Testing**: 40 tests pass; ruff checks clean. Post-merge manual verification against affected NARA items is planned to audit existing orphan duplicates.

**No Deployment Required**: This is a pure application code fix with no environment variables, AWS infrastructure changes, API modifications, or database migrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->