### PR TITLE
uploader: redirect-handler must run even when drift_action=upload_only

### DIFF
--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -406,13 +406,24 @@ class Uploader:
 
                 wiki_file_page = get_page(self.site, page_title)
 
-                # If the intended title is a redirect caused by title drift,
-                # move the file there first so the upload lands at the right name.
-                # This path is reached when the hash is new (not yet on Commons)
-                # and the intended title is a redirect from a prior drift correction.
-                # Skip when drift resolution returned "upload_only" — in that case
-                # we've decided not to touch any other file; just upload directly.
-                if wiki_file_page.isRedirectPage() and drift_action != "upload_only":
+                # If the intended title is a redirect, route through the
+                # redirect-handler regardless of what `_resolve_hash_drift`
+                # returned. Uploading directly onto a redirect page fails with
+                # `fileexists-shared-forbidden` — the API treats the upload as
+                # creating a duplicate of the redirect's target. The
+                # redirect-handler below picks the right strategy (move, or
+                # overwrite-in-place with the appropriate metadata
+                # preservation) based on the redirect target, and always sets
+                # `force_ignore_warnings=True` for the subsequent upload.
+                #
+                # Earlier this branch was gated on `drift_action != "upload_only"`,
+                # but `_resolve_hash_drift` can legitimately return "upload_only"
+                # while the intended title is still a redirect — specifically
+                # when the redirect's target is a sibling page rather than the
+                # SHA1's current location. The misleading warning at line ~880
+                # in `_resolve_hash_drift` was the symptom of that earlier
+                # gating mistake.
+                if wiki_file_page.isRedirectPage():
                     target_title = wiki_file_page.getRedirectTarget().title(
                         with_ns=False
                     )
@@ -869,11 +880,19 @@ class Uploader:
                     existing_file, intended_page, dpla_id, "Case 1", wiki_markup
                 )
                 return "moved"
-            logging.warning(
+            # Intended title is a redirect, but its target is somewhere
+            # other than where our SHA1 currently lives. We can't apply
+            # the Case 1 move; instead let the caller's redirect-handler
+            # decide (overwrite as same-item relic, overwrite as
+            # cross-item, etc). "upload_only" here just means
+            # "drift-resolution didn't move or tag anything"; the
+            # redirect-handler still runs unconditionally now.
+            logging.info(
                 f"Hash drift for {dpla_id} {ordinal}: intended title "
-                f"[[File:{intended_page.title(with_ns=False)}]] redirects to "
-                f"{redirect_target.title(with_ns=False)!r}, "
-                f"which does not share DPLA ID {dpla_id}; uploading anyway."
+                f"[[File:{intended_page.title(with_ns=False)}]] is a redirect to "
+                f"[[File:{redirect_target.title(with_ns=False)}]], which is not "
+                f"the location of our SHA1 ([[File:{actual_filename}]]); "
+                f"deferring to the redirect-handler in process_file."
             )
             return "upload_only"
 


### PR DESCRIPTION
## The bug

Live failure observed on 2026-05-27 during the NARA Center for Legislative Archives upload:

```
[INFO] 12:08:43: Hash drift detected for fe6e5f7e3cf9e4bfc908c41ee3455adb 3: SHA1 found at [[File:...(page 3).jpg]]
[WARNING] 12:08:44: Hash drift for fe6e5f7e3cf9e4bfc908c41ee3455adb 3: intended title [[File:...(page 2).jpg]]
   redirects to '...(page 1).jpg', which does not share DPLA ID fe6e5f7e3cf9e4bfc908c41ee3455adb; uploading anyway.
[ERROR] 12:08:45: Failed: File already uploaded
pywikibot.exceptions.APIError: fileexists-shared-forbidden: A file with this name already exists in the shared file repository.
```

The misleading warning was masking the real situation: the redirect target IS this item's own sibling — but `_resolve_hash_drift` was checking redirect-target-vs-SHA1-current-location, not redirect-target-vs-DPLA-ID, and falling through to `upload_only` whenever they didn't match.

### Cause

`_resolve_hash_drift` returns `"upload_only"` in two distinct situations:

1. **Cross-item hash collision** — existing file at the wrong title belongs to a different valid DPLA item; correct behavior is to upload to our intended title and leave their file alone.
2. **Intended title is a redirect whose target ≠ where our SHA1 currently lives** — typically because an earlier ordinal of the same item moved its file in the same session, turning the intended title into a redirect to a sibling page.

The `process_file` redirect-handler at line ~415 was gated on `drift_action != "upload_only"`. Correct for case (1), wrong for case (2): in case (2) the intended title IS a redirect, and uploading directly onto a redirect page produces `fileexists-shared-forbidden`.

### Why the retry worked

Today's manual retry succeeded by accident: between yesterday's run and today's, the SHA1 was no longer on Commons at its original location (the orphan-tagged `(page 3).jpg` got cleaned up). So `find_file_by_hash` returned None, `_resolve_hash_drift` was never called, `drift_action` stayed `None`, and the redirect-handler ran via the "same-item redirect relic" path — overwriting the redirect in place with `force_ignore_warnings=True`. The page-history shows the successful retry edit at 2026-05-28 04:42.

## Fix

Remove the `drift_action != "upload_only"` gate from `process_file`'s redirect-handler condition. The redirect-handler knows how to dispatch correctly between move-and-overwrite (target is a same-item sibling) and overwrite-in-place (target is foreign / no-DPLA-ID); it should always run when the intended title is a redirect, regardless of why drift resolution chose `"upload_only"`.

Also: replace the misleading `which does not share DPLA ID` warning in `_resolve_hash_drift`'s redirect-mismatch path with an INFO log that accurately states the redirect target isn't the SHA1's current location and that the redirect-handler will take over.

## Test plan

- [x] `pytest tests/` — **293 passed** on EC2 (Python 3.13).
- [x] `ruff check` + `ruff format` clean.
- [ ] Next NARA-CLA run should successfully process items where ordinal 3 finds its SHA1 at a sibling location AND its intended title has just been turned into a redirect by ordinal 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a live failure during NARA CLA uploads where upload attempts failed with `pywikibot.exceptions.APIError: fileexists-shared-forbidden`. The root cause was that the redirect-handler in `process_file()` was gated by `drift_action != "upload_only"`, preventing it from running when `_resolve_hash_drift()` returned `"upload_only"` for cases involving redirect-title scenarios. This caused the uploader to attempt direct uploads onto redirects, triggering the API error.

## Changes

**tools/uploader.py:**
- Removed the `drift_action != "upload_only"` gate in `process_file()` so the redirect-handler always runs when the intended Commons title is a redirect, regardless of the drift_action value
- Updated comments clarifying that `_resolve_hash_drift()` may legitimately return `"upload_only"` while the intended title remains a redirect
- In `_resolve_hash_drift()`, changed the log message from a misleading warning to an INFO-level statement when a redirect target does not match the current SHA1 location, indicating that the redirect-handler will manage resolution

The redirect-handler itself already contains logic to distinguish between same-item moves (move-and-overwrite) and foreign/no-DPLA-ID cases (overwrite-in-place), so this change safely enables redirect resolution in all relevant scenarios.

## Testing

- 293 tests passed on EC2 (Python 3.13)
- Code style checks (ruff) passed
- Follow-up verification planned on the next NARA-CLA run

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->