### PR TITLE
get_page_title: strip ALL `:` and `/` to match Commons file-title validation

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -76,93 +76,62 @@ def _break_query_string_pattern(title: str) -> str:
     return title
 
 
-# All Commons namespace canonical names + aliases as of 2026-05-23 (snapshot of
-# `action=query&meta=siteinfo&siprop=namespaces|namespacealiases`). If the
-# prefix of an item title (before the first `:`) matches one of these, the
-# API would mis-route the upload into that namespace. The list is stable in
-# practice; if Commons adds a namespace later, the worst case is the new
-# prefix is treated as title text rather than a namespace alias — same as
-# the old unconditional `:` → `-` replacement, never worse.
-_MW_NAMESPACE_PREFIXES: frozenset[str] = frozenset(
-    [
-        "campaign",
-        "campaign talk",
-        "cat",
-        "category",
-        "category talk",
-        "com",
-        "commons",
-        "commons talk",
-        "creator",
-        "creator talk",
-        "data",
-        "data talk",
-        "event",
-        "event talk",
-        "file",
-        "file talk",
-        "help",
-        "help talk",
-        "image",
-        "image talk",
-        "institution",
-        "institution talk",
-        "media",
-        "mediawiki",
-        "mediawiki talk",
-        "module",
-        "module talk",
-        "museum",
-        "museum talk",
-        "project",
-        "project talk",
-        "sequence",
-        "sequence talk",
-        "special",
-        "talk",
-        "template",
-        "template talk",
-        "timedtext",
-        "timedtext talk",
-        "topic",
-        "translations",
-        "translations talk",
-        "user",
-        "user talk",
-    ]
-)
-
-
-def _break_namespace_prefix_colon(title: str) -> str:
-    """If a title begins with `<namespace>:`, replace just that first colon
-    with `-` so the API doesn't mis-parse the upload as a `<namespace>:<rest>`
-    page in the wrong namespace. Mid-title colons (which Commons accepts
-    fine — e.g. `Boston, Mass.: City Hall`) are left intact.
-
-    DPLA records occasionally start with strings like `Image: …` or
-    `Media: …`; under the old unconditional `:` → `-` rule these were
-    correctly safe but every *other* mid-title colon got mangled too.
-    """
-    head, sep, _tail = title.partition(":")
-    if not sep:
-        return title
-    # MediaWiki treats spaces and underscores as equivalent in namespace
-    # names, and case-folds the first letter; normalise both before lookup.
-    normalised = head.strip().replace("_", " ").lower()
-    if normalised in _MW_NAMESPACE_PREFIXES:
-        return title.replace(":", "-", 1)
-    return title
-
-
 def get_page_title(
     item_title: str, dpla_identifier: str, suffix: str, page=None
 ) -> str:
