### PR TITLE
slack: add /wikimedia-upload sdc <target> subcommand

### DIFF
--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -145,6 +145,17 @@ def _dispatch_and_reply(
         return _slack_reply(
             f"Failed to trigger workflow (HTTP {e.code}).", ephemeral=ephemeral
         )
+    except TimeoutError:
+        # A slow GitHub API response often still results in a successful
+        # dispatch — telling the user "internal error" here is misleading,
+        # because the workflow may already be queued. Mirror the direct-
+        # launch path's softer message so the user knows where to verify.
+        logging.warning("Timeout waiting for GitHub dispatch response (%s)", workflow)
+        return _slack_reply(
+            "GitHub API was slow — workflow may have been dispatched anyway."
+            " Check #tech-alerts in ~2 minutes or the Actions tab to confirm.",
+            ephemeral=ephemeral,
+        )
     except Exception:
         logging.exception("Unexpected error dispatching workflow")
         return _slack_reply(
@@ -304,7 +315,7 @@ def handler(event, context):
                 ' `/wikimedia-upload "indiana|Indiana State Library"`\n'
                 "To stop a session: `/wikimedia-upload kill <label> [<label> ...]`\n"
                 "To retry transient failures: `/wikimedia-upload retry <days> [<partner>]`\n"
-                "To refresh S3 files: `/wikimedia-upload refresh <target> <days>`\n"
+                "To refresh S3 files: `/wikimedia-upload refresh <target> [<target> ...] <days>`\n"
                 "To re-run only the SDC sync phase: `/wikimedia-upload sdc <target> [<target> ...]`",
                 ephemeral=True,
             )
@@ -416,11 +427,12 @@ def handler(event, context):
             refresh_tokens = tokens[1:]
             if len(refresh_tokens) < 2:
                 return _slack_reply(
-                    "Usage: `/wikimedia-upload refresh <target> <days>`\n"
+                    "Usage: `/wikimedia-upload refresh <target> [<target> ...] <days>`\n"
                     "Re-downloads files already in S3 that are older than DAYS days,"
                     " without re-uploading to Commons.\n"
                     "Example: `/wikimedia-upload refresh ohio 90`\n"
-                    'Example: `/wikimedia-upload refresh "indiana|Indiana State Library" 30`',
+                    'Example: `/wikimedia-upload refresh "indiana|Indiana State Library" 30`\n'
+                    "Example: `/wikimedia-upload refresh bpl pa ohio 30`",
                     ephemeral=True,
                 )
             days, err = _parse_positive_int(refresh_tokens[-1])

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -14,6 +14,11 @@ Handles:
                          Wikidata QID        e.g. "Q12345"
   /wikimedia-upload kill <hub> [<hub> ...]
                      — dispatches wikimedia-kill.yml to stop running sessions.
+  /wikimedia-upload sdc <target> [<target> ...]
+                     — dispatches wikimedia-launch.yml with sdc_only=true to
+                       re-enumerate IDs and run the SDC sync phase only,
+                       skipping download + upload. Used to recover from
+                       aborted SDC syncs.
 
 Validates the incoming Slack request signature before dispatching.
 
@@ -89,6 +94,39 @@ def _slack_reply(text: str, ephemeral: bool = False) -> dict:
             }
         ),
     }
