### PR TITLE
sdc-sync: include Commons response body in relogin+save RuntimeError messages

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -657,3 +657,81 @@ def test_post_new_refs_runtime_error_caught_by_per_ordinal_handler(monkeypatch):
         " per-ordinal handler in process_one_from_sdc catches it (was previously"
         " SystemExit, which bypassed that handler and aborted the whole partner)"
     )
+
+
+# --------------------------------------------------------------------------
+# Response-body inclusion in the relogin+save failure messages.
+#
+# When the per-ordinal handler in process_one_from_sdc logs an exception
+# from these helpers, the only thing we currently see is "Claims
+# relogin+save failed for <mediaid> (<dpla_id>)" plus a chained
+# KeyError from json parsing. That isn't enough to diagnose the
+# underlying problem — Commons returns errors like
+# {"error": {"code": "permissiondenied", "info": "..."}} which have
+# NO "success" key, so post["success"] raises KeyError and the actual
+# error code is lost. Baking save.text into the RuntimeError message
+# captures the Commons error code in the structured exception, where
+# logging.exception will write it to the SDC log.
+# --------------------------------------------------------------------------
+
+
+def test_post_new_claims_relogin_failure_message_includes_response_body(monkeypatch):
+    """When the relogin retry also returns a response with no ``"success"``
+    key, the chained KeyError + new RuntimeError message must include the
+    Commons response body so we can read the error code from the SDC log.
+
+    Without this, the per-ordinal traceback only tells us the helper hit
+    line 1421 — useful for locating the abort but useless for figuring
+    out *why* a specific item is being rejected by Commons.
+    """
+    from tools import sdc_sync
+
+    response = MagicMock()
+    response.text = (
+        '{"error": {"code": "permissiondenied", "info": "Permission denied."}}'
+    )
+    _install_module_globals(
+        monkeypatch, sdc_sync, response, claims_payload=[{"some": "claim"}]
+    )
+    # Stub ``login()`` so the relogin path completes successfully (no
+    # auth-side error masking the real save failure under test).
+    monkeypatch.setattr(sdc_sync, "login", lambda: "stub-token-2", raising=False)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        sdc_sync._post_new_claims("M12345", "abcdef01abcdef01abcdef01abcdef01")
+
+    msg = str(excinfo.value)
+    assert "M12345" in msg
+    assert "abcdef01abcdef01abcdef01abcdef01" in msg
+    assert "relogin+save failed" in msg
+    # The Commons error code from the response body must be reachable from
+    # the message — that's the whole point of this PR.
+    assert "permissiondenied" in msg, (
+        "Commons error code must appear in the RuntimeError message so the"
+        " per-ordinal logging.exception captures it; got: " + repr(msg)
+    )
+
+
+def test_post_new_refs_relogin_failure_message_includes_response_body(monkeypatch):
+    """Same contract for the refs helper."""
+    from tools import sdc_sync
+
+    response = MagicMock()
+    response.text = (
+        '{"error": {"code": "abusefilter-disallowed", "info": "Rule X tripped."}}'
+    )
+    _install_module_globals(
+        monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
+    )
+    monkeypatch.setattr(sdc_sync, "login", lambda: "stub-token-2", raising=False)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        sdc_sync._post_new_refs("M67890", "fedcba98fedcba98fedcba98fedcba98")
+
+    msg = str(excinfo.value)
+    assert "M67890" in msg
+    assert "fedcba98fedcba98fedcba98fedcba98" in msg
+    assert "relogin+save failed" in msg
+    assert "abusefilter-disallowed" in msg, (
+        "Commons error code must appear in the RuntimeError message; got: " + repr(msg)
+    )

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1331,9 +1331,17 @@ def _post_new_refs(mediaid, dpla_id):
         except RuntimeError:
             raise
         except Exception as retry_e:
+            # `save` may not be bound if http.fetch raised before the response
+            # landed — guard with ``locals()`` so we don't mask the real cause
+            # with an UnboundLocalError. When ``save`` IS bound, the response
+            # body is the diagnostic we actually want (e.g. a Commons error
+            # like ``{"error": {"code": "permissiondenied", ...}}`` will raise
+            # KeyError on ``post["success"]`` above, but the response body
+            # itself names the cause).
             print(f" --- Error encountered. 2: {retry_e!r}")
+            body_suffix = f": {_truncate(save.text)}" if "save" in locals() else ""
             raise RuntimeError(
-                f"Refs relogin+save failed for {mediaid} ({dpla_id})"
+                f"Refs relogin+save failed for {mediaid} ({dpla_id}){body_suffix}"
             ) from retry_e
 
 
@@ -1422,12 +1430,22 @@ def _post_new_claims(mediaid, dpla_id):
             # `post` may not be assigned yet if http.fetch / json.loads raised —
             # referencing it directly would mask the real error with an
             # UnboundLocalError. Log what we actually have.
+            #
+            # Bake ``save.text`` into the RuntimeError message (when bound) so
+            # the per-ordinal ``logging.exception`` captures the Commons error
+            # response body — the existing ``print(save.text)`` goes to stdout,
+            # which is block-buffered to a non-TTY and got dropped on
+            # ``sys.exit()``. The May 2026 NARA aborts ended with ``KeyError:
+            # 'success'`` propagating out of this block, which only happens
+            # when Commons returned ``{"error": {...}}`` (no ``success`` field)
+            # — the error code in that body is the missing diagnostic.
             print(f" --- Retry after token refresh failed: {retry_e!r}")
             if "save" in locals():
                 print(save.text)
             print(" --- Error encountered. 3")