-    """
-    Makes a proper Wikimedia page title from the DPLA identifier and
-    the title of the image.
+    """Build a Commons file title from a DPLA item title + identifier.
+
+    Applies the same character normalisations Commons enforces at upload
+    time so that the title returned here matches what Commons stores once
+    the upload completes.  Equality of constructed vs. stored title is
+    load-bearing for every downstream check — skip-if-already-there,
+    hash-drift detection, expected_item_titles sibling protection,
+    orphan probes, tag-as-duplicate targets, SDC sidecar bookkeeping —
+    so any character Commons normalises but we don't would silently
+    bypass those checks (see PR #261's audit).
     """
     escaped_title = (
-        _break_namespace_prefix_colon(_break_query_string_pattern(item_title[:181]))
+        # MediaWiki's `stripIllegalFilenameChars` strips `:` from File-
+        # namespace titles unconditionally (filesystem path-separator
+        # concern), replacing with `-`.  Apply the same rule here.  An
+        # earlier version of this code only broke a leading
+        # `<namespace>:` prefix and left mid-title colons intact on the
+        # assumption that Commons "accepts mid-title colons fine".  That
+        # was wrong: titles like `Delegation: "Wooden Lance"` are
+        # silently stored as `Delegation- "Wooden Lance"`.  The mismatch
+        # broke every downstream title-equality check for items whose
+        # source title contained `:` — 5 NARA items in May 2026 ended
+        # up as orphan duplicates because the uploader treated the
+        # colon-form title as the canonical one while Commons stored
+        # the dash form.
+        _break_query_string_pattern(item_title[:181])
+        .replace(":", "-")
+        # `/` must also be substituted.  An earlier reading of MediaWiki's
+        # rules (PR #223) removed this substitution because
+        # `action=query&titles=File:Test/Sub.jpg` returned "missing"
+        # rather than "invalid", which was taken as proof that Commons
+        # accepts `/` in file titles.  That reading conflated two
+        # different layers: `action=query` exercises the title PARSER
+        # (which accepts most characters including `/`), whereas
+        # UPLOAD/MOVE operations run `UploadBase::isValidName` →
+        # `Title::makeTitleSafe(NS_FILE, …)` which DOES reject titles
+        # whose `/` triggers subpage parsing.  4,114 NARA items in the
+        # May 2026 Nixon/LBJ upload sessions hit
+        # `imageinvalidfilename` during Case 3 drift-correction moves
+        # because the move target contained `/` from a date like
+        # `1/5/1966`.  Substituting up front matches what Commons
+        # actually stores (the older code's `1-5-1966` form, as visible
+        # in 2025-vintage Commons titles) and eliminates the cascade.
+        .replace("/", "-")
+        # MediaWiki's `stripIllegalFilenameChars` also strips `\` and
+        # any character outside Title::legalChars().  Of those, `<` and
+        # `>` are the only ones the existing replace-chain DIDN'T
+        # already cover.  Mirror the strip here so our constructed
+        # title matches what Commons stores — same class of fix as the
+        # `:` and `/` rules, audited together.
+        .replace("\\", "-")  # MediaWiki: stripped from file titles
+        .replace("<", "-")  # MediaWiki: not in Title::legalChars()
+        .replace(">", "-")  # MediaWiki: not in Title::legalChars()
         .replace("''", '"')  # titleblacklist: double-apostrophe rule → double-quote
         .replace("[", "(")  # MediaWiki: forbidden in page names
         .replace("]", ")")  # MediaWiki: forbidden in page names

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -99,53 +99,121 @@ def test_get_page_title_breaks_query_string_when_both_present():
     assert "filter-value+other-thing" in title
 
 
-def test_get_page_title_preserves_slash():
-    """Slashes are valid in Commons File: titles — no subpage handling in
-    File namespace — and must NOT be rewritten to `-`."""
+def test_get_page_title_replaces_slash_with_dash():
+    """`/` in source titles must be substituted with `-`. The earlier
+    reasoning that "slashes are valid in Commons File: titles" came from
+    `action=query` returning "missing" for a slash-containing title,
+    which only tests the title PARSER. The actual UPLOAD/MOVE path runs
+    `UploadBase::isValidName` → `Title::makeTitleSafe(NS_FILE, …)` which
+    rejects titles whose `/` triggers subpage parsing — observed as
+    `imageinvalidfilename` errors on 4,114 NARA items (Nixon + LBJ
+    libraries) in May 2026, where Case 3 drift moves tried to move
+    files from the older code's `1-5-1966` (dash) form to a constructed
+    `1/5/1966` (slash) target. Commons rejected every such move."""
     title = get_page_title("Page 1/2 of the survey", "abcd" * 8, ".jpg")
-    assert "/" in title
-    assert "Page 1/2 of the survey" in title
+    assert "/" not in title.split(" - DPLA -")[0]
+    assert title.startswith("Page 1-2 of the survey")
 
 
-def test_get_page_title_preserves_mid_title_colon():
-    """Colons mid-title are valid on Commons (e.g. `Boston, Mass.: City Hall`)
-    and must NOT be rewritten when there's no namespace prefix."""
+def test_get_page_title_lbj_diary_date_case():
+    """Regression pin for the LBJ-library item that surfaced the slash
+    side of the bug: `Lady Bird Johnson's Daily Diary Entry, 1/1/1968`.
+    The 2025-04-29 upload (with older code) stored as `1-1-1968` on
+    Commons. After PR #223 removed `/` → `-` from get_page_title, the
+    current code constructs the title with `/` again, so hash-drift
+    detection fires and tries to MOVE the existing dash-form file to
+    the slash-form target — which Commons rejects with
+    `imageinvalidfilename`. Restoring the substitution makes the
+    constructed title match the stored title, so no drift fires."""
+    title = get_page_title(
+        "Lady Bird Johnson's Daily Diary Entry, 1/1/1968",
+        "0b4d8351fe4b20831966e33905a2aa5a",
+        ".pdf",
+        page="1",
+    )
+    assert title.startswith("Lady Bird Johnson's Daily Diary Entry, 1-1-1968")
+    assert "/" not in title
+
+
+def test_get_page_title_replaces_all_colons_with_dashes():
+    """MediaWiki's stripIllegalFilenameChars strips `:` from File-namespace
+    titles unconditionally and replaces with `-` (filesystem path-separator
+    concern). Our get_page_title must apply the same rule so the title we
+    construct matches the title Commons stores on upload.
+
+    Before May 2026 this code only broke a leading namespace-prefix colon
+    and left mid-title colons intact on the false premise that Commons
+    accepts them. The mismatch produced 5 NARA orphan duplicates whose
+    legacy 2011 NARA-bot uploads (with `:`) silently coexisted with the
+    new DPLA-bot uploads (with `-` after Commons normalised) — see PR #261.
+    """
     title = get_page_title("Boston, Mass.: City Hall", "abcd" * 8, ".jpg")
-    assert ":" in title
-    assert "Boston, Mass.: City Hall" in title
+    assert ":" not in title.split(" - DPLA -")[0]
+    assert title.startswith("Boston, Mass.- City Hall")
 
 
-def test_get_page_title_breaks_namespace_prefix_colon():
-    """When a title begins with `<namespace>:`, the first colon must be
-    replaced so the API doesn't mis-route the upload into that namespace."""
-    # `Image:` is a File namespace alias on Commons — would re-route the upload.
+def test_get_page_title_namespace_prefix_collision_still_broken():
+    """The DPLA-records-starting-with-`Image:` case still works correctly:
+    the colon is replaced (same as any other colon) so the API doesn't
+    mis-route the upload into the File namespace alias. The mechanism is
+    no longer a namespace-list lookup — it's just the global `:` → `-`
+    rule that handles namespace and non-namespace cases identically."""
     title = get_page_title("Image: New England farmhouse", "abcd" * 8, ".jpg")
-    # First colon (the namespace-collision one) → `-`
     assert title.startswith("Image- New England farmhouse")
 
 
-def test_get_page_title_namespace_prefix_check_is_case_insensitive():
-    """MediaWiki case-folds the first letter of namespace names."""
-    for prefix in ("image:", "IMAGE:", "Image :", "image  :"):
-        title = get_page_title(f"{prefix} test", "abcd" * 8, ".jpg")
-        assert ":" not in title.split(" - DPLA -")[0], (
-            f"Namespace prefix {prefix!r} should have triggered colon replacement"
-        )
-
-
-def test_get_page_title_only_breaks_first_colon_when_namespace_match():
-    """Even when the prefix matches a namespace, only the FIRST colon is
-    replaced — any later colons in the title are mid-title and preserved."""
+def test_get_page_title_replaces_every_colon_not_just_the_first():
+    """Multiple colons in the source title — all of them must be replaced
+    so the constructed title matches what Commons stores. Previously only
+    the first colon (after a namespace prefix) would be touched, leaving
+    later colons to be normalised by Commons at upload time — exactly
+    the source of the May 2026 NARA orphan duplicates."""
     title = get_page_title("Image: Boston, Mass.: City Hall", "abcd" * 8, ".jpg")
-    # First `:` after `Image` is replaced, but the mid-title `:` after `Mass.` survives.
-    assert title.startswith("Image- Boston, Mass.:")
+    pre_dpla = title.split(" - DPLA -")[0]
+    assert ":" not in pre_dpla, f"every colon must be replaced; got: {pre_dpla!r}"
+    assert pre_dpla == "Image- Boston, Mass.- City Hall"
 
 
-def test_get_page_title_passes_through_non_namespace_prefix():
-    """A `:` after non-namespace text must be preserved."""
-    title = get_page_title("Notes:1865 inventory", "abcd" * 8, ".jpg")
-    # `Notes` is not a namespace; the `:` stays.
-    assert title.startswith("Notes:1865 inventory")
+def test_get_page_title_strips_backslash_lt_gt():
+    """Companion to the colon fix. MediaWiki's stripIllegalFilenameChars
+    strips `\\`, and any character not in Title::legalChars() — which
+    includes `<` and `>` — from file titles. None of these are likely
+    to appear in real DPLA item titles, but if they do, our constructed
+    title must match what Commons stores so downstream title-equality
+    checks don't silently mismatch (same class of bug as the colon case)."""
+    title = get_page_title(
+        "Edge<chars>here\\with backslash",
+        "abcd" * 8,
+        ".jpg",
+    )
+    pre_dpla = title.split(" - DPLA -")[0]
+    for ch in ("\\", "<", ">"):
+        assert ch not in pre_dpla, (
+            f"character {ch!r} must be replaced; got: {pre_dpla!r}"
+        )
+    assert pre_dpla == "Edge-chars-here-with backslash"
+
+
+def test_get_page_title_nara_native_american_delegations_case():
+    """Regression pin for the exact NARA item that surfaced the bug:
+    `Delegation: "Wooden Lance" (Kiowa)…`. Before the fix, get_page_title
+    produced `Delegation: "Wooden Lance"…` and the file was uploaded to
+    Commons under that title, which Commons then stored as
+    `Delegation- "Wooden Lance"…`. The stored-vs-constructed mismatch
+    silently disabled the duplicate_source_sha1s sibling check, producing
+    an orphan-duplicate alongside the 2011 NARA-bot upload (also stored
+    with the dash form because Commons normalised the same way). The
+    fix: construct the dash form ourselves so the comparison succeeds."""
+    title = get_page_title(
+        'Delegation: "Wooden Lance" (Kiowa), "Apache John" (Apache)',
+        "2617677db09ca8ae0dada8408e400191",
+        ".tiff",
+        page="1",
+    )
+    assert title.startswith(
+        'Delegation- "Wooden Lance" (Kiowa), "Apache John" (Apache)'
+    )
+    assert ":" not in title
 
 
 def test_license_to_markup_code():


### PR DESCRIPTION
## Summary

MediaWiki's file-namespace title validation (\`UploadBase::isValidName\` → \`Title::makeTitleSafe(NS_FILE, …)\`) silently rejects file titles containing \`:\` (filesystem path-separator concern; stripped by \`stripIllegalFilenameChars\` and replaced with \`-\`) AND \`/\` (triggers subpage parsing; the result of \`makeTitleSafe\` differs from input, which \`isValidName\` treats as invalid).

Our code constructed titles with both characters under PR #223's reasoning that they were "accepted fine" — based on \`action=query&titles=…\` returning "missing" instead of "invalid". **That conflated two layers**: \`action=query\` exercises the title PARSER (forgiving), whereas UPLOAD and MOVE go through \`isValidName\` (strict).

## Symptoms observed in May 2026 NARA upload runs

| Character | Items affected | Symptom | Examples |
|---|---|---|---|
| \`:\` | **3,362** unique | Orphan duplicates (legitimate siblings mistakenly tagged); also imageinvalidfilename on Case 3 moves | \`WHSF: Contested, …\`, \`Memo to Ron Ziegler RE: …\`, \`Memoranda from the President:\` |
| \`/\` | **4,114** unique | imageinvalidfilename on every Case 3 move | \`Lady Bird Johnson's Daily Diary Entry, 1/1/1968\`, \`NSC Meetings, Volume 3, Tab 37, 1/5/1966, …\` |
| Overlap | 75 unique | Both | |

35,006 individual move failures across LBJ + Nixon library upload sessions, all FAILED in upload-result.json. PR #255 partially addressed the colon side (sibling protection), but couldn't fix the underlying cause; this PR is the root fix.

## Fix

Single change to \`get_page_title\` in \`ingest_wikimedia/wikimedia.py\`: extend the existing escape chain with the characters MediaWiki normalises that we currently leak through.

\`\`\`python
.replace(":", "-")    # stripIllegalFilenameChars: explicit
.replace("/", "-")    # makeTitleSafe rejects via subpage parsing
.replace("\\", "-")   # stripIllegalFilenameChars: explicit
.replace("<", "-")    # not in Title::legalChars()
.replace(">", "-")    # not in Title::legalChars()
\`\`\`

Plus removal of \~50 lines of dead code (\`_break_namespace_prefix_colon\` helper + supporting \`_MW_NAMESPACE_PREFIXES\` frozenset) — both were band-aids on the old wrong-premise rule and are subsumed by the global \`:\` → \`-\` substitution.

The other findings from PR #223 (narrowing \`&\`/\`=\` substitution to the joint \`&…=\` query-string pattern) are correct and unchanged — \`&\` alone IS valid on Commons (verified by 2025-vintage \`… suffragiis & orationibus.\` titles that landed correctly).

## Test plan

- [x] 7 new/updated tests pinning the substitutions and the two real-world regression cases (NARA \`Delegation: "Wooden Lance"…\` for colon, LBJ \`1/1/1968\` for slash)
- [x] Removed 3 tests that pinned the wrong PR #223 behaviour
- [x] All 65 tests in \`tests/test_wikimedia.py\` pass
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] After merge: re-run a NARA institution with affected items (Nixon Library or LBJ Library) and confirm no imageinvalidfilename / no spurious orphan-tagging

## Cleanup of existing data

For the 7,401 affected items, no Commons-side cleanup is needed — their files are already correctly stored at the dash-form titles (from 2025-vintage uploads or post-Commons-normalisation). The only damage was the FAILED entries in upload-result.json, which a re-run with this PR deployed will heal automatically (drift won't fire → SKIPPED status → SDC sync eligible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a critical issue in `get_page_title()` where constructed Wikimedia Commons file-page titles were not matching Commons' filename normalization, causing widespread move/upload failures and duplicate-tagging errors. The fix extends the character-escaping chain to normalize all characters that MediaWiki's filename validation silently converts, bringing constructed titles into alignment with what Commons actually stores.

## The Problem

During May 2026 NARA upload runs, mismatches between constructed titles and stored filenames resulted in:
- 3,362 unique items containing ":" 
- 4,114 unique items containing "/"
- 35,006 individual move failures
- Cascading orphan-duplicate tagging

Root cause: MediaWiki's `Title::makeTitleSafe()` / `wfStripIllegalFilenameChars()` silently normalizes illegal filename characters (`:` → `-`, `/` → `-`, etc.), but the ingest code was not performing the same normalization when constructing titles, causing lookups and equality checks to fail.

## Changes

**ingest_wikimedia/wikimedia.py:**
- Modified `get_page_title()` to apply comprehensive filename character normalization: `:`, `/`, `\`, `<`, and `>` are all converted to `-` as part of the general escaping chain
- Removed `_break_namespace_prefix_colon()` helper function and `_MW_NAMESPACE_PREFIXES` frozenset (~50 lines of dead code)—these were a band-aid that only handled colons in namespace prefixes, not throughout titles
- Retained the narrower `_break_query_string_pattern()` handling for `&…=` query strings from PR `#223`
- Expanded docstring to document that `get_page_title()` mirrors Commons' character normalizations and that exact title matching is load-bearing for downstream equality/duplicate/hash-drift logic
- Lines changed: +51/-82

**tests/test_wikimedia.py:**
- Removed 5 tests that asserted the old selective-rewriting behavior (namespace-prefix-only colon handling, mid-title colon preservation, case-insensitive namespace matching)
- Added 7 new tests covering:
  - All colons are normalized to dashes (including mid-title)
  - Slashes normalized to dashes
  - Backslash, `<`, and `>` stripped/converted
  - Two regression cases: LBJ diary date with `/`, NARA "Delegation: …" title ensuring colon normalization
- Lines changed: +104/-36

## Testing & Validation

- All 64 tests in `tests/test_wikimedia.py` pass
- `ruff` checks pass
- Post-merge plan: re-run affected NARA institution uploads to confirm move/upload failures are resolved

## Notes

Defensive additions: The PR also includes normalization for `\` and `<>` characters, which were not observed in past upload logs (zero occurrences in seven days of EC2 logs) but are added for defensive alignment with MediaWiki's full set of illegal filename characters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->