### PR TITLE
sdc-sync: raise RuntimeError instead of sys.exit on Commons write failures

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -516,3 +516,109 @@ def test_run_partner_mode_logs_traceback_on_keyboardinterrupt(
 
     messages = " | ".join(r.getMessage() for r in caplog.records)
     assert "KeyboardInterrupt" in messages
+
+
+# --------------------------------------------------------------------------
+# Tests for SDC POST helpers raising RuntimeError instead of sys.exit().
+#
+# Background: the original sys.exit() calls in _post_new_refs /
+# _post_new_claims / _reconcile_existing_claims aborted the entire
+# partner batch for a single failed Commons write. SystemExit is a
+# BaseException, so the per-ordinal `except Exception:` in
+# process_one_from_sdc could not catch it. Replacing with
+# `raise RuntimeError(...)`:
+#   1. Makes the failure self-documenting (mediaid + dpla_id + the
+#      response body / underlying exception type).
+#   2. Routes through the per-ordinal handler, so the partner batch
+#      logs the traceback and continues with the next ordinal instead
+#      of losing thousands of items' worth of work.
+# --------------------------------------------------------------------------
+
+
+def test_truncate_helper_returns_under_limit_unchanged_and_truncates_long():
+    """Sanity check for the _truncate helper used in the new error messages."""
+    from tools import sdc_sync
+
+    assert sdc_sync._truncate("short", limit=100) == "short"
+    truncated = sdc_sync._truncate("x" * 1000, limit=10)
+    assert truncated.startswith("x" * 10)
+    assert "truncated" in truncated
+    assert "1000" in truncated  # original length is preserved in the suffix
+    assert sdc_sync._truncate(None) == ""
+
+
+def test_post_new_refs_raises_runtime_error_on_non_success_save(monkeypatch):
+    """A non-success wbeditentity refs response must raise RuntimeError,
+    not call sys.exit(). The error message must include the mediaid and
+    DPLA id so the failure is self-identifying in the SDC log."""
+    from tools import sdc_sync
+
+    response = MagicMock()
+    response.text = '{"error": {"code": "badtoken", "info": "Invalid token"}}'
+
+    # Pre-populate the module-level refclaims so the helper actually posts.
+    monkeypatch.setitem(sdc_sync.refclaims, "claims", [{"some": "ref"}])
+    monkeypatch.setattr(sdc_sync, "token", "stub-token", raising=False)
+    monkeypatch.setattr(sdc_sync.http, "fetch", lambda *a, **kw: response)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        sdc_sync._post_new_refs("M12345", "abcdef01abcdef01abcdef01abcdef01")
+
+    msg = str(excinfo.value)
+    assert "M12345" in msg
+    assert "abcdef01abcdef01abcdef01abcdef01" in msg
+    assert "non-success" in msg
+
+
+def test_post_new_claims_raises_runtime_error_on_non_success_save(monkeypatch):
+    """Same contract for the claims POST helper."""
+    from tools import sdc_sync
+
+    response = MagicMock()
+    response.text = '{"error": {"code": "ratelimited"}}'
+
+    monkeypatch.setitem(sdc_sync.claims, "claims", [{"some": "claim"}])
+    monkeypatch.setattr(sdc_sync, "token", "stub-token", raising=False)
+    monkeypatch.setattr(sdc_sync.http, "fetch", lambda *a, **kw: response)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        sdc_sync._post_new_claims("M67890", "fedcba98fedcba98fedcba98fedcba98")
+
+    msg = str(excinfo.value)
+    assert "M67890" in msg
+    assert "fedcba98fedcba98fedcba98fedcba98" in msg
+    assert "non-success" in msg
+
+
+def test_post_new_refs_runtime_error_caught_by_per_ordinal_handler(monkeypatch):
+    """The RuntimeError raised from inside _post_new_refs must be a
+    plain Exception subclass (not BaseException), so the per-ordinal
+    `except Exception:` in process_one_from_sdc catches it and the
+    partner batch can continue with the next ordinal.
+
+    This is the key behavioural difference vs the old sys.exit() — old
+    code raised SystemExit (BaseException, not caught by the per-ordinal
+    handler), so a single failed write tanked the entire partner.
+    """
+    from tools import sdc_sync
+
+    response = MagicMock()
+    response.text = '{"error": {"code": "badtoken"}}'
+    monkeypatch.setitem(sdc_sync.refclaims, "claims", [{"some": "ref"}])
+    monkeypatch.setattr(sdc_sync, "token", "stub-token", raising=False)
+    monkeypatch.setattr(sdc_sync.http, "fetch", lambda *a, **kw: response)
+
+    skipped = False
+    try:
+        sdc_sync._post_new_refs("M12345", "abcdef01abcdef01abcdef01abcdef01")
+    except Exception:
+        # This is the same `except Exception:` clause that wraps each
+        # ordinal in process_one_from_sdc — catching it here proves the
+        # per-ordinal handler will skip rather than abort the partner.
+        skipped = True
+
+    assert skipped, (
+        "RuntimeError from _post_new_refs must be an Exception subclass so the"
+        " per-ordinal handler in process_one_from_sdc catches it (was previously"
+        " SystemExit, which bypassed that handler and aborted the whole partner)"
+    )

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -578,11 +578,21 @@ def _install_module_globals(
 def test_post_new_refs_raises_runtime_error_on_non_success_save(monkeypatch):
     """A non-success wbeditentity refs response must raise RuntimeError,
     not call sys.exit(). The error message must include the mediaid and
-    DPLA id so the failure is self-identifying in the SDC log."""
+    DPLA id so the failure is self-identifying in the SDC log.
+
+    The response payload must carry an explicit ``"success": 0`` so the
+    helper's initial save lands in the ``else`` branch (the path that
+    raises the structured "non-success" error). A response with no
+    ``"success"`` key at all would raise KeyError instead and divert
+    into the relogin retry — useful for the catch-by-per-ordinal test
+    below, but not what this one is checking.
+    """
     from tools import sdc_sync
 
     response = MagicMock()
-    response.text = '{"error": {"code": "badtoken", "info": "Invalid token"}}'
+    response.text = (
+        '{"success": 0, "error": {"code": "badtoken", "info": "Invalid token"}}'
+    )
     _install_module_globals(
         monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
     )
@@ -601,7 +611,7 @@ def test_post_new_claims_raises_runtime_error_on_non_success_save(monkeypatch):
     from tools import sdc_sync
 
     response = MagicMock()
-    response.text = '{"error": {"code": "ratelimited"}}'
+    response.text = '{"success": 0, "error": {"code": "ratelimited"}}'
     _install_module_globals(
         monkeypatch, sdc_sync, response, claims_payload=[{"some": "claim"}]
     )
@@ -628,7 +638,7 @@ def test_post_new_refs_runtime_error_caught_by_per_ordinal_handler(monkeypatch):
     from tools import sdc_sync
 
     response = MagicMock()
-    response.text = '{"error": {"code": "badtoken"}}'
+    response.text = '{"success": 0, "error": {"code": "badtoken"}}'
     _install_module_globals(
         monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
     )

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -547,6 +547,34 @@ def test_truncate_helper_returns_under_limit_unchanged_and_truncates_long():
     assert sdc_sync._truncate(None) == ""
 
 
+def _install_module_globals(
+    monkeypatch, sdc_sync, response, *, refclaims_payload=None, claims_payload=None
+):
+    """Inject the module-level globals the SDC POST helpers expect.
+
+    ``refclaims`` / ``claims`` / ``token`` are not initialised at import
+    time — they're declared ``global`` and populated inside ``process_one``
+    / ``process_one_from_sdc`` before each item. Tests that call the POST
+    helpers directly have to install those globals themselves;
+    ``raising=False`` lets monkeypatch set + tear down attributes that
+    didn't exist on the module yet.
+    """
+    monkeypatch.setattr(
+        sdc_sync,
+        "refclaims",
+        {"claims": refclaims_payload if refclaims_payload is not None else []},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        sdc_sync,
+        "claims",
+        {"claims": claims_payload if claims_payload is not None else []},
+        raising=False,
+    )
+    monkeypatch.setattr(sdc_sync, "token", "stub-token", raising=False)
+    monkeypatch.setattr(sdc_sync.http, "fetch", lambda *a, **kw: response)
+
+
 def test_post_new_refs_raises_runtime_error_on_non_success_save(monkeypatch):
     """A non-success wbeditentity refs response must raise RuntimeError,
     not call sys.exit(). The error message must include the mediaid and
@@ -555,11 +583,9 @@ def test_post_new_refs_raises_runtime_error_on_non_success_save(monkeypatch):
 
     response = MagicMock()
     response.text = '{"error": {"code": "badtoken", "info": "Invalid token"}}'
-
-    # Pre-populate the module-level refclaims so the helper actually posts.
-    monkeypatch.setitem(sdc_sync.refclaims, "claims", [{"some": "ref"}])
-    monkeypatch.setattr(sdc_sync, "token", "stub-token", raising=False)
-    monkeypatch.setattr(sdc_sync.http, "fetch", lambda *a, **kw: response)
+    _install_module_globals(
+        monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
+    )
 
     with pytest.raises(RuntimeError) as excinfo:
         sdc_sync._post_new_refs("M12345", "abcdef01abcdef01abcdef01abcdef01")
@@ -576,10 +602,9 @@ def test_post_new_claims_raises_runtime_error_on_non_success_save(monkeypatch):
 
     response = MagicMock()
     response.text = '{"error": {"code": "ratelimited"}}'
-
-    monkeypatch.setitem(sdc_sync.claims, "claims", [{"some": "claim"}])
-    monkeypatch.setattr(sdc_sync, "token", "stub-token", raising=False)
-    monkeypatch.setattr(sdc_sync.http, "fetch", lambda *a, **kw: response)
+    _install_module_globals(
+        monkeypatch, sdc_sync, response, claims_payload=[{"some": "claim"}]
+    )
 
     with pytest.raises(RuntimeError) as excinfo:
         sdc_sync._post_new_claims("M67890", "fedcba98fedcba98fedcba98fedcba98")
@@ -604,9 +629,9 @@ def test_post_new_refs_runtime_error_caught_by_per_ordinal_handler(monkeypatch):
 
     response = MagicMock()
     response.text = '{"error": {"code": "badtoken"}}'
-    monkeypatch.setitem(sdc_sync.refclaims, "claims", [{"some": "ref"}])
-    monkeypatch.setattr(sdc_sync, "token", "stub-token", raising=False)
-    monkeypatch.setattr(sdc_sync.http, "fetch", lambda *a, **kw: response)
+    _install_module_globals(
+        monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
+    )
 
     skipped = False
     try:

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1702,7 +1702,7 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
             print(" --- Error encountered on removals save.")
             raise RuntimeError(
                 f"wbremoveclaims save returned non-success for"
-                f" {mediaid} ({dpla_id}): {rm_post}"
+                f" {mediaid} ({dpla_id}): {_truncate(rm_resp.text)}"
             )
 
 

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -117,7 +117,7 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
-def _truncate(text: str, limit: int = 500) -> str:
+def _truncate(text: str | None, limit: int = 500) -> str:
     """Return ``text`` shortened to ``limit`` chars with an ellipsis suffix.
 
     Used to keep RuntimeError messages from the SDC POST helpers readable

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -10,7 +10,6 @@ import datetime
 import argparse
 import random
 import os
-import sys
 import time
 import tomllib
 import urllib.parse
@@ -116,6 +115,22 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     return p
+
+
+def _truncate(text: str, limit: int = 500) -> str:
+    """Return ``text`` shortened to ``limit`` chars with an ellipsis suffix.
+
+    Used to keep RuntimeError messages from the SDC POST helpers readable
+    when Commons returns a verbose error body — the full response still
+    ends up in the per-ordinal traceback via ``logging.exception``; the
+    truncated version is just for the one-line message.
+    """
+    if text is None:
+        return ""
+    text = str(text)
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"... [truncated, {len(text)} chars total]"
 
 
 def _normalize_rights_uri(uri):
@@ -1271,9 +1286,12 @@ def _post_new_refs(mediaid, dpla_id):
                     method="POST",
                     data=postrefs,
                 )
-            except (requests.exceptions.ConnectionError, ConnectionError):
+            except (requests.exceptions.ConnectionError, ConnectionError) as final_e:
                 print(" --- Network error posting new refs: all retries failed.")
-                sys.exit()
+                raise RuntimeError(
+                    f"Network error posting new refs for {mediaid} ({dpla_id}):"
+                    " all 3 ConnectionError retries failed"
+                ) from final_e
     try:
         post = json.loads(save.text)
         if post["success"] == 1:
@@ -1282,7 +1300,14 @@ def _post_new_refs(mediaid, dpla_id):
         else:
             print(post)
             print(" --- Error encountered on save.")
-            sys.exit()
+            raise RuntimeError(
+                f"wbeditentity refs save returned non-success for"
+                f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
+            )
+    except RuntimeError:
+        # Our own structured failure — let the per-ordinal handler see it
+        # as-is rather than restarting the relogin path below.
+        raise
     except Exception:
         try:
             token = login()
@@ -1296,13 +1321,20 @@ def _post_new_refs(mediaid, dpla_id):
             if post["success"] == 1:
                 print(" --- Saved new refs!")
                 tracker.increment(Result.SDC_REFS_ADDED, refs_to_post)
-            else:
-                print(post)
-                print(" --- Error encountered on save.")
-                sys.exit()
-        except Exception:
-            print(" --- Error encountered. 2")
-            sys.exit()
+                return
+            print(post)
+            print(" --- Error encountered on save.")
+            raise RuntimeError(
+                f"wbeditentity refs save still non-success after relogin for"
+                f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
+            )
+        except RuntimeError:
+            raise
+        except Exception as retry_e:
+            print(f" --- Error encountered. 2: {retry_e!r}")
+            raise RuntimeError(
+                f"Refs relogin+save failed for {mediaid} ({dpla_id})"
+            ) from retry_e
 
 
 def _post_new_claims(mediaid, dpla_id):
@@ -1344,9 +1376,12 @@ def _post_new_claims(mediaid, dpla_id):
                     method="POST",
                     data=postdata,
                 )
-            except (requests.exceptions.ConnectionError, ConnectionError):
+            except (requests.exceptions.ConnectionError, ConnectionError) as final_e:
                 print(" --- Network error posting new claims: all retries failed.")
-                sys.exit()
+                raise RuntimeError(
+                    f"Network error posting new claims for {mediaid} ({dpla_id}):"
+                    " all 3 ConnectionError retries failed"
+                ) from final_e
     try:
         post = json.loads(save.text)
         if post["success"] == 1:
@@ -1355,7 +1390,12 @@ def _post_new_claims(mediaid, dpla_id):
         else:
             print(post)
             print(" --- Error encountered on save.")
-            sys.exit()
+            raise RuntimeError(
+                f"wbeditentity claims save returned non-success for"
+                f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
+            )
+    except RuntimeError:
+        raise
     except Exception:
         try:
             token = login()
@@ -1369,10 +1409,15 @@ def _post_new_claims(mediaid, dpla_id):
             if post["success"] == 1:
                 print(" --- Saved new claims!")
                 tracker.increment(Result.SDC_CLAIMS_ADDED, claims_to_post)
-            else:
-                print(post)
-                print(" --- Error encountered on save.")
-                sys.exit()
+                return
+            print(post)
+            print(" --- Error encountered on save.")
+            raise RuntimeError(
+                f"wbeditentity claims save still non-success after relogin for"
+                f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
+            )
+        except RuntimeError:
+            raise
         except Exception as retry_e:
             # `post` may not be assigned yet if http.fetch / json.loads raised —
             # referencing it directly would mask the real error with an
@@ -1381,7 +1426,9 @@ def _post_new_claims(mediaid, dpla_id):
             if "save" in locals():
                 print(save.text)
             print(" --- Error encountered. 3")
-            sys.exit()
+            raise RuntimeError(
+                f"Claims relogin+save failed for {mediaid} ({dpla_id})"
+            ) from retry_e
 
 
 def dpla_claims(
@@ -1641,16 +1688,22 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
         )
         try:
             rm_post = json.loads(rm_resp.text)
-        except (ValueError, AttributeError):
+        except (ValueError, AttributeError) as parse_e:
             print(" --- Could not parse removals response.")
-            sys.exit()
+            raise RuntimeError(
+                f"wbremoveclaims response was not parseable JSON for"
+                f" {mediaid} ({dpla_id}): {_truncate(getattr(rm_resp, 'text', ''))}"
+            ) from parse_e
         if rm_post.get("success") == 1:
             print(" --- Saved removals!")
             tracker.increment(Result.SDC_REMOVALS, len(removals))
         else:
             print(rm_post)
             print(" --- Error encountered on removals save.")
-            sys.exit()
+            raise RuntimeError(
+                f"wbremoveclaims save returned non-success for"
+                f" {mediaid} ({dpla_id}): {rm_post}"
+            )
 
 
 def _fetch_dpla_doc_from_api(dpla_id, dpla_api):


### PR DESCRIPTION
## Summary

Closes the root cause of the May 2026 SDC abort cluster diagnosed in PR #260's follow-up investigation.

Ten `sys.exit()` calls in `_post_new_refs`, `_post_new_claims`, and the removals block of `_reconcile_existing_claims` triggered on any non-success Commons `wbeditentity` / `wbremoveclaims` response (bad token, rate-limited, conflict, parse error, etc.). `SystemExit` is a `BaseException`, so the per-ordinal `except Exception:` handler in `process_one_from_sdc` couldn't catch it — a **single** failed write tanked the entire partner's SDC phase. For NARA that's potentially thousands of items lost per abort.

The two-near-simultaneous aborts on 5/28 (Reagan at 07:42:08, NPRC at 07:42:11, both mid-loop) are consistent with a shared CSRF/login state expiring across parallel pywikibot processes — relogin retry fails for both → both hit the bottom `sys.exit()` within seconds.

## Changes

- Replace every `sys.exit()` with `raise RuntimeError(...)` carrying mediaid, dpla_id, and a truncated Commons response body so the failure is self-identifying.
- Add a small `_truncate(text, limit=500)` helper for readable error messages (verbose Commons error bodies still appear in full in the per-ordinal `logging.exception` traceback — the truncation is only for the one-line message).
- Add `except RuntimeError: raise` guards in the relogin/retry branches so our structured failures don't get caught + restarted by the broad `except Exception:`.
- Remove now-unused `import sys`.

## Behavioural change (the important bit)

Because `RuntimeError` IS an `Exception`, the existing per-ordinal handler at `process_one_from_sdc` (line 2287 pre-edit) now catches it:

1. Logs the full traceback via `logging.exception` (visible in the SDC log file and surfaced by `notify_pipeline_fail`'s `_summarize_log` in Slack).
2. Increments `SDC_ORDINALS_SKIPPED_ERROR`.
3. **Continues with the next ordinal.**

The partner batch no longer aborts on a single failed write — it skips the affected item and proceeds. This is effectively "Option 2" (log + skip + continue) for free, because the per-ordinal handler was already in place; only the escape mechanism needed changing.

Legacy modes (lists/files/cat → `process_one`) aren't wrapped in that handler, so they preserve the old abort-on-failure semantics — but now with a real traceback in the log instead of silent exit.

## Tests

- `test_truncate_helper_*` — sanity check the new helper (with the `test_` prefix this time — original had a leading underscore and would have been silently skipped, caught in self-review).
- `test_post_new_refs_raises_runtime_error_on_non_success_save` — verifies mediaid + dpla_id + "non-success" appear in the error message.
- `test_post_new_claims_raises_runtime_error_on_non_success_save` — same contract for the claims helper.
- `test_post_new_refs_runtime_error_caught_by_per_ordinal_handler` — proves the key invariant: a RuntimeError from the helper IS catchable by `except Exception:`, so the per-ordinal handler in `process_one_from_sdc` will skip rather than abort the partner. This is the critical regression guard.

## Test plan

- [ ] Pytest passes (CI)
- [ ] After deploy, re-run an SDC sync for an aborted NARA partner (e.g. `nara|William J. Clinton Library`). Confirm the run completes (or skips items with logged tracebacks) instead of aborting silently.
- [ ] If items do skip with errors, inspect the SDC log for the new RuntimeError messages — confirm mediaid + dpla_id are present and the response body is informative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR changes error handling in the SDC (Structured Data Commons) synchronization tool so Commons write failures raise RuntimeError with contextual details instead of calling sys.exit() (SystemExit). This makes per-ordinal processing resilient: failures are logged with tracebacks, the SDC_ORDINALS_SKIPPED_ERROR counter is incremented, and processing continues with the next ordinal. Legacy modes that call process_one still abort on failure but will now emit full tracebacks instead of a silent exit.

## Changes

tools/sdc_sync.py
- Replaced sys.exit() calls in Commons write/removal paths (_post_new_refs, _post_new_claims, and the removals block of _reconcile_existing_claims) with raise RuntimeError(...) including mediaid, dpla_id, and a truncated Commons response body.
- Added helper _truncate(text, limit=500) (signature updated to accept None) to produce concise one-line error messages while preserving full response bodies in tracebacks/logs.
- Added except RuntimeError: raise guards in relogin/retry branches so deliberately raised RuntimeError instances are not swallowed by broad except Exception handlers.
- Ensured explicit return on success paths after token refresh/relogin to avoid fallthrough.
- Removed unused import sys.

tests/test_sdc_sync.py
- Added unit tests for _truncate (None → "", short unchanged, long truncated with marker and original length).
- Added tests asserting _post_new_refs and _post_new_claims raise RuntimeError on non-success wbeditentity responses and that error messages include mediaid + dpla_id + truncated response.
- Added test verifying the per-ordinal except Exception handler in process_one_from_sdc catches RuntimeError and causes skip-not-abort behavior.
- Added test helper _install_module_globals to monkeypatch module-level dependencies for isolated testing.

## Behavioral changes / impact

- SDC sync (process_one_from_sdc): Single-item write failures are now non-fatal to the partner batch — the error is logged with a traceback, the skip counter is incremented, and processing continues with subsequent ordinals.
- Legacy modes that call process_one (lists/files/cat): Retain abort-on-failure semantics because they are not wrapped by the per-ordinal handler; however, they now produce tracebacks in logs instead of a quiet exit.
- Error messages are more informative (mediaid + dpla_id + truncated response) while keeping full responses available in tracebacks.
- _truncate signature now accepts None to match runtime behavior and tests.

## Tests & deployment

- New unit tests added; CI pytest must pass.
- Post-deploy verification recommended: re-run an SDC sync for a previously aborted partner (e.g., NARA) to confirm runs now skip failing items with logged tracebacks.

## Checklist for infra/security/ops considerations

- Manual pipeline trigger / ECS redeploy required: No. This is a code-only change; standard CI/CD deploy applies.
- Environment variables / AWS Secrets Manager keys added/removed/renamed: No changes.
- Database migrations: None.
- Shared infra configuration changes (CodePipeline/CodeBuild/ECS task definitions/IAM): None.
- Public-facing API response shape or endpoints changed: No.
- Security implications: No credential-handling/auth changes. Note: the change surfaces mediaid and dpla_id in error messages and tracebacks — ensure logs and retention/PII policies account for inclusion of these identifiers if relevant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->