+            body_suffix = f": {_truncate(save.text)}" if "save" in locals() else ""
             raise RuntimeError(
-                f"Claims relogin+save failed for {mediaid} ({dpla_id})"
+                f"Claims relogin+save failed for {mediaid} ({dpla_id}){body_suffix}"
             ) from retry_e
 
 


### PR DESCRIPTION
## Summary

Follow-up to PR #263. That PR made SDC write failures non-fatal (raise → caught by per-ordinal handler → skip + continue) and ensured each failure logs a traceback. **But it doesn't tell us *why* specific items are being rejected.**

Empirical data from two re-runs after #260's BaseException widening was deployed:

| Hub | Latest log | Outcome | Traceback at |
|---|---|---|---|
| Clinton | `20260529-063451-...-sdc.log` | aborted | `_post_new_claims:1352/1369` `KeyError: 'success'` |
| Johnson | `20260529-065636-...-sdc.log` | aborted | `_post_new_claims:1352/1369` `KeyError: 'success'` |

Both aborts have **identical signatures**. Two chained `KeyError: 'success'` (initial save + retry save), both from `post["success"] == 1` access — which only fires when the response is shaped like `{"error": {"code": "...", "info": "..."}}` with no `success` field. Commons is consistently rejecting these items, and the fresh token from `login()` didn't help, because the token wasn't the problem.

The existing `print(save.text)` inside the inner except went to stdout, which is block-buffered to a non-TTY and got dropped on `sys.exit()`. PR #263's `raise RuntimeError(...) from retry_e` carries the chained `KeyError` but **not the Commons response body** — the error code (`permissiondenied`? `abusefilter-disallowed`? `editconflict`?) is the missing diagnostic.

## Changes

- `tools/sdc_sync.py`: Both inner `except Exception as retry_e:` blocks (in `_post_new_refs` and `_post_new_claims`) now bake `_truncate(save.text)` into the RuntimeError message — guarded by `"save" in locals()` so a pre-fetch failure (e.g. `login()` raising before assignment) doesn't mask itself with an `UnboundLocalError`.
- `tests/test_sdc_sync.py`: Two new tests that drive the relogin retry path (response missing `"success"` key → `KeyError` chain) and assert the Commons error code appears verbatim in the raised `RuntimeError`'s message:
  - `test_post_new_claims_relogin_failure_message_includes_response_body` — asserts `"permissiondenied"` lands in the message.
  - `test_post_new_refs_relogin_failure_message_includes_response_body` — asserts `"abusefilter-disallowed"` lands in the message.

The full response body is also still captured in the per-ordinal `logging.exception` traceback context via the `__cause__` chain — the message addition is so it's visible in one-line log scans without expanding the traceback.

## What this lets us do next

Once Clinton / Johnson re-run on EC2 with this fix, the SDC log will contain something like:

```
ERROR Ordinal 8 (M192145428) for 0c3cefdaacbbc24c0cbc1194b774d6d6: SDC sync failed; skipping ordinal.
RuntimeError: Claims relogin+save failed for M192145428 (0c3cefdaacbbc24c0cbc1194b774d6d6): {"error": {"code": "...", "info": "..."}}
```

That error code tells us whether to fix the claim format, filter the items out, request a Commons account-level review, or escalate. From there we can actually post the missing SDC instead of skipping it.

## Test plan

- [ ] Pytest passes (CI)
- [ ] After merge + next launch on EC2, Clinton (`nara|William J. Clinton Library`) and Johnson (`nara|Lyndon Baines Johnson Library`) SDC re-runs surface the actual Commons error code in their per-ordinal error messages
- [ ] From those codes, decide the actual fix (claim sanitization, item filter, etc.) in a subsequent PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves error diagnostics in the SDC POST helpers (`_post_new_refs` and `_post_new_claims`) by including the truncated Commons response body in RuntimeError messages when a relogin+save retry fails. The change guards against unbound `save` variables (which can occur if the initial request fails before a response is received) and surfaces Commons error codes (e.g., `permissiondenied`, `abusefilter-disallowed`) directly in one-line error messages for improved log scanning.

## Changes

**tools/sdc_sync.py** (+20/-2 lines)
- Updated exception handling in `_post_new_refs` and `_post_new_claims` to conditionally include the truncated response body in RuntimeError messages on relogin retry failures
- Guard clause uses `"save" in locals()` to avoid masking pre-fetch failures with UnboundLocalError
- Full response body remains available in traceback context via the `__cause__` chain

**tests/test_sdc_sync.py** (+78/-0 lines)
- Added `test_post_new_claims_relogin_failure_message_includes_response_body()`: verifies that Commons error code `"permissiondenied"` appears in the RuntimeError message when relogin+save retry fails
- Added `test_post_new_refs_relogin_failure_message_includes_response_body()`: verifies that Commons error code `"abusefilter-disallowed"` appears in the RuntimeError message when relogin+save retry fails

## Notes

- No changes to public APIs, environment variables, infrastructure, or database
- This is a code quality/logging improvement with no deployment, security, or infrastructure implications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->