### PR TITLE
retry: merge download+upload CSVs into single uploader call

### DIFF
--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -313,15 +313,47 @@ def main() -> None:
             steps.append(
                 f"downloader --max-age-days 1 {shlex.quote(download_csv)} {slug}"
             )
-            # The uploader's notify_upload_complete folds the download
-            # phase's FAILED count into the final Slack summary by
-            # discovering this session's download log itself, via
-            # WIKIMEDIA_SESSION_LABEL + WIKIMEDIA_PARTNER_DIR (both
-            # exported with literal values by label_export above). See
-            # slack._find_retry_download_log.
-            steps.append(f"uploader {shlex.quote(download_csv)} {slug}")
+        # Run the uploader at most ONCE per hub.  When both download and
+        # upload retry CSVs exist for this hub, merge them (de-duplicated,
+        # first-seen-order via awk) into a single combined CSV so the
+        # uploader's notify_phase_start + notify_upload_complete pair
+        # fires exactly once per retry hub.  Two separate uploader calls
+        # would post duplicate "starting upload" and duplicate "Wikimedia
+        # Retry Complete" messages — visible to the user as a confusing
+        # phase report after the summary header.
+        #
+        # The uploader's notify_upload_complete still folds the download
+        # phase's FAILED count via slack._find_retry_download_log when
+        # WIKIMEDIA_RETRY_HAS_DOWNLOAD is set (see has_download_env above).
+        upload_inputs = []
+        if download_csv:
+            upload_inputs.append(download_csv)
         if upload_csv:
-            steps.append(f"uploader {shlex.quote(upload_csv)} {slug}")
+            upload_inputs.append(upload_csv)
+        if len(upload_inputs) == 1:
+            steps.append(f"uploader {shlex.quote(upload_inputs[0])} {slug}")
+        elif len(upload_inputs) > 1:
+            combined_csv = f"{RETRY_DIR}/{slug}-retry-{days}d-combined.csv"
+            # `awk '!seen[$0]++'` is the standard idempotent dedup-while-
+            # preserving-order one-liner.  Each retry CSV is one DPLA ID
+            # per line, so per-line uniqueness is the right grain.
+            #
+            # The `$0` MUST be backslash-escaped.  pipeline_cmd is embedded
+            # as `"{pipeline_cmd}"` in tmux_cmd below — a double-quoted
+            # argument — and the outer bash on EC2 expands unescaped `$0`
+            # inside double quotes before tmux ever sees the command. `$0`
+            # would resolve to the outer shell's argv[0] (typically the
+            # string "bash"), so awk would dedupe by that literal string
+            # on every line — producing a single-line output and silently
+            # losing 99% of the retry IDs.  Same class of bug as PR #246's
+            # `\$?`/`\$rc` escapes in notify_fail_cmd.  With `\$0` the
+            # outer bash leaves the `$` literal and awk evaluates `$0` as
+            # the current input line.
+            cat_args = " ".join(shlex.quote(c) for c in upload_inputs)
+            steps.append(
+                rf"awk '!seen[\$0]++' {cat_args} > {shlex.quote(combined_csv)}"
+            )
+            steps.append(f"uploader {shlex.quote(combined_csv)} {slug}")
         target_steps = " && ".join(steps)
         target_blocks.append(
             f"{label_export}; {{ {target_steps}; }}"

--- a/tests/test_wikimedia_retry.py
+++ b/tests/test_wikimedia_retry.py
@@ -267,6 +267,172 @@ def test_retry_pipeline_escapes_dollar_in_notify_fail_cmd():
     )
 
 
