### PR TITLE
uploader: suppress CommonsDelinker when moving away from a sibling slot

### DIFF
--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -963,3 +963,124 @@ def test_dup_sha1_sibling_false_when_duplicate_source_sha1s_is_empty_set():
         )
         is False
     )
+
+
+# --------------------------------------------------------------------------
+# CommonsDelinker suppression when actual_filename will be overwritten by
+# a later ordinal in the same session. See process_file's per-ordinal
+# iteration and _resolve_hash_drift's Case 1 / Case 3 paths.
+#
+# Background: when Case 3 moves existing_file → intended_title, the source
+# title becomes a redirect. If THAT title also happens to be one of this
+# item's other current asset positions (i.e. a later ordinal will write
+# different content to it), the CommonsDelinker request to rewrite
+# external references away from the source title becomes invalid the
+# moment the redirect is overwritten — external uses pointing at the new
+# content get silently rewritten to the wrong file. Suppress the
+# request in that case. The move itself is still useful (places the file
+# at its new canonical title cheaply); only the link-rewrite is wrong.
+# --------------------------------------------------------------------------
+
+
+_ITEM_PAGE_8 = "Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page 8).jpg"
+_ITEM_PAGE_11 = "Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page 11).jpg"
+
+
+def _make_intended_page(title, exists=False, is_redirect=False, redirect_target=None):
+    p = MagicMock()
+    p.exists.return_value = exists
+    p.isRedirectPage.return_value = is_redirect
+    p.title.return_value = title
+    if redirect_target:
+        rt = MagicMock()
+        rt.title.return_value = redirect_target
+        p.getRedirectTarget.return_value = rt
+    return p
+
+
+def test_case3_move_suppresses_commonsdelinker_when_actual_is_sibling():
+    """Reproduces the production bug: ord 11 of a multi-page item finds its
+    SHA1 at (page 11).jpg but its renumbered intended title is (page 8).jpg.
+    Case 3 fires — but (page 11).jpg is in this item's expected_item_titles
+    because a LATER ordinal will write different content to it. The
+    CommonsDelinker request must be suppressed."""
+    uploader = _build_uploader_with_dpla()
+    intended = _make_intended_page(_ITEM_PAGE_8, exists=False)
+    expected_titles = {
+        _ITEM_PAGE_8,
+        _ITEM_PAGE_11,  # ← sibling: another ordinal will overwrite this slot
+    }
+    with (
+        patch("tools.uploader.get_page", return_value=intended),
+        patch.object(uploader, "_move_to_correct_title") as mock_move,
+    ):
+        action = uploader._resolve_hash_drift(
+            existing_file=_drift_existing_file(_ITEM_PAGE_11),
+            page_title=_ITEM_PAGE_8,
+            dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ordinal=11,
+            wiki_markup="",
+            expected_item_titles=expected_titles,
+        )
+    assert action == "moved"
+    mock_move.assert_called_once()
+    kwargs = mock_move.call_args.kwargs
+    assert kwargs.get("post_commonsdelinker") is False, (
+        "Case 3 must suppress CommonsDelinker when actual_filename is a"
+        " sibling slot that will be overwritten by a later ordinal."
+    )
+
+
+def test_case3_move_posts_commonsdelinker_when_actual_is_not_sibling():
+    """The common case: existing file at a legacy NARA-bot title that's
+    NOT in the current asset positions. CommonsDelinker request stays."""
+    uploader = _build_uploader_with_dpla()
+    intended = _make_intended_page(_ITEM_PAGE_8, exists=False)
+    # Old NARA-bot title from an earlier scheme — not part of current asset list.
+    legacy_title = "Foo - NAID 99999.jpg"
+    expected_titles = {_ITEM_PAGE_8, _ITEM_PAGE_11}
+    with (
+        patch("tools.uploader.get_page", return_value=intended),
+        patch.object(uploader, "_move_to_correct_title") as mock_move,
+    ):
+        action = uploader._resolve_hash_drift(
+            existing_file=_drift_existing_file(legacy_title),
+            page_title=_ITEM_PAGE_8,
+            dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ordinal=11,
+            wiki_markup="",
+            expected_item_titles=expected_titles,
+        )
+    assert action == "moved"
+    kwargs = mock_move.call_args.kwargs
+    assert kwargs.get("post_commonsdelinker") is True, (
+        "Case 3 must post the CommonsDelinker request when actual_filename"
+        " is a legitimate orphan (not one of this item's current slots)."
+    )
+
+
+def test_case1_move_suppresses_commonsdelinker_when_actual_is_sibling():
+    """Case 1: intended title is a redirect pointing at actual_filename.
+    The Case-1 move overwrites the redirect with the file. Same
+    sibling-slot logic: if actual_filename is in expected_item_titles,
+    suppress the CommonsDelinker request."""
+    uploader = _build_uploader_with_dpla()
+    intended = _make_intended_page(
+        _ITEM_PAGE_8, exists=True, is_redirect=True, redirect_target=_ITEM_PAGE_11
+    )
+    expected_titles = {_ITEM_PAGE_8, _ITEM_PAGE_11}
+    with (
+        patch("tools.uploader.get_page", return_value=intended),
+        patch.object(uploader, "_move_to_correct_title") as mock_move,
+    ):
+        action = uploader._resolve_hash_drift(
+            existing_file=_drift_existing_file(_ITEM_PAGE_11),
+            page_title=_ITEM_PAGE_8,
+            dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ordinal=11,
+            wiki_markup="",
+            expected_item_titles=expected_titles,
+        )
+    assert action == "moved"
+    kwargs = mock_move.call_args.kwargs
+    assert kwargs.get("post_commonsdelinker") is False

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -759,11 +759,21 @@ class Uploader:
         dpla_id: str,
         case_label: str,
         wiki_markup: str | None = None,
