### PR TITLE
sdc-sync: treat no-such-entity as a clean skip, not an error

### DIFF
--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -28,6 +28,15 @@ class Result(Enum):
     # whole partner batch — the matching try/except is in
     # tools/sdc_sync.py::_run_partner_mode.
     SDC_ORDINALS_SKIPPED_ERROR = auto()
+    # Ordinals where Commons returned `no-such-entity` for the staged
+    # M-id — the file page has been deleted (often as a duplicate by a
+    # human curator) or was never uploaded in this run path. Not a
+    # failure of the SDC phase — the SDC phase only writes to existing
+    # MediaInfo entities; ensuring the entity exists is the upload
+    # phase's responsibility. Tracked separately so genuine errors
+    # (claim rejection, throttle, etc.) stay distinguishable from
+    # not-our-problem skips.
+    SDC_ORDINALS_SKIPPED_MISSING_ENTITY = auto()
     # Items where every eligible ordinal hit the per-ordinal exception
     # path — i.e., the item didn't fail due to malformed data
     # (MAPPING) or missing sidecars (NO_SIDECAR), but because all of

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -735,3 +735,115 @@ def test_post_new_refs_relogin_failure_message_includes_response_body(monkeypatc
     assert "abusefilter-disallowed" in msg, (
         "Commons error code must appear in the RuntimeError message; got: " + repr(msg)
     )
+
+
+# --------------------------------------------------------------------------
+# `no-such-entity` is treated as a clean skip, NOT a failure.
+#
+# When Commons returns `{"error": {"code": "no-such-entity"}}`, it means
+# the MediaInfo entity for the staged M-id doesn't exist — most commonly
+# because the file page was deleted by a Commons curator as a duplicate,
+# or because this is an SDC-only run for a file that wasn't uploaded
+# through our pipeline. Neither is the SDC phase's fault, and re-running
+# wouldn't help — the entity isn't coming back via retry. The phase
+# must:
+#   1. NOT divert into the relogin retry path (token isn't the problem)
+#   2. raise a specific `_MissingEntityError` rather than `RuntimeError`
+#   3. propagate that exception to the per-ordinal handler, which logs
+#      it at INFO (not ERROR) and increments a dedicated counter.
+# --------------------------------------------------------------------------
+
+
+def test_raise_if_missing_entity_helper():
+    """Direct unit test of the helper."""
+    from tools import sdc_sync
+
+    # no-such-entity payload → raises _MissingEntityError
+    with pytest.raises(sdc_sync._MissingEntityError):
+        sdc_sync._raise_if_missing_entity(
+            {"error": {"code": "no-such-entity"}}, "M12345"
+        )
+
+    # Other error codes do NOT raise — they fall through to the generic
+    # error path so the existing retry / RuntimeError logic still runs.
+    sdc_sync._raise_if_missing_entity({"error": {"code": "permissiondenied"}}, "M12345")
+    sdc_sync._raise_if_missing_entity({"success": 1}, "M12345")
+    sdc_sync._raise_if_missing_entity({}, "M12345")
+    # Defensive: non-dict input shouldn't blow up.
+    sdc_sync._raise_if_missing_entity(None, "M12345")  # type: ignore[arg-type]
+
+
+def test_post_new_claims_no_such_entity_raises_missing_entity_error(monkeypatch):
+    """Claims POST helper must raise `_MissingEntityError` (not RuntimeError)
+    when Commons returns ``no-such-entity``.
+
+    The relogin retry path must NOT run — `_MissingEntityError` must
+    propagate through the `except (RuntimeError, _MissingEntityError): raise`
+    guard intact, exactly like the structured `RuntimeError` does, so the
+    per-ordinal handler sees the specific exception class.
+    """
+    from tools import sdc_sync
+
+    response = MagicMock()
+    response.text = '{"error": {"code": "no-such-entity", "info": "⧼no-such-entity⧽"}}'
+    _install_module_globals(
+        monkeypatch, sdc_sync, response, claims_payload=[{"some": "claim"}]
+    )
+    # Stub login() so a *bug* that diverted us into the retry path would
+    # still produce diagnosable output (instead of an UnboundLocalError
+    # masking the actual control-flow defect).
+    login_called = []
+    monkeypatch.setattr(
+        sdc_sync,
+        "login",
+        lambda: (login_called.append(True), "stub-token-2")[1],
+        raising=False,
+    )
+
+    with pytest.raises(sdc_sync._MissingEntityError) as excinfo:
+        sdc_sync._post_new_claims("M12345", "abcdef01abcdef01abcdef01abcdef01")
+
+    assert "M12345" in str(excinfo.value)
+    # CRITICAL invariant: login() must NOT have been called. The relogin
+    # path is for "maybe our token expired" — which is irrelevant here.
+    assert login_called == [], (
+        "_post_new_claims must skip the relogin retry path on no-such-entity;"
+        " login() should not have been called"
+    )
+
+
+def test_post_new_refs_no_such_entity_raises_missing_entity_error(monkeypatch):
+    """Same contract for the refs POST helper."""
+    from tools import sdc_sync
+
+    response = MagicMock()
+    response.text = '{"error": {"code": "no-such-entity"}}'
+    _install_module_globals(
+        monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
+    )
+    login_called = []
+    monkeypatch.setattr(
+        sdc_sync,
+        "login",
+        lambda: (login_called.append(True), "stub-token-2")[1],
+        raising=False,
+    )
+
+    with pytest.raises(sdc_sync._MissingEntityError) as excinfo:
+        sdc_sync._post_new_refs("M67890", "fedcba98fedcba98fedcba98fedcba98")
+
+    assert "M67890" in str(excinfo.value)
+    assert login_called == []
+
+
+def test_missing_entity_error_is_not_a_runtime_error():
+    """The per-ordinal handler distinguishes `_MissingEntityError` from
+    generic `RuntimeError`/`Exception`. The exception class must NOT be
+    a `RuntimeError` subclass or it would be caught by every
+    `except RuntimeError:` guard in the POST helpers, restarting the
+    relogin loop on it.
+    """
+    from tools import sdc_sync
+
+    assert issubclass(sdc_sync._MissingEntityError, Exception)
+    assert not issubclass(sdc_sync._MissingEntityError, RuntimeError)

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -20,6 +20,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ingest_wikimedia.tracker import Result
+
 
 def _qual_entity(prop, qid):
     """Build a single wikibase-entityid qualifier snak under `prop`."""
@@ -847,3 +849,80 @@ def test_missing_entity_error_is_not_a_runtime_error():
 
     assert issubclass(sdc_sync._MissingEntityError, Exception)
     assert not issubclass(sdc_sync._MissingEntityError, RuntimeError)
+
+
+def test_legacy_process_one_treats_missing_entity_as_clean_skip(monkeypatch):
+    """``process_one()`` is the legacy entry point used by ``--file`` /
+    ``--cat`` / ``--list`` runs (separate from partner mode's
+    ``process_one_from_sdc``). It must apply the same
+    ``_MissingEntityError`` → skip contract — otherwise a Commons
+    ``no-such-entity`` response would abort the legacy run, exactly the
+    cascade the PR's partner-mode handler avoids.
+    """
+    from tools import sdc_sync
+
+    # parsed() returns a real DPLA-shaped tuple so process_one proceeds
+    # past the "missing id" early return.
+    monkeypatch.setattr(
+        sdc_sync,
+        "parsed",
+        lambda dpla_id, dpla_api: (
+            "http://example/url",  # url
+            ["desc"],  # descs
+            ["2020"],  # dates
+            ["title"],  # titles
+            "nara",  # hub
+            ["local-id-1"],  # local_ids
+            "National Archives",  # institution
+            "http://creativecommons.org/publicdomain/mark/1.0/",  # rs
+            ["creator"],  # creators
+            [("subject", None)],  # subjects
+            ["12345"],  # naids
+            "access",  # access
+            "level",  # level
+        ),
+    )
+    monkeypatch.setattr(sdc_sync, "dpla_api", "stub-api-key", raising=False)
+    monkeypatch.setattr(sdc_sync, "invalidate_entity", lambda *_a, **_k: None)
+    monkeypatch.setattr(sdc_sync, "get_entity", lambda *_a, **_k: {})
+    # Skip every add_* helper — they call check() which hits the real
+    # Commons API for entity reads. Replace them with no-ops.
+    for name in [
+        "add_rs",
+        "add_id",
+        "add_title",
+        "add_collection",
+        "add_creator",
+        "add_date",
+        "add_subject",
+        "add_subject_entity",
+        "add_desc",
+        "add_contributed",
+        "add_source",
+        "add_local_id",
+        "add_naid",
+        "add_access",
+        "add_level",
+    ]:
+        monkeypatch.setattr(sdc_sync, name, lambda *_a, **_k: None)
+    # `dpla_claims` calls `_reconcile_existing_claims` — stub it too.
+    monkeypatch.setattr(sdc_sync, "dpla_claims", lambda *_a, **_k: None)
+    # The actual POST helper raises the missing-entity error.
+    monkeypatch.setattr(
+        sdc_sync,
+        "_post_new_refs",
+        lambda *_a, **_k: (_ for _ in ()).throw(sdc_sync._MissingEntityError("M12345")),
+    )
+    monkeypatch.setattr(sdc_sync, "_post_new_claims", lambda *_a, **_k: None)
+
+    counter_before = sdc_sync.tracker.count(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY)
+
+    # Should NOT raise — process_one must catch _MissingEntityError and
+    # return cleanly.
+    sdc_sync.process_one("M12345", "abcdef01abcdef01abcdef01abcdef01")
+
+    counter_after = sdc_sync.tracker.count(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY)
+    assert counter_after == counter_before + 1, (
+        "process_one must increment SDC_ORDINALS_SKIPPED_MISSING_ENTITY on"
+        f" the no-such-entity skip path; before={counter_before}, after={counter_after}"
+    )

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2127,26 +2127,39 @@ def process_one(mediaid, dpla_id):
     add_access(mediaid, access, dpla_id)
     add_level(mediaid, level, dpla_id)
 
-    _post_new_refs(mediaid, dpla_id)
-    _post_new_claims(mediaid, dpla_id)
-
-    dpla_claims(
-        mediaid,
-        dpla_id,
-        url,
-        descs,
-        dates,
-        titles,
-        hub,
-        local_ids,
-        institution,
-        rs,
-        creators,
-        subjects,
-        naids,
-        access,
-        level,
-    )
+    # Mirror the partner-mode handler at `_run_partner_mode`: ``no-such-entity``
+    # is a clean skip, not an error — the MediaInfo entity doesn't exist
+    # (file deleted by a Commons curator as a duplicate, or this is a
+    # legacy --file/--cat/--list run for a file we never owned). Without
+    # this guard the same Commons response that the partner path treats
+    # as a skip would crash the legacy entry points.
+    try:
+        _post_new_refs(mediaid, dpla_id)
+        _post_new_claims(mediaid, dpla_id)
+        dpla_claims(
+            mediaid,
+            dpla_id,
+            url,
+            descs,
+            dates,
+            titles,
+            hub,
+            local_ids,
+            institution,
+            rs,
+            creators,
+            subjects,
+            naids,
+            access,
+            level,
+        )
+    except _MissingEntityError:
+        logging.info(
+            f" -- {mediaid} for {dpla_id}: Commons MediaInfo entity does not"
+            " exist; skipping (not an error)."
+        )
+        tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY)
+        return
 
 
 def process_one_from_sdc(mediaid, dpla_id, sdc_payload):

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -117,6 +117,45 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
+class _MissingEntityError(Exception):
+    """Commons returned ``no-such-entity`` for the staged M-id.
+
+    Raised by the wbeditentity / wbremoveclaims POST helpers when Commons
+    reports the MediaInfo entity doesn't exist. This is not a failure of
+    the SDC phase — it just means the file page is gone (most commonly
+    because a Commons curator deleted it as a duplicate, or because this
+    is an SDC-only run for an M-id whose upload was never confirmed). The
+    per-ordinal handler in ``_run_partner_mode`` catches this distinctly
+    from generic ``Exception`` so it can:
+
+    - log at INFO instead of ERROR (it isn't an error to log against),
+    - increment ``SDC_ORDINALS_SKIPPED_MISSING_ENTITY`` instead of
+      ``SDC_ORDINALS_SKIPPED_ERROR``,
+    - leave ``had_ordinal_error`` unchanged so the item's bucket
+      classification (SYNCED / SKIPPED_ERROR / SKIPPED_MAPPING) is
+      decided by the other ordinals' outcomes, not by these skips.
+
+    Re-uploading the file or re-resolving the M-id is upstream work
+    (upload phase, drift handling) — not something this phase can or
+    should try to fix.
+    """
+
+
+def _raise_if_missing_entity(post: dict, mediaid: str) -> None:
+    """Inspect a parsed wbeditentity / wbremoveclaims response and raise
+    ``_MissingEntityError`` if Commons reported ``no-such-entity``.
+
+    Must be called BEFORE accessing ``post["success"]`` — a response with
+    no ``success`` key (the shape of every Commons error response) would
+    otherwise raise ``KeyError`` and divert into the generic retry path,
+    masking the specific cause from the per-ordinal handler.
+    """
+    if isinstance(post, dict):
+        err = post.get("error") or {}
+        if err.get("code") == "no-such-entity":
+            raise _MissingEntityError(mediaid)
+
+
 def _truncate(text: str | None, limit: int = 500) -> str:
     """Return ``text`` shortened to ``limit`` chars with an ellipsis suffix.
 
@@ -1294,6 +1333,7 @@ def _post_new_refs(mediaid, dpla_id):
                 ) from final_e
     try:
         post = json.loads(save.text)
+        _raise_if_missing_entity(post, mediaid)
         if post["success"] == 1:
             print(" --- Saved new refs!")
             tracker.increment(Result.SDC_REFS_ADDED, refs_to_post)
@@ -1304,9 +1344,11 @@ def _post_new_refs(mediaid, dpla_id):
                 f"wbeditentity refs save returned non-success for"
                 f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
             )
-    except RuntimeError:
+    except (RuntimeError, _MissingEntityError):
         # Our own structured failure — let the per-ordinal handler see it
         # as-is rather than restarting the relogin path below.
+        # ``_MissingEntityError`` in particular must skip the relogin: the
+        # entity isn't coming back via a fresh token.
         raise
     except Exception:
         try:
@@ -1318,6 +1360,7 @@ def _post_new_refs(mediaid, dpla_id):
                 data=postrefs,
             )
             post = json.loads(save.text)
+            _raise_if_missing_entity(post, mediaid)
             if post["success"] == 1:
                 print(" --- Saved new refs!")
                 tracker.increment(Result.SDC_REFS_ADDED, refs_to_post)
@@ -1328,7 +1371,7 @@ def _post_new_refs(mediaid, dpla_id):
                 f"wbeditentity refs save still non-success after relogin for"
                 f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
             )
-        except RuntimeError:
+        except (RuntimeError, _MissingEntityError):
             raise
         except Exception as retry_e:
             # `save` may not be bound if http.fetch raised before the response
@@ -1392,6 +1435,7 @@ def _post_new_claims(mediaid, dpla_id):
                 ) from final_e
     try:
         post = json.loads(save.text)
+        _raise_if_missing_entity(post, mediaid)
         if post["success"] == 1:
             print(" --- Saved new claims!")
             tracker.increment(Result.SDC_CLAIMS_ADDED, claims_to_post)
@@ -1402,7 +1446,7 @@ def _post_new_claims(mediaid, dpla_id):
                 f"wbeditentity claims save returned non-success for"
                 f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
             )
-    except RuntimeError:
+    except (RuntimeError, _MissingEntityError):
         raise
     except Exception:
         try:
@@ -1414,6 +1458,7 @@ def _post_new_claims(mediaid, dpla_id):
                 data=postdata,
             )
             post = json.loads(save.text)
+            _raise_if_missing_entity(post, mediaid)
             if post["success"] == 1:
                 print(" --- Saved new claims!")
                 tracker.increment(Result.SDC_CLAIMS_ADDED, claims_to_post)
@@ -1424,7 +1469,7 @@ def _post_new_claims(mediaid, dpla_id):
                 f"wbeditentity claims save still non-success after relogin for"
                 f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
             )
-        except RuntimeError:
+        except (RuntimeError, _MissingEntityError):
             raise
         except Exception as retry_e:
             # `post` may not be assigned yet if http.fetch / json.loads raised —
@@ -1712,6 +1757,7 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
                 f"wbremoveclaims response was not parseable JSON for"
                 f" {mediaid} ({dpla_id}): {_truncate(getattr(rm_resp, 'text', ''))}"
             ) from parse_e
+        _raise_if_missing_entity(rm_post, mediaid)
         if rm_post.get("success") == 1:
             print(" --- Saved removals!")
             tracker.increment(Result.SDC_REMOVALS, len(removals))
@@ -2355,6 +2401,22 @@ def _run_partner_mode(partner, ids_file):
                 # `_summarize_log` can surface it in Slack.
                 try:
                     process_one_from_sdc(mediaid, dpla_id, sdc_payload)
+                except _MissingEntityError:
+                    # Commons says the MediaInfo entity at this M-id doesn't
+                    # exist. Almost always means the file page was deleted
+                    # (often by a Commons curator as a duplicate) between
+                    # upload and SDC sync, OR this is an SDC-only run for a
+                    # file that wasn't uploaded through our pipeline in this
+                    # run. Either way it's outside the SDC phase's remit —
+                    # not an error, just a clean skip. Tracked separately
+                    # from real errors so operators can tell them apart.
+                    logging.info(
+                        f" -- Ordinal {ord_str} ({mediaid}) for {dpla_id}:"
+                        " Commons MediaInfo entity does not exist; skipping"
+                        " ordinal (not an error)."
+                    )
+                    tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY)
+                    continue
                 except Exception:
                     logging.exception(
                         f" -- Ordinal {ord_str} ({mediaid}) for {dpla_id}:"


### PR DESCRIPTION
## Summary

Architectural fix to the SDC phase: stop treating Commons' \`no-such-entity\` response as a failure.

When Commons returns \`{\"error\": {\"code\": \"no-such-entity\"}}\` for a \`wbeditentity\` / \`wbremoveclaims\` POST, it means the MediaInfo entity at the staged M-id doesn't exist — the file page has been deleted (typically by a Commons curator flagging our upload as a duplicate), or this is an SDC-only run for a file that wasn't uploaded through our pipeline. **Ensuring the entity exists is the upload phase's responsibility; the SDC phase has nothing it can or should fix here.**

## Concrete evidence motivating this fix

An SDC-only retry of DPLA ID \`0034db749eabed986395f6fe1b7439db\` (NACPSP / native-american-delegations) hit \`no-such-entity\` on two ordinals after PR #266's diagnostic surfaced the code. Cross-referenced against Commons logs:

| Time (UTC) | Event |
|---|---|
| 5/26 20:20 | DPLA bot uploads pages 1 + 2 → pageids 192836795, 192836797 |
| 5/28 21:30 + 21:37 | Commons editor \"Ziv\" deletes both pages: \`Exact or scaled-down duplicate: File:Cliff Palace, Mesa Verde - NARA - 523560.tif\` |
| 5/30 05:02 | Our retry → \`no-such-entity\`, classified as \`SDC_ORDINALS_SKIPPED_ERROR\` |

No amount of retry will bring those entities back. They were correctly identified as duplicates of a canonical NARA-titled file and removed.

## Pre-fix behaviour

The error response shape \`{\"error\": {\"code\": \"no-such-entity\"}}\` has no \`success\` key. The existing code does \`post[\"success\"] == 1\`, which raises \`KeyError\`, gets caught by \`except Exception:\`, diverts into the relogin retry path (which fails identically), and finally surfaces as \`RuntimeError: Claims relogin+save failed for M...\`. The per-ordinal handler classifies that as \`SDC_ORDINALS_SKIPPED_ERROR\`, logs at \`ERROR\`, and conflates it with real failures like \`permissiondenied\` or \`abusefilter-disallowed\`.

## Changes

1. **\`Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY\`** added to the tracker enum.
2. **\`_MissingEntityError\`** — a plain \`Exception\` (deliberately NOT a \`RuntimeError\`) in \`tools/sdc_sync.py\`.
3. **\`_raise_if_missing_entity(post, mediaid)\`** helper called before each \`post[\"success\"]\` check in \`_post_new_refs\`, \`_post_new_claims\`, and the \`_reconcile_existing_claims\` removals block.
4. **\`except (RuntimeError, _MissingEntityError): raise\`** guards updated in both helpers so the new exception class propagates cleanly without triggering the relogin retry (the token isn't the problem).
5. **Dedicated \`except _MissingEntityError:\` branch** in the per-ordinal handler in \`_run_partner_mode\`:
   - Logs at \`INFO\` (not \`ERROR\`)
   - Increments \`SDC_ORDINALS_SKIPPED_MISSING_ENTITY\` (not \`SDC_ORDINALS_SKIPPED_ERROR\`)
   - Leaves \`had_ordinal_error\` untouched — item bucket classification (SYNCED / SKIPPED_ERROR / SKIPPED_MAPPING) reflects the other ordinals' actual outcomes.

## Tests

- \`test_raise_if_missing_entity_helper\` — direct unit on the helper (raises on no-such-entity, no-op for other codes).
- \`test_post_new_claims_no_such_entity_raises_missing_entity_error\` — verifies the claims helper raises \`_MissingEntityError\` AND **explicitly asserts \`login()\` was not called** (proving the relogin retry is skipped).
- \`test_post_new_refs_no_such_entity_raises_missing_entity_error\` — same contract for the refs helper.
- \`test_missing_entity_error_is_not_a_runtime_error\` — asserts the class hierarchy so a future \`except RuntimeError:\` regression doesn't silently swallow it back into the retry path.

## Out of scope (intentionally)

This PR is the minimum-viable architectural separation: \"no-such-entity is a skip.\" It deliberately does NOT:

- Add retry-with-backoff for actually-transient codes (\`maxlag\`, \`ratelimited\`, \`readonly\`) — that's a separate concern; will be its own PR.
- Add wbgetentities-based pre-checks for entity existence — also out of scope.
- Move the script onto pywikibot's higher-level API — a broader audit of SDC-related code is queued separately.

## Test plan

- [ ] Pytest passes (CI)
- [ ] After deploy, an SDC-only re-run that hits a deleted-page case logs at INFO with \"Commons MediaInfo entity does not exist; skipping ordinal (not an error).\"
- [ ] COUNTS dump shows \`SDC_ORDINALS_SKIPPED_MISSING_ENTITY\` distinct from \`SDC_ORDINALS_SKIPPED_ERROR\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR treats Commons API responses with {"error": {"code": "no-such-entity"}} from wbeditentity and wbremoveclaims as a clean skip rather than an SDC-phase failure. Such responses indicate the MediaInfo entity for the staged M-id does not exist (file page deleted or never uploaded by this pipeline) and are the upload phase's responsibility; SDC should skip the ordinal rather than trigger relogin/retry or count it as an SDC error.

## Changes

- ingest_wikimedia/tracker.py
  - Added Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY to track ordinals skipped due to missing Commons entities.

- tools/sdc_sync.py
  - Added internal exception class _MissingEntityError(Exception).
  - Added helper _raise_if_missing_entity(post: dict, mediaid: str) that detects Commons no-such-entity responses and raises _MissingEntityError. Must be called before accessing post["success"].
  - Updated POST helpers (_post_new_refs, _post_new_claims) and removals in _reconcile_existing_claims to call _raise_if_missing_entity immediately after parsing JSON so missing-entity cases raise the new exception instead of producing KeyError/diverting into relogin retry paths.
  - Adjusted exception handling so _MissingEntityError propagates out of retry/relogin logic.
  - In partner-mode per-ordinal handling (_run_partner_mode), catch _MissingEntityError, log at INFO, increment Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY, and skip the ordinal without marking it as an error or changing had_ordinal_error.
  - Extended legacy process_one() flow to catch _MissingEntityError around the bulk-POST + dpla_claims section, log at INFO, increment the new counter, and return without raising — preventing legacy single-file runs from aborting on the same response shape.

- tests/test_sdc_sync.py
  - Added tests verifying:
    - _raise_if_missing_entity helper raises on no-such-entity.
    - _post_new_claims and _post_new_refs propagate _MissingEntityError and do not call login()/retrigger retry logic.
    - _MissingEntityError is an Exception but not a RuntimeError subclass (so it bypasses generic RuntimeError retry logic).
    - legacy process_one() path catches _MissingEntityError, increments the new counter, and does not raise.

## Test plan

- CI: pytest coverage included; new tests added in tests/test_sdc_sync.py.
- Post-deploy: INFO logs should show skipped ordinals for missing entities, and COUNTS output should include SDC_ORDINALS_SKIPPED_MISSING_ENTITY distinct from SDC_ORDINALS_SKIPPED_ERROR.

## Operational / infra notes (explicit)

- No database migrations.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No changes to shared infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM).
- No public-facing API response shape changes or new endpoints.
- No security-sensitive credential handling changes; no new external inputs beyond existing Commons API usage.
- Deployment note: these are code changes to the sdc_sync tool. Any running deployments or scheduled jobs that package this repository (for example an ECS task, container image, or other runner) must be redeployed/updated to pick up the change. There are no configuration or secret changes required to enable the behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->