+def _run_main_with_csvs(argv: list[str], csv_paths: list[str]) -> list[str]:
+    """Variant of _run_main_and_capture_full_pipeline that lets the test
+    parameterize which retry CSVs the mocked `find` step returns.  The
+    fixed helper above is hard-coded to a download-only smithsonian CSV;
+    these tests need to exercise the upload-only and both-CSVs paths."""
+    captured: list[str] = []
+
+    csv_block = "\n".join(csv_paths)
+
+    def fake_ssm_run(_client, command, **_kwargs):
+        captured.append(command)
+        if "UPDATE_DONE" in command:
+            return "UPDATE_DONE"
+        if "get-ids-retry" in command:
+            return "Partner found failures.\n"
+        if "__MEM_CHECK__" in command:
+            return f"{csv_block}\n__MEM_CHECK__\n8000 5000"
+        return ""
+
+    with (
+        patch("scripts.wikimedia_retry.ssm_run", side_effect=fake_ssm_run),
+        patch("scripts.wikimedia_retry.boto3.client", return_value=MagicMock()),
+        patch("scripts.wikimedia_retry.post_message"),
+        patch("sys.argv", argv),
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        from scripts import wikimedia_retry
+
+        try:
+            wikimedia_retry.main()
+        except SystemExit:
+            # Expected: main() reaches _slack_fail after the mocked tmux launch
+            # returns "" (no SESSION_STARTED). All SSM commands the test cares
+            # about have been captured by this point — mirrors the established
+            # pattern in _run_main_and_capture_full_pipeline above.
+            pass
+
+    return captured
+
+
+def test_retry_merges_download_and_upload_csvs_into_single_uploader_call():
+    """Regression: when a hub has BOTH a download-retry and upload-retry
+    CSV, the pipeline must merge them into ONE combined CSV and run the
+    uploader exactly once.
+
+    The pre-fix code ran `uploader <download_csv>` then `uploader <upload_csv>`
+    back-to-back, so notify_phase_start("upload") and notify_upload_complete
+    both fired TWICE per retry hub. Users saw a confusing "starting upload"
+    appear right after the "Wikimedia Retry Complete" summary header.
+    """
+    commands = _run_main_with_csvs(
+        ["wikimedia_retry.py", "--days", "1", "--partner", "nara"],
+        [
+            "/home/ec2-user/ingest-wikimedia/retry/nara-download-retry.csv",
+            "/home/ec2-user/ingest-wikimedia/retry/nara-upload-retry.csv",
+        ],
+    )
+    pipeline_cmd = next(c for c in commands if "tmux new-session" in c)
+
+    # The combined CSV merge step must be present and feed the (single)
+    # uploader invocation.  The `$0` in the awk program MUST be
+    # backslash-escaped — pipeline_cmd is embedded into the tmux launch
+    # as `"{pipeline_cmd}"` (double-quoted), and the outer bash on EC2
+    # would expand an unescaped `$0` before tmux ever sees the command.
+    # See the comment in scripts/wikimedia_retry.py around the awk step
+    # for the full rationale (same class of bug as PR #246).
+    expected_combined = (
+        "/home/ec2-user/ingest-wikimedia/retry/nara-retry-1d-combined.csv"
+    )
+    assert (
+        r"awk '!seen[\$0]++' "
+        "/home/ec2-user/ingest-wikimedia/retry/nara-download-retry.csv "
+        "/home/ec2-user/ingest-wikimedia/retry/nara-upload-retry.csv "
+        f"> {expected_combined}"
+    ) in pipeline_cmd, (
+        f"expected awk merge step missing or malformed; got: {pipeline_cmd!r}"
+    )
+    # Defence: the UNESCAPED form must not appear anywhere in the
+    # pipeline command.  If it ever reappears the silent-loss bug
+    # returns — awk would dedupe by the outer shell's argv[0] (typically
+    # the string "bash"), collapsing every retry CSV to a single line.
+    assert "awk '!seen[$0]++'" not in pipeline_cmd, (
+        f"found unescaped `$0` in pipeline_cmd; outer bash will expand "
+        f"$0 to its argv[0] before tmux sees the command. Use `\\$0`. "
+        f"Got: {pipeline_cmd!r}"
+    )
+
+    # Exactly ONE `uploader` invocation, pointing at the combined CSV.
+    # The downloader still runs separately on the download CSV (that's
+    # the actual re-download work), but only one upload pass.
+    uploader_calls = [
+        seg
+        for seg in pipeline_cmd.split("&&")
+        if " uploader " in f" {seg.strip()} " or seg.strip().startswith("uploader ")
+    ]
+    assert len(uploader_calls) == 1, (
+        f"expected exactly one uploader invocation in the merged pipeline; "
+        f"got {len(uploader_calls)}: {uploader_calls!r}"
+    )
+    assert expected_combined in uploader_calls[0], (
+        f"the single uploader call must target the combined CSV; "
+        f"got: {uploader_calls[0]!r}"
+    )
+
+    # Sanity: downloader still runs on the download CSV (uploader and
+    # downloader work different inputs in this design).
+    assert (
+        "downloader --max-age-days 1 "
+        "/home/ec2-user/ingest-wikimedia/retry/nara-download-retry.csv nara"
+    ) in pipeline_cmd
+
+
+def test_retry_download_only_csv_runs_uploader_once_without_merge_step():
+    """Download-only retry path: the existing single-CSV behavior must
+    still hold (uploader runs on the download CSV, no awk merge step,
+    notify_phase_start + notify_upload_complete fire exactly once)."""
+    commands = _run_main_with_csvs(
+        ["wikimedia_retry.py", "--days", "30", "--partner", "si"],
+        ["/home/ec2-user/ingest-wikimedia/retry/smithsonian-download-retry.csv"],
+    )
+    pipeline_cmd = next(c for c in commands if "tmux new-session" in c)
+
+    assert "awk '!seen" not in pipeline_cmd, (
+        f"no merge step expected when only one retry CSV is present; "
+        f"got: {pipeline_cmd!r}"
+    )
+    assert "-retry-30d-combined.csv" not in pipeline_cmd
+    # Exactly one uploader invocation, on the download CSV.
+    uploader_calls = [
+        seg
+        for seg in pipeline_cmd.split("&&")
+        if " uploader " in f" {seg.strip()} " or seg.strip().startswith("uploader ")
+    ]
+    assert len(uploader_calls) == 1
+    assert (
+        "uploader "
+        "/home/ec2-user/ingest-wikimedia/retry/smithsonian-download-retry.csv si"
+    ) in uploader_calls[0]
+
+
+def test_retry_upload_only_csv_runs_uploader_once_without_merge_step():
+    """Upload-only retry path: same expectation."""
+    commands = _run_main_with_csvs(
+        ["wikimedia_retry.py", "--days", "30", "--partner", "si"],
+        ["/home/ec2-user/ingest-wikimedia/retry/smithsonian-upload-retry.csv"],
+    )
+    pipeline_cmd = next(c for c in commands if "tmux new-session" in c)
+
+    assert "awk '!seen" not in pipeline_cmd
+    assert "-retry-30d-combined.csv" not in pipeline_cmd
+    # No downloader call — there's nothing to re-download for an upload-
+    # only retry; the items were already in S3 from their original run.
+    assert "downloader" not in pipeline_cmd, (
+        f"upload-only retry must not invoke downloader; got: {pipeline_cmd!r}"
+    )
+    uploader_calls = [
+        seg
+        for seg in pipeline_cmd.split("&&")
+        if " uploader " in f" {seg.strip()} " or seg.strip().startswith("uploader ")
+    ]
+    assert len(uploader_calls) == 1
+    assert (
+        "uploader /home/ec2-user/ingest-wikimedia/retry/smithsonian-upload-retry.csv si"
+    ) in uploader_calls[0]
+
+
 def test_retry_clears_stale_csvs_even_when_no_partner_given():
     """When the user runs `/wikimedia-upload retry 30` (no partner), the
     scan still needs to clear stale CSVs so that hubs which legitimately


### PR DESCRIPTION
## Summary

When a retry pipeline has BOTH a download-retry and an upload-retry CSV for the same hub, the pre-fix code ran:

\`\`\`
downloader <download_csv> && uploader <download_csv> && uploader <upload_csv>
\`\`\`

Each \`uploader\` invocation fires \`notify_phase_start(partner, "upload")\` at start and \`notify_upload_complete(...)\` in its \`finally\`. So users saw a confusing per-hub notification pattern:

\`\`\`
⬇ wikimedia-retry-nara: starting download
⬆ wikimedia-retry-nara: starting upload          ← uploader #1 start
Wikimedia Retry Complete: wikimedia-retry-nara   ← uploader #1 complete
⬆ wikimedia-retry-nara: starting upload          ← uploader #2 start
Wikimedia Retry Complete: wikimedia-retry-nara   ← uploader #2 complete
\`\`\`

— "starting upload" appearing right after the summary card was the user-visible symptom that flagged this.

## Fix

Merge the two retry CSVs into one combined CSV via \`awk '!seen[$0]++'\` (idempotent dedup, preserving first-seen order), and run the uploader exactly once per hub on that combined input. The downloader still runs separately on the download CSV (that's the actual re-download work).

\`notify_phase_start\` and \`notify_upload_complete\` each fire exactly once per retry hub. The existing combined-summary logic in \`notify_upload_complete\` still folds the download phase's FAILED count via \`_find_retry_download_log\` because \`WIKIMEDIA_RETRY_HAS_DOWNLOAD\` remains set.

## Three retry paths

| CSVs present | Behavior |
|---|---|
| download + upload | merge step + one uploader call on the combined CSV |
| download only | unchanged: one uploader call on download CSV (no merge step) |
| upload only | unchanged: one uploader call on upload CSV (no downloader, no merge step) |

## Test plan

- [x] 3 new tests pin all three paths in \`tests/test_wikimedia_retry.py\`
- [x] All 8 retry tests pass; ruff clean
- [ ] After merge: re-run \`/wikimedia-upload retry 1 nara\` and verify exactly one "starting upload" and one "Wikimedia Retry Complete" per hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Merges download-retry and upload-retry CSVs into a single combined CSV when both exist for the same hub, so the uploader runs exactly once per hub and duplicate per-hub "starting upload"/"Wikimedia Retry Complete" notifications are eliminated.

## Changes

**scripts/wikimedia_retry.py**
- Collects available retry CSV inputs into a list and ensures uploader runs at most once per slug.
- When both `*-download-retry.csv` and `*-upload-retry.csv` exist, concatenates and deduplicates them into `RETRY_DIR/{slug}-retry-{days}d-combined.csv` using awk with the expression awk '!seen[\$0]++' (note: the dollar sign is escaped to avoid shell expansion), then runs `uploader <combined_csv> <slug>`.
- If only one CSV exists (download-only or upload-only), behavior is unchanged: uploader runs once on that CSV; downloader runs only when download CSV is present.
- notify_phase_start and notify_upload_complete now fire exactly once per retry hub. notify_upload_complete still folds the download phase's FAILED count via _find_retry_download_log because WIKIMEDIA_RETRY_HAS_DOWNLOAD remains set.
- Added a clarified except SystemExit: pass comment to match style and satisfy code-quality checks.

**tests/test_wikimedia_retry.py**
- Added helper `_run_main_with_csvs` to parameterize CSV inputs for the mocked find flow.
- Added three regression tests covering download+upload, download-only, and upload-only cases. Tests assert the presence of the escaped awk merge step when appropriate and explicitly guard against the unescaped, buggy form.
- All retry tests still pass locally; ruff clean.

## Notes & Fix Details
- Important shell-escaping fix: the awk expression needed the dollar sign escaped ( \$0 ) so the outer bash on EC2/tmux does not expand $0 before awk sees it. Without this fix, the CSV could collapse to a single line and lose IDs.
- Post-merge manual verification recommended: run /wikimedia-upload retry 1 <partner> and confirm exactly one "starting upload" and one "Wikimedia Retry Complete" per hub.

## Behavioral Impact / Operational Notes
- No changes to environment variables or AWS Secrets Manager keys.
- No database migrations.
- No modifications to shared infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM) or public API shape.
- No security-sensitive changes (no new credential handling or auth changes).
- No manual pipeline trigger or ECS redeployment required for this code change to take effect (it's a scripts change executed when the retry command runs).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->