+        post_commonsdelinker: bool = True,
     ) -> None:
         """Move existing_file to intended_page and post a CommonsDelinker request.
 
         If wiki_markup is provided, the moved page's description is updated to
         reflect current DPLA metadata after the move.
+
+        post_commonsdelinker controls whether we ask CommonsDelinker to
+        rewrite external references to actual_filename. Default True (the
+        usual title-drift case where actual_filename's redirect will outlive
+        this session). Callers pass False when they know actual_filename is
+        a sibling slot that another ordinal in this same session will
+        overwrite with different content — making the
+        rewrite-to-intended_filename request invalid the moment the
+        redirect is replaced.
         """
         actual_filename = existing_file.title(with_ns=False)
         intended_filename = intended_page.title(with_ns=False)
@@ -780,7 +790,16 @@ class Uploader:
             movetalk=False,
             noredirect=False,
         )
-        post_commonsdelinker_request(self.site, actual_filename, intended_filename)
+        if post_commonsdelinker:
+            post_commonsdelinker_request(self.site, actual_filename, intended_filename)
+        else:
+            logging.info(
+                f"Suppressing CommonsDelinker request "
+                f"[[File:{actual_filename}]] → [[File:{intended_filename}]]: "
+                f"actual_filename is one of this item's current asset "
+                f"positions and will be overwritten with different content "
+                f"by a later ordinal in this session."
+            )
 
         if wiki_markup:
             moved_page = get_page(self.site, intended_page.title())
@@ -864,10 +883,31 @@ class Uploader:
 
         intended_page = get_page(self.site, page_title)
 
+        # Pre-compute the "actual_filename is a sibling slot" guard once;
+        # used by Case 1 and Case 3 below to decide whether the post-move
+        # CommonsDelinker request would survive long enough to be valid.
+        # When actual_filename is one of this item's expected titles, a
+        # later ordinal's iteration will overwrite the redirect at
+        # actual_filename with different content. CommonsDelinker would
+        # then rewrite external references away from a title that is no
+        # longer a redirect — silently showing the wrong file to readers
+        # who landed via the rewritten link. Skip the request in that
+        # case; the move itself is still useful (it places the file at
+        # its new canonical title cheaply), but external link rewrites
+        # would be incorrect.
+        sibling_slot = bool(
+            expected_item_titles and actual_filename in expected_item_titles
+        )
+
         if not intended_page.exists():
             # Case 3: nothing at the intended title — simple move.
             self._move_to_correct_title(
-                existing_file, intended_page, dpla_id, "Case 3", wiki_markup
+                existing_file,
+                intended_page,
+                dpla_id,
+                "Case 3",
+                wiki_markup,
+                post_commonsdelinker=not sibling_slot,
             )
             return "moved"
 
@@ -877,7 +917,12 @@ class Uploader:
             redirect_target = intended_page.getRedirectTarget()
             if redirect_target.title(with_ns=False) == actual_filename:
                 self._move_to_correct_title(
-                    existing_file, intended_page, dpla_id, "Case 1", wiki_markup
+                    existing_file,
+                    intended_page,
+                    dpla_id,
+                    "Case 1",
+                    wiki_markup,
+                    post_commonsdelinker=not sibling_slot,
                 )
                 return "moved"
             # Intended title is a redirect, but its target is somewhere


