### PR TITLE
sdc-sync: route SDC writes through pywikibot's simple_request

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -550,16 +550,29 @@ def test_truncate_helper_returns_under_limit_unchanged_and_truncates_long():
 
 
 def _install_module_globals(
-    monkeypatch, sdc_sync, response, *, refclaims_payload=None, claims_payload=None
+    monkeypatch,
+    sdc_sync,
+    *,
+    refclaims_payload=None,
+    claims_payload=None,
+    submit_side_effect=None,
+    submit_return=None,
 ):
-    """Inject the module-level globals the SDC POST helpers expect.
+    """Inject the module-level globals the SDC POST helpers expect AND
+    mock the pywikibot path the helpers now write through.
 
-    ``refclaims`` / ``claims`` / ``token`` are not initialised at import
-    time — they're declared ``global`` and populated inside ``process_one``
-    / ``process_one_from_sdc`` before each item. Tests that call the POST
-    helpers directly have to install those globals themselves;
-    ``raising=False`` lets monkeypatch set + tear down attributes that
-    didn't exist on the module yet.
+    The POST helpers no longer hit raw ``http.fetch`` — they call
+    ``site.simple_request(action=..., ...).submit()``, which is
+    pywikibot's high-level write entry point. To exercise the helpers
+    without an actual network round-trip we mock the ``site`` module
+    global so ``simple_request`` returns a request object whose
+    ``submit()`` either returns ``submit_return`` (success) or raises
+    ``submit_side_effect`` (the pywikibot ``APIError`` we're modelling).
+
+    ``refclaims`` / ``claims`` are not initialised at import time —
+    they're declared ``global`` and populated inside ``process_one`` /
+    ``process_one_from_sdc`` before each item, so tests that call the
+    POST helpers directly install them here with ``raising=False``.
     """
     monkeypatch.setattr(
         sdc_sync,
@@ -573,30 +586,48 @@ def _install_module_globals(
         {"claims": claims_payload if claims_payload is not None else []},
         raising=False,
     )
-    monkeypatch.setattr(sdc_sync, "token", "stub-token", raising=False)
-    monkeypatch.setattr(sdc_sync.http, "fetch", lambda *a, **kw: response)
+
+    request_mock = MagicMock()
+    if submit_side_effect is not None:
+        request_mock.submit.side_effect = submit_side_effect
+    else:
+        request_mock.submit.return_value = (
+            submit_return if submit_return is not None else {"success": 1}
+        )
+
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value = request_mock
+    # Pywikibot's lazy CSRF cache surfaces as ``site.tokens["csrf"]``.
+    # The migration accesses it; mock it to a deterministic value.
+    fake_site.tokens = {"csrf": "stub-csrf-token"}
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+    return fake_site
 
 
-def test_post_new_refs_raises_runtime_error_on_non_success_save(monkeypatch):
-    """A non-success wbeditentity refs response must raise RuntimeError,
-    not call sys.exit(). The error message must include the mediaid and
-    DPLA id so the failure is self-identifying in the SDC log.
+def _api_error(code, info=""):
+    """Construct a ``pywikibot.exceptions.APIError`` for tests.
 
-    The response payload must carry an explicit ``"success": 0`` so the
-    helper's initial save lands in the ``else`` branch (the path that
-    raises the structured "non-success" error). A response with no
-    ``"success"`` key at all would raise KeyError instead and divert
-    into the relogin retry — useful for the catch-by-per-ordinal test
-    below, but not what this one is checking.
+    APIError's constructor signature is ``(code, info, **kwargs)`` and
+    callers across pywikibot pass extra context (servedby, etc.) as
+    kwargs. We only need code + info for assertions.
+    """
+    import pywikibot.exceptions
+
+    return pywikibot.exceptions.APIError(code=code, info=info)
+
+
+def test_post_new_refs_raises_runtime_error_on_apierror(monkeypatch):
+    """Pywikibot's ``APIError`` for any code OTHER than ``no-such-entity``
+    must be re-raised as ``RuntimeError`` carrying mediaid + dpla_id +
+    Commons error code so the per-ordinal handler logs a useful traceback.
     """
     from tools import sdc_sync
 
-    response = MagicMock()
-    response.text = (
-        '{"success": 0, "error": {"code": "badtoken", "info": "Invalid token"}}'
-    )
     _install_module_globals(
-        monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
+        monkeypatch,
+        sdc_sync,
+        refclaims_payload=[{"some": "ref"}],
+        submit_side_effect=_api_error("badtoken", info="Invalid token"),
     )
 
     with pytest.raises(RuntimeError) as excinfo:
@@ -605,17 +636,22 @@ def test_post_new_refs_raises_runtime_error_on_non_success_save(monkeypatch):
     msg = str(excinfo.value)
     assert "M12345" in msg
     assert "abcdef01abcdef01abcdef01abcdef01" in msg
-    assert "non-success" in msg
+    # The Commons error code must appear in the RuntimeError message so
+    # the per-ordinal ``logging.exception`` captures it without needing
+    # to unwrap the ``__cause__`` chain.
+    assert "badtoken" in msg, f"expected 'badtoken' in {msg!r}"
 
 
-def test_post_new_claims_raises_runtime_error_on_non_success_save(monkeypatch):
-    """Same contract for the claims POST helper."""
+def test_post_new_claims_raises_runtime_error_on_apierror(monkeypatch):
+    """Same contract for the claims POST helper — non-no-such-entity
+    APIErrors come out as RuntimeError with the code in the message."""
     from tools import sdc_sync
 
-    response = MagicMock()
-    response.text = '{"success": 0, "error": {"code": "ratelimited"}}'
     _install_module_globals(
-        monkeypatch, sdc_sync, response, claims_payload=[{"some": "claim"}]
+        monkeypatch,
+        sdc_sync,
+        claims_payload=[{"some": "claim"}],
+        submit_side_effect=_api_error("abusefilter-disallowed", info="Rule X tripped."),
     )
 
     with pytest.raises(RuntimeError) as excinfo:
@@ -624,226 +660,220 @@ def test_post_new_claims_raises_runtime_error_on_non_success_save(monkeypatch):
     msg = str(excinfo.value)
     assert "M67890" in msg
     assert "fedcba98fedcba98fedcba98fedcba98" in msg
-    assert "non-success" in msg
+    assert "abusefilter-disallowed" in msg, f"expected error code in {msg!r}"
 
 
 def test_post_new_refs_runtime_error_caught_by_per_ordinal_handler(monkeypatch):
-    """The RuntimeError raised from inside _post_new_refs must be a
-    plain Exception subclass (not BaseException), so the per-ordinal
-    `except Exception:` in process_one_from_sdc catches it and the
-    partner batch can continue with the next ordinal.
+    """The RuntimeError raised from inside ``_post_new_refs`` must be a
+    plain ``Exception`` subclass (not ``BaseException``), so the
+    ``except Exception:`` clause in ``process_one_from_sdc`` catches it
+    and the partner batch can continue with the next ordinal.
 
-    This is the key behavioural difference vs the old sys.exit() — old
-    code raised SystemExit (BaseException, not caught by the per-ordinal
-    handler), so a single failed write tanked the entire partner.
+    Regression guard against the pre-PR-#263 ``sys.exit()`` behaviour,
+    which raised ``SystemExit`` (a ``BaseException``) and bypassed the
+    per-ordinal handler — one failed write tanked the entire partner.
     """
     from tools import sdc_sync
 
-    response = MagicMock()
-    response.text = '{"success": 0, "error": {"code": "badtoken"}}'
     _install_module_globals(
-        monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
+        monkeypatch,
+        sdc_sync,
+        refclaims_payload=[{"some": "ref"}],
+        submit_side_effect=_api_error("badtoken"),
     )
 
     skipped = False
     try:
         sdc_sync._post_new_refs("M12345", "abcdef01abcdef01abcdef01abcdef01")
     except Exception:
-        # This is the same `except Exception:` clause that wraps each
-        # ordinal in process_one_from_sdc — catching it here proves the
+        # Same ``except Exception:`` clause that wraps each ordinal in
+        # ``process_one_from_sdc`` — catching it here proves the
         # per-ordinal handler will skip rather than abort the partner.
         skipped = True
 
     assert skipped, (
-        "RuntimeError from _post_new_refs must be an Exception subclass so the"
-        " per-ordinal handler in process_one_from_sdc catches it (was previously"
-        " SystemExit, which bypassed that handler and aborted the whole partner)"
+        "RuntimeError from _post_new_refs must be an Exception subclass so"
+        " the per-ordinal handler in process_one_from_sdc catches it"
     )
 
 
-# --------------------------------------------------------------------------
-# Response-body inclusion in the relogin+save failure messages.
-#
-# When the per-ordinal handler in process_one_from_sdc logs an exception
-# from these helpers, the only thing we currently see is "Claims
-# relogin+save failed for <mediaid> (<dpla_id>)" plus a chained
-# KeyError from json parsing. That isn't enough to diagnose the
-# underlying problem — Commons returns errors like
-# {"error": {"code": "permissiondenied", "info": "..."}} which have
-# NO "success" key, so post["success"] raises KeyError and the actual
-# error code is lost. Baking save.text into the RuntimeError message
-# captures the Commons error code in the structured exception, where
-# logging.exception will write it to the SDC log.
-# --------------------------------------------------------------------------
+def test_post_new_refs_success_path_increments_counter(monkeypatch):
+    """The happy path: ``simple_request().submit()`` returns success →
+    the SDC_REFS_ADDED counter increments by the number of refs posted."""
+    from tools import sdc_sync
+
+    _install_module_globals(
+        monkeypatch,
+        sdc_sync,
+        refclaims_payload=[{"ref": "a"}, {"ref": "b"}, {"ref": "c"}],
+        submit_return={"success": 1, "entity": {}},
+    )
+
+    before = sdc_sync.tracker.count(Result.SDC_REFS_ADDED)
+    sdc_sync._post_new_refs("M12345", "abcdef01abcdef01abcdef01abcdef01")
+    after = sdc_sync.tracker.count(Result.SDC_REFS_ADDED)
+    assert after == before + 3, (
+        f"SDC_REFS_ADDED should bump by 3; before={before}, after={after}"
+    )
 
 
-def test_post_new_claims_relogin_failure_message_includes_response_body(monkeypatch):
-    """When the relogin retry also returns a response with no ``"success"``
-    key, the chained KeyError + new RuntimeError message must include the
-    Commons response body so we can read the error code from the SDC log.
+def test_post_new_claims_success_path_increments_counter(monkeypatch):
+    """Same happy-path contract for claims."""
+    from tools import sdc_sync
 
-    Without this, the per-ordinal traceback only tells us the helper hit
-    line 1421 — useful for locating the abort but useless for figuring
-    out *why* a specific item is being rejected by Commons.
+    _install_module_globals(
+        monkeypatch,
+        sdc_sync,
+        claims_payload=[{"c": "a"}, {"c": "b"}],
+        submit_return={"success": 1, "entity": {}},
+    )
+
+    before = sdc_sync.tracker.count(Result.SDC_CLAIMS_ADDED)
+    sdc_sync._post_new_claims("M12345", "abcdef01abcdef01abcdef01abcdef01")
+    after = sdc_sync.tracker.count(Result.SDC_CLAIMS_ADDED)
+    assert after == before + 2
+
+
+def test_post_new_refs_uses_pywikibot_simple_request_with_csrf_token(monkeypatch):
+    """Verify the helper actually routes through pywikibot's
+    ``simple_request`` and passes the CSRF token from ``site.tokens``
+    (rather than a stale module-global ``token``, which the migration
+    deleted).
     """
     from tools import sdc_sync
 
-    response = MagicMock()
-    response.text = (
-        '{"error": {"code": "permissiondenied", "info": "Permission denied."}}'
-    )
-    _install_module_globals(
-        monkeypatch, sdc_sync, response, claims_payload=[{"some": "claim"}]
-    )
-    # Stub ``login()`` so the relogin path completes successfully (no
-    # auth-side error masking the real save failure under test).
-    monkeypatch.setattr(sdc_sync, "login", lambda: "stub-token-2", raising=False)
-
-    with pytest.raises(RuntimeError) as excinfo:
-        sdc_sync._post_new_claims("M12345", "abcdef01abcdef01abcdef01abcdef01")
-
-    msg = str(excinfo.value)
-    assert "M12345" in msg
-    assert "abcdef01abcdef01abcdef01abcdef01" in msg
-    assert "relogin+save failed" in msg
-    # The Commons error code from the response body must be reachable from
-    # the message — that's the whole point of this PR.
-    assert "permissiondenied" in msg, (
-        "Commons error code must appear in the RuntimeError message so the"
-        " per-ordinal logging.exception captures it; got: " + repr(msg)
+    fake_site = _install_module_globals(
+        monkeypatch,
+        sdc_sync,
+        refclaims_payload=[{"some": "ref"}],
+        submit_return={"success": 1},
     )
 
+    sdc_sync._post_new_refs("M12345", "abcdef01abcdef01abcdef01abcdef01")
 
-def test_post_new_refs_relogin_failure_message_includes_response_body(monkeypatch):
-    """Same contract for the refs helper."""
-    from tools import sdc_sync
-
-    response = MagicMock()
-    response.text = (
-        '{"error": {"code": "abusefilter-disallowed", "info": "Rule X tripped."}}'
-    )
-    _install_module_globals(
-        monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
-    )
-    monkeypatch.setattr(sdc_sync, "login", lambda: "stub-token-2", raising=False)
-
-    with pytest.raises(RuntimeError) as excinfo:
-        sdc_sync._post_new_refs("M67890", "fedcba98fedcba98fedcba98fedcba98")
-
-    msg = str(excinfo.value)
-    assert "M67890" in msg
-    assert "fedcba98fedcba98fedcba98fedcba98" in msg
-    assert "relogin+save failed" in msg
-    assert "abusefilter-disallowed" in msg, (
-        "Commons error code must appear in the RuntimeError message; got: " + repr(msg)
-    )
+    assert fake_site.simple_request.call_count == 1
+    kwargs = fake_site.simple_request.call_args.kwargs
+    assert kwargs["action"] == "wbeditentity"
+    assert kwargs["id"] == "M12345"
+    assert kwargs["bot"] is True
+    assert kwargs["token"] == "stub-csrf-token"
+    # The encoded claims payload should be the JSON of refclaims.
+    assert "ref" in kwargs["data"]
 
 
 # --------------------------------------------------------------------------
 # `no-such-entity` is treated as a clean skip, NOT a failure.
 #
-# When Commons returns `{"error": {"code": "no-such-entity"}}`, it means
-# the MediaInfo entity for the staged M-id doesn't exist — most commonly
+# When pywikibot raises ``APIError(code="no-such-entity")``, the
+# MediaInfo entity for the staged M-id doesn't exist — most commonly
 # because the file page was deleted by a Commons curator as a duplicate,
 # or because this is an SDC-only run for a file that wasn't uploaded
 # through our pipeline. Neither is the SDC phase's fault, and re-running
 # wouldn't help — the entity isn't coming back via retry. The phase
-# must:
-#   1. NOT divert into the relogin retry path (token isn't the problem)
-#   2. raise a specific `_MissingEntityError` rather than `RuntimeError`
-#   3. propagate that exception to the per-ordinal handler, which logs
-#      it at INFO (not ERROR) and increments a dedicated counter.
+# converts this specific APIError code into ``_MissingEntityError``,
+# which the per-ordinal handler logs at INFO (not ERROR) and counts
+# under ``SDC_ORDINALS_SKIPPED_MISSING_ENTITY`` (not ``..._ERROR``).
 # --------------------------------------------------------------------------
 
 
-def test_raise_if_missing_entity_helper():
-    """Direct unit test of the helper."""
-    from tools import sdc_sync
-
-    # no-such-entity payload → raises _MissingEntityError
-    with pytest.raises(sdc_sync._MissingEntityError):
-        sdc_sync._raise_if_missing_entity(
-            {"error": {"code": "no-such-entity"}}, "M12345"
-        )
-
-    # Other error codes do NOT raise — they fall through to the generic
-    # error path so the existing retry / RuntimeError logic still runs.
-    sdc_sync._raise_if_missing_entity({"error": {"code": "permissiondenied"}}, "M12345")
-    sdc_sync._raise_if_missing_entity({"success": 1}, "M12345")
-    sdc_sync._raise_if_missing_entity({}, "M12345")
-    # Defensive: non-dict input shouldn't blow up.
-    sdc_sync._raise_if_missing_entity(None, "M12345")  # type: ignore[arg-type]
-
-
 def test_post_new_claims_no_such_entity_raises_missing_entity_error(monkeypatch):
-    """Claims POST helper must raise `_MissingEntityError` (not RuntimeError)
-    when Commons returns ``no-such-entity``.
-
-    The relogin retry path must NOT run — `_MissingEntityError` must
-    propagate through the `except (RuntimeError, _MissingEntityError): raise`
-    guard intact, exactly like the structured `RuntimeError` does, so the
-    per-ordinal handler sees the specific exception class.
-    """
+    """Claims POST helper must raise ``_MissingEntityError`` (not
+    ``RuntimeError``) when pywikibot reports ``no-such-entity``."""
     from tools import sdc_sync
 
-    response = MagicMock()
-    response.text = '{"error": {"code": "no-such-entity", "info": "⧼no-such-entity⧽"}}'
     _install_module_globals(
-        monkeypatch, sdc_sync, response, claims_payload=[{"some": "claim"}]
-    )
-    # Stub login() so a *bug* that diverted us into the retry path would
-    # still produce diagnosable output (instead of an UnboundLocalError
-    # masking the actual control-flow defect).
-    login_called = []
-    monkeypatch.setattr(
+        monkeypatch,
         sdc_sync,
-        "login",
-        lambda: (login_called.append(True), "stub-token-2")[1],
-        raising=False,
+        claims_payload=[{"some": "claim"}],
+        submit_side_effect=_api_error("no-such-entity", info="⧼no-such-entity⧽"),
     )
 
     with pytest.raises(sdc_sync._MissingEntityError) as excinfo:
         sdc_sync._post_new_claims("M12345", "abcdef01abcdef01abcdef01abcdef01")
 
     assert "M12345" in str(excinfo.value)
-    # CRITICAL invariant: login() must NOT have been called. The relogin
-    # path is for "maybe our token expired" — which is irrelevant here.
-    assert login_called == [], (
-        "_post_new_claims must skip the relogin retry path on no-such-entity;"
-        " login() should not have been called"
-    )
 
 
 def test_post_new_refs_no_such_entity_raises_missing_entity_error(monkeypatch):
     """Same contract for the refs POST helper."""
     from tools import sdc_sync
 
-    response = MagicMock()
-    response.text = '{"error": {"code": "no-such-entity"}}'
     _install_module_globals(
-        monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
-    )
-    login_called = []
-    monkeypatch.setattr(
+        monkeypatch,
         sdc_sync,
-        "login",
-        lambda: (login_called.append(True), "stub-token-2")[1],
-        raising=False,
+        refclaims_payload=[{"some": "ref"}],
+        submit_side_effect=_api_error("no-such-entity"),
     )
 
     with pytest.raises(sdc_sync._MissingEntityError) as excinfo:
         sdc_sync._post_new_refs("M67890", "fedcba98fedcba98fedcba98fedcba98")
 
     assert "M67890" in str(excinfo.value)
-    assert login_called == []
+
+
+def test_submit_sdc_write_translates_no_such_entity_for_wbremoveclaims(monkeypatch):
+    """The shared write helper translates ``APIError(no-such-entity)``
+    for ANY action — proving the wbremoveclaims path
+    (``_reconcile_existing_claims`` removals block) inherits the same
+    clean-skip contract as the wbeditentity path, since they both go
+    through ``_submit_sdc_write``.
+    """
+    from tools import sdc_sync
+
+    fake_site = _install_module_globals(
+        monkeypatch,
+        sdc_sync,
+        submit_side_effect=_api_error("no-such-entity"),
+    )
+
+    with pytest.raises(sdc_sync._MissingEntityError) as excinfo:
+        sdc_sync._submit_sdc_write(
+            "wbremoveclaims",
+            "M12345",
+            "abcdef01abcdef01abcdef01abcdef01",
+            claim="M12345$id-1|M12345$id-2",
+        )
+
+    assert "M12345" in str(excinfo.value)
+    assert fake_site.simple_request.call_args.kwargs["action"] == "wbremoveclaims"
+
+
+def test_submit_sdc_write_runtime_error_message_names_the_action(monkeypatch):
+    """The RuntimeError message includes the action name so the
+    per-ordinal log distinguishes ``wbeditentity failed`` from
+    ``wbremoveclaims failed`` without needing to inspect the traceback.
+    """
+    from tools import sdc_sync
+
+    _install_module_globals(
+        monkeypatch,
+        sdc_sync,
+        submit_side_effect=_api_error("permissiondenied", info="Denied."),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        sdc_sync._submit_sdc_write(
+            "wbremoveclaims",
+            "M99999",
+            "deadbeefdeadbeefdeadbeefdeadbeef",
+            claim="M99999$x",
+        )
+
+    msg = str(excinfo.value)
+    assert "wbremoveclaims" in msg
+    assert "M99999" in msg
+    assert "permissiondenied" in msg
 
 
 def test_missing_entity_error_is_not_a_runtime_error():
-    """The per-ordinal handler distinguishes `_MissingEntityError` from
-    generic `RuntimeError`/`Exception`. The exception class must NOT be
-    a `RuntimeError` subclass or it would be caught by every
-    `except RuntimeError:` guard in the POST helpers, restarting the
-    relogin loop on it.
+    """The per-ordinal handler distinguishes ``_MissingEntityError`` from
+    generic ``RuntimeError`` / ``Exception``. Keep the class hierarchy
+    explicit: it must be an ``Exception`` (so the per-ordinal handler
+    catches it at all) but NOT a ``RuntimeError`` subclass, so the
+    per-ordinal handler's separate ``except _MissingEntityError:`` arm
+    (logged at INFO + counted under SKIPPED_MISSING_ENTITY) reliably
+    fires before the broader ``except Exception:`` arm (logged at ERROR
+    + counted under SKIPPED_ERROR).
     """
     from tools import sdc_sync
 

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -14,7 +14,6 @@ import time
 import tomllib
 import urllib.parse
 from bs4 import BeautifulSoup
-from pywikibot.comms import http
 from pywikibot import pagegenerators
 from ingest_wikimedia.logs import setup_logging
 from ingest_wikimedia.slack import notify_phase_start, notify_sdc_complete
@@ -39,7 +38,6 @@ site: pywikibot.site.BaseSite
 hubs: dict
 rights: dict
 subject_ids: dict
-token: str
 _s3_partner: str | None = None
 _s3_client = None
 
@@ -120,13 +118,16 @@ def _build_parser() -> argparse.ArgumentParser:
 class _MissingEntityError(Exception):
     """Commons returned ``no-such-entity`` for the staged M-id.
 
-    Raised by the wbeditentity / wbremoveclaims POST helpers when Commons
-    reports the MediaInfo entity doesn't exist. This is not a failure of
-    the SDC phase — it just means the file page is gone (most commonly
-    because a Commons curator deleted it as a duplicate, or because this
-    is an SDC-only run for an M-id whose upload was never confirmed). The
-    per-ordinal handler in ``_run_partner_mode`` catches this distinctly
-    from generic ``Exception`` so it can:
+    Raised by the wbeditentity / wbremoveclaims POST helpers when
+    pywikibot's ``simple_request`` translates Commons'
+    ``{"error": {"code": "no-such-entity", ...}}`` response into an
+    ``APIError`` with ``code == "no-such-entity"``; the helpers
+    re-raise it as this dedicated class. This is not a failure of the
+    SDC phase — it just means the file page is gone (most commonly
+    because a Commons curator deleted it as a duplicate, or because
+    this is an SDC-only run for an M-id whose upload was never
+    confirmed). The per-ordinal handler in ``_run_partner_mode``
+    catches this distinctly from generic ``Exception`` so it can:
 
     - log at INFO instead of ERROR (it isn't an error to log against),
     - increment ``SDC_ORDINALS_SKIPPED_MISSING_ENTITY`` instead of
@@ -139,21 +140,6 @@ class _MissingEntityError(Exception):
     (upload phase, drift handling) — not something this phase can or
     should try to fix.
     """
-
-
-def _raise_if_missing_entity(post: dict, mediaid: str) -> None:
-    """Inspect a parsed wbeditentity / wbremoveclaims response and raise
-    ``_MissingEntityError`` if Commons reported ``no-such-entity``.
-
-    Must be called BEFORE accessing ``post["success"]`` — a response with
-    no ``success`` key (the shape of every Commons error response) would
-    otherwise raise ``KeyError`` and divert into the generic retry path,
-    masking the specific cause from the per-ordinal handler.
-    """
-    if isinstance(post, dict):
-        err = post.get("error") or {}
-        if err.get("code") == "no-such-entity":
-            raise _MissingEntityError(mediaid)
 
 
 def _truncate(text: str | None, limit: int = 500) -> str:
@@ -198,7 +184,7 @@ def _initialize() -> None:
     time. Kept out of import-time so `import tools.sdc_sync` (e.g. by the
     console-script entry point) does no I/O.
     """
-    global parser, args, method, dpla_api, site, hubs, rights, subject_ids, token
+    global parser, args, method, dpla_api, site, hubs, rights, subject_ids
     global _s3_partner, _s3_client
 
     parser = _build_parser()
@@ -211,11 +197,11 @@ def _initialize() -> None:
 
     site = pywikibot.Site()
     site.login()
-    # Fetch the wbeditentity CSRF token here so importing the module
-    # remains side-effect free — the helper post functions (_post_new_refs,
-    # _post_new_claims) read `token` at call time and refresh it
-    # themselves via `login()` on save failure.
-    token = login()
+    # CSRF tokens are managed by pywikibot's ``site.tokens["csrf"]`` —
+    # lazy-loaded on first read, refreshed automatically on ``badtoken``
+    # responses. No manual token fetch or relogin loops here; the
+    # ``_wbeditentity_via_pywikibot``, ``postqual``, and removals helpers
+    # all pull from the same auto-managed source at write time.
 
     # Hubs and subject mappings are fetched live from ingestion3 on every run,
     # by design: this sync exists precisely to propagate upstream changes to
@@ -326,53 +312,46 @@ def formattedclaim(prop, value, value_type, dpla_id):
     return claim
 
 
-# This is the function that will perform the POST to the Wikimedia Commons API, when passed all necessary parameters, to add a qualifier if it is missing for an existing claim. Currently, this is only used for P459. It creates a JSON object to send in the body of the request with the data to post and the login token.
+# Adds a missing qualifier to an existing claim via ``wbsetqualifier``.
+# Currently only used for P459 (determination method). The POST is
+# submitted through pywikibot's ``site.simple_request``, which manages
+# the CSRF token and retries on transient errors automatically.
 
 
 def postqual(claimid, prop, value):
-    global token
+    """Add a qualifier to an existing claim via ``wbsetqualifier``.
+
+    Routed through ``site.simple_request`` so pywikibot handles CSRF token
+    refresh, ``maxlag`` / ``Retry-After`` honoring, exponential backoff on
+    transient errors, and auto-relogin on ``badtoken`` — all automatically.
+    Replaces a hand-rolled refresh-token-and-retry-once pattern that didn't
+    cover ``maxlag`` or rate-limit signaling.
+
+    Best-effort: a final failure logs and continues; the partner is not
+    aborted for a missing qualifier amendment.
+    """
     summary = f"Adding [[:d:Property:{prop}]] to {claimid}."
-
-    postdata = {
-        "action": "wbsetqualifier",
-        "format": "json",
-        "claim": claimid,
-        "property": prop,
-        "snaktype": "value",
-        "value": value,
-        "token": token,
-        "bot": True,
-    }
-
     try:
-        json.loads(
-            http.fetch(
-                "https://commons.wikimedia.org/w/api.php", method="POST", data=postdata
-            ).text
-        )
+        site.simple_request(
+            action="wbsetqualifier",
+            claim=claimid,
+            property=prop,
+            snaktype="value",
+            value=value,
+            bot=True,
+            summary=summary,
+            token=site.tokens["csrf"],
+        ).submit()
         pywikibot.output(summary)
-
-    except Exception as e:
-        # Refresh the global token and retry once. The previous version only
-        # refreshed pywikibot's internal cache and didn't update the module
-        # `token` (used in postdata above) nor retry the POST, so qualifiers
-        # were silently dropped on any transient CSRF failure. Mirror the
-        # token-refresh pattern used by process_one().
-        print(repr(e))
-        print(" -- Refreshing CSRF token after API error and retrying...")
-        token = login()
-        postdata["token"] = token
-        try:
-            json.loads(
-                http.fetch(
-                    "https://commons.wikimedia.org/w/api.php",
-                    method="POST",
-                    data=postdata,
-                ).text
-            )
-            pywikibot.output(summary)
-        except Exception as retry_e:
-            print(f" -- Retry after token refresh failed: {repr(retry_e)}")
+    except pywikibot.exceptions.APIError as e:
+        # Log and continue — qualifier amends are best-effort, and pywikibot
+        # has already exhausted its built-in retry policy by the time an
+        # APIError surfaces here. Surface the Commons error code so it's
+        # diagnosable from the log without needing to enable verbose tracing.
+        print(
+            f" -- Failed to amend qualifier {prop} for {claimid}:"
+            f" {e.code} — {getattr(e, 'info', '')}"
+        )
 
 
 # This function performs an initial GET request on the given Wikimedia file to check if the statement we will be adding is already in the page. It returns a boolean, with True if the statement is not found and can be added. "qid" is passed as a tuple with both the value and the data type, so this check can handle the formatting for different data types. If statements are found in the entity with the prop and value, but no qualifiers, we return the statement id instead, so that the qualifier can be added to that statement instead of creating a new one using postqual().
@@ -1287,211 +1266,98 @@ def _build_expected_from_sdc(sdc_payload):
     return expected
 
 
-def _post_new_refs(mediaid, dpla_id):
-    """POST the accumulated `refclaims["claims"]` to wbeditentity.
+def _submit_sdc_write(action, mediaid, dpla_id, **params):
+    """Submit an SDC write (wbeditentity or wbremoveclaims) through
+    pywikibot's ``simple_request``.
 
-    Reads the module-global `refclaims` (populated by `add_ref` during the
-    per-claim check loop). No-op when nothing to post. Refreshes the
-    module-global `token` and retries once on save error.
+    Shared by the three write paths (``_post_new_refs``,
+    ``_post_new_claims``, removals in ``_reconcile_existing_claims``)
+    so they all get pywikibot's built-in behaviours for free:
+
+    - automatic CSRF token management (``site.tokens["csrf"]``);
+    - ``maxlag`` honoring (sleep ``lag + 1``, retry; default
+      ``Site.maxlag`` is 5s);
+    - ``Retry-After`` header honoring on 429/503;
+    - exponential backoff on ``internal_api_error_*`` / ``srvtimeout``;
+    - auto-relogin on ``badtoken``;
+    - structured ``APIError(code=..., info=...)`` instead of JSON
+      response inspection.
+
+    Raises :class:`_MissingEntityError` when Commons returns
+    ``no-such-entity`` (the entity doesn't exist; not the SDC phase's
+    problem — see PR #267). Other ``APIError`` codes propagate as a
+    ``RuntimeError`` carrying the code + info, which the per-ordinal
+    handler catches and treats as an ``SDC_ORDINALS_SKIPPED_ERROR``.
+
+    ``params`` is the per-action payload — for wbeditentity, the
+    serialized ``data``; for wbremoveclaims, the pipe-joined ``claim``
+    string. ``bot=True``, the CSRF token, and ``id=mediaid`` are
+    injected here so call sites stay focused on the action-specific
+    differences.
     """
-    global token
+    try:
+        site.simple_request(
+            action=action,
+            id=mediaid,
+            bot=True,
+            token=site.tokens["csrf"],
+            **params,
+        ).submit()
+    except pywikibot.exceptions.APIError as e:
+        if e.code == "no-such-entity":
+            raise _MissingEntityError(mediaid) from e
+        raise RuntimeError(
+            f"{action} failed for {mediaid} ({dpla_id}):"
+            f" {e.code} — {_truncate(getattr(e, 'info', ''))}"
+        ) from e
+
+
+def _post_new_refs(mediaid, dpla_id):
+    """POST the accumulated ``refclaims["claims"]`` to ``wbeditentity``.
+
+    Reads the module-global ``refclaims`` (populated by ``add_ref`` during
+    the per-claim check loop). No-op when nothing to post.
+    """
     if not refclaims["claims"]:
         return
     refs_to_post = len(refclaims["claims"])
-    postrefs = {
-        "action": "wbeditentity",
-        "format": "json",
-        "id": mediaid,
-        "data": json.dumps(refclaims),
-        "token": token,
-        "bot": True,
-        "summary": f"Added structured data references from [[COM:DPLA|DPLA]] item '[[dpla:{dpla_id}|{dpla_id}]]'. [[COM:DPLA/MOD|Leave feedback]]!",
-    }
-    try:
-        save = http.fetch(
-            "https://commons.wikimedia.org/w/api.php", method="POST", data=postrefs
-        )
-    except (requests.exceptions.ConnectionError, ConnectionError):
-        try:
-            save = http.fetch(
-                "https://commons.wikimedia.org/w/api.php",
-                method="POST",
-                data=postrefs,
-            )
-        except (requests.exceptions.ConnectionError, ConnectionError):
-            try:
-                save = http.fetch(
-                    "https://commons.wikimedia.org/w/api.php",
-                    method="POST",
-                    data=postrefs,
-                )
-            except (requests.exceptions.ConnectionError, ConnectionError) as final_e:
-                print(" --- Network error posting new refs: all retries failed.")
-                raise RuntimeError(
-                    f"Network error posting new refs for {mediaid} ({dpla_id}):"
-                    " all 3 ConnectionError retries failed"
-                ) from final_e
-    try:
-        post = json.loads(save.text)
-        _raise_if_missing_entity(post, mediaid)
-        if post["success"] == 1:
-            print(" --- Saved new refs!")
-            tracker.increment(Result.SDC_REFS_ADDED, refs_to_post)
-        else:
-            print(post)
-            print(" --- Error encountered on save.")
-            raise RuntimeError(
-                f"wbeditentity refs save returned non-success for"
-                f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
-            )
-    except (RuntimeError, _MissingEntityError):
-        # Our own structured failure — let the per-ordinal handler see it
-        # as-is rather than restarting the relogin path below.
-        # ``_MissingEntityError`` in particular must skip the relogin: the
-        # entity isn't coming back via a fresh token.
-        raise
-    except Exception:
-        try:
-            token = login()
-            postrefs["token"] = token
-            save = http.fetch(
-                "https://commons.wikimedia.org/w/api.php",
-                method="POST",
-                data=postrefs,
-            )
-            post = json.loads(save.text)
-            _raise_if_missing_entity(post, mediaid)
-            if post["success"] == 1:
-                print(" --- Saved new refs!")
-                tracker.increment(Result.SDC_REFS_ADDED, refs_to_post)
-                return
-            print(post)
-            print(" --- Error encountered on save.")
-            raise RuntimeError(
-                f"wbeditentity refs save still non-success after relogin for"
-                f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
-            )
-        except (RuntimeError, _MissingEntityError):
-            raise
-        except Exception as retry_e:
-            # `save` may not be bound if http.fetch raised before the response
-            # landed — guard with ``locals()`` so we don't mask the real cause
-            # with an UnboundLocalError. When ``save`` IS bound, the response
-            # body is the diagnostic we actually want (e.g. a Commons error
-            # like ``{"error": {"code": "permissiondenied", ...}}`` will raise
-            # KeyError on ``post["success"]`` above, but the response body
-            # itself names the cause).
-            print(f" --- Error encountered. 2: {retry_e!r}")
-            body_suffix = f": {_truncate(save.text)}" if "save" in locals() else ""
-            raise RuntimeError(
-                f"Refs relogin+save failed for {mediaid} ({dpla_id}){body_suffix}"
-            ) from retry_e
+    _submit_sdc_write(
+        "wbeditentity",
+        mediaid,
+        dpla_id,
+        data=json.dumps(refclaims),
+        summary=(
+            f"Added structured data references from [[COM:DPLA|DPLA]] item"
+            f" '[[dpla:{dpla_id}|{dpla_id}]]'."
+            f" [[COM:DPLA/MOD|Leave feedback]]!"
+        ),
+    )
+    print(" --- Saved new refs!")
+    tracker.increment(Result.SDC_REFS_ADDED, refs_to_post)
 
 
 def _post_new_claims(mediaid, dpla_id):
-    """POST the accumulated `claims["claims"]` to wbeditentity.
+    """POST the accumulated ``claims["claims"]`` to ``wbeditentity``.
 
-    Reads the module-global `claims` (populated by add_* helpers during the
-    per-claim check loop). No-op when nothing to post. Retries the initial
-    fetch up to three times on ConnectionError; refreshes the module-global
-    `token` and retries the whole save once on parse / save error.
+    Reads the module-global ``claims`` (populated by add_* helpers during
+    the per-claim check loop). No-op when nothing to post.
     """
-    global token
     if not claims["claims"]:
         return
     claims_to_post = len(claims["claims"])
-    postdata = {
-        "action": "wbeditentity",
-        "format": "json",
-        "id": mediaid,
-        "data": json.dumps(claims),
-        "token": token,
-        "bot": True,
-        "summary": f"Added structured data claims from [[COM:DPLA|DPLA]] item '[[dpla:{dpla_id}|{dpla_id}]]'. [[COM:DPLA/MOD|Leave feedback]]!",
-    }
-    try:
-        save = http.fetch(
-            "https://commons.wikimedia.org/w/api.php", method="POST", data=postdata
-        )
-    except (requests.exceptions.ConnectionError, ConnectionError):
-        try:
-            save = http.fetch(
-                "https://commons.wikimedia.org/w/api.php",
-                method="POST",
-                data=postdata,
-            )
-        except (requests.exceptions.ConnectionError, ConnectionError):
-            try:
-                save = http.fetch(
-                    "https://commons.wikimedia.org/w/api.php",
-                    method="POST",
-                    data=postdata,
-                )
-            except (requests.exceptions.ConnectionError, ConnectionError) as final_e:
-                print(" --- Network error posting new claims: all retries failed.")
-                raise RuntimeError(
-                    f"Network error posting new claims for {mediaid} ({dpla_id}):"
-                    " all 3 ConnectionError retries failed"
-                ) from final_e
-    try:
-        post = json.loads(save.text)
-        _raise_if_missing_entity(post, mediaid)
-        if post["success"] == 1:
-            print(" --- Saved new claims!")
-            tracker.increment(Result.SDC_CLAIMS_ADDED, claims_to_post)
-        else:
-            print(post)
-            print(" --- Error encountered on save.")
-            raise RuntimeError(
-                f"wbeditentity claims save returned non-success for"
-                f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
-            )
-    except (RuntimeError, _MissingEntityError):
-        raise
-    except Exception:
-        try:
-            token = login()
-            postdata["token"] = token
-            save = http.fetch(
-                "https://commons.wikimedia.org/w/api.php",
-                method="POST",
-                data=postdata,
-            )
-            post = json.loads(save.text)
-            _raise_if_missing_entity(post, mediaid)
-            if post["success"] == 1:
-                print(" --- Saved new claims!")
-                tracker.increment(Result.SDC_CLAIMS_ADDED, claims_to_post)
-                return
-            print(post)
-            print(" --- Error encountered on save.")
-            raise RuntimeError(
-                f"wbeditentity claims save still non-success after relogin for"
-                f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
-            )
-        except (RuntimeError, _MissingEntityError):
-            raise
-        except Exception as retry_e:
-            # `post` may not be assigned yet if http.fetch / json.loads raised —
-            # referencing it directly would mask the real error with an
-            # UnboundLocalError. Log what we actually have.
-            #
-            # Bake ``save.text`` into the RuntimeError message (when bound) so
-            # the per-ordinal ``logging.exception`` captures the Commons error
-            # response body — the existing ``print(save.text)`` goes to stdout,
-            # which is block-buffered to a non-TTY and got dropped on
-            # ``sys.exit()``. The May 2026 NARA aborts ended with ``KeyError:
-            # 'success'`` propagating out of this block, which only happens
-            # when Commons returned ``{"error": {...}}`` (no ``success`` field)
-            # — the error code in that body is the missing diagnostic.
-            print(f" --- Retry after token refresh failed: {retry_e!r}")
-            if "save" in locals():
-                print(save.text)
-            print(" --- Error encountered. 3")
-            body_suffix = f": {_truncate(save.text)}" if "save" in locals() else ""
-            raise RuntimeError(
-                f"Claims relogin+save failed for {mediaid} ({dpla_id}){body_suffix}"
-            ) from retry_e
+    _submit_sdc_write(
+        "wbeditentity",
+        mediaid,
+        dpla_id,
+        data=json.dumps(claims),
+        summary=(
+            f"Added structured data claims from [[COM:DPLA|DPLA]] item"
+            f" '[[dpla:{dpla_id}|{dpla_id}]]'."
+            f" [[COM:DPLA/MOD|Leave feedback]]!"
+        ),
+    )
+    print(" --- Saved new claims!")
+    tracker.increment(Result.SDC_CLAIMS_ADDED, claims_to_post)
 
 
 def dpla_claims(
@@ -1732,42 +1598,19 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
             elif claim[prop]["value"] not in expected[prop]:
                 removals.append(claim[prop]["id"])
     if removals:
-        rmdata = {
-            "action": "wbremoveclaims",
-            "format": "json",
-            "id": mediaid,
-            "claim": "|".join(removals),
-            "token": token,
-            "bot": True,
-            "summary": f"Changing structured data claims from [[COM:DPLA|DPLA]] item '[[dpla:{dpla_id}|{dpla_id}]]'. [[COM:DPLA/MOD|Leave feedback]]!",
-        }
-        # Only count removals once we've seen `success: 1` on the
-        # wbremoveclaims response, matching what `_post_new_refs` and
-        # `_post_new_claims` do for their respective POSTs. Without this
-        # check, a rejected removal batch (bad token, replication lag,
-        # claim already gone, etc.) would silently inflate the counter.
-        rm_resp = http.fetch(
-            "https://commons.wikimedia.org/w/api.php", method="POST", data=rmdata
+        _submit_sdc_write(
+            "wbremoveclaims",
+            mediaid,
+            dpla_id,
+            claim="|".join(removals),
+            summary=(
+                f"Changing structured data claims from [[COM:DPLA|DPLA]]"
+                f" item '[[dpla:{dpla_id}|{dpla_id}]]'."
+                f" [[COM:DPLA/MOD|Leave feedback]]!"
+            ),
         )
-        try:
-            rm_post = json.loads(rm_resp.text)
-        except (ValueError, AttributeError) as parse_e:
-            print(" --- Could not parse removals response.")
-            raise RuntimeError(
-                f"wbremoveclaims response was not parseable JSON for"
-                f" {mediaid} ({dpla_id}): {_truncate(getattr(rm_resp, 'text', ''))}"
-            ) from parse_e
-        _raise_if_missing_entity(rm_post, mediaid)
-        if rm_post.get("success") == 1:
-            print(" --- Saved removals!")
-            tracker.increment(Result.SDC_REMOVALS, len(removals))
-        else:
-            print(rm_post)
-            print(" --- Error encountered on removals save.")
-            raise RuntimeError(
-                f"wbremoveclaims save returned non-success for"
-                f" {mediaid} ({dpla_id}): {_truncate(rm_resp.text)}"
-            )
+        print(" --- Saved removals!")
+        tracker.increment(Result.SDC_REMOVALS, len(removals))
 
 
 def _fetch_dpla_doc_from_api(dpla_id, dpla_api):
@@ -2019,15 +1862,6 @@ def _parse_dpla_doc(dpla, dpla_id):
     )
 
 
-def login():
-    tokenrequest = http.fetch(
-        "https://commons.wikimedia.org/w/api.php?action=query&meta=tokens&type=csrf&format=json"
-    )
-    tokendata = json.loads(tokenrequest.text)
-    token = tokendata.get("query").get("tokens").get("csrftoken")
-    return token
-
-
 def _resolve_dpla_id(title, dpla_api):
     """Return the DPLA item ID for a Commons file title.
 
@@ -2061,7 +1895,7 @@ def _resolve_dpla_id(title, dpla_api):
 
 def process_one(mediaid, dpla_id):
     """Fetch DPLA metadata and sync SDC claims for a single Commons file."""
-    global claims, refclaims, token
+    global claims, refclaims
 
     # Drop any stale cache from a prior file so check() always reads fresh state
     # for this mediaid.


### PR DESCRIPTION
## Summary

Replaces the four `tools/sdc_sync.py` raw `http.fetch` write paths with `site.simple_request(...).submit()` so every Commons SDC POST goes through pywikibot's high-level API. The script keeps producing the same wire format (the `add_*` claim builders are unchanged), but the request now flows through pywikibot's retry/auth/throttle infrastructure instead of hand-rolled equivalents.

## What pywikibot gives us, that the previous custom code didn't

| Behaviour | Previously | Now |
|---|---|---|
| CSRF token management | Manual: `login()` function fetches via raw `query?meta=tokens`, stores in module global, manually refreshed once on save failure | Automatic via `site.tokens["csrf"]` — lazy-loaded, refreshed on `badtoken`, shared across write paths |
| `maxlag` honouring | None — we'd hammer Commons during replica lag | `Site.maxlag` defaults to 5s; sleeps `lag + 1` and retries automatically |
| `Retry-After` header | Ignored | Honoured |
| Backoff on `internal_api_error_*`, `srvtimeout`, transient network errors | None (immediate retry, then fail) | Exponential backoff, up to 25 retries by default |
| Inter-write throttle | None (uncapped) | Built-in bot-account throttle to stay under rate limits |
| Error surface | JSON inspection on `post["success"]`, crashes with `KeyError` when response shape is the error shape | `pywikibot.exceptions.APIError(code=..., info=...)` raised directly |

## Migration map

| Call site | Action | Before (LoC) | After (LoC) |
|---|---|---|---|
| `_post_new_refs` | `wbeditentity` (refs bulk) | ~70 | 16 |
| `_post_new_claims` | `wbeditentity` (claims bulk) | ~80 | 16 |
| `_reconcile_existing_claims` removals | `wbremoveclaims` | ~35 | 12 |
| `postqual` | `wbsetqualifier` | ~30 | 18 |

All four route through a new shared `_submit_sdc_write(action, mediaid, dpla_id, **params)` helper which:
- passes `bot=True` and `token=site.tokens["csrf"]` uniformly,
- catches `pywikibot.exceptions.APIError`,
- translates `code == "no-such-entity"` into `_MissingEntityError` (preserving the PR #267 skip contract),
- re-raises every other `APIError` as a `RuntimeError` carrying action name + mediaid + Commons error code + truncated info — exactly what surfaces in the per-ordinal `logging.exception` traceback today via PR #266.

## Deleted code

- `login()` function (lines 1881–1888 pre-migration) — no longer needed; pywikibot manages tokens
- `_raise_if_missing_entity()` JSON-inspection helper — `APIError.code == "no-such-entity"` replaces it
- `global token` declarations across `process_one`, `postqual`, `_post_new_refs`, `_post_new_claims`
- `token: str` module-level annotation
- `token = login()` in `_initialize`
- `from pywikibot.comms import http` import
- The hand-rolled ConnectionError 3-retry loops and the relogin-and-retry-once blocks in both bulk POST helpers (~80 lines combined)

## Out of scope (separate follow-up)

The 17 `add_*` claim builder helpers (`add_rs`, `add_id`, `add_title`, `add_collection`, etc.) and the `formattedclaim()` factory still produce raw `wbeditentity`-format dicts. `MediaInfo.editEntity(data=dict, ...)` accepts that format natively, so the migration gets every operational benefit without touching them. Converting them to `pywikibot.Claim` objects is a follow-up — ~1500 lines of churn that buys idiom but no behaviour.

## Tests

Reworked the test scaffolding to mock `site.simple_request().submit()` instead of `http.fetch`. New helper `_install_module_globals(monkeypatch, sdc_sync, submit_side_effect=..., submit_return=...)` constructs the fake site + token wallet + request object.

Coverage:

- **Success path** increments `SDC_REFS_ADDED` / `SDC_CLAIMS_ADDED` by the correct amount.
- **`no-such-entity`** APIError → `_MissingEntityError` for refs, claims, AND the wbremoveclaims path (proves the shared helper applies the same contract to all actions).
- **Other APIError codes** (`badtoken`, `abusefilter-disallowed`, `permissiondenied`) → `RuntimeError` carrying the code in the message.
- **RuntimeError message includes action name** so the per-ordinal log distinguishes `wbeditentity failed` from `wbremoveclaims failed` without inspecting the traceback.
- **`Exception`-subclass guarantee**: regression guard against `BaseException`-style aborts (pre-PR-#263 `sys.exit()` problem).
- **CSRF token passthrough**: verifies `site.tokens["csrf"]` is the actual value passed to `simple_request`, not a stale module-global `token`.

## Net diff

-136 lines (-166 in `tools/sdc_sync.py`, +30 in `tests/test_sdc_sync.py`).

## Test plan

- [ ] Pytest passes (CI)
- [ ] After deploy: run an SDC-only retry on a known-good item and verify it completes
- [ ] Run on a known-failing item (e.g. a stale-M-id case) and verify the log shows `Commons MediaInfo entity does not exist; skipping ordinal (not an error).` from the per-ordinal handler — proving the no-such-entity path still works end-to-end
- [ ] If any partner hits `maxlag`, verify the SDC log shows the pywikibot-style backoff line rather than the previous immediate-failure pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## sdc-sync: Route SDC writes through pywikibot's simple_request

Refactors Commons Structured Data writes in `tools/sdc_sync.py` to use pywikibot's high-level `site.simple_request(...).submit()` API instead of manual HTTP fetch calls, token management, and retry logic.

### Key changes

**tools/sdc_sync.py:**
- Eliminates manual `login()` function and module-level token globals
- Introduces centralized `_submit_sdc_write()` helper that:
  - Injects CSRF token from pywikibot's `site.tokens["csrf"]`
  - Translates pywikibot's `APIError(code="no-such-entity")` to new `_MissingEntityError` exception (preserves prior skip behavior)
  - Raises `RuntimeError` for other API errors with truncated context
- Routes four write paths through the new helper: `wbeditentity` (refs and claims), `wbremoveclaims` (removals), and `wbsetqualifier` (qualifiers via best-effort logging)
- Removes custom ConnectionError retry loops and JSON-based response inspection
- Delegates to pywikibot's token management, throttling, maxlag handling, Retry-After support, and exponential backoff (up to 25 retries)

**tests/test_sdc_sync.py:**
- Updates test helper `_install_module_globals()` to mock `site.simple_request().submit()` instead of `http.fetch`
- Adds `_api_error()` factory for constructing pywikibot `APIError` instances in tests
- Verifies `_MissingEntityError` exception subclass behavior for both claim and ref writes
- Confirms CSRF token passthrough and successful write accounting
- Tests `RuntimeError` surfacing for non-recoverable API errors with Commons error codes
- Validates regression behavior: `RuntimeError` from writes is catchable by per-ordinal `except Exception:` handlers

### Net effect
- **Security improvement:** Pywikibot's automated CSRF token management replaces custom globals, eliminating token state bugs
- **Code reduction:** 136 fewer lines of custom error handling and retry logic
- **Behavioral consistency:** All Commons writes now use pywikibot's standardized exception handling, throttling, and resilience mechanisms
- No changes to wire format, claim builders, or public APIs; fully covered by updated test suite

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->