+
+
+def _launch_with_targets(
+    token: str,
+    repo: str,
+    response_url: str,
+    targets: list[str],
+    extra_inputs: dict,
+    success_text_fn,
+) -> dict:
+    """Dispatch ``wikimedia-launch.yml`` for a list of validated targets.
+
+    Shared by the ``sdc`` and ``refresh`` subcommands (and any future variant
+    that just toggles a launch.yml input). ``extra_inputs`` is merged with the
+    standard partner/response_url/concurrency_key payload; ``success_text_fn``
+    receives the comma-joined ```backtick``-wrapped targets_display.
+    """
+    if not targets:
+        return _slack_reply("No valid targets provided.", ephemeral=True)
+    partner_input = shlex.join(targets)
+    targets_display = ", ".join(f"`{t}`" for t in targets)
+    # Keep the concurrency group name well under GitHub's 400-char limit by
+    # hashing the full partner string down to a 16-char hex prefix.
+    concurrency_key = hashlib.sha256(partner_input.encode()).hexdigest()[:16]
+    inputs = {
+        "partner": partner_input,
+        "response_url": response_url,
+        "concurrency_key": concurrency_key,
+        **extra_inputs,
+    }
+    return _dispatch_and_reply(
+        token, repo, "wikimedia-launch.yml", inputs, success_text_fn(targets_display)
+    )
 
 
 def _dispatch_and_reply(
@@ -266,7 +304,8 @@ def handler(event, context):
                 ' `/wikimedia-upload "indiana|Indiana State Library"`\n'
                 "To stop a session: `/wikimedia-upload kill <label> [<label> ...]`\n"
                 "To retry transient failures: `/wikimedia-upload retry <days> [<partner>]`\n"
-                "To refresh S3 files: `/wikimedia-upload refresh <target> <days>`",
+                "To refresh S3 files: `/wikimedia-upload refresh <target> <days>`\n"
+                "To re-run only the SDC sync phase: `/wikimedia-upload sdc <target> [<target> ...]`",
                 ephemeral=True,
             )
 
@@ -343,6 +382,34 @@ def handler(event, context):
                 ephemeral=True,
             )
 
+        # SDC subcommand: /wikimedia-upload sdc <target> [<target> ...]
+        # Re-enumerates IDs and runs sdc-sync; skips download + upload phases.
+        # Used to recover SDC sync runs that were aborted before completion.
+        if tokens[0] == "sdc":
+            sdc_tokens = tokens[1:]
+            if not sdc_tokens:
+                return _slack_reply(
+                    "Usage: `/wikimedia-upload sdc <target> [<target> ...]`\n"
+                    "Re-enumerates IDs and runs the SDC sync phase only"
+                    " (skips download + upload).\n"
+                    'Example: `/wikimedia-upload sdc "nara|William J. Clinton Library"`',
+                    ephemeral=True,
+                )
+            sdc_targets, err = _validate_launch_targets(sdc_tokens)
+            if err is not None:
+                return err
+            return _launch_with_targets(
+                gh_token,
+                repo,
+                response_url,
+                sdc_targets,
+                {"sdc_only": "true"},
+                lambda targets_display: (
+                    f"Launching SDC-only sync for {targets_display}"
+                    " — confirmation will post to #tech-alerts shortly."
+                ),
+            )
+
         # Refresh subcommand: /wikimedia-upload refresh <target> [<target> ...] <days>
         # Re-downloads files older than DAYS days without running the uploader.
         if tokens[0] == "refresh":
@@ -362,25 +429,18 @@ def handler(event, context):
             refresh_targets, err = _validate_launch_targets(refresh_tokens[:-1])
             if err is not None:
                 return err
-            if not refresh_targets:
-                return _slack_reply("No valid targets provided.", ephemeral=True)
-            partner_input = shlex.join(refresh_targets)
-            targets_display = ", ".join(f"`{t}`" for t in refresh_targets)
-            concurrency_key = hashlib.sha256(partner_input.encode()).hexdigest()[:16]
-            return _dispatch_and_reply(
+            return _launch_with_targets(
                 gh_token,
                 repo,
-                "wikimedia-launch.yml",
-                {
-                    "partner": partner_input,
-                    "response_url": response_url,
-                    "concurrency_key": concurrency_key,
-                    "max_age_days": str(days),
-                    "refresh_only": "true",
-                },
-                f"Launching download refresh for {targets_display}"
-                f" — re-downloading files older than {days} day{'s' if days != 1 else ''}"
-                ", no upload. Confirmation will post to #tech-alerts shortly.",
+                response_url,
+                refresh_targets,
+                {"max_age_days": str(days), "refresh_only": "true"},
+                lambda targets_display: (
+                    f"Launching download refresh for {targets_display}"
+                    f" — re-downloading files older than {days}"
+                    f" day{'s' if days != 1 else ''}, no upload."
+                    " Confirmation will post to #tech-alerts shortly."
+                ),
             )
 
         # Launch subcommand: /wikimedia-upload <target> [<target> ...]

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -96,6 +96,23 @@ def _slack_reply(text: str, ephemeral: bool = False) -> dict:
     }
 
 