### PR DESCRIPTION
## Bug

Observed live on Indiana State Library map collection upload, DPLA item `6ccf118701d9e96844bdf129dc2fcccc`:

```
09:37:22  Title drift (Case 3): moving (page 11).jpg → (page 8).jpg
09:37:39  Hash drift for {id} 14: intended title (page 11).jpg is a redirect to (page 8).jpg, …
          deferring to the redirect-handler in process_file
09:37:40  Replacing redirect at (page 11).jpg …
09:37:43  Uploaded to (page 11).jpg   ← different content
```

History on `(page 11).jpg`: https://commons.wikimedia.org/w/index.php?title=File:The_county_of_Wayne,_Indiana,_an_imperial_atlas_and_art_folio_-_DPLA_-_6ccf118701d9e96844bdf129dc2fcccc_(page_11).jpg&action=history

## Why does the move happen at all?

Legitimate. PR #173 introduced per-extension `(page N)` numbering. When the source has mixed content types (here ordinals 8–10 are `text/plain`), the JPG numbering compacts around the gaps — so ord 11's content moves from `(page 11)` to `(page 8)`. The move is correct.

## What's the bug?

The Case-3 move side-effects a CommonsDelinker request: "rewrite external references to `(page 11).jpg` → `(page 8).jpg`". Moments later, the redirect at `(page 11).jpg` gets overwritten by ord 14's different content (via the redirect-handler from PR #258). When CommonsDelinker eventually processes the queued request, external uses of `(page 11).jpg` are silently rewritten to `(page 8).jpg` — but `(page 11).jpg` now holds completely different content. Readers who followed the rewritten link see the wrong file.

The same `actual_filename in expected_item_titles` predicate already routes Case 2 → `upload_only` (uploader.py line ~914) precisely to avoid tagging a sibling slot as an orphan duplicate. Cases 1 and 3 had no equivalent guard.

## Fix

Add `post_commonsdelinker: bool = True` to `_move_to_correct_title`. In `_resolve_hash_drift`, compute `sibling_slot = actual_filename in expected_item_titles` once and pass `post_commonsdelinker=not sibling_slot` to both Case 1 and Case 3 move sites. The move still happens (cheap rename, places the file at its new canonical title); only the link-rewrite is suppressed in the cases where it would become invalid the moment a later ordinal lands.

## Test plan

- [x] 3 new tests in `tests/test_uploader.py`:
  - Case 3 with sibling-slot source → `post_commonsdelinker=False`
  - Case 3 with legitimate-orphan source → `post_commonsdelinker=True`
  - Case 1 with sibling-slot source → `post_commonsdelinker=False`
- [x] `pytest tests/` — **300 passed** on EC2 (Python 3.13).
- [x] `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix CommonsDelinker suppression for sibling slot overwrites during ordinal compaction

**Problem:** During file uploads with per-extension numbering, a Case-3 filename move (e.g., `(page 11).jpg` → `(page 8).jpg`) could queue a CommonsDelinker request to rewrite external references, but a subsequent upload could overwrite the original filename with different content. When CommonsDelinker later processed the queued request, it would incorrectly rewrite references that were no longer valid.

**Root cause:** The per-extension numbering system can cause ordinal compaction, which changes a file's canonical title. The move logic posted CommonsDelinker rewrite requests even when the source filename was a sibling slot that would be overwritten by a later ordinal. This predicate guard (`actual_filename in expected_item_titles`) already existed for Case 2 moves but was missing for Cases 1 and 3.

**Solution:**
- Add a `post_commonsdelinker` boolean parameter to `Uploader._move_to_correct_title()` (default `True`) to conditionally control whether CommonsDelinker rewrite requests are posted
- In `_resolve_hash_drift`, pre-compute whether the actual filename being moved is a sibling slot (`actual_filename in expected_item_titles`)
- For Case 1 and Case 3 moves, pass `post_commonsdelinker=not sibling_slot` so moves still occur but CommonsDelinker requests are suppressed when the sibling slot would be overwritten by a subsequent ordinal

**Changes:**
- `tools/uploader.py`: Added `post_commonsdelinker` parameter to `_move_to_correct_title()` and updated `_resolve_hash_drift` to conditionally suppress CommonsDelinker requests (+48/-3 lines)
- `tests/test_uploader.py`: Added three new test cases validating that Case 3 and Case 1 moves suppress CommonsDelinker requests when moving from sibling slots, plus a helper function `_make_intended_page()` for test setup (+121 lines)

All tests passing (300 tests) and ruff checks clean.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->