### PR TITLE
status: fix retry sessions reporting "/ 0 items" denominator

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -105,7 +105,30 @@ def get_phase_and_progress(
         return None, 0
 
     log_path = shlex.quote(f"{base}/logs/{log_file}")
-    csv_path = shlex.quote(f"{base}/{label}.csv")
+    # Resolve the CSV(s) backing this label so `wc -l` returns a meaningful
+    # "items in scope" denominator.
+    #
+    # Launch sessions write a single per-target CSV at `{base}/{label}.csv`
+    # (e.g. `northwest-heritage/northwest-heritage+local-history.csv`).
+    #
+    # Retry sessions are different: the retry pipeline writes its CSVs into
+    # a shared `retry/` directory using the partner *directory* name plus a
+    # phase suffix (matching wikimedia_retry.py's RETRY_DIR layout). For a
+    # retry label like `retry-northwest-heritage` the relevant CSVs are
+    # `retry/northwest-heritage-download-retry.csv` and/or
+    # `retry/northwest-heritage-upload-retry.csv`. Sum lines from whichever
+    # exist — `cat` silently skips missing files (stderr suppressed) and
+    # `wc -l` of an empty stream is 0. Without this, the status script was
+    # always reporting "/ 0 items" for retry sessions because no file at
+    # `{base}/retry-<slug>.csv` existed.
+    if label.startswith("retry-"):
+        retry_dir = "/home/ec2-user/ingest-wikimedia/retry"
+        download_csv = shlex.quote(f"{retry_dir}/{pdir}-download-retry.csv")
+        upload_csv = shlex.quote(f"{retry_dir}/{pdir}-upload-retry.csv")
+        csv_count_cmd = f"cat {download_csv} {upload_csv} 2>/dev/null | wc -l"
+    else:
+        csv_path = shlex.quote(f"{base}/{label}.csv")
+        csv_count_cmd = f"wc -l < {csv_path} 2>/dev/null || echo 0"
 
     sep = "__WM_SEP__"
     # One awk pass counts all four marker lines in a single sequential read
@@ -130,7 +153,7 @@ def get_phase_and_progress(
         f"/COUNTS:/ {{c++}} "
         f"END {{ print d+0; print u+0; print s+0; print c+0 }}"
         f"' {log_path} 2>/dev/null || printf '0\\n0\\n0\\n0\\n'; "
-        f"wc -l < {csv_path} 2>/dev/null || echo 0",
+        f"{csv_count_cmd}",
     )
 
     sections = out.split(f"{sep}\n", 2)

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -159,6 +159,95 @@ def _fake_ssm_for_phase(
     return fake_ssm_run
 
 
+def test_get_phase_and_progress_retry_label_reads_retry_dir_csvs():
+    """Regression: for `retry-<slug>` labels the CSV "items in scope"
+    denominator must come from the retry pipeline's CSV(s) in the shared
+    /retry/ directory, NOT from `{partner_base}/retry-<slug>.csv` (which
+    never exists). Without this, every retry session's status reported
+    "N / 0 items" because the wc -l fell back to the `|| echo 0` branch.
+
+    `northwest-heritage` is a partner whose EC2 directory name matches its
+    canonical slug (so PARTNER_DIR has no override), exercising the
+    pdir=hub fall-through.
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    captured: list[str] = []
+
+    def fake_ssm_run(_client, command, **_kwargs):
+        captured.append(command)
+        if len(captured) == 1:
+            return "1700000000\n20260601-120000-retry-northwest-heritage-download.log\n"
+        # awk pass: dpla_id=2, uploaded=0, skipping=0, counts=0;
+        # then csv total = 5 (sum of download+upload retry CSVs)
+        return (
+            "1700000000\n1700000000\n__WM_SEP__\nDownloading something\n"
+            "__WM_SEP__\n2\n0\n0\n0\n5\n"
+        )
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-retry-7d-northwest-heritage",
+            hub="northwest-heritage",
+            label="retry-northwest-heritage",
+        )
+    assert phase is not None
+    # Phase is "Downloading (2 / 5 items, ~40.0%)" — total must be 5, not 0.
+    assert "2" in phase and "5" in phase, phase
+    assert "/ 0 items" not in phase, (
+        f"Status should not show '/ 0 items' for retry sessions; got: {phase!r}"
+    )
+
+    # The main SSM call must reference the retry/-directory CSVs, not the
+    # nonexistent {base}/retry-{slug}.csv. Pin both paths so neither half
+    # of the lookup can regress.
+    main_cmd = captured[1]
+    assert "/retry/northwest-heritage-download-retry.csv" in main_cmd, main_cmd
+    assert "/retry/northwest-heritage-upload-retry.csv" in main_cmd, main_cmd
+    # The bogus path the bug was reading must NOT be in the command.
+    assert "/retry-northwest-heritage.csv" not in main_cmd, (
+        f"status must not look for `{{base}}/retry-<slug>.csv` for retry "
+        f"sessions; got: {main_cmd!r}"
+    )
+
+
+def test_get_phase_and_progress_retry_label_uses_partner_dir_name():
+    """Retry CSVs are named by partner *directory*, not canonical slug.
+    For `si` (canonical slug) the directory is `smithsonian`, so the CSV
+    is `/retry/smithsonian-download-retry.csv`, not
+    `/retry/si-download-retry.csv`. The status script must honor
+    PARTNER_DIR the same way the retry pipeline does.
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    captured: list[str] = []
+
+    def fake_ssm_run(_client, command, **_kwargs):
+        captured.append(command)
+        if len(captured) == 1:
+            return "1700000000\n20260601-120000-retry-si-download.log\n"
+        return "1700000000\n1700000000\n__WM_SEP__\n.\n__WM_SEP__\n1\n0\n0\n0\n3\n"
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
+        get_phase_and_progress(
+            client=None,
+            session="wikimedia-retry-7d-si",
+            hub="si",
+            label="retry-si",
+        )
+    main_cmd = captured[1]
+    assert "/retry/smithsonian-download-retry.csv" in main_cmd
+    assert "/retry/smithsonian-upload-retry.csv" in main_cmd
+    assert "/retry/si-" not in main_cmd, (
+        f"must use partner dir name (smithsonian), not slug (si); got: {main_cmd!r}"
+    )
+
+
 def test_get_phase_and_progress_reports_sdc_syncing_in_progress():
     """An -sdc.log with DPLA IDs logged but no terminal COUNTS marker
     surfaces as "SDC syncing (N / total items, ~pct%)".


### PR DESCRIPTION
## Summary

`/wikimedia-status` was showing `wikimedia-retry-7d-northwest-heritage [retry-northwest-heritage] Downloading (2 / 0 items, ~?%)` — the "2 downloaded so far" half was correct but the denominator was always 0, making the progress indicator useless and looking like a session-internal bug.

## Root cause

`get_phase_and_progress` resolves the CSV-line-count denominator (the "items in scope" for the phase) by reading `{partner_base}/{label}.csv`. For launch sessions that works — the launch script writes `{base}/{label}.csv` per target.

For retry sessions it doesn't: `wikimedia_retry.py` writes CSVs into a shared `retry/` directory using `<partner-dir>-<phase>-retry.csv` (e.g. `/home/ec2-user/ingest-wikimedia/retry/northwest-heritage-download-retry.csv`). The status script was looking at `northwest-heritage/retry-northwest-heritage.csv`, which never exists; `wc -l 2>/dev/null || echo 0` fell to 0; the status line read "/ 0 items".

I confirmed both halves on EC2: the path the old code targeted doesn't exist for this session, and the path the new code targets contains 31 lines.

## Fix

Detect `retry-<slug>` labels and resolve to the actual retry CSV layout. Sum lines across the download-retry and upload-retry CSVs (whichever exist) so the denominator reflects total items in this retry's scope. `cat A B 2>/dev/null | wc -l` handles "neither exists" (output 0), "only one exists" (count that one), and "both exist" (sum) cleanly without an extra `|| echo 0` fallback.

Honors `PARTNER_DIR` the same way the retry pipeline itself does, so `retry-si` resolves to `smithsonian-*-retry.csv` rather than `si-*-retry.csv`.

## Test plan

- [x] `test_get_phase_and_progress_retry_label_reads_retry_dir_csvs` — pins both halves of the path (download-retry + upload-retry) and asserts the bogus `{base}/retry-<slug>.csv` form does NOT appear in the SSM command.
- [x] `test_get_phase_and_progress_retry_label_uses_partner_dir_name` — verifies `si` resolves to `smithsonian-*-retry.csv`, not `si-*-retry.csv` (regression guard for the PARTNER_DIR override).
- [x] `ruff check` / `ruff format --check` clean.
- [ ] Next `/wikimedia-status` invocation on a live retry session should show the correct denominator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes retry session status reporting on `/wikimedia-status` to display correct item counts instead of "/ 0 items" denominators.

### Problem
For retry sessions (labels starting with `retry-`), the status page displayed progress like "Downloading (2 / 0 items, ~?%)" because `get_phase_and_progress()` computed the CSV path as `{partner_base}/retry-<slug>.csv`, a location that never exists. Retry pipeline CSVs actually live in a shared `/retry/` directory with names like `<pdir>-download-retry.csv` and `<pdir>-upload-retry.csv`. The fallback `wc -l 2>/dev/null || echo 0` always produced 0.

### Changes
Updated `get_phase_and_progress()` to detect `retry-<slug>` labels and sum line counts from the actual retry CSV layout: `/home/ec2-user/ingest-wikimedia/retry/<pdir>-download-retry.csv` and/or `<pdir>-upload-retry.csv` using `cat A B 2>/dev/null | wc -l`. This respects `PARTNER_DIR` mapping the same way the retry pipeline does (e.g., `si` resolves to `smithsonian-*-retry.csv`).

**Verified on EC2:** For the live `retry-northwest-heritage` session, status now shows "2 / 31 items" instead of "2 / 0 items".

### Testing
Added two regression tests verifying:
1. Retry labels read correct CSV totals from `/retry/` directory (common case: `pdir == hub`)
2. `PARTNER_DIR`-mapped slugs resolve to the correct partner directory name in retry CSV paths (e.g., `si` → `smithsonian`)

### Deployment Notes
Script requires deployment to apply the fix. Existing environment variables (`DPLA_SLACK_BOT_TOKEN`, `NOTIFY_IF_IDLE`) remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->