+def _is_dispatch_timeout(exc: BaseException) -> bool:
+    """True if ``exc`` indicates the dispatch may have arrived late, not failed.
+
+    ``urllib.request.urlopen()`` with a ``timeout=`` argument doesn't propagate
+    a raw ``TimeoutError`` — the underlying ``socket.timeout`` (aliased to
+    ``TimeoutError`` in Python 3.10+) is wrapped inside ``urllib.error.URLError``
+    via ``URLError.reason``. Catching only ``TimeoutError`` would therefore miss
+    the realistic slow-but-delivered case and route it to the misleading
+    "internal error" branch.
+    """
+    if isinstance(exc, TimeoutError):
+        return True
+    if isinstance(exc, urllib.error.URLError):
+        return isinstance(getattr(exc, "reason", None), TimeoutError)
+    return False
+
+
 def _launch_with_targets(
     token: str,
     repo: str,
@@ -145,16 +162,25 @@ def _dispatch_and_reply(
         return _slack_reply(
             f"Failed to trigger workflow (HTTP {e.code}).", ephemeral=ephemeral
         )
-    except TimeoutError:
+    except (TimeoutError, urllib.error.URLError) as e:
         # A slow GitHub API response often still results in a successful
-        # dispatch — telling the user "internal error" here is misleading,
-        # because the workflow may already be queued. Mirror the direct-
-        # launch path's softer message so the user knows where to verify.
-        logging.warning("Timeout waiting for GitHub dispatch response (%s)", workflow)
+        # dispatch — telling the user "internal error" in that case is
+        # misleading, because the workflow may already be queued. Use the
+        # softer message only for timeout-shaped errors; other URL errors
+        # (DNS failure, connection refused, etc.) still indicate the
+        # dispatch did not happen and should keep the hard-failure wording.
+        if _is_dispatch_timeout(e):
+            logging.warning(
+                "Timeout waiting for GitHub dispatch response (%s)", workflow
+            )
+            return _slack_reply(
+                "GitHub API was slow — workflow may have been dispatched anyway."
+                " Check #tech-alerts in ~2 minutes or the Actions tab to confirm.",
+                ephemeral=ephemeral,
+            )
+        logging.exception("URL error dispatching workflow")
         return _slack_reply(
-            "GitHub API was slow — workflow may have been dispatched anyway."
-            " Check #tech-alerts in ~2 minutes or the Actions tab to confirm.",
-            ephemeral=ephemeral,
+            "Failed to trigger workflow due to an internal error.", ephemeral=ephemeral
         )
     except Exception:
         logging.exception("Unexpected error dispatching workflow")
@@ -484,14 +510,19 @@ def handler(event, context):
             return _slack_reply(
                 f"Failed to launch pipeline for {targets_display} (HTTP {e.code})."
             )
-        except TimeoutError:
-            logging.warning(
-                "Timeout waiting for GitHub dispatch response for targets: %s",
-                targets_display,
-            )
+        except (TimeoutError, urllib.error.URLError) as e:
+            if _is_dispatch_timeout(e):
+                logging.warning(
+                    "Timeout waiting for GitHub dispatch response for targets: %s",
+                    targets_display,
+                )
+                return _slack_reply(
+                    f"GitHub API was slow — pipeline for {targets_display} may have been dispatched anyway. "
+                    "Check #tech-alerts in ~2 minutes or the Actions tab to confirm."
+                )
+            logging.exception("URL error dispatching workflow")
             return _slack_reply(
-                f"GitHub API was slow — pipeline for {targets_display} may have been dispatched anyway. "
-                "Check #tech-alerts in ~2 minutes or the Actions tab to confirm."
+                f"Failed to launch pipeline for {targets_display} due to an internal error."
             )
         except Exception:
             logging.exception("Unexpected error dispatching workflow")

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -147,14 +147,14 @@ def test_top_level_usage_mentions_sdc_subcommand(monkeypatch, handler_module):
     assert "/wikimedia-upload sdc" in text
 
 
-def test_dispatch_helper_treats_timeout_as_possibly_dispatched(
+def test_dispatch_helper_treats_raw_timeout_as_possibly_dispatched(
     monkeypatch, handler_module
 ):
-    """Timeouts from `_dispatch_workflow` must not surface as 'internal error'.
+    """Bare ``TimeoutError`` must not surface as 'internal error'.
 
-    A slow GitHub API response often still results in a successful dispatch,
-    so the helper-routed paths (``sdc`` / ``refresh``) must mirror the
-    direct-launch path's softer message instead of reporting failure.
+    Kept as a backstop even though ``urllib.request.urlopen`` normally wraps
+    timeouts in ``URLError`` — defensive in case a future urllib change (or
+    a different code path) propagates the raw exception.
     """
     monkeypatch.setenv("SLACK_SIGNING_SECRET", "shh")
     monkeypatch.setenv("GH_TOKEN", "tok")
@@ -176,3 +176,70 @@ def test_dispatch_helper_treats_timeout_as_possibly_dispatched(
     assert "internal error" not in text.lower()
     assert "may have been dispatched" in text
     assert "#tech-alerts" in text
+
+
+def test_dispatch_helper_treats_urlerror_wrapping_timeout_as_possibly_dispatched(
+    monkeypatch, handler_module
+):
+    """The realistic urllib timeout shape: ``URLError`` wrapping ``TimeoutError``.
+
+    ``urllib.request.urlopen()`` does not propagate a raw ``TimeoutError`` from
+    its ``timeout=`` parameter — it wraps the underlying ``socket.timeout``
+    (aliased to ``TimeoutError`` in Python 3.10+) inside ``URLError.reason``.
+    This is the shape that actually hits the Lambda in production, so the
+    timeout branch must recognise it and route to the softer message.
+    """
+    import urllib.error
+
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "shh")
+    monkeypatch.setenv("GH_TOKEN", "tok")
+    monkeypatch.setattr(
+        handler_module, "_verify_slack_signature", lambda *_a, **_k: True
+    )
+
+    def wrapped_timeout_dispatch(*_a, **_k):
+        raise urllib.error.URLError(TimeoutError("timed out"))
+
+    monkeypatch.setattr(handler_module, "_dispatch_workflow", wrapped_timeout_dispatch)
+
+    reply = handler_module.handler(
+        _make_event('sdc "nara|William J. Clinton Library"'), None
+    )
+
+    assert reply["statusCode"] == 200
+    text = _decode_reply(reply)["text"]
+    assert "internal error" not in text.lower()
+    assert "may have been dispatched" in text
+    assert "#tech-alerts" in text
+
+
+def test_dispatch_helper_non_timeout_urlerror_is_hard_failure(
+    monkeypatch, handler_module
+):
+    """A non-timeout URLError (DNS, connection refused) must NOT use the soft message.
+
+    Only timeout-shaped URLErrors leave the dispatch in ambiguous-status
+    territory. A connection refused or DNS failure means the request never
+    arrived, so the hard-failure wording is correct.
+    """
+    import urllib.error
+
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "shh")
+    monkeypatch.setenv("GH_TOKEN", "tok")
+    monkeypatch.setattr(
+        handler_module, "_verify_slack_signature", lambda *_a, **_k: True
+    )
+
+    def refused_dispatch(*_a, **_k):
+        raise urllib.error.URLError(ConnectionRefusedError("connection refused"))
+
+    monkeypatch.setattr(handler_module, "_dispatch_workflow", refused_dispatch)
+
+    reply = handler_module.handler(
+        _make_event('sdc "nara|William J. Clinton Library"'), None
+    )
+
+    assert reply["statusCode"] == 200
+    text = _decode_reply(reply)["text"]
+    assert "may have been dispatched" not in text
+    assert "internal error" in text.lower()

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1,0 +1,147 @@
+"""
+Tests for the Slack slash-command Lambda handler.
+
+The handler lives outside the importable package (in ``lambda/...``), so the
+tests load it via ``importlib`` rather than a normal ``import`` statement.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HANDLER_PATH = REPO_ROOT / "lambda" / "wikimedia-slack-dispatch" / "handler.py"
+
+
+@pytest.fixture(scope="module")
+def handler_module():
+    # Ensure the package import inside the handler resolves to the repo's
+    # ingest_wikimedia, not anything installed globally.
+    sys.path.insert(0, str(REPO_ROOT))
+    spec = importlib.util.spec_from_file_location(
+        "slack_dispatch_handler", HANDLER_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_event(text: str) -> dict:
+    body = urllib.parse.urlencode(
+        {
+            "command": "/wikimedia-upload",
+            "text": text,
+            "response_url": "https://hooks.slack.example/response",
+        }
+    )
+    return {
+        "headers": {
+            "x-slack-request-timestamp": "0",
+            "x-slack-signature": "v0=stub",
+        },
+        "body": body,
+    }
+
+
+def _setup_env_and_stubs(monkeypatch, handler_module, dispatched: list[dict]):
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "shh")
+    monkeypatch.setenv("GH_TOKEN", "tok")
+    monkeypatch.setattr(
+        handler_module, "_verify_slack_signature", lambda *_a, **_k: True
+    )
+
+    def fake_dispatch(token, repo, workflow, inputs):
+        dispatched.append({"workflow": workflow, "inputs": inputs})
+        return 204
+
+    monkeypatch.setattr(handler_module, "_dispatch_workflow", fake_dispatch)
+
+
+def _decode_reply(reply: dict) -> dict:
+    return json.loads(reply["body"])
+
+
+def test_sdc_subcommand_dispatches_launch_with_sdc_only_true(
+    monkeypatch, handler_module
+):
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(
+        _make_event('sdc "nara|William J. Clinton Library"'), None
+    )
+
+    assert reply["statusCode"] == 200
+    assert len(dispatched) == 1
+    call = dispatched[0]
+    assert call["workflow"] == "wikimedia-launch.yml"
+    assert call["inputs"]["sdc_only"] == "true"
+    # SDC-only must never set refresh_only (mutually exclusive in wikimedia_launch.py).
+    assert "refresh_only" not in call["inputs"]
+    assert call["inputs"]["partner"] == "'nara|William J. Clinton Library'"
+    # concurrency_key is required so SDC + regular launch queue against each
+    # other; ``_launch_with_targets`` derives it from the partner string.
+    assert len(call["inputs"]["concurrency_key"]) == 16
+    assert "SDC-only sync" in _decode_reply(reply)["text"]
+
+
+def test_sdc_subcommand_supports_multiple_targets(monkeypatch, handler_module):
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(
+        _make_event(
+            'sdc "nara|William J. Clinton Library" "nara|John F. Kennedy Library"'
+        ),
+        None,
+    )
+
+    assert reply["statusCode"] == 200
+    assert len(dispatched) == 1
+    partner = dispatched[0]["inputs"]["partner"]
+    # shlex.join re-quotes targets containing spaces — both must survive.
+    assert "William J. Clinton Library" in partner
+    assert "John F. Kennedy Library" in partner
+
+
+def test_sdc_subcommand_with_no_targets_returns_usage(monkeypatch, handler_module):
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(_make_event("sdc"), None)
+
+    assert reply["statusCode"] == 200
+    assert dispatched == []  # no workflow dispatched on usage-error replies
+    text = _decode_reply(reply)["text"]
+    assert "Usage:" in text
+    assert "/wikimedia-upload sdc" in text
+
+
+def test_sdc_subcommand_rejects_unknown_hub(monkeypatch, handler_module):
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(_make_event("sdc not-a-real-hub"), None)
+
+    assert reply["statusCode"] == 200
+    assert dispatched == []
+    assert "Unknown hub" in _decode_reply(reply)["text"]
+
+
+def test_top_level_usage_mentions_sdc_subcommand(monkeypatch, handler_module):
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(_make_event(""), None)
+
+    assert reply["statusCode"] == 200
+    text = _decode_reply(reply)["text"]
+    assert "/wikimedia-upload sdc" in text

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -145,3 +145,34 @@ def test_top_level_usage_mentions_sdc_subcommand(monkeypatch, handler_module):
     assert reply["statusCode"] == 200
     text = _decode_reply(reply)["text"]
     assert "/wikimedia-upload sdc" in text
+
+
+def test_dispatch_helper_treats_timeout_as_possibly_dispatched(
+    monkeypatch, handler_module
+):
+    """Timeouts from `_dispatch_workflow` must not surface as 'internal error'.
+
+    A slow GitHub API response often still results in a successful dispatch,
+    so the helper-routed paths (``sdc`` / ``refresh``) must mirror the
+    direct-launch path's softer message instead of reporting failure.
+    """
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "shh")
+    monkeypatch.setenv("GH_TOKEN", "tok")
+    monkeypatch.setattr(
+        handler_module, "_verify_slack_signature", lambda *_a, **_k: True
+    )
+
+    def slow_dispatch(*_a, **_k):
+        raise TimeoutError("simulated slow GitHub API")
+
+    monkeypatch.setattr(handler_module, "_dispatch_workflow", slow_dispatch)
+
+    reply = handler_module.handler(
+        _make_event('sdc "nara|William J. Clinton Library"'), None
+    )
+
+    assert reply["statusCode"] == 200
+    text = _decode_reply(reply)["text"]
+    assert "internal error" not in text.lower()
+    assert "may have been dispatched" in text
+    assert "#tech-alerts" in text


### PR DESCRIPTION
## Summary
- Adds a new `/wikimedia-upload sdc <target> [<target> ...]` slash subcommand that dispatches `wikimedia-launch.yml` with `sdc_only=true`. Previously, recovering an aborted SDC sync required `gh workflow run` from a terminal or the Actions UI — the slash handler never wired the `sdc_only` launch input through.
- Refactors the duplicated `_validate_launch_targets → shlex.join → sha256 concurrency_key → _dispatch_and_reply` chain (previously copy-pasted between `refresh` and the new `sdc` block) into a single `_launch_with_targets` helper.
- Adds `tests/test_lambda_handler.py` — first tests for the Lambda handler. Covers happy path (`sdc_only=true` is set, `refresh_only` is **not** set, partner shlex-joined, concurrency_key present), multi-target dispatch, usage reply when no targets supplied, unknown-hub rejection, and that the top-level usage advertises the new subcommand.

Background: 13 explicit "SDC sync aborted before completion" entries appeared in NARA logs over the past three days. The friction of the manual `gh workflow run` path discouraged prompt retries; this closes the gap so the same Slack workflow that handles launches and refreshes can also re-run SDC.

## Test plan
- [ ] Pytest passes (CI)
- [ ] After merge + Lambda redeploy: `/wikimedia-upload sdc "nara|William J. Clinton Library"` dispatches `wikimedia-launch.yml` with `sdc_only=true` and posts a `Launching SDC-only sync for ...` confirmation to #tech-alerts
- [ ] `/wikimedia-upload sdc` (no targets) returns the usage hint ephemerally
- [ ] `/wikimedia-upload sdc not-a-real-hub` returns "Unknown hub: ..." ephemerally
- [ ] `/wikimedia-upload refresh ohio 90` (regression) still works after the `_launch_with_targets` extraction
- [ ] Top-level `/wikimedia-upload` (no args) help now lists `sdc` alongside `kill`/`retry`/`refresh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a new /wikimedia-upload sdc <target> [<target> ...] Slack slash subcommand to enable recovery from aborted SDC (Structured Data on Commons) syncs. The handler dispatches the existing GitHub Actions workflow wikimedia-launch.yml with sdc_only=true so users can re-enumerate IDs and run only the SDC sync phase (skipping download + upload).

### Changes

lambda/wikimedia-slack-dispatch/handler.py
- Added the `sdc` subcommand handler accepting the same target grammar as existing commands (hub, hub|institution, hub|institution|collection; also supports DPLA/Wikidata IDs as before).
- Introduced `_launch_with_targets(...)` to centralize: target validation → partner string construction (shlex.join) → deterministic SHA256-derived 16-character concurrency_key → workflow dispatch → Slack reply. This replaces duplicated logic between `refresh` and the new `sdc` handler.
- `sdc` dispatches wikimedia-launch.yml with `sdc_only=true` and does not set `refresh_only`.
- Refactored the existing `/wikimedia-upload refresh` path to use `_launch_with_targets(...)` and to accept multiple targets plus trailing <days>.
- Improved dispatch error handling:
  - Added `_is_dispatch_timeout(...)` to treat raw TimeoutError and URLError-wrapping-TimeoutError as timeout-shaped errors.
  - `_dispatch_and_reply(...)` now returns a softer “may have been dispatched” message when timeouts occur (directing users to `#tech-alerts` / Actions) and a harder “internal error” wording for non-timeout URL failures.
- Updated module docstring and top-level usage/help text to document the new `sdc` subcommand.

tests/test_lambda_handler.py
- Expanded tests to cover `sdc` behavior and dispatch error handling (importing the handler module, stubbing env, forcing Slack signature verification success, and monkeypatching `_dispatch_workflow`).
- Added tests verifying:
  - Happy path: dispatch includes `sdc_only == "true"`, `refresh_only` not set, partner preserved (quoted targets retained), concurrency_key present (16 chars), and reply mentions SDC-only sync.
  - Multiple targets dispatch into a single workflow with combined partner string.
  - Usage reply (no dispatch) when `sdc` is invoked without targets.
  - Unknown hub rejection returns ephemeral error (no dispatch).
  - Top-level `/wikimedia-upload` usage mentions `sdc`.
  - Timeout-shape error cases (raw TimeoutError and URLError wrapping TimeoutError) cause the softer “may have been dispatched” reply and still return HTTP 200.
  - Non-timeout URLError (e.g., connection refused) is treated as a hard failure and returns messaging that indicates an internal error (still HTTP 200).

### Deployment & infra impact

- Requires a Lambda redeploy (this is a Lambda handler change). No extra manual pipeline trigger or ECS redeployment beyond the normal Lambda deployment process.
- No environment variables or AWS Secrets Manager keys are added, removed, or renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No changes to public HTTP API shapes; this is a new Slack slash subcommand exposed via the existing Slack app.

### Security considerations

- No new credentials introduced; existing environment variables (e.g., SLACK_SIGNING_SECRET and GH_TOKEN) remain in use.
- Slack signature verification remains enabled.
- The handler forwards response_url and GitHub dispatch inputs as before; there are no additional external credential-handling changes.

### Behavior changes / Notes

- New public Slack slash subcommand: `/wikimedia-upload sdc <target> [<target> ...]`.
- Top-level `/wikimedia-upload` help now lists `sdc`.
- Existing subcommands (including `refresh`) are refactored to use the shared helper and remain functionally unchanged.
- Dispatch-timeout handling is refined: timeout-shaped failures produce softer messaging advising the workflow may already have been queued; non-timeout URL errors produce hard-failure messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->