### PR TITLE
sdc-sync: tighten amend-in-place gate to no user-authored content

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1,20 +1,19 @@
 """Tests for sdc_sync's existing-statement reconciliation logic.
 
-Focused on the bug fix that motivated the helper: foreign statements
-(carrying qualifiers DPLA didn't author) must never be amended via
-wbeditentity-with-id, because Wikibase replaces the entire claim's
-qualifiers + references with what we send.
+These tests focus on the amend-in-place gate that decides whether an
+existing matching statement on Commons is safe for the bot to amend
+via `wbeditentity`-with-id (a wholesale replace of qualifiers +
+references) or must be left alone with the DPLA-authored claim added
+as a separate statement.
 
-The full check() flow is hard to unit-test without standing up a fake
-get_entity() return — these tests mock that at module scope and cover
-the four observable outcomes:
+The gate is `_is_safe_to_amend_in_place`: amend only when every
+existing qualifier property is one DPLA writes for that property
+(P459 always, plus per-property extras from
+`_DPLA_EXTRA_QUALIFIER_PROPS`) AND every existing reference carries
+the DPLA publisher marker (P123=Q2944483 via `_is_dpla_reference`).
 
-  * existing matching statement that is DPLA-shaped → don't add duplicate
-  * existing matching statement that is foreign → add ours alongside,
-    don't capture its id for ref-stamping (the bug case)
-  * existing matching statement with no qualifiers at all → stamp our
-    P459 qualifier onto it
-  * no matching statement → add new
+A claim that contains any user-authored qualifier or reference is
+NOT safe — the wbeditentity round-trip would erase that data.
 """
 
 from unittest.mock import patch
@@ -22,26 +21,8 @@ from unittest.mock import patch
 import pytest
 
 
