### PR TITLE
wikimedia: make tag_as_duplicate idempotent on already-tagged pages

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -626,11 +626,16 @@ def merge_preserved_wikitext(existing_text: str, new_artwork: str) -> str:
     return "\n".join(parts) + "\n"
 
 
-# Anchored loosely on `{{` + (D|d)uplicate to catch the standard Commons
-# variants we (and other editors) emit. The follow-on `[|}]` ensures we
-# match the actual template invocation `{{Duplicate|...}}` or `{{Duplicate}}`
-# and don't false-positive on something like `{{DuplicateImageFinder}}`.
-_DUPLICATE_TAG_RE = re.compile(r"\{\{[Dd]uplicate[|}]")
+# Matches a real {{Duplicate}} template invocation. `\s*` on both sides of
+# `duplicate` accepts the whitespace/newlines wikitext allows inside the
+# braces — `{{ Duplicate|…}}`, `{{Duplicate |…}}` and `{{Duplicate\n|…}}`
+# are all valid invocations Commons editors do use. The trailing
+# `(?:\||\}\})` is what prevents `{{DuplicateImageFinder|…}}` from
+# false-matching: we only count it as a duplicate template when the next
+# non-whitespace token is the parameter pipe or the template's closing
+# braces. IGNORECASE handles both `Duplicate` and the `{{duplicate}}`
+# variant some Commons editors use.
+_DUPLICATE_TAG_RE = re.compile(r"\{\{\s*duplicate\s*(?:\||\}\})", re.IGNORECASE)
 
 
 def tag_as_duplicate(

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -626,6 +626,13 @@ def merge_preserved_wikitext(existing_text: str, new_artwork: str) -> str:
     return "\n".join(parts) + "\n"
 
 
+# Anchored loosely on `{{` + (D|d)uplicate to catch the standard Commons
+# variants we (and other editors) emit. The follow-on `[|}]` ensures we
+# match the actual template invocation `{{Duplicate|...}}` or `{{Duplicate}}`
+# and don't false-positive on something like `{{DuplicateImageFinder}}`.
+_DUPLICATE_TAG_RE = re.compile(r"\{\{[Dd]uplicate[|}]")
+
+
 def tag_as_duplicate(
     site: BaseSite,
     file_page: FilePage,
@@ -637,15 +644,27 @@ def tag_as_duplicate(
     correct_filename should be bare (no 'File:' prefix).
     reason is the free-text reason shown in the template.
 
+    Idempotent: if the page already carries a {{Duplicate}} (or
+    {{duplicate}}) template, this is a no-op. Two distinct uploader code
+    paths can both identify the same file as a duplicate of the same
+    target — the per-asset hash-drift correction during upload, and the
+    post-item trailing-orphan sweep that runs after the asset loop —
+    and unconditionally prepending each time produces a stack of
+    redundant tags on the page (see uploader regression where one file
+    got tagged twice within three seconds with the same correct title).
+
     Uses the MediaWiki `prependtext` API parameter so the existing page
-    text doesn't need to be fetched into the process just to be re-saved
-    unchanged. Each call writes a different file page (so self-conflicts
-    of the kind that hit `post_commonsdelinker_request` aren't possible
-    here), but the read-modify-write form still costs an extra GET per
-    call and is vulnerable to rare external edit conflicts on the same
-    page. `prependtext` skips the GET, skips the basetimestamp check,
-    and lets MediaWiki concatenate atomically on the primary.
+    text doesn't need to be fetched, modified, and re-saved. The
+    idempotency check above does cost one GET to read `file_page.text`
+    that the pure-prependtext path avoided, but skipping a redundant
+    write is worth the single read.
     """
+    if _DUPLICATE_TAG_RE.search(file_page.text or ""):
+        logging.info(
+            f"Skipping duplicate tag on [[File:{file_page.title(with_ns=False)}]] — "
+            f"already tagged as duplicate."
+        )
+        return
     tag = f"{{{{Duplicate|{correct_filename}|{reason}}}}}"
     summary = f"Tagging as duplicate: correct title is [[File:{correct_filename}]]"
     # Trailing newline so the tag sits on its own line above whatever

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -850,20 +850,17 @@ def test_tag_as_duplicate_uses_prependtext_not_read_modify_write():
     """tag_as_duplicate must use site.editpage(prependtext=...) rather
     than `file_page.text = tag + file_page.text; file_page.save()`.
 
-    Unlike post_commonsdelinker_request this isn't a self-conflict
-    hotspot (each call edits a different file page), but the same
-    arguments apply: skip the unnecessary GET of the existing page text,
-    let MediaWiki concatenate atomically on the primary, and keep the
-    pattern consistent with the other shared-page edits.
+    The page-text read is now required for the idempotency check (see
+    test_tag_as_duplicate_is_idempotent_when_already_tagged), but the
+    write side must still go through prependtext — MediaWiki concatenates
+    atomically on the primary, no basetimestamp, no read-modify-write
+    save() that would re-introduce edit-conflict risk.
     """
     site = MagicMock()
     file_page = MagicMock()
-    text_accessed = MagicMock(
-        side_effect=AssertionError(
-            "file_page.text must not be accessed — use prependtext"
-        )
-    )
-    type(file_page).text = property(text_accessed)
+    # No prior tag — idempotency check sees empty text and proceeds to write.
+    type(file_page).text = property(lambda self: "")
+    file_page.title.return_value = "Stranded.jpg"
 
     tag_as_duplicate(
         site,
@@ -888,3 +885,66 @@ def test_tag_as_duplicate_uses_prependtext_not_read_modify_write():
         f"line-separated; got {kwargs['prependtext']!r}"
     )
     file_page.save.assert_not_called()
+
+
+def test_tag_as_duplicate_is_idempotent_when_already_tagged():
+    """Regression: a page that already carries a {{Duplicate}} template
+    must NOT receive a second one. Two uploader code paths (per-asset
+    hash-drift correction during upload + the post-item trailing-orphan
+    sweep) can both identify the same file as a duplicate of the same
+    target. Unconditionally prepending each time stacks redundant
+    `{{Duplicate|Correct.jpg|...}}` templates on the page — seen in
+    production on a NARA file that got tagged twice within three
+    seconds with the same correct title and two different reasons.
+    """
+    site = MagicMock()
+    file_page = MagicMock()
+    # Page already tagged by an earlier upstream caller in this run.
+    type(file_page).text = property(
+        lambda self: (
+            "{{Duplicate|Correct.jpg|Other file has the correct title.}}\n"
+            "{{Information|description=...}}\n"
+        )
+    )
+    file_page.title.return_value = "Stranded.jpg"
+
+    tag_as_duplicate(
+        site,
+        file_page,
+        correct_filename="Correct.jpg",
+        reason="Trailing-page orphan: this title has no corresponding asset.",
+    )
+
+    site.editpage.assert_not_called()
+    file_page.save.assert_not_called()
+
+
+def test_tag_as_duplicate_idempotency_detects_lowercase_template():
+    """The duplicate-detection regex must also catch `{{duplicate}}`
+    (lowercase variant some Commons editors use) — otherwise our bot
+    would add `{{Duplicate}}` on top of an existing `{{duplicate}}` and
+    re-introduce the double-tag we just fixed."""
+    site = MagicMock()
+    file_page = MagicMock()
+    type(file_page).text = property(lambda self: "{{duplicate|Correct.jpg|reason}}")
+    file_page.title.return_value = "Stranded.jpg"
+
+    tag_as_duplicate(site, file_page, "Correct.jpg", "reason")
+    site.editpage.assert_not_called()
+
+
+def test_tag_as_duplicate_idempotency_does_not_match_unrelated_templates():
+    """The regex must NOT false-positive on unrelated templates whose
+    name happens to start with 'Duplicate' (e.g. {{DuplicateImageFinder}}).
+    A page with only such a template should still receive its first
+    `{{Duplicate}}` tag from us."""
+    site = MagicMock()
+    file_page = MagicMock()
+    type(file_page).text = property(
+        lambda self: "{{DuplicateImageFinder|param=value}}\n"
+    )
+    file_page.title.return_value = "Stranded.jpg"
+
+    tag_as_duplicate(site, file_page, "Correct.jpg", "reason")
+    # First tag still applied — the unrelated template should not count.
+    assert site.editpage.call_count == 1

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -933,6 +933,33 @@ def test_tag_as_duplicate_idempotency_detects_lowercase_template():
     site.editpage.assert_not_called()
 
 
+def test_tag_as_duplicate_idempotency_detects_whitespace_variants():
+    """The regex must also catch the spaced/newline variants of the
+    template invocation that wikitext allows: `{{ Duplicate|...}}`,
+    `{{Duplicate |...}}`, and `{{Duplicate\\n|...}}` are all valid
+    forms Commons editors emit. Earlier the regex required `|` or `}`
+    to follow `Duplicate` with no whitespace, which would have missed
+    every one of these and re-introduced the double-tag bug whenever
+    the prior tagger used a less-compact form.
+    """
+    for prior_tag in (
+        "{{ Duplicate|Correct.jpg|reason}}",  # space after `{{`
+        "{{Duplicate |Correct.jpg|reason}}",  # space before `|`
+        "{{Duplicate\n|Correct.jpg|reason}}",  # newline before `|`
+        "{{Duplicate}}",  # no args (closes immediately)
+        "{{Duplicate }}",  # no args with trailing whitespace
+    ):
+        site = MagicMock()
+        file_page = MagicMock()
+        type(file_page).text = property(lambda self, t=prior_tag: t)
+        file_page.title.return_value = "Stranded.jpg"
+        tag_as_duplicate(site, file_page, "Correct.jpg", "reason")
+        assert site.editpage.call_count == 0, (
+            f"prior tag {prior_tag!r} should have been detected; "
+            f"editpage was called {site.editpage.call_count} time(s)"
+        )
+
+
 def test_tag_as_duplicate_idempotency_does_not_match_unrelated_templates():
     """The regex must NOT false-positive on unrelated templates whose
     name happens to start with 'Duplicate' (e.g. {{DuplicateImageFinder}}).


### PR DESCRIPTION
## Summary

Fixes the regression you spotted on `File:Churchill to FDR - June 1944 - DPLA - 75956a0a6ce69b7f8c800c12e3cbca5f (page 130).jpg`: two consecutive bot edits within three seconds, both prepending `{{Duplicate|...page 129).jpg|...}}` to the same page with different reasons. Page now has two stacked `{{Duplicate}}` templates.

## Root cause

Two distinct uploader code paths can both identify the same file as a duplicate of the same target:

| Path | Where | Reason text |
|---|---|---|
| `_tag_drift_duplicate` | per-asset during upload, when SHA1 already lives at a wrong title (`_resolve_hash_drift` → `upload_and_tag`) | "Other file has the correct title." |
| `_post_item_orphan_check` | after the per-asset loop, scans trailing-ordinal positions for orphans whose SHA1 matches a kept title | "Trailing-page orphan: this title has no corresponding asset..." |

Both call `tag_as_duplicate`, which since PR #247 unconditionally prepends via `site.editpage(..., prependtext=...)`. Neither path knows the other has already tagged the page.

## Fix

Make `tag_as_duplicate` idempotent: read `file_page.text` and skip if the page already carries a `{{Duplicate}}` (or `{{duplicate}}`) template. Centralising in the helper protects both call sites and any future caller without coupling them to each other.

## Trade-off

This re-introduces one GET per call to read `file_page.text` that PR #247's pure-prependtext path had eliminated. The trade-off is clearly worth it — skipping a redundant write is more valuable than skipping a single read, and the read happens at most once per orphan candidate per item (a small set in practice). The atomicity argument PR #247 made for `post_commonsdelinker_request` still holds there — that path doesn't read at all, and its self-conflict pattern was structural rather than coordination-with-other-code.

## Test plan

- [x] `test_tag_as_duplicate_uses_prependtext_not_read_modify_write` — still pins the prependtext write path; updated to allow the new idempotency read.
- [x] `test_tag_as_duplicate_is_idempotent_when_already_tagged` — regression guard for the actual bug: a page that already has `{{Duplicate|...}}` doesn't get a second tag.
- [x] `test_tag_as_duplicate_idempotency_detects_lowercase_template` — `{{duplicate}}` variant also short-circuits.
- [x] `test_tag_as_duplicate_idempotency_does_not_match_unrelated_templates` — `{{DuplicateImageFinder}}` etc. don't false-positive.
- [x] `ruff check` / `ruff format --check` clean.
- [ ] Next upload run that involves hash-drift correction + a trailing orphan on the same file should produce exactly one `{{Duplicate}}` tag, not two.

## Side note

The already-double-tagged page on Commons (`(page 130).jpg`) is unaffected by this PR — that page has two stacked `{{Duplicate}}` templates and will need a separate manual or scripted cleanup edit. If you want, I can scan recent revisions for other files with the same double-tag and produce a cleanup edit, similar to the CommonsDelinker filemovers recovery we just did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes a regression where two uploader code paths could both call tag_as_duplicate for the same Commons file page within seconds, producing stacked {{Duplicate}} templates (observed in production on a NARA file that received two duplicate tags three seconds apart with different reason texts).

Root cause: both _tag_drift_duplicate (per-asset hash-drift correction during upload) and _post_item_orphan_check (post-item trailing-orphan sweep) unconditionally prepended a {{Duplicate}} template and did not coordinate.

Solution: make tag_as_duplicate idempotent by reading file_page.text and skipping the prepend when the page already contains a {{Duplicate}} (case-insensitive). The idempotency check is centralized via a module-level regex so both existing call sites and any future callers benefit.

Implementation details
- Adds _DUPLICATE_TAG_RE = re.compile(r"\{\{\s*duplicate\s*(?:\||\}\})", re.IGNORECASE) to detect real {{Duplicate}} / {{duplicate}} invocations while avoiding false-positives on templates whose names merely start with "Duplicate" (e.g., {{DuplicateImageFinder}}). The pattern accepts optional whitespace/newlines inside the braces so forms like {{ Duplicate|…}}, {{Duplicate |…}}, and {{Duplicate\n|…}} are detected.
- tag_as_duplicate now reads file_page.text and, if the regex matches, logs an info message and returns without calling site.editpage(...). If no prior tag is present it continues to write via site.editpage(prependtext=...) so the atomic prepend behavior is preserved (avoiding read-modify-write edit conflicts).
- Commit expands the idempotency regex and adds a targeted test to cover spaced/newline variants.

Trade-off
- Reintroduces one GET per call to read file_page.text (PR `#247` had removed this read). The author accepts this cost to avoid redundant writes; the read occurs at most once per orphan candidate per item.

Tests
- Updated/added tests to preserve the prependtext write path and verify idempotency:
  - test_tag_as_duplicate_uses_prependtext_not_read_modify_write (adjusted to allow the idempotency read but still assert prependtext write)
  - test_tag_as_duplicate_is_idempotent_when_already_tagged
  - test_tag_as_duplicate_idempotency_detects_lowercase_template
  - test_tag_as_duplicate_idempotency_detects_whitespace_variants (covers spaces/newline before the `|`)
  - test_tag_as_duplicate_idempotency_does_not_match_unrelated_templates
- Ruff checks pass locally.
- One real-world verification remains: observe the next relevant upload run to confirm duplicate-tagging no longer occurs in production.

Files/lines changed
- ingest_wikimedia/wikimedia.py — idempotency logic + regex and docstring/comments updated.
- tests/test_wikimedia.py — added/expanded idempotency tests and adjusted existing prependtext test.

Infrastructure / security / migration notes
- No manual pipeline trigger or ECS redeployment required to take effect.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task defs, IAM).
- No changes to public API shapes or endpoints.
- No security-sensitive changes to auth or credential handling beyond normal bot edits.

Notes
- Change is intentionally conservative: centralizes idempotency check and retains prependtext for atomic writes while accepting one extra read to avoid duplicate tagging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->