### PR TITLE
status: skip stale aborted phases; add sdc-sync phase-start; catch BaseException

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -11,12 +11,18 @@ from ingest_wikimedia.tracker import Result, Tracker
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
 
-Phase = Literal["id-generation", "download", "upload"]
+Phase = Literal["id-generation", "download", "upload", "sdc-sync"]
 
 _PHASE_EMOJI: dict[str, str] = {
     "id-generation": "🔍",
     "download": "⬇",
     "upload": "⬆",
+    # SDC sync follows upload in the pipeline. Without a phase-start
+    # notification for it, the gap between the last "upload complete"
+    # message and the eventual "SDC complete" summary can stretch hours
+    # on a large hub with no indication that work has actually moved on
+    # to the SDC phase.
+    "sdc-sync": "🔗",
 }
 
 

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -42,7 +42,21 @@ _DOWNLOAD_COMPLETE_PREFIX = "Download complete"
 _STALE_SECONDS = 1800  # 30 minutes
 
 
-def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | None:
+def get_phase_and_progress(
+    client, session: str, hub: str, label: str
+) -> tuple[str | None, int]:
+    """Return ``(phase_str, log_mtime)`` for this label.
+
+    ``phase_str`` is ``None`` when no log exists for this label yet (label
+    skipped or pipeline hasn't started it).  ``log_mtime`` is the unix
+    epoch seconds of the most recent write to the log file (0 when no
+    log exists).  The mtime is used by ``main`` to break ties between
+    multiple non-complete labels — a phase that aborted hours ago but
+    didn't write a ``COUNTS:`` terminal marker (so it doesn't look
+    "complete" via the count-marker test) must not eclipse a subsequent
+    label that's actively progressing now.
+    """
+
     def _safe_int(s: str) -> int:
         try:
             return int(s)
@@ -88,7 +102,7 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
         # been skipped (e.g. ineligible institution — get-ids-es exits 1 without
         # ever launching the downloader). Return None so the caller can decide
         # whether to keep looking at later labels.
-        return None
+        return None, 0
 
     log_path = shlex.quote(f"{base}/logs/{log_file}")
     csv_path = shlex.quote(f"{base}/{label}.csv")
@@ -126,7 +140,7 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
 
     # Log predates this session — no new log yet, treat same as no log.
     if session_created > 0 and log_mtime < session_created:
-        return None
+        return None, 0
 
     tail = sections[1].strip() if len(sections) > 1 else ""
     count_lines = sections[2].strip().splitlines() if len(sections) > 2 else []
@@ -161,25 +175,40 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
         # Use the COUNTS: terminal marker as the definitive completion signal —
         # "Downloading" may still appear in the tail even after the run finishes.
         if counts_marker > 0:
-            return f"{_DOWNLOAD_COMPLETE_PREFIX} ({dpla_id_count:,} / {total:,} items)"
+            return (
+                f"{_DOWNLOAD_COMPLETE_PREFIX} ({dpla_id_count:,} / {total:,} items)",
+                log_mtime,
+            )
         if "Downloading" in tail or "Key already in S3" in tail:
-            return f"Downloading ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}"
+            return (
+                f"Downloading ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}",
+                log_mtime,
+            )
         # Log exists for this session but no active download indicators and no COUNTS
         # marker — downloader likely crashed. Report item count without implying
         # get-ids-es is running (the old "Generating IDs" fallback was wrong here).
-        return f"Stalled ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}"
+        return (
+            f"Stalled ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}",
+            log_mtime,
+        )
 
     if log_file.endswith("-upload.log"):
         if dpla_id_count == 0:
             # dpla_id_count == 0 means no items logged yet — uploader just started.
             # Staleness here would be a false positive from the normal start-up lag.
-            return "Uploading (starting...)"
+            return "Uploading (starting...)", log_mtime
         # Use the COUNTS: terminal marker as the definitive completion signal.
         # dpla_id_count is logged at the start of each item, not after all its
         # files finish, so count arithmetic alone can fire too early.
         if counts_marker > 0:
-            return f"{_UPLOAD_COMPLETE_PREFIX} ({uploaded_count:,} uploaded, {skipped_count:,} already on Commons)"
-        return f"Uploading ({dpla_id_count:,} / {total:,}, ~{pct(dpla_id_count)}%){stale_suffix}"
+            return (
+                f"{_UPLOAD_COMPLETE_PREFIX} ({uploaded_count:,} uploaded, {skipped_count:,} already on Commons)",
+                log_mtime,
+            )
+        return (
+            f"Uploading ({dpla_id_count:,} / {total:,}, ~{pct(dpla_id_count)}%){stale_suffix}",
+            log_mtime,
+        )
 
     if log_file.endswith("-sdc.log"):
         # sdc-sync's _run_partner_mode logs `DPLA ID: <id> (n/total)` per
@@ -192,12 +221,18 @@ def get_phase_and_progress(client, session: str, hub: str, label: str) -> str | 
         # summary surfaces the real synced count via the tracker's
         # SDC_ITEMS_SYNCED line.
         if dpla_id_count == 0:
-            return "SDC syncing (starting...)"
+            return "SDC syncing (starting...)", log_mtime
         if counts_marker > 0:
-            return f"{_SDC_COMPLETE_PREFIX} ({dpla_id_count:,} items processed)"
-        return f"SDC syncing ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}"
+            return (
+                f"{_SDC_COMPLETE_PREFIX} ({dpla_id_count:,} items processed)",
+                log_mtime,
+            )
+        return (
+            f"SDC syncing ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}",
+            log_mtime,
+        )
 
-    return "Unknown"
+    return "Unknown", log_mtime
 
 
 def post_to_slack(token: str, rows: list[tuple[str, str]]) -> None:
@@ -316,7 +351,7 @@ def main() -> None:
                 hub = resolve_slug(raw_hub) or raw_hub
 
             try:
-                phase = get_phase_and_progress(ssm, session, hub, label)
+                phase, _ = get_phase_and_progress(ssm, session, hub, label)
             except Exception:
                 logging.exception(
                     "Failed to get retry status for %s (%s)", session, label
@@ -332,58 +367,66 @@ def main() -> None:
             return session, "Unknown (unrecognised session name)"
         multi = len(labels) > 1
 
-        # Walk labels in pipeline order. Skip past labels with no log file — they
-        # may have been skipped (e.g. ineligible institution errored during ID
-        # generation). Track the first no-log label after the last completed one
-        # as a fallback in case all remaining labels lack logs (meaning the session
-        # genuinely hasn't started the next phase yet).
-        first_pending: str | None = None
-        last_complete_label: str | None = None
-        last_complete_phase: str = ""
-
+        # Walk every label in the pipeline and collect each one's phase
+        # string and log mtime. We need ALL labels (not a forward-walk that
+        # short-circuits at the first non-complete one) because a label
+        # earlier in the pipeline can be "non-complete" — e.g. its SDC
+        # phase aborted without writing the COUNTS: terminal marker — yet
+        # a later label is actively progressing right now. Reporting the
+        # first non-complete label in that case freezes the Slack notice
+        # on the aborted phase forever.  Pick the label with the LATEST
+        # log mtime among those still in-flight; an active label always
+        # wins over an aborted earlier one because its log was just
+        # written, while the abort's last log write is hours stale.
+        per_label: list[tuple[str, str | None, int]] = []
         for label in labels:
             hub = label.split("+")[0]
             try:
-                phase = get_phase_and_progress(ssm, session, hub, label)
+                phase, log_mtime = get_phase_and_progress(ssm, session, hub, label)
             except Exception:
                 logging.exception("Failed to get status for %s (%s)", session, label)
-                phase = "Unknown (error)"
+                phase, log_mtime = "Unknown (error)", 0
+            per_label.append((label, phase, log_mtime))
 
-            if phase is None:
-                # No log: either skipped or not yet started. Keep looking at
-                # later labels — if any of them have a log, this one was skipped.
-                if first_pending is None:
-                    first_pending = label
-                continue
-
-            # This label has a log. Any earlier no-log labels were skipped.
-            first_pending = None
-
-            if not (
+        def _is_complete(phase: str | None) -> bool:
+            return phase is not None and (
                 phase.startswith(_UPLOAD_COMPLETE_PREFIX)
                 or phase.startswith(_DOWNLOAD_COMPLETE_PREFIX)
                 or phase.startswith(_SDC_COMPLETE_PREFIX)
-            ):
-                # Active or stalled label — this is the one to report.
-                return session, f"[{label}] {phase}" if multi else phase
+            )
 
-            last_complete_label = label
-            last_complete_phase = phase
+        # Labels with a log AND not in a "complete" terminal state.
+        active = [
+            (lbl, phase, mtime)
+            for lbl, phase, mtime in per_label
+            if phase is not None and not _is_complete(phase)
+        ]
+        if active:
+            # Latest write wins — see comment above for the rationale.
+            lbl, phase, _ = max(active, key=lambda t: t[2])
+            return session, f"[{lbl}] {phase}" if multi else phase
 
-        # Loop exhausted. Either the pipeline is waiting to start the next phase
-        # (first_pending), or everything finished (last_complete_label).
+        # No active labels.  Either everything completed, or the
+        # pipeline is between phases (no log yet for the next label).
+        # Prefer the LAST completed label in pipeline order when present;
+        # otherwise fall back to the first no-log label as "Generating IDs"
+        # (the pipeline's resting state before any phase writes a log).
+        completed = [(lbl, phase) for lbl, phase, _ in per_label if _is_complete(phase)]
+        if completed:
+            lbl, phase = completed[-1]
+            return session, f"[{lbl}] {phase}" if multi else phase
+
+        first_pending = next(
+            (lbl for lbl, phase, _ in per_label if phase is None), None
+        )
         if first_pending is not None:
             return (
                 session,
                 f"[{first_pending}] Generating IDs" if multi else "Generating IDs",
             )
-        if last_complete_label is not None:
-            return (
-                session,
-                f"[{last_complete_label}] {last_complete_phase}"
-                if multi
-                else last_complete_phase,
-            )
+        # `per_label` is built directly from `labels`, which we already
+        # checked is non-empty, so every reachable path above returned.
+        # This is a defensive fallback that should never fire.
         return session, "Generating IDs"
 
     with ThreadPoolExecutor(max_workers=min(len(sessions), 8)) as executor:

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -16,7 +16,7 @@ A claim that contains any user-authored qualifier or reference is
 NOT safe — the wbeditentity round-trip would erase that data.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -407,3 +407,112 @@ def test_check_foreign_match_other_value_types(kind, value, mainsnak_value):
     with patch.object(sdc_sync, "get_entity", return_value=fake_entity):
         result = sdc_sync.check("M999", (kind, value), "P760")
     assert result == (True, "")
+
+
+# --------------------------------------------------------------------------
+# _run_partner_mode — SystemExit / KeyboardInterrupt diagnostic capture
+#
+# 11 SDC aborts were observed across 3 days in May 2026 with the warning
+# "SDC sync aborted before completion" but NO traceback or exception
+# class logged.  The old `except Exception:` only catches Exception-class
+# exceptions; SystemExit / KeyboardInterrupt / GeneratorExit (all
+# subclasses of BaseException, not Exception) bypassed it entirely.
+# Widened to `except BaseException` so the next abort logs a traceback +
+# the exception type name, making future occurrences self-diagnosing.
+# --------------------------------------------------------------------------
+
+
+def test_run_partner_mode_logs_traceback_and_type_on_systemexit(
+    tmp_path, caplog, monkeypatch
+):
+    """A SystemExit raised during partner-mode iteration must:
+      1. Be caught by the outer handler (not propagate silently)
+      2. Get logged with `logging.exception(...)` so the SDC log file
+         captures the traceback + exception class name
+      3. Be re-raised so the shell pipeline still sees a non-zero exit
+         and `notify_pipeline_fail` still fires.
+    The 11-abort cluster all WROTE the abort warning (so finally ran)
+    but produced no diagnostic, which only makes sense if the exception
+    class wasn't `Exception` — exactly what this widened catch fixes.
+    """
+    import logging as _logging
+
+    from tools import sdc_sync
+
+    ids_file = tmp_path / "ids.txt"
+    ids_file.write_text("abcdef01abcdef01abcdef01abcdef01\n")
+
+    fake_s3_client = MagicMock(name="S3Client_instance")
+    fake_s3_client.get_sdc_json.side_effect = SystemExit("simulated pywikibot exit")
+
+    notify_complete_calls = []
+
+    with (
+        patch.object(sdc_sync, "setup_logging"),
+        patch.object(sdc_sync, "notify_phase_start"),
+        patch.object(
+            sdc_sync,
+            "notify_sdc_complete",
+            side_effect=lambda **kw: notify_complete_calls.append(kw),
+        ),
+        # _run_partner_mode imports S3Client inside the function body
+        # (`from ingest_wikimedia.s3 import S3Client`).  Patch the
+        # constructor in the source module so the inner import picks
+        # up the mock.
+        patch("ingest_wikimedia.s3.S3Client", return_value=fake_s3_client),
+        caplog.at_level(_logging.WARNING, logger="root"),
+    ):
+        with pytest.raises(SystemExit):
+            sdc_sync._run_partner_mode("nara", str(ids_file))
+
+    # The completion notification must NOT have fired — the abort path
+    # explicitly suppresses it (otherwise the status reporter would see
+    # a `COUNTS:` marker and treat the aborted run as done).
+    assert notify_complete_calls == [], (
+        f"notify_sdc_complete must not be called on abort; got: {notify_complete_calls!r}"
+    )
+
+    # The diagnostic log must include the exception type name so future
+    # aborts are self-identifying (was it SystemExit?  KeyboardInterrupt?).
+    messages = " | ".join(r.getMessage() for r in caplog.records)
+    assert "SDC sync aborted with unhandled exception" in messages
+    assert "SystemExit" in messages, (
+        f"exception type name must be in the log message for diagnosis; "
+        f"got: {messages!r}"
+    )
+
+    # The finally-block warning must still fire (the message that the
+    # 11 May 2026 aborts were the ONLY log output for).  This is the
+    # signal `wikimedia_upload_status` reads as "not complete".
+    assert "SDC sync aborted before completion" in messages
+
+
+def test_run_partner_mode_logs_traceback_on_keyboardinterrupt(
+    tmp_path, caplog, monkeypatch
+):
+    """Same contract for KeyboardInterrupt — also a BaseException
+    subclass not caught by `except Exception`.  Default Python signal
+    handler raises KeyboardInterrupt on SIGINT, so this covers the
+    "process group received SIGINT" hypothesis."""
+    import logging as _logging
+
+    from tools import sdc_sync
+
+    ids_file = tmp_path / "ids.txt"
+    ids_file.write_text("abcdef01abcdef01abcdef01abcdef01\n")
+
+    fake_s3_client = MagicMock(name="S3Client_instance")
+    fake_s3_client.get_sdc_json.side_effect = KeyboardInterrupt()
+
+    with (
+        patch.object(sdc_sync, "setup_logging"),
+        patch.object(sdc_sync, "notify_phase_start"),
+        patch.object(sdc_sync, "notify_sdc_complete"),
+        patch("ingest_wikimedia.s3.S3Client", return_value=fake_s3_client),
+        caplog.at_level(_logging.WARNING, logger="root"),
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            sdc_sync._run_partner_mode("nara", str(ids_file))
+
+    messages = " | ".join(r.getMessage() for r in caplog.records)
+    assert "KeyboardInterrupt" in messages

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -13,15 +13,48 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ingest_wikimedia.slack import (
+    _PHASE_EMOJI,
     _decode_exit_code,
     _find_latest_log,
     _read_download_failed_count,
     _summarize_log,
+    notify_phase_start,
     notify_pipeline_fail,
     notify_sdc_complete,
     notify_upload_complete,
 )
 from ingest_wikimedia.tracker import Result, Tracker
+
+
+def test_notify_phase_start_supports_sdc_sync_phase():
+    """Regression: ``sdc-sync`` is a valid Phase value, with a distinct
+    emoji, so the SDC phase posts its own "starting" notification to
+    Slack the same way get-ids-es / downloader / uploader do.
+
+    Without this, a multi-target run reports `[label] Upload complete …`
+    and then goes silent for hours during SDC sync — the operator has
+    no Slack signal that the SDC phase actually started.
+    """
+    assert "sdc-sync" in _PHASE_EMOJI
+    assert _PHASE_EMOJI["sdc-sync"] != _PHASE_EMOJI["upload"]
+
+    posted = []
+
+    def _capture(token, text):
+        posted.append((token, text))
+
+    with (
+        patch.dict(os.environ, {"DPLA_SLACK_BOT_TOKEN": "x"}, clear=False),
+        patch("ingest_wikimedia.slack.post_message", side_effect=_capture),
+    ):
+        notify_phase_start("nara", "sdc-sync")
+
+    assert len(posted) == 1
+    _, text = posted[0]
+    # Emoji + session label + phase label, mirroring the other phases.
+    assert _PHASE_EMOJI["sdc-sync"] in text
+    assert "starting sdc-sync" in text
+    assert "wikimedia-nara" in text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -121,13 +121,26 @@ def test_log_filename_pattern_always_starts_with_dash():
         )
 
 
-def _fake_ssm_for_phase(log_filename: str, awk_counts: list[int], csv_total: int):
+def _fake_ssm_for_phase(
+    log_filename: str,
+    awk_counts: list[int],
+    csv_total: int,
+    *,
+    mtime: int = 1700000000,
+):
     """Build a fake `ssm_run` that returns the precheck + counts payload
     `get_phase_and_progress` expects, with the named log file and counts.
 
     Sequence (matches the real two-call flow):
       1. precheck — `session_created\nlog_filename`
       2. main — `now\nmtime\nSEP\ntail\nSEP\n<5 lines of awk + wc>`
+
+    ``mtime`` is parameterised so tests can verify the mtime tiebreak in
+    ``main`` — an "aborted phase" fake with an earlier mtime must be
+    distinguishable from an "active phase" fake with a later mtime, even
+    though both produce a non-COUNTS-marker phase string.  ``now`` is
+    kept at the same value so the staleness suffix doesn't fire (it
+    would change the phase-string assertions in unrelated callers).
     """
     call_count = [0]
     sep = "__WM_SEP__"
@@ -135,9 +148,10 @@ def _fake_ssm_for_phase(log_filename: str, awk_counts: list[int], csv_total: int
     def fake_ssm_run(_client, _command, **_kwargs):
         call_count[0] += 1
         if call_count[0] == 1:
-            return f"1700000000\n{log_filename}\n"
-        # now=mtime so no staleness suffix; counts payload then csv_total
-        body = f"1700000000\n1700000000\n{sep}\nlast log line\n{sep}\n"
+            return f"{mtime}\n{log_filename}\n"
+        # now and mtime both come from the same `mtime` parameter so the
+        # staleness suffix never fires (now == mtime → idle == 0).
+        body = f"{mtime}\n{mtime}\n{sep}\nlast log line\n{sep}\n"
         body += "\n".join(str(n) for n in awk_counts) + "\n"
         body += f"{csv_total}\n"
         return body
@@ -160,7 +174,7 @@ def test_get_phase_and_progress_reports_sdc_syncing_in_progress():
         csv_total=10,
     )
     with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
-        phase = get_phase_and_progress(
+        phase, log_mtime = get_phase_and_progress(
             client=None,
             session="wikimedia-minnesota",
             hub="minnesota",
@@ -169,6 +183,9 @@ def test_get_phase_and_progress_reports_sdc_syncing_in_progress():
     assert phase.startswith("SDC syncing")
     assert "3" in phase
     assert "10" in phase
+    # mtime is the second tuple element — present so callers can compare
+    # across labels (see test_main_picks_latest_active_label_by_mtime).
+    assert log_mtime > 0
 
 
 def test_get_phase_and_progress_reports_sdc_complete():
@@ -185,7 +202,7 @@ def test_get_phase_and_progress_reports_sdc_complete():
         csv_total=10,
     )
     with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
-        phase = get_phase_and_progress(
+        phase, _ = get_phase_and_progress(
             client=None,
             session="wikimedia-minnesota",
             hub="minnesota",
@@ -208,10 +225,116 @@ def test_get_phase_and_progress_reports_sdc_starting_with_no_items():
         csv_total=10,
     )
     with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
-        phase = get_phase_and_progress(
+        phase, _ = get_phase_and_progress(
             client=None,
             session="wikimedia-minnesota",
             hub="minnesota",
             label="minnesota",
         )
     assert phase == "SDC syncing (starting...)"
+
+
+def test_main_picks_latest_active_label_by_mtime_when_earlier_label_aborted():
+    """Regression: when a multi-target session has an EARLIER label whose
+    phase ended without a COUNTS terminal marker (e.g. an SDC sync that
+    aborted via SystemExit) and a LATER label is actively progressing
+    right now, the reporter must surface the LATER one, not freeze on
+    the stale earlier one.
+
+    Concrete case (May 28 2026): a six-target NARA pipeline aborted the
+    Clinton SDC at item 250/4879 around 09:57 UTC.  The shell-level
+    target separator is `;` (not `&&`), so subsequent targets ran:
+    Eisenhower SDC completed, Presidential Materials Division SDC
+    completed, and Center for Legislative Archives SDC is currently
+    running.  The reporter was reporting `[nara+william-j-clinton-library]
+    SDC syncing (250 / 4,879 items, ~5.1%) ⚠ idle 5h38m` because its
+    forward-walk returned the first non-complete phase it found.
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    # The fix swaps the walk for an mtime-based tiebreak.  Verify the
+    # primitive that backs it: get_phase_and_progress reports the
+    # log_mtime alongside the phase, and an aborted older phase reports
+    # a smaller mtime than a currently-active later phase.  We then run
+    # the same `max(..., key=lambda t: t[2])` selection main() uses, to
+    # demonstrate that the active phase wins.
+    ABORT_MTIME = 1700000000  # the moment Clinton SDC aborted
+    ACTIVE_MTIME = ABORT_MTIME + 5 * 3600  # ~5h later: CFLA SDC last write
+
+    aborted = _fake_ssm_for_phase(
+        log_filename="20260528-091047-nara+william-j-clinton-library-sdc.log",
+        awk_counts=[250, 0, 0, 0],  # no COUNTS marker → not complete
+        csv_total=4879,
+        mtime=ABORT_MTIME,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=aborted):
+        aborted_phase, aborted_mtime = get_phase_and_progress(
+            client=None,
+            session="wikimedia-multi",
+            hub="nara",
+            label="nara+william-j-clinton-library",
+        )
+
+    active = _fake_ssm_for_phase(
+        log_filename="20260528-140954-nara+center-for-legislative-archives-sdc.log",
+        awk_counts=[3101, 0, 0, 0],
+        csv_total=6946,
+        mtime=ACTIVE_MTIME,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=active):
+        active_phase, active_mtime = get_phase_and_progress(
+            client=None,
+            session="wikimedia-multi",
+            hub="nara",
+            label="nara+center-for-legislative-archives",
+        )
+
+    # Both phases say "SDC syncing" (neither has COUNTS) — both look
+    # "active" by the count-marker test, which is exactly what tripped
+    # up the pre-fix forward-walk: it stopped at the first non-complete
+    # label and never advanced.
+    assert aborted_phase.startswith("SDC syncing")
+    assert active_phase.startswith("SDC syncing")
+    assert aborted_mtime > 0 and active_mtime > 0
+
+    # The contract that backs the tiebreak: distinct mtimes are returned
+    # and the active one is strictly later than the aborted one.
+    assert active_mtime > aborted_mtime
+    assert active_mtime - aborted_mtime == 5 * 3600
+
+    # Run the same selection main() runs on the (label, phase, mtime)
+    # tuples: pick the latest-mtime active label.  The active label
+    # must win — otherwise we're back to the "stuck on Clinton" bug.
+    active_labels = [
+        ("nara+william-j-clinton-library", aborted_phase, aborted_mtime),
+        ("nara+center-for-legislative-archives", active_phase, active_mtime),
+    ]
+    chosen_label, chosen_phase, _ = max(active_labels, key=lambda t: t[2])
+    assert chosen_label == "nara+center-for-legislative-archives"
+    assert chosen_phase == active_phase
+
+
+def test_get_phase_and_progress_returns_none_tuple_when_no_log_exists():
+    """The signature change must preserve the `phase is None` sentinel:
+    when no log file matches, return ``(None, 0)`` so the caller's
+    membership-and-tiebreak loop can detect "no log" and skip the
+    label without crashing on a string operation."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    # Return empty for both ls invocations (no matching log + no hub
+    # fallback log) so the function takes the "no log" early-return path.
+    def fake_ssm_run(_client, _command, **_kwargs):
+        return "1700000000\n\n"
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
+        result = get_phase_and_progress(
+            client=None,
+            session="wikimedia-unknown",
+            hub="bpl",
+            label="bpl+nonexistent",
+        )
+    assert result == (None, 0)

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -18,7 +18,7 @@ from bs4 import BeautifulSoup
 from pywikibot.comms import http
 from pywikibot import pagegenerators
 from ingest_wikimedia.logs import setup_logging
-from ingest_wikimedia.slack import notify_sdc_complete
+from ingest_wikimedia.slack import notify_phase_start, notify_sdc_complete
 from ingest_wikimedia.tracker import Result, Tracker
 from ingest_wikimedia.wikimedia import extract_dpla_id_from_commons_title
 
@@ -2127,6 +2127,13 @@ def _run_partner_mode(partner, ids_file):
     from ingest_wikimedia.s3 import S3Client
 
     setup_logging(partner, "sdc", logging.INFO)
+    # Post the phase-start notification immediately after setup_logging so
+    # the operator sees that the SDC phase has actually begun — matching
+    # the get-ids-es / downloader / uploader convention. Without this,
+    # the gap between the upload-complete message and the eventual
+    # sdc-complete summary can stretch hours on a large hub with no
+    # indication that work has moved on.
+    notify_phase_start(partner, "sdc-sync")
     start_time = time.time()
 
     # Reset the module-level tracker so per-partner counts don't carry
@@ -2326,7 +2333,7 @@ def _run_partner_mode(partner, ids_file):
             else:
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
         completed = True
-    except Exception:
+    except BaseException as exc:
         # The per-ordinal try/except above already swallows every routine
         # SDC-write failure. Reaching this outer handler means something
         # truly outside-the-loop went wrong (sidecar enumeration, S3 auth,
@@ -2335,7 +2342,20 @@ def _run_partner_mode(partner, ids_file):
         # Slack failure message — otherwise the traceback only hits stderr
         # (the file handler doesn't capture it) and the operator sees an
         # abort warning with no diagnostic.
-        logging.exception("SDC sync aborted with unhandled exception")
+        #
+        # Widened to BaseException to capture SystemExit and KeyboardInterrupt
+        # too.  A cluster of 11 SDC aborts in May 2026 (two within 3 seconds
+        # of each other across two unrelated processes) all wrote the abort
+        # warning but no traceback — meaning a non-Exception class escaped
+        # this handler.  `except Exception` doesn't catch SystemExit /
+        # KeyboardInterrupt / GeneratorExit, so those bypassed the original
+        # log line entirely.  Widening to BaseException + re-raising
+        # preserves the original semantics (the shell-level pipeline still
+        # sees a non-zero exit and `notify_pipeline_fail` still fires) while
+        # making the next abort self-diagnosing.
+        logging.exception(
+            "SDC sync aborted with unhandled exception (%s)", type(exc).__name__
+        )
         raise
     finally:
         elapsed = time.time() - start_time


### PR DESCRIPTION
## Summary

Three related Slack-reporting gaps surfaced by the cluster of 11 SDC aborts observed May 26–28 2026 (notably Clinton on May 28 at 09:57 and the Reagan+NPRC pair within 3 seconds of each other at 07:42).

### 1. `wikimedia-upload-status` froze on the aborted phase

Reporter posted \`[nara+william-j-clinton-library] SDC syncing (250 / 4,879 items, ~5.1%) ⚠ idle 5h38m\` for hours even though Center for Legislative Archives SDC was actively progressing at item 3,101/6,946.

**Cause**: the multi-label walk in \`main()\` returned the FIRST label whose phase didn't start with one of the \`*-complete\` prefixes. Aborted-but-not-COUNTS-marked phases stay non-complete forever and the walker froze on them.

**Fix**: walk every label, collect each one's phase + log mtime, and pick the **latest-mtime active (non-complete) label**. \`get_phase_and_progress\` now returns \`(phase, log_mtime)\` so the walk loop has the mtime needed for the tiebreak.

### 2. SDC sync had no phase-start Slack notification

A multi-target run's user-visible Slack signal was \`Upload Complete\` → silence for hours → \`SDC Complete\`, with no indication that the SDC phase had actually begun.

**Fix**: add \`"sdc-sync"\` to the \`Phase\` literal (with 🔗 emoji), call \`notify_phase_start(partner, "sdc-sync")\` at the top of \`_run_partner_mode\`.

### 3. `_run_partner_mode`'s outer except missed SystemExit / KeyboardInterrupt

All 11 May 2026 SDC aborts wrote the "aborted before completion" warning (so finally ran) but no traceback or exception class — meaning a non-Exception class escaped the outer handler. \`except Exception\` doesn't catch SystemExit / KeyboardInterrupt / GeneratorExit (all BaseException subclasses).

Two aborts within 3 seconds of each other across unrelated processes (Reagan+NPRC at 07:42:08 / 07:42:11) point at either a process-group SIGINT or pywikibot calling \`sys.exit()\` — but we can't tell which without a traceback.

**Fix**: widen the outer catch to \`except BaseException as exc\` and include \`type(exc).__name__\` in the log message, so the next abort is self-diagnosing. Re-raise preserves the original semantics.

## Test plan

- [x] 1 new test in \`test_slack.py\` pins the \`sdc-sync\` Phase contract
- [x] 2 new tests in \`test_wikimedia_upload_status.py\` pin the tuple return shape AND exercise the mtime tiebreak with distinct earlier/later mtimes (addresses CodeRabbit review)
- [x] 2 new tests in \`test_sdc_sync.py\` pin the BaseException catch — SystemExit + KeyboardInterrupt both re-raise and log the type name
- [x] 3 existing SDC progress tests updated to destructure the tuple
- [x] All 66 tests pass; ruff clean
- [ ] After merge: next \`/wikimedia-status\` reports CFLA SDC (not stale Clinton); next NARA pipeline posts \`🔗 starting sdc-sync\` between upload-complete and SDC-complete; **next SDC abort logs the exception class + traceback so we can finally identify what's killing these processes**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR implements three related fixes addressing Slack-reporting and abort-tracing gaps observed during an SDC abort cluster (May 26–28, 2026):

1) Avoid freezing on aborted phases
- scripts/wikimedia_upload_status.py: get_phase_and_progress now returns (phase_str | None, log_mtime:int). main’s multi-label walker collects (label, phase, mtime) for every label, considers any non-*-complete phase active, and selects the active label with the newest log mtime as the in-flight target. If no active label exists, prior fallback behavior is preserved (last completed label or first pending label). This prevents a previously-aborted-but-not-COUNTS-marked phase from permanently eclipsing a later active label.
- Tests: tests/test_wikimedia_upload_status.py updated to unpack (phase, mtime), _fake_ssm_for_phase accepts mtime to simulate distinct mtimes, and a regression test asserts main picks the later-active label by mtime. Also added coverage that no-log returns (None, 0).

2) Add SDC phase-start Slack notification
- ingest_wikimedia/slack.py: Phase literal extended to include "sdc-sync" and _PHASE_EMOJI maps a distinct emoji ("🔗").
- tools/sdc_sync.py: notify_phase_start(partner, "sdc-sync") is called at the start of _run_partner_mode (immediately after setup_logging) so SDC phase starts are announced like other phases.
- Tests: tests/test_slack.py adds test_notify_phase_start_supports_sdc_sync_phase asserting the sdc-sync emoji, "starting sdc-sync" text, and session label appear in the posted message.

3) Surface non-Exception aborts
- tools/sdc_sync.py: broadened the outer exception handler in _run_partner_mode from except Exception to except BaseException as exc. Abort logging now includes the unhandled exception’s type name via logging.exception("SDC sync aborted with unhandled exception (%s)", type(exc).__name__), then re-raises to preserve prior semantics. This ensures non-Exception aborts (SystemExit/KeyboardInterrupt/GeneratorExit) produce a traceback and a logged exception-type name for diagnosis.
- Tests: tests/test_sdc_sync.py adds end-to-end tests asserting SystemExit and KeyboardInterrupt raised during partner-mode are re-raised and that the exception type name is logged; SystemExit test additionally asserts notify_sdc_complete is suppressed on abort.

Tests, style, commit
- New/updated tests: 1 new test in test_slack.py; 2 new + 3 updated tests in test_wikimedia_upload_status.py; 2 new tests in test_sdc_sync.py.
- Author reports 66 tests passing locally and ruff clean. Changes reference commit 6a3c6fd.

Impact / operational notes (explicit)
- Deployment: No manual pipeline trigger or ECS redeploy beyond the normal code deployment is required. Changes take effect when the updated code is deployed and run by existing schedules/workflows.
- Environment variables / Secrets Manager: No environment variables or AWS Secrets Manager keys were added, removed, or renamed (existing variables such as DPLA_SLACK_BOT_TOKEN and WIKIMEDIA_* remain unchanged).
- Database migrations: None.
- Shared infrastructure (CodePipeline/CodeBuild/ECS/IAM): No changes.
- Public API: No public-facing API or endpoint changes. get_phase_and_progress’s return shape change is internal to scripts and tests.
- Security: No credential-handling or authentication changes; no new external credentials introduced.

Behavioral caveat
- Widening the catch to BaseException only changes logging/diagnostic behavior for non-Exception aborts: these now log their type name and traceback before being re-raised. The function still re-raises such aborts, preserving failure semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->