-def _qual_p459(qid):
-    """Build a `qualifiers.P459` snak list with a single entity value."""
-    return [
-        {
-            "snaktype": "value",
-            "property": "P459",
-            "datavalue": {
-                "type": "wikibase-entityid",
-                "value": {
-                    "entity-type": "item",
-                    "numeric-id": int(qid.replace("Q", "")),
-                    "id": qid,
-                },
-            },
-        }
-    ]
-
-
-def _qual_other(prop, qid):
-    """Build a non-P459 entity-valued qualifier snak list."""
+def _qual_entity(prop, qid):
+    """Build a single wikibase-entityid qualifier snak under `prop`."""
     return [
         {
             "snaktype": "value",
@@ -58,12 +39,83 @@ def _qual_other(prop, qid):
     ]
 
 
-def _item_statement(stmt_id, value_qid, qualifiers=None, references=None):
+def _qual_string(prop, value):
+    """Build a string-valued qualifier snak (e.g. P973 URL, P2093 name)."""
+    return [
+        {
+            "snaktype": "value",
+            "property": prop,
+            "datavalue": {"type": "string", "value": value},
+        }
+    ]
+
+
+def _dpla_p459():
+    return _qual_entity("P459", "Q61848113")
+
+
+def _dpla_reference(dpla_id="abcdef"):
+    """Build a DPLA-authored reference snak set (P854 URL, P123 publisher,
+    P813 retrieved)."""
+    return {
+        "snaks": {
+            "P854": [
+                {
+                    "snaktype": "value",
+                    "property": "P854",
+                    "datavalue": {
+                        "type": "string",
+                        "value": f"https://dp.la/item/{dpla_id}",
+                    },
+                }
+            ],
+            "P123": _qual_entity("P123", "Q2944483"),
+            "P813": [
+                {
+                    "snaktype": "value",
+                    "property": "P813",
+                    "datavalue": {
+                        "type": "time",
+                        "value": {
+                            "time": "+2026-05-27T00:00:00Z",
+                            "timezone": 0,
+                            "before": 0,
+                            "after": 0,
+                            "precision": 11,
+                            "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
+                        },
+                    },
+                }
+            ],
+        }
+    }
+
+
+def _foreign_reference():
+    """A reference snak set without the DPLA publisher marker — e.g. a
+    user-added reference pointing to some other source."""
+    return {
+        "snaks": {
+            "P854": [
+                {
+                    "snaktype": "value",
+                    "property": "P854",
+                    "datavalue": {
+                        "type": "string",
+                        "value": "https://example.org/citation",
+                    },
+                }
+            ],
+        }
+    }
+
+
+def _item_statement(stmt_id, value_qid, qualifiers=None, references=None, prop="P6216"):
     """Construct a Commons MediaInfo statement dict for tests."""
     stmt = {
         "id": stmt_id,
         "mainsnak": {
-            "property": "P6216",
+            "property": prop,
             "snaktype": "value",
             "datavalue": {
                 "type": "wikibase-entityid",
@@ -82,107 +134,249 @@ def _item_statement(stmt_id, value_qid, qualifiers=None, references=None):
     return stmt
 
 
-def test_is_dpla_shaped_recognises_p459_marker():
-    """_is_dpla_shaped is the sole gate that distinguishes our writes from
-    foreign ones. Confirm it fires on Q61848113 (our marker) and only that."""
-    from tools.sdc_sync import _is_dpla_shaped
+# ---------------------------------------------------------------------------
+# _is_dpla_reference
+# ---------------------------------------------------------------------------
 
-    assert _is_dpla_shaped(
-        _item_statement("Z$1", "Q19652", qualifiers={"P459": _qual_p459("Q61848113")})
+
+def test_is_dpla_reference_recognises_p123_publisher_marker():
+    """A reference is DPLA-authored iff its P123 snak resolves to Q2944483."""
+    from tools.sdc_sync import _is_dpla_reference
+
+    assert _is_dpla_reference(_dpla_reference())
+    # Foreign reference (no P123).
+    assert not _is_dpla_reference(_foreign_reference())
+    # Reference with P123 but pointing at a different publisher.
+    assert not _is_dpla_reference({"snaks": {"P123": _qual_entity("P123", "Q9999999")}})
+    assert not _is_dpla_reference(None)
+    assert not _is_dpla_reference({})
+
+
+# ---------------------------------------------------------------------------
+# _is_safe_to_amend_in_place
+# ---------------------------------------------------------------------------
+
+
+def test_safe_to_amend_truly_bare_statement():
+    """No qualifiers, no references → safe (vacuously)."""
+    from tools.sdc_sync import _is_safe_to_amend_in_place
+
+    assert _is_safe_to_amend_in_place(_item_statement("Z$1", "Q19652"), "P6216")
+
+
+def test_safe_to_amend_dpla_only_qualifier():
+    """Only P459=Q61848113 → safe (it's DPLA's universal marker)."""
+    from tools.sdc_sync import _is_safe_to_amend_in_place
+
+    assert _is_safe_to_amend_in_place(
+        _item_statement("Z$2", "Q19652", qualifiers={"P459": _dpla_p459()}), "P6216"
     )
-    # Foreign P459 value (e.g. "work of US federal government") must not be
-    # confused for ours — that's exactly the case that caused the bug.
-    assert not _is_dpla_shaped(
-        _item_statement("Z$2", "Q19652", qualifiers={"P459": _qual_p459("Q60671452")})
+
+
+def test_safe_to_amend_dpla_only_reference_no_qualifier():
+    """Has DPLA reference, no qualifier → safe. This is the case the bot
+    should be able to amend by adding the missing P459 qualifier."""
+    from tools.sdc_sync import _is_safe_to_amend_in_place
+
+    assert _is_safe_to_amend_in_place(
+        _item_statement("Z$3", "Q19652", references=[_dpla_reference()]), "P6216"
     )
-    # No P459 qualifier at all.
-    assert not _is_dpla_shaped(
+
+
+def test_safe_to_amend_dpla_qualifier_no_reference():
+    """Has DPLA's P459 qualifier, no reference → safe. The bot should be
+    able to amend by adding the missing DPLA reference."""
+    from tools.sdc_sync import _is_safe_to_amend_in_place
+
+    assert _is_safe_to_amend_in_place(
+        _item_statement("Z$4", "Q19652", qualifiers={"P459": _dpla_p459()}), "P6216"
+    )
+
+
+def test_unsafe_when_user_authored_qualifier_alongside_dpla():
+    """The residual bug case: claim has DPLA's P459 AND a user-added
+    qualifier (e.g. P1001=Q30 added by a community editor after our
+    write). The looser `_is_dpla_shaped` predecessor returned True here;
+    `_is_safe_to_amend_in_place` correctly returns False."""
+    from tools.sdc_sync import _is_safe_to_amend_in_place
+
+    assert not _is_safe_to_amend_in_place(
         _item_statement(
-            "Z$3", "Q19652", qualifiers={"P1001": _qual_other("P1001", "Q30")}
-        )
+            "Z$5",
+            "Q19652",
+            qualifiers={
+                "P459": _dpla_p459(),
+                "P1001": _qual_entity("P1001", "Q30"),
+            },
+        ),
+        "P6216",
     )
-    # No qualifiers at all.
-    assert not _is_dpla_shaped(_item_statement("Z$4", "Q19652"))
 
 
-def test_check_foreign_match_adds_alongside_not_overwrite():
-    """Reproduces the production bug. Foreign P6216=Q19652 statement with
-    P1001+P459 qualifiers must NOT get its id captured for ref-stamping
-    (which would clobber its qualifiers via wbeditentity-with-id).
+def test_unsafe_when_foreign_reference_present():
+    """Claim with a non-DPLA reference (someone else cited a source) →
+    unsafe, even if all qualifiers are DPLA's. The round-trip would
+    erase that foreign reference."""
+    from tools.sdc_sync import _is_safe_to_amend_in_place
 
-    Expected: check returns (True, "") meaning 'add a new DPLA-authored
-    statement alongside'. The foreign statement is left untouched."""
+    assert not _is_safe_to_amend_in_place(
+        _item_statement(
+            "Z$6",
+            "Q19652",
+            qualifiers={"P459": _dpla_p459()},
+            references=[_foreign_reference()],
+        ),
+        "P6216",
+    )
+
+
+def test_safe_when_per_property_extra_qualifier_is_recognised():
+    """P7482 (source-of-file) statements legitimately carry P973 and P137
+    qualifiers in addition to P459 — these are DPLA-authored per
+    _DPLA_EXTRA_QUALIFIER_PROPS. The same qualifier set on a DIFFERENT
+    property (P6216) is foreign."""
+    from tools.sdc_sync import _is_safe_to_amend_in_place
+
+    stmt_with_p973 = _item_statement(
+        "Z$7",
+        "Q74228490",
+        qualifiers={
+            "P459": _dpla_p459(),
+            "P973": _qual_string("P973", "https://example.gov/item/1"),
+            "P137": _qual_entity("P137", "Q123"),
+        },
+        prop="P7482",
+    )
+    # Safe under P7482 — P973 and P137 are DPLA-authored qualifiers
+    # for source-of-file statements.
+    assert _is_safe_to_amend_in_place(stmt_with_p973, "P7482")
+    # Unsafe under P6216 — P973/P137 are not DPLA-authored for
+    # copyright-status statements.
+    assert not _is_safe_to_amend_in_place(stmt_with_p973, "P6216")
+
+
+# ---------------------------------------------------------------------------
+# check() — end-to-end behaviour through the tightened gate
+# ---------------------------------------------------------------------------
+
+
+def test_check_foreign_qualifier_match_adds_alongside():
+    """Production bug case: P6216=Q19652 claim with P1001+P459 qualifiers
+    that we didn't author. The bot must NOT capture this claim's id —
+    that would clobber P1001 via wbeditentity-with-id. Instead add the
+    DPLA-authored claim alongside as a separate statement."""
     from tools import sdc_sync
 
     foreign_stmt = _item_statement(
         "M999$abc",
         "Q19652",
         qualifiers={
-            "P1001": _qual_other("P1001", "Q30"),
-            "P459": _qual_p459("Q60671452"),
+            "P1001": _qual_entity("P1001", "Q30"),
+            "P459": _qual_entity("P459", "Q60671452"),
         },
     )
-    fake_entity = {
-        "pageid": 999,
-        "statements": {"P6216": [foreign_stmt]},
-    }
+    fake_entity = {"pageid": 999, "statements": {"P6216": [foreign_stmt]}}
     with patch.object(sdc_sync, "get_entity", return_value=fake_entity):
         result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
-    # First element True → add new statement. Second element "" → no
-    # ref-stamp candidate; in particular, NOT the foreign statement's id.
     assert result == (True, "")
 
 
-def test_check_dpla_shaped_match_doesnt_duplicate():
-    """When the existing matching statement is DPLA-shaped, we've already
-    written this claim. Don't add a duplicate. Capture its id for
-    ref-stamping if it lacks references — safe because we own it."""
+def test_check_mixed_dpla_and_foreign_qualifier_treated_as_foreign():
+    """A claim with BOTH DPLA's P459=Q61848113 AND a user-added qualifier
+    (e.g. P1001=Q30 added by a community editor later) is no longer
+    safe to amend — the prior `_is_dpla_shaped` gate would have
+    misclassified this as DPLA-shaped. Expected: add new alongside.
+
+    This is the residual-bug case the tightened gate now handles."""
+    from tools import sdc_sync
+
+    mixed_stmt = _item_statement(
+        "M999$mixed",
+        "Q19652",
+        qualifiers={
+            "P459": _dpla_p459(),
+            "P1001": _qual_entity("P1001", "Q30"),
+        },
+    )
+    fake_entity = {"pageid": 999, "statements": {"P6216": [mixed_stmt]}}
+    with patch.object(sdc_sync, "get_entity", return_value=fake_entity):
+        result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
+    assert result == (True, "")
+
+
+def test_check_dpla_only_match_no_reference_captures_ref():
+    """Pure DPLA-shaped claim (P459=Q61848113 only) without a reference
+    is the partial-DPLA-write case: we should capture its id for
+    ref-stamping, not duplicate the claim."""
     from tools import sdc_sync
 
     dpla_stmt = _item_statement(
-        "M999$ours",
-        "Q19652",
-        qualifiers={"P459": _qual_p459("Q61848113")},
+        "M999$ours", "Q19652", qualifiers={"P459": _dpla_p459()}
     )
-    fake_entity = {
-        "pageid": 999,
-        "statements": {"P6216": [dpla_stmt]},
-    }
+    fake_entity = {"pageid": 999, "statements": {"P6216": [dpla_stmt]}}
     with patch.object(sdc_sync, "get_entity", return_value=fake_entity):
         result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
-    # add_new=False (already there), ref="M999$ours" (safe to amend — ours).
     assert result == (False, "M999$ours")
 
 
-def test_check_no_qualifiers_match_stamps_p459():
-    """An existing statement with matching value and NO qualifiers is the
-    legitimate "stamp our P459 qualifier" case — preserved from the
-    pre-fix behavior. wbsetqualifier is non-destructive."""
+def test_check_no_qualifier_match_stamps_p459_via_add_det():
+    """An existing matching statement with no qualifiers triggers
+    branch 2's add_det call (wbsetqualifier — non-destructive)."""
     from tools import sdc_sync
 
     empty_stmt = _item_statement("M999$empty", "Q19652")
     fake_entity = {"pageid": 999, "statements": {"P6216": [empty_stmt]}}
     with (
         patch.object(sdc_sync, "get_entity", return_value=fake_entity),
-        # The production add_det returns None implicitly; mirror that on the
-        # mock so the (None, ref) tuple comparison below is exact.
         patch.object(sdc_sync, "add_det", return_value=None) as mock_add_det,
     ):
         result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
-    # add_det was called with the matching statement id (stamps the P459
-    # qualifier via wbsetqualifier).
     mock_add_det.assert_called_once_with("M999", "M999$empty")
-    # First element is add_det's return (None) — the caller's `if checkclaim[0] is True`
-    # is False, so no new statement gets queued. Second element is the
-    # captured ref ("M999$empty" — also DPLA-safe because no qualifiers).
     assert result == (None, "M999$empty")
 
 
 def test_check_no_matching_statement_adds_new():
-    """No existing P6216 statement at all → add new (True), no ref to amend."""
+    """No existing P6216 statement at all → add new, no ref to amend."""
     from tools import sdc_sync
 
     fake_entity = {"pageid": 999, "statements": {}}
+    with patch.object(sdc_sync, "get_entity", return_value=fake_entity):
+        result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
+    assert result == (True, "")
+
+
+def test_check_dpla_only_with_dpla_reference_no_action():
+    """A claim that already has DPLA's P459 qualifier AND a DPLA reference
+    is fully covered — don't duplicate, don't re-amend."""
+    from tools import sdc_sync
+
+    fully_done = _item_statement(
+        "M999$done",
+        "Q19652",
+        qualifiers={"P459": _dpla_p459()},
+        references=[_dpla_reference()],
+    )
+    fake_entity = {"pageid": 999, "statements": {"P6216": [fully_done]}}
+    with patch.object(sdc_sync, "get_entity", return_value=fake_entity):
+        result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
+    # First element False → don't add new. Second element "" → no
+    # ref-stamp needed (statement already has its reference).
+    assert result == (False, "")
+
+
+def test_check_foreign_reference_match_adds_alongside():
+    """Even with DPLA-style qualifiers, a foreign reference on the
+    matching statement makes it unsafe to amend (the round-trip would
+    replace the foreign reference with ours). Add alongside."""
+    from tools import sdc_sync
+
+    foreign_ref_stmt = _item_statement(
+        "M999$foreignref",
+        "Q19652",
+        qualifiers={"P459": _dpla_p459()},
+        references=[_foreign_reference()],
+    )
+    fake_entity = {"pageid": 999, "statements": {"P6216": [foreign_ref_stmt]}}
     with patch.object(sdc_sync, "get_entity", return_value=fake_entity):
         result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
     assert result == (True, "")
@@ -196,8 +390,8 @@ def test_check_no_matching_statement_adds_new():
     ],
 )
 def test_check_foreign_match_other_value_types(kind, value, mainsnak_value):
-    """Same foreign-match-don't-overwrite behavior for string and
-    monolingualtext mainsnaks (P760, P1476 etc.)."""
+    """Same add-alongside behavior for string and monolingualtext
+    mainsnak types (P760, P1476, P10358, etc.)."""
     from tools import sdc_sync
 
     foreign_stmt = {
@@ -207,7 +401,7 @@ def test_check_foreign_match_other_value_types(kind, value, mainsnak_value):
             "snaktype": "value",
             "datavalue": {"type": kind, "value": mainsnak_value},
         },
-        "qualifiers": {"P1001": _qual_other("P1001", "Q30")},
+        "qualifiers": {"P1001": _qual_entity("P1001", "Q30")},
     }
     fake_entity = {"pageid": 999, "statements": {"P760": [foreign_stmt]}}
     with patch.object(sdc_sync, "get_entity", return_value=fake_entity):

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -348,26 +348,83 @@ def invalidate_entity(mediaid):
     _entity_cache.pop(mediaid, None)
 
 
-def _is_dpla_shaped(statement):
-    """Return True when `statement` carries the P459=Q61848113 marker that
-    DPLA stamps on every claim it writes (determination method = "determined
-    by GLAM institution and stated at its website").
+# Per-statement-property registry of additional qualifier properties DPLA
+# writes via the add_* helpers below. Every formattedclaim() also stamps
+# P459=Q61848113 (the determination-method marker), so P459 is always
+# included implicitly via _allowed_qualifier_props.
+#
+# Keep this aligned with the add_* functions in this file:
+#   * add_creator (P170)        — P2093 (author name string)
+#   * add_date (P571)           — P1932 (stated as)
+#   * add_contributed (P9126)   — P3831 (object has role)
+#   * add_local_id (P217)       — P195 (collection)
+#   * add_source (P7482)        — P973 (described at URL), P137 (operator)
+_DPLA_EXTRA_QUALIFIER_PROPS = {
+    "P170": {"P2093"},
+    "P571": {"P1932"},
+    "P9126": {"P3831"},
+    "P217": {"P195"},
+    "P7482": {"P973", "P137"},
+}
 
-    Used by check() to decide whether an existing matching statement is one
-    we wrote (safe to amend in place via wbeditentity-with-id) or one
-    someone else wrote (must not be touched — wbeditentity-with-id replaces
-    the whole claim's qualifiers + references with what we send, so
-    capturing such a statement's id for ref-stamping would silently erase
-    qualifiers we don't know about).
+
+def _allowed_qualifier_props(prop):
+    """Return the set of qualifier property IDs DPLA writes for a given
+    statement property. Always includes P459 (the determination-method
+    marker stamped by formattedclaim)."""
+    return {"P459"} | _DPLA_EXTRA_QUALIFIER_PROPS.get(prop, set())
+
+
+def _is_dpla_reference(reference):
+    """Return True iff `reference` is a DPLA-authored reference, identified
+    by a `P123 = Q2944483` snak (publisher = "Digital Public Library of
+    America"). DPLA stamps that snak on every reference it writes via
+    formattedclaim, so it's a sufficient marker for "we authored this".
     """
-    qualifiers = statement.get("qualifiers") or {}
-    for snak in qualifiers.get("P459") or []:
+    snaks = (reference or {}).get("snaks") or {}
+    for snak in snaks.get("P123") or []:
         try:
-            if snak["datavalue"]["value"]["id"] == "Q61848113":
+            if snak["datavalue"]["value"]["id"] == "Q2944483":
                 return True
         except (KeyError, TypeError):
             continue
     return False
+
+
+def _is_safe_to_amend_in_place(statement, prop):
+    """Return True iff `statement` is safe to amend via
+    wbeditentity-with-id without losing user-authored data.
+
+    wbeditentity-with-id replaces a claim's qualifiers and references
+    wholesale with what we send. The round-trip is data-preserving iff
+    every existing qualifier/reference is already DPLA-authored — then
+    our outgoing claim shape is a superset of the existing one and the
+    write only adds the missing pieces.
+
+    A statement is safe to amend iff:
+      * every qualifier property is one DPLA writes for `prop`
+        (P459 universally, plus the per-property extras tracked in
+        `_DPLA_EXTRA_QUALIFIER_PROPS`), AND
+      * every reference is a DPLA reference (carries the publisher
+        marker checked by `_is_dpla_reference`).
+
+    An empty qualifier dict and an empty references list both pass
+    vacuously, so this also covers the "truly bare" case.
+
+    The previous, looser gate `_is_dpla_shaped` returned True as soon
+    as one P459 snak matched, ignoring other qualifiers on the same
+    claim. A claim like {P459=Q61848113 (DPLA), P1001=Q30 (user)}
+    was mis-classified as DPLA-shaped; amending it via
+    wbeditentity-with-id silently erased the P1001 qualifier.
+    """
+    allowed = _allowed_qualifier_props(prop)
+    for qualifier_prop in (statement.get("qualifiers") or {}).keys():
+        if qualifier_prop not in allowed:
+            return False
+    for reference in statement.get("references") or []:
+        if not _is_dpla_reference(reference):
+            return False
+    return True
 
 
 def check(mediaid, qid, prop):
@@ -383,26 +440,31 @@ def check(mediaid, qid, prop):
     except Exception:
         return True, ""
 
-    # Inspect existing statements that match `prop` and decide what to do:
+    # Inspect existing statements that match `prop` and decide what to do.
+    # The amend-in-place gate is `_is_safe_to_amend_in_place`: amend only
+    # when every existing qualifier and reference is DPLA-authored, so the
+    # wbeditentity-with-id round-trip cannot erase user-authored data.
     #
-    #   * Capture `ref` from a matching statement only when amending it is
-    #     SAFE — either the statement has no qualifiers or it carries the
-    #     P459=Q61848113 marker (DPLA-shaped, written by us). Otherwise
-    #     wbeditentity-with-id would clobber qualifiers we didn't author.
+    #   * Capture `ref` from a matching no-reference statement that is
+    #     safe to amend (truly bare, or contains only DPLA-authored
+    #     qualifiers). The caller will stamp our reference via
+    #     wbeditentity-with-id.
     #   * If a matching statement has no qualifiers at all, stamp our
-    #     P459=Q61848113 qualifier onto it (wbsetqualifier is non-destructive).
-    #   * If a matching statement carries qualifiers AND it's DPLA-shaped,
-    #     we've already written this claim — don't add a duplicate.
-    #   * If a matching statement carries qualifiers AND it's FOREIGN
-    #     (no P459=Q61848113), leave it alone and add the DPLA-authored
-    #     statement alongside as a separate claim. The two coexist with
-    #     different rationales.
+    #     P459=Q61848113 qualifier onto it via wbsetqualifier
+    #     (non-destructive — does not touch references).
+    #   * If a matching statement is safe to amend AND has qualifiers,
+    #     we already wrote this claim — don't add a duplicate; the
+    #     missing ref (if any) is stamped via the captured `ref`.
+    #   * If a matching statement contains any user-authored qualifier
+    #     or reference, leave it untouched and add the DPLA-authored
+    #     statement alongside as a separate claim, so the DPLA
+    #     reference is scoped only to the DPLA-authored qualifiers.
     if qid[0] == "item":
         for statement in statements:
             if (
                 statement["mainsnak"]["datavalue"]["value"]["id"] == qid[1]
                 and not statement.get("references")
-                and (not statement.get("qualifiers") or _is_dpla_shaped(statement))
+                and _is_safe_to_amend_in_place(statement, prop)
             ):
                 ref = statement["id"]
                 break
@@ -414,7 +476,7 @@ def check(mediaid, qid, prop):
 
         if any(
             statement["mainsnak"]["datavalue"]["value"]["id"] == qid[1]
-            and _is_dpla_shaped(statement)
+            and _is_safe_to_amend_in_place(statement, prop)
             for statement in statements
         ):
             print(
@@ -437,7 +499,7 @@ def check(mediaid, qid, prop):
             if (
                 statement["mainsnak"]["datavalue"]["value"] == qid[1]
                 and not statement.get("references")
-                and (not statement.get("qualifiers") or _is_dpla_shaped(statement))
+                and _is_safe_to_amend_in_place(statement, prop)
             ):
                 ref = statement["id"]
                 break
@@ -449,7 +511,7 @@ def check(mediaid, qid, prop):
 
         if any(
             statement["mainsnak"]["datavalue"]["value"] == qid[1]
-            and _is_dpla_shaped(statement)
+            and _is_safe_to_amend_in_place(statement, prop)
             for statement in statements
         ):
             print(
@@ -472,7 +534,7 @@ def check(mediaid, qid, prop):
             if (
                 statement["mainsnak"]["datavalue"]["value"]["text"] == qid[1]
                 and not statement.get("references")
-                and (not statement.get("qualifiers") or _is_dpla_shaped(statement))
+                and _is_safe_to_amend_in_place(statement, prop)
             ):
                 ref = statement["id"]
                 break
@@ -484,7 +546,7 @@ def check(mediaid, qid, prop):
 
         if any(
             statement["mainsnak"]["datavalue"]["value"]["text"] == qid[1]
-            and _is_dpla_shaped(statement)
+            and _is_safe_to_amend_in_place(statement, prop)
             for statement in statements
         ):
             print(
@@ -517,7 +579,7 @@ def check(mediaid, qid, prop):
                             q.get("datavalue", {}).get("value") == qid[1]
                             for q in qualifiers
                         )
-                        and _is_dpla_shaped(statement)
+                        and _is_safe_to_amend_in_place(statement, prop)
                         and not statement.get("references")
                     ):
                         ref = statement["id"]
@@ -530,7 +592,7 @@ def check(mediaid, qid, prop):
                     if any(
                         q.get("datavalue", {}).get("value") == qid[1]
                         for q in qualifiers
-                    ) and _is_dpla_shaped(statement):
+                    ) and _is_safe_to_amend_in_place(statement, prop):
                         print(
                             f" -- There already exists a DPLA-authored statement with a {prop} > {qid[1]} claim for {mediaid}."
                         )
@@ -568,7 +630,7 @@ def check(mediaid, qid, prop):
                             q.get("datavalue", {}).get("value") == qid[1]
                             for q in qualifiers
                         )
-                        and _is_dpla_shaped(statement)
+                        and _is_safe_to_amend_in_place(statement, prop)
                         and not statement.get("references")
                     ):
                         ref = statement["id"]
@@ -579,7 +641,7 @@ def check(mediaid, qid, prop):
                     if any(
                         q.get("datavalue", {}).get("value") == qid[1]
                         for q in qualifiers
-                    ) and _is_dpla_shaped(statement):
+                    ) and _is_safe_to_amend_in_place(statement, prop):
                         print(
                             f" -- There already exists a DPLA-authored statement with a {prop} > {qid[1]} claim for {mediaid}."
                         )


### PR DESCRIPTION
## Background

PR #254 fixed the immediate foreign-statement overwrite bug by introducing `_is_dpla_shaped(statement)` — a check that returned True when the statement carried the `P459=Q61848113` marker DPLA stamps on every claim. That check was correct for the case in front of us but residually too permissive: a claim with **both** DPLA's `P459` **and** a user-added qualifier (e.g. a community editor adds `P1001=Q30` after our first write) was still classified as DPLA-shaped. The bot's next reconciliation pass would amend the claim via `wbeditentity`-with-id, replacing qualifiers + references wholesale, and the user's `P1001` would be erased — same class of bug, one user-action further down the timeline.

## Fix

Replace `_is_dpla_shaped` with `_is_safe_to_amend_in_place(statement, prop)`. A statement is **safe to amend** iff every existing piece is already DPLA-authored:

- Every qualifier property is one DPLA writes for that statement property. Universal `P459`, plus per-property extras tracked in a new `_DPLA_EXTRA_QUALIFIER_PROPS` registry:
  - `P170` (creator) → `P2093`
  - `P571` (date) → `P1932`
  - `P9126` (partnership) → `P3831`
  - `P217` (local ID) → `P195`
  - `P7482` (source) → `P973`, `P137`
- Every reference is a DPLA reference, recognised by `P123=Q2944483` (DPLA publisher), via a new `_is_dpla_reference` helper.

An empty qualifier dict and empty reference list pass vacuously, so "truly bare" stays safe. So does a "partial DPLA write" where only the qualifier OR only the reference is present.

The amend-in-place semantics now cleanly cover:

| Existing claim shape | Action |
|---|---|
| Truly bare | Amend: add P459 + DPLA ref |
| Has DPLA ref, no qualifier | Amend: add P459 qualifier |
| Has DPLA P459 qualifier, no ref | Amend: add DPLA ref |
| Fully DPLA (P459 + DPLA ref) | Skip — covered |
| Any user-authored qualifier or non-DPLA ref present | Leave alone; add new claim alongside |

All `_is_dpla_shaped` callsites in `check()` are updated to pass `prop` so the new predicate can consult the per-property registry.

## Tests

`tests/test_sdc_sync.py` rewritten:

- `_is_dpla_reference`: recognises `P123=Q2944483`; rejects everything else (including `P123` pointing at a different publisher)
- `_is_safe_to_amend_in_place`: truly-bare, DPLA-only qualifier, DPLA-only-reference, DPLA-only-qualifier-no-ref, **mixed DPLA + user qualifier (residual bug)**, **foreign reference**, per-property `P973`/`P137` recognised for `P7482` but flagged foreign for `P6216`
- `check()`: foreign mainsnak match adds alongside (regression for PR #254); **mixed DPLA + foreign qualifier now also adds alongside (this PR's win)**; pure-DPLA no-reference captures ref; foreign reference forces add-alongside; fully-done claim is a no-op

**293/293 tests pass** on EC2 (Python 3.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Summary: sdc-sync Amend-in-Place Safety Gate Tightening

This PR tightens the bot's amend-in-place logic to prevent overwriting user-authored content on existing Wikidata statements. The change replaces the permissive `_is_dpla_shaped(statement)` check with a stricter `_is_safe_to_amend_in_place(statement, prop)` safety gate.

### Key Changes

**Logic Changes to `tools/sdc_sync.py`:**
- Introduces `_DPLA_EXTRA_QUALIFIER_PROPS` registry mapping per-property additional qualifier types that DPLA is known to author (e.g., P170 → P2093, P571 → P1932, P9126 → P3831, P217 → P195, P7482 → P973/P137)
- Adds `_is_dpla_reference()` function to identify DPLA-authored references via P123 publisher check (Q2944483)
- Implements `_is_safe_to_amend_in_place(statement, prop)` to verify all existing qualifiers and references are DPLA-authored before amending
- Updates all amend-in-place callsites in `check()` (item, string, monolingualtext, somevalue, source dispatch branches) to pass the `prop` parameter for per-property qualifier rules

**Statement Handling:**
- Truly bare statements → amend in place (add P459 + DPLA reference)
- Statements with only DPLA references or P459 → amend in place
- Statements with any user-authored qualifiers or non-DPLA references → do NOT amend in place; add as separate statement instead

**Test Coverage (`tests/test_sdc_sync.py`):**
- Added helper fixtures for building qualifier/reference snaks and DPLA references
- Extended test coverage for `_is_dpla_reference()` and `_is_safe_to_amend_in_place()` safety checks
- Added end-to-end `check()` tests validating correct statement handling (amend vs. add-alongside behavior)
- Test results: 293/293 passing on Python 3.13

### Deployment Impact

No deployment action required. This is a logic-only change to an existing bot script with no infrastructure, configuration, API, or database implications. The change is backwards-compatible with existing statements and improves data integrity by preventing accidental overwrites of user-authored statement qualifiers and references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->