### PR TITLE
sdc-sync: build formattedclaim's wire-format dict via pywikibot.Claim

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -985,6 +985,11 @@ def test_set_claim_target_dispatches_each_value_type(monkeypatch):
     - ``wikibase-entityid`` → ``ItemPage(repo, "Q...")``
     - ``string``            → raw string
     - ``monolingualtext``   → ``WbMonolingualText(text, language)``
+
+    ``pywikibot.ItemPage`` validates that its ``site`` arg is a real
+    ``DataSite`` (raises ``TypeError`` on a ``MagicMock``), so it's
+    monkeypatched here to a stub that returns a labelled sentinel —
+    the assertion is on the dispatch, not on ``ItemPage`` internals.
     """
     from tools import sdc_sync
     from unittest.mock import MagicMock
@@ -993,27 +998,37 @@ def test_set_claim_target_dispatches_each_value_type(monkeypatch):
     fake_claim = MagicMock()
     fake_repo = MagicMock()
 
-    # wikibase-entityid
+    # wikibase-entityid — mock ItemPage so the real constructor doesn't
+    # try to validate the MagicMock repo.
+    item_page_stub = MagicMock(
+        side_effect=lambda repo, qid: ("stub-ItemPage", repo, qid)
+    )
+    monkeypatch.setattr(pywikibot, "ItemPage", item_page_stub)
+
     sdc_sync._set_claim_target(
         fake_claim,
         fake_repo,
         {"entity-type": "item", "numeric-id": 19652},
         "wikibase-entityid",
     )
-    target = fake_claim.setTarget.call_args.args[0]
-    assert isinstance(target, pywikibot.ItemPage)
-    # Pywikibot stores the QID via getID(); confirm it's the right Q-id.
-    assert target.getID() == "Q19652"
+    item_page_stub.assert_called_once_with(fake_repo, "Q19652")
+    # setTarget receives the stubbed ItemPage return value verbatim.
+    assert fake_claim.setTarget.call_args.args[0] == (
+        "stub-ItemPage",
+        fake_repo,
+        "Q19652",
+    )
 
     fake_claim.reset_mock()
 
-    # string
+    # string — no pywikibot wrapping; raw string passed straight through.
     sdc_sync._set_claim_target(fake_claim, fake_repo, "abc123", "string")
     assert fake_claim.setTarget.call_args.args[0] == "abc123"
 
     fake_claim.reset_mock()
 
-    # monolingualtext
+    # monolingualtext — WbMonolingualText is a plain data class with no
+    # site validation, so it doesn't need monkeypatching.
     sdc_sync._set_claim_target(
         fake_claim,
         fake_repo,

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -956,3 +956,89 @@ def test_legacy_process_one_treats_missing_entity_as_clean_skip(monkeypatch):
         "process_one must increment SDC_ORDINALS_SKIPPED_MISSING_ENTITY on"
         f" the no-such-entity skip path; before={counter_before}, after={counter_after}"
     )
+
+
+# --------------------------------------------------------------------------
+# formattedclaim now produces its dict via pywikibot.Claim + Claim.toJSON().
+# The function-boundary contract is unchanged — it still returns a
+# wbeditentity wire-format dict that the add_* callers append directly
+# to claims["claims"] — but the body is now type-safe (pywikibot.Claim
+# validates value/property combinations at build time) and idiomatic
+# (uses pywikibot.WbMonolingualText, pywikibot.WbTime, pywikibot.ItemPage
+# instead of hand-built dicts).
+#
+# The order keys pywikibot's toJSON emits (qualifiers-order, snaks-order)
+# are stripped so the existing inline-qualifier mutation pattern in
+# add_date / add_subject_entity / etc. (claim["qualifiers"][prop] = ...)
+# stays correct without each callsite having to also update the order
+# list.
+# --------------------------------------------------------------------------
+
+
+def test_set_claim_target_dispatches_each_value_type(monkeypatch):
+    """Each of the 4 value_types our 17 add_* helpers use must dispatch
+    to the right ``setTarget`` argument shape.
+
+    Verifies the value-type → pywikibot type translation matches the
+    contract the previous hand-built dict expressed inline:
+
+    - ``wikibase-entityid`` → ``ItemPage(repo, "Q...")``
+    - ``string``            → raw string
+    - ``monolingualtext``   → ``WbMonolingualText(text, language)``
+    """
+    from tools import sdc_sync
+    from unittest.mock import MagicMock
+    import pywikibot
+
+    fake_claim = MagicMock()
+    fake_repo = MagicMock()
+
+    # wikibase-entityid
+    sdc_sync._set_claim_target(
+        fake_claim,
+        fake_repo,
+        {"entity-type": "item", "numeric-id": 19652},
+        "wikibase-entityid",
+    )
+    target = fake_claim.setTarget.call_args.args[0]
+    assert isinstance(target, pywikibot.ItemPage)
+    # Pywikibot stores the QID via getID(); confirm it's the right Q-id.
+    assert target.getID() == "Q19652"
+
+    fake_claim.reset_mock()
+
+    # string
+    sdc_sync._set_claim_target(fake_claim, fake_repo, "abc123", "string")
+    assert fake_claim.setTarget.call_args.args[0] == "abc123"
+
+    fake_claim.reset_mock()
+
+    # monolingualtext
+    sdc_sync._set_claim_target(
+        fake_claim,
+        fake_repo,
+        {"text": "Hello", "language": "en"},
+        "monolingualtext",
+    )
+    target = fake_claim.setTarget.call_args.args[0]
+    assert isinstance(target, pywikibot.WbMonolingualText)
+    assert target.text == "Hello"
+    assert target.language == "en"
+
+
+def test_set_claim_target_rejects_unknown_value_type():
+    """The translator helper must raise on a value_type it doesn't know,
+    so a future caller can't silently produce malformed wire data.
+    ``"time"`` is intentionally rejected here because the only time
+    callsite (``add_date``) passes ``"somevalue"``, which is handled by
+    ``formattedclaim`` before reaching this translator.
+    """
+    from tools import sdc_sync
+    from unittest.mock import MagicMock
+
+    claim = MagicMock()
+    repo = MagicMock()
+    with pytest.raises(ValueError, match="unsupported value_type"):
+        sdc_sync._set_claim_target(claim, repo, "x", "globe-coordinate")
+    with pytest.raises(ValueError, match="unsupported value_type"):
+        sdc_sync._set_claim_target(claim, repo, {}, "time")

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -550,16 +550,29 @@ def test_truncate_helper_returns_under_limit_unchanged_and_truncates_long():
 
 
 def _install_module_globals(
-    monkeypatch, sdc_sync, response, *, refclaims_payload=None, claims_payload=None
+    monkeypatch,
+    sdc_sync,
+    *,
+    refclaims_payload=None,
+    claims_payload=None,
+    submit_side_effect=None,
+    submit_return=None,
 ):
-    """Inject the module-level globals the SDC POST helpers expect.
+    """Inject the module-level globals the SDC POST helpers expect AND
+    mock the pywikibot path the helpers now write through.
 
-    ``refclaims`` / ``claims`` / ``token`` are not initialised at import
-    time — they're declared ``global`` and populated inside ``process_one``
-    / ``process_one_from_sdc`` before each item. Tests that call the POST
-    helpers directly have to install those globals themselves;
-    ``raising=False`` lets monkeypatch set + tear down attributes that
-    didn't exist on the module yet.
+    The POST helpers no longer hit raw ``http.fetch`` — they call
+    ``site.simple_request(action=..., ...).submit()``, which is
+    pywikibot's high-level write entry point. To exercise the helpers
+    without an actual network round-trip we mock the ``site`` module
+    global so ``simple_request`` returns a request object whose
+    ``submit()`` either returns ``submit_return`` (success) or raises
+    ``submit_side_effect`` (the pywikibot ``APIError`` we're modelling).
+
+    ``refclaims`` / ``claims`` are not initialised at import time —
+    they're declared ``global`` and populated inside ``process_one`` /
+    ``process_one_from_sdc`` before each item, so tests that call the
+    POST helpers directly install them here with ``raising=False``.
     """
     monkeypatch.setattr(
         sdc_sync,
@@ -573,30 +586,48 @@ def _install_module_globals(
         {"claims": claims_payload if claims_payload is not None else []},
         raising=False,
     )
-    monkeypatch.setattr(sdc_sync, "token", "stub-token", raising=False)
-    monkeypatch.setattr(sdc_sync.http, "fetch", lambda *a, **kw: response)
+
+    request_mock = MagicMock()
+    if submit_side_effect is not None:
+        request_mock.submit.side_effect = submit_side_effect
+    else:
+        request_mock.submit.return_value = (
+            submit_return if submit_return is not None else {"success": 1}
+        )
+
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value = request_mock
+    # Pywikibot's lazy CSRF cache surfaces as ``site.tokens["csrf"]``.
+    # The migration accesses it; mock it to a deterministic value.
+    fake_site.tokens = {"csrf": "stub-csrf-token"}
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+    return fake_site
 
 
-def test_post_new_refs_raises_runtime_error_on_non_success_save(monkeypatch):
-    """A non-success wbeditentity refs response must raise RuntimeError,
-    not call sys.exit(). The error message must include the mediaid and
-    DPLA id so the failure is self-identifying in the SDC log.
+def _api_error(code, info=""):
+    """Construct a ``pywikibot.exceptions.APIError`` for tests.
 
-    The response payload must carry an explicit ``"success": 0`` so the
-    helper's initial save lands in the ``else`` branch (the path that
-    raises the structured "non-success" error). A response with no
-    ``"success"`` key at all would raise KeyError instead and divert
-    into the relogin retry — useful for the catch-by-per-ordinal test
-    below, but not what this one is checking.
+    APIError's constructor signature is ``(code, info, **kwargs)`` and
+    callers across pywikibot pass extra context (servedby, etc.) as
+    kwargs. We only need code + info for assertions.
+    """
+    import pywikibot.exceptions
+
+    return pywikibot.exceptions.APIError(code=code, info=info)
+
+
+def test_post_new_refs_raises_runtime_error_on_apierror(monkeypatch):
+    """Pywikibot's ``APIError`` for any code OTHER than ``no-such-entity``
+    must be re-raised as ``RuntimeError`` carrying mediaid + dpla_id +
+    Commons error code so the per-ordinal handler logs a useful traceback.
     """
     from tools import sdc_sync
 
-    response = MagicMock()
-    response.text = (
-        '{"success": 0, "error": {"code": "badtoken", "info": "Invalid token"}}'
-    )
     _install_module_globals(
-        monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
+        monkeypatch,
+        sdc_sync,
+        refclaims_payload=[{"some": "ref"}],
+        submit_side_effect=_api_error("badtoken", info="Invalid token"),
     )
 
     with pytest.raises(RuntimeError) as excinfo:
@@ -605,17 +636,22 @@ def test_post_new_refs_raises_runtime_error_on_non_success_save(monkeypatch):
     msg = str(excinfo.value)
     assert "M12345" in msg
     assert "abcdef01abcdef01abcdef01abcdef01" in msg
-    assert "non-success" in msg
+    # The Commons error code must appear in the RuntimeError message so
+    # the per-ordinal ``logging.exception`` captures it without needing
+    # to unwrap the ``__cause__`` chain.
+    assert "badtoken" in msg, f"expected 'badtoken' in {msg!r}"
 
 
-def test_post_new_claims_raises_runtime_error_on_non_success_save(monkeypatch):
-    """Same contract for the claims POST helper."""
+def test_post_new_claims_raises_runtime_error_on_apierror(monkeypatch):
+    """Same contract for the claims POST helper — non-no-such-entity
+    APIErrors come out as RuntimeError with the code in the message."""
     from tools import sdc_sync
 
-    response = MagicMock()
-    response.text = '{"success": 0, "error": {"code": "ratelimited"}}'
     _install_module_globals(
-        monkeypatch, sdc_sync, response, claims_payload=[{"some": "claim"}]
+        monkeypatch,
+        sdc_sync,
+        claims_payload=[{"some": "claim"}],
+        submit_side_effect=_api_error("abusefilter-disallowed", info="Rule X tripped."),
     )
 
     with pytest.raises(RuntimeError) as excinfo:
@@ -624,226 +660,220 @@ def test_post_new_claims_raises_runtime_error_on_non_success_save(monkeypatch):
     msg = str(excinfo.value)
     assert "M67890" in msg
     assert "fedcba98fedcba98fedcba98fedcba98" in msg
-    assert "non-success" in msg
+    assert "abusefilter-disallowed" in msg, f"expected error code in {msg!r}"
 
 
 def test_post_new_refs_runtime_error_caught_by_per_ordinal_handler(monkeypatch):
-    """The RuntimeError raised from inside _post_new_refs must be a
-    plain Exception subclass (not BaseException), so the per-ordinal
-    `except Exception:` in process_one_from_sdc catches it and the
-    partner batch can continue with the next ordinal.
+    """The RuntimeError raised from inside ``_post_new_refs`` must be a
+    plain ``Exception`` subclass (not ``BaseException``), so the
+    ``except Exception:`` clause in ``process_one_from_sdc`` catches it
+    and the partner batch can continue with the next ordinal.
 
-    This is the key behavioural difference vs the old sys.exit() — old
-    code raised SystemExit (BaseException, not caught by the per-ordinal
-    handler), so a single failed write tanked the entire partner.
+    Regression guard against the pre-PR-#263 ``sys.exit()`` behaviour,
+    which raised ``SystemExit`` (a ``BaseException``) and bypassed the
+    per-ordinal handler — one failed write tanked the entire partner.
     """
     from tools import sdc_sync
 
-    response = MagicMock()
-    response.text = '{"success": 0, "error": {"code": "badtoken"}}'
     _install_module_globals(
-        monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
+        monkeypatch,
+        sdc_sync,
+        refclaims_payload=[{"some": "ref"}],
+        submit_side_effect=_api_error("badtoken"),
     )
 
     skipped = False
     try:
         sdc_sync._post_new_refs("M12345", "abcdef01abcdef01abcdef01abcdef01")
     except Exception:
-        # This is the same `except Exception:` clause that wraps each
-        # ordinal in process_one_from_sdc — catching it here proves the
+        # Same ``except Exception:`` clause that wraps each ordinal in
+        # ``process_one_from_sdc`` — catching it here proves the
         # per-ordinal handler will skip rather than abort the partner.
         skipped = True
 
     assert skipped, (
-        "RuntimeError from _post_new_refs must be an Exception subclass so the"
-        " per-ordinal handler in process_one_from_sdc catches it (was previously"
-        " SystemExit, which bypassed that handler and aborted the whole partner)"
+        "RuntimeError from _post_new_refs must be an Exception subclass so"
+        " the per-ordinal handler in process_one_from_sdc catches it"
     )
 
 
-# --------------------------------------------------------------------------
-# Response-body inclusion in the relogin+save failure messages.
-#
-# When the per-ordinal handler in process_one_from_sdc logs an exception
-# from these helpers, the only thing we currently see is "Claims
-# relogin+save failed for <mediaid> (<dpla_id>)" plus a chained
-# KeyError from json parsing. That isn't enough to diagnose the
-# underlying problem — Commons returns errors like
-# {"error": {"code": "permissiondenied", "info": "..."}} which have
-# NO "success" key, so post["success"] raises KeyError and the actual
-# error code is lost. Baking save.text into the RuntimeError message
-# captures the Commons error code in the structured exception, where
-# logging.exception will write it to the SDC log.
-# --------------------------------------------------------------------------
+def test_post_new_refs_success_path_increments_counter(monkeypatch):
+    """The happy path: ``simple_request().submit()`` returns success →
+    the SDC_REFS_ADDED counter increments by the number of refs posted."""
+    from tools import sdc_sync
+
+    _install_module_globals(
+        monkeypatch,
+        sdc_sync,
+        refclaims_payload=[{"ref": "a"}, {"ref": "b"}, {"ref": "c"}],
+        submit_return={"success": 1, "entity": {}},
+    )
+
+    before = sdc_sync.tracker.count(Result.SDC_REFS_ADDED)
+    sdc_sync._post_new_refs("M12345", "abcdef01abcdef01abcdef01abcdef01")
+    after = sdc_sync.tracker.count(Result.SDC_REFS_ADDED)
+    assert after == before + 3, (
+        f"SDC_REFS_ADDED should bump by 3; before={before}, after={after}"
+    )
 
 
-def test_post_new_claims_relogin_failure_message_includes_response_body(monkeypatch):
-    """When the relogin retry also returns a response with no ``"success"``
-    key, the chained KeyError + new RuntimeError message must include the
-    Commons response body so we can read the error code from the SDC log.
+def test_post_new_claims_success_path_increments_counter(monkeypatch):
+    """Same happy-path contract for claims."""
+    from tools import sdc_sync
 
-    Without this, the per-ordinal traceback only tells us the helper hit
-    line 1421 — useful for locating the abort but useless for figuring
-    out *why* a specific item is being rejected by Commons.
+    _install_module_globals(
+        monkeypatch,
+        sdc_sync,
+        claims_payload=[{"c": "a"}, {"c": "b"}],
+        submit_return={"success": 1, "entity": {}},
+    )
+
+    before = sdc_sync.tracker.count(Result.SDC_CLAIMS_ADDED)
+    sdc_sync._post_new_claims("M12345", "abcdef01abcdef01abcdef01abcdef01")
+    after = sdc_sync.tracker.count(Result.SDC_CLAIMS_ADDED)
+    assert after == before + 2
+
+
+def test_post_new_refs_uses_pywikibot_simple_request_with_csrf_token(monkeypatch):
+    """Verify the helper actually routes through pywikibot's
+    ``simple_request`` and passes the CSRF token from ``site.tokens``
+    (rather than a stale module-global ``token``, which the migration
+    deleted).
     """
     from tools import sdc_sync
 
-    response = MagicMock()
-    response.text = (
-        '{"error": {"code": "permissiondenied", "info": "Permission denied."}}'
-    )
-    _install_module_globals(
-        monkeypatch, sdc_sync, response, claims_payload=[{"some": "claim"}]
-    )
-    # Stub ``login()`` so the relogin path completes successfully (no
-    # auth-side error masking the real save failure under test).
-    monkeypatch.setattr(sdc_sync, "login", lambda: "stub-token-2", raising=False)
-
-    with pytest.raises(RuntimeError) as excinfo:
-        sdc_sync._post_new_claims("M12345", "abcdef01abcdef01abcdef01abcdef01")
-
-    msg = str(excinfo.value)
-    assert "M12345" in msg
-    assert "abcdef01abcdef01abcdef01abcdef01" in msg
-    assert "relogin+save failed" in msg
-    # The Commons error code from the response body must be reachable from
-    # the message — that's the whole point of this PR.
-    assert "permissiondenied" in msg, (
-        "Commons error code must appear in the RuntimeError message so the"
-        " per-ordinal logging.exception captures it; got: " + repr(msg)
+    fake_site = _install_module_globals(
+        monkeypatch,
+        sdc_sync,
+        refclaims_payload=[{"some": "ref"}],
+        submit_return={"success": 1},
     )
 
+    sdc_sync._post_new_refs("M12345", "abcdef01abcdef01abcdef01abcdef01")
 
-def test_post_new_refs_relogin_failure_message_includes_response_body(monkeypatch):
-    """Same contract for the refs helper."""
-    from tools import sdc_sync
-
-    response = MagicMock()
-    response.text = (
-        '{"error": {"code": "abusefilter-disallowed", "info": "Rule X tripped."}}'
-    )
-    _install_module_globals(
-        monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
-    )
-    monkeypatch.setattr(sdc_sync, "login", lambda: "stub-token-2", raising=False)
-
-    with pytest.raises(RuntimeError) as excinfo:
-        sdc_sync._post_new_refs("M67890", "fedcba98fedcba98fedcba98fedcba98")
-
-    msg = str(excinfo.value)
-    assert "M67890" in msg
-    assert "fedcba98fedcba98fedcba98fedcba98" in msg
-    assert "relogin+save failed" in msg
-    assert "abusefilter-disallowed" in msg, (
-        "Commons error code must appear in the RuntimeError message; got: " + repr(msg)
-    )
+    assert fake_site.simple_request.call_count == 1
+    kwargs = fake_site.simple_request.call_args.kwargs
+    assert kwargs["action"] == "wbeditentity"
+    assert kwargs["id"] == "M12345"
+    assert kwargs["bot"] is True
+    assert kwargs["token"] == "stub-csrf-token"
+    # The encoded claims payload should be the JSON of refclaims.
+    assert "ref" in kwargs["data"]
 
 
 # --------------------------------------------------------------------------
 # `no-such-entity` is treated as a clean skip, NOT a failure.
 #
-# When Commons returns `{"error": {"code": "no-such-entity"}}`, it means
-# the MediaInfo entity for the staged M-id doesn't exist — most commonly
+# When pywikibot raises ``APIError(code="no-such-entity")``, the
+# MediaInfo entity for the staged M-id doesn't exist — most commonly
 # because the file page was deleted by a Commons curator as a duplicate,
 # or because this is an SDC-only run for a file that wasn't uploaded
 # through our pipeline. Neither is the SDC phase's fault, and re-running
 # wouldn't help — the entity isn't coming back via retry. The phase
-# must:
-#   1. NOT divert into the relogin retry path (token isn't the problem)
-#   2. raise a specific `_MissingEntityError` rather than `RuntimeError`
-#   3. propagate that exception to the per-ordinal handler, which logs
-#      it at INFO (not ERROR) and increments a dedicated counter.
+# converts this specific APIError code into ``_MissingEntityError``,
+# which the per-ordinal handler logs at INFO (not ERROR) and counts
+# under ``SDC_ORDINALS_SKIPPED_MISSING_ENTITY`` (not ``..._ERROR``).
 # --------------------------------------------------------------------------
 
 
-def test_raise_if_missing_entity_helper():
-    """Direct unit test of the helper."""
-    from tools import sdc_sync
-
-    # no-such-entity payload → raises _MissingEntityError
-    with pytest.raises(sdc_sync._MissingEntityError):
-        sdc_sync._raise_if_missing_entity(
-            {"error": {"code": "no-such-entity"}}, "M12345"
-        )
-
-    # Other error codes do NOT raise — they fall through to the generic
-    # error path so the existing retry / RuntimeError logic still runs.
-    sdc_sync._raise_if_missing_entity({"error": {"code": "permissiondenied"}}, "M12345")
-    sdc_sync._raise_if_missing_entity({"success": 1}, "M12345")
-    sdc_sync._raise_if_missing_entity({}, "M12345")
-    # Defensive: non-dict input shouldn't blow up.
-    sdc_sync._raise_if_missing_entity(None, "M12345")  # type: ignore[arg-type]
-
-
 def test_post_new_claims_no_such_entity_raises_missing_entity_error(monkeypatch):
-    """Claims POST helper must raise `_MissingEntityError` (not RuntimeError)
-    when Commons returns ``no-such-entity``.
-
-    The relogin retry path must NOT run — `_MissingEntityError` must
-    propagate through the `except (RuntimeError, _MissingEntityError): raise`
-    guard intact, exactly like the structured `RuntimeError` does, so the
-    per-ordinal handler sees the specific exception class.
-    """
+    """Claims POST helper must raise ``_MissingEntityError`` (not
+    ``RuntimeError``) when pywikibot reports ``no-such-entity``."""
     from tools import sdc_sync
 
-    response = MagicMock()
-    response.text = '{"error": {"code": "no-such-entity", "info": "⧼no-such-entity⧽"}}'
     _install_module_globals(
-        monkeypatch, sdc_sync, response, claims_payload=[{"some": "claim"}]
-    )
-    # Stub login() so a *bug* that diverted us into the retry path would
-    # still produce diagnosable output (instead of an UnboundLocalError
-    # masking the actual control-flow defect).
-    login_called = []
-    monkeypatch.setattr(
+        monkeypatch,
         sdc_sync,
-        "login",
-        lambda: (login_called.append(True), "stub-token-2")[1],
-        raising=False,
+        claims_payload=[{"some": "claim"}],
+        submit_side_effect=_api_error("no-such-entity", info="⧼no-such-entity⧽"),
     )
 
     with pytest.raises(sdc_sync._MissingEntityError) as excinfo:
         sdc_sync._post_new_claims("M12345", "abcdef01abcdef01abcdef01abcdef01")
 
     assert "M12345" in str(excinfo.value)
-    # CRITICAL invariant: login() must NOT have been called. The relogin
-    # path is for "maybe our token expired" — which is irrelevant here.
-    assert login_called == [], (
-        "_post_new_claims must skip the relogin retry path on no-such-entity;"
-        " login() should not have been called"
-    )
 
 
 def test_post_new_refs_no_such_entity_raises_missing_entity_error(monkeypatch):
     """Same contract for the refs POST helper."""
     from tools import sdc_sync
 
-    response = MagicMock()
-    response.text = '{"error": {"code": "no-such-entity"}}'
     _install_module_globals(
-        monkeypatch, sdc_sync, response, refclaims_payload=[{"some": "ref"}]
-    )
-    login_called = []
-    monkeypatch.setattr(
+        monkeypatch,
         sdc_sync,
-        "login",
-        lambda: (login_called.append(True), "stub-token-2")[1],
-        raising=False,
+        refclaims_payload=[{"some": "ref"}],
+        submit_side_effect=_api_error("no-such-entity"),
     )
 
     with pytest.raises(sdc_sync._MissingEntityError) as excinfo:
         sdc_sync._post_new_refs("M67890", "fedcba98fedcba98fedcba98fedcba98")
 
     assert "M67890" in str(excinfo.value)
-    assert login_called == []
+
+
+def test_submit_sdc_write_translates_no_such_entity_for_wbremoveclaims(monkeypatch):
+    """The shared write helper translates ``APIError(no-such-entity)``
+    for ANY action — proving the wbremoveclaims path
+    (``_reconcile_existing_claims`` removals block) inherits the same
+    clean-skip contract as the wbeditentity path, since they both go
+    through ``_submit_sdc_write``.
+    """
+    from tools import sdc_sync
+
+    fake_site = _install_module_globals(
+        monkeypatch,
+        sdc_sync,
+        submit_side_effect=_api_error("no-such-entity"),
+    )
+
+    with pytest.raises(sdc_sync._MissingEntityError) as excinfo:
+        sdc_sync._submit_sdc_write(
+            "wbremoveclaims",
+            "M12345",
+            "abcdef01abcdef01abcdef01abcdef01",
+            claim="M12345$id-1|M12345$id-2",
+        )
+
+    assert "M12345" in str(excinfo.value)
+    assert fake_site.simple_request.call_args.kwargs["action"] == "wbremoveclaims"
+
+
+def test_submit_sdc_write_runtime_error_message_names_the_action(monkeypatch):
+    """The RuntimeError message includes the action name so the
+    per-ordinal log distinguishes ``wbeditentity failed`` from
+    ``wbremoveclaims failed`` without needing to inspect the traceback.
+    """
+    from tools import sdc_sync
+
+    _install_module_globals(
+        monkeypatch,
+        sdc_sync,
+        submit_side_effect=_api_error("permissiondenied", info="Denied."),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        sdc_sync._submit_sdc_write(
+            "wbremoveclaims",
+            "M99999",
+            "deadbeefdeadbeefdeadbeefdeadbeef",
+            claim="M99999$x",
+        )
+
+    msg = str(excinfo.value)
+    assert "wbremoveclaims" in msg
+    assert "M99999" in msg
+    assert "permissiondenied" in msg
 
 
 def test_missing_entity_error_is_not_a_runtime_error():
-    """The per-ordinal handler distinguishes `_MissingEntityError` from
-    generic `RuntimeError`/`Exception`. The exception class must NOT be
-    a `RuntimeError` subclass or it would be caught by every
-    `except RuntimeError:` guard in the POST helpers, restarting the
-    relogin loop on it.
+    """The per-ordinal handler distinguishes ``_MissingEntityError`` from
+    generic ``RuntimeError`` / ``Exception``. Keep the class hierarchy
+    explicit: it must be an ``Exception`` (so the per-ordinal handler
+    catches it at all) but NOT a ``RuntimeError`` subclass, so the
+    per-ordinal handler's separate ``except _MissingEntityError:`` arm
+    (logged at INFO + counted under SKIPPED_MISSING_ENTITY) reliably
+    fires before the broader ``except Exception:`` arm (logged at ERROR
+    + counted under SKIPPED_ERROR).
     """
     from tools import sdc_sync
 

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -998,26 +998,20 @@ def test_set_claim_target_dispatches_each_value_type(monkeypatch):
     fake_claim = MagicMock()
     fake_repo = MagicMock()
 
-    # wikibase-entityid — mock ItemPage so the real constructor doesn't
-    # try to validate the MagicMock repo.
-    item_page_stub = MagicMock(
-        side_effect=lambda repo, qid: ("stub-ItemPage", repo, qid)
-    )
-    monkeypatch.setattr(pywikibot, "ItemPage", item_page_stub)
-
-    sdc_sync._set_claim_target(
-        fake_claim,
-        fake_repo,
-        {"entity-type": "item", "numeric-id": 19652},
-        "wikibase-entityid",
-    )
-    item_page_stub.assert_called_once_with(fake_repo, "Q19652")
-    # setTarget receives the stubbed ItemPage return value verbatim.
-    assert fake_claim.setTarget.call_args.args[0] == (
-        "stub-ItemPage",
-        fake_repo,
-        "Q19652",
-    )
+    # wikibase-entityid — patch ItemPage so the real constructor doesn't
+    # try to validate the MagicMock repo. ``patch.object`` gives us a
+    # default ``MagicMock`` whose ``return_value`` we identity-check
+    # against the value ``setTarget`` receives — more conventional than
+    # a ``side_effect`` lambda returning a sentinel tuple.
+    with patch.object(pywikibot, "ItemPage") as mock_item_page:
+        sdc_sync._set_claim_target(
+            fake_claim,
+            fake_repo,
+            {"entity-type": "item", "numeric-id": 19652},
+            "wikibase-entityid",
+        )
+    mock_item_page.assert_called_once_with(fake_repo, "Q19652")
+    assert fake_claim.setTarget.call_args.args[0] is mock_item_page.return_value
 
     fake_claim.reset_mock()
 

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -233,83 +233,93 @@ def _initialize() -> None:
 # This is the JSON used for formatting a claim. The P459 -> Q61848113 (determination method) qualifier is hardcoded in for everything DPLA adds. Not all data types have the same format for value, so this is formatted in the function for each property added.
 
 
+def _set_claim_target(claim, repo, value, value_type):
+    """Apply ``setTarget`` to ``claim`` using the right pywikibot type
+    for ``value_type``.
+
+    Mirrors the value-type → wire-format mapping the previous
+    hand-built ``formattedclaim`` dict expressed inline. Only the four
+    types our 17 add_* helpers actually use are handled — anything else
+    raises so a new caller can't silently miss a translation.
+    """
+    if value_type == "wikibase-entityid":
+        qid = f"Q{value['numeric-id']}"
+        claim.setTarget(pywikibot.ItemPage(repo, qid))
+    elif value_type == "string":
+        claim.setTarget(value)
+    elif value_type == "monolingualtext":
+        claim.setTarget(
+            pywikibot.WbMonolingualText(text=value["text"], language=value["language"])
+        )
+    else:
+        # The only ``"time"`` callsite (``add_date``) passes ``"somevalue"``
+        # as the value, which is handled by the caller before we get here.
+        # If a future helper passes a real time value, add the case.
+        raise ValueError(f"formattedclaim: unsupported value_type {value_type!r}")
+
+
 def formattedclaim(prop, value, value_type, dpla_id):
-    claim = {
-        "mainsnak": {
-            "snaktype": "value",
-            "property": prop,
-            "datavalue": {"value": value, "type": value_type},
-        },
-        "type": "statement",
-        "rank": "normal",
-        "qualifiers": {
-            "P459": [
-                {
-                    "snaktype": "value",
-                    "property": "P459",
-                    "datavalue": {
-                        "value": {"entity-type": "item", "numeric-id": 61848113},
-                        "type": "wikibase-entityid",
-                    },
-                    "datatype": "wikibase-item",
-                }
-            ]
-        },
-        "references": [
-            {
-                "snaks": {
-                    "P854": [
-                        {
-                            "snaktype": "value",
-                            "property": "P854",
-                            "datavalue": {
-                                "value": f"https://dp.la/item/{dpla_id}",
-                                "type": "string",
-                            },
-                        }
-                    ],
-                    "P123": [
-                        {
-                            "snaktype": "value",
-                            "property": "P123",
-                            "datavalue": {
-                                "value": {
-                                    "entity-type": "item",
-                                    "numeric-id": 2944483,
-                                },
-                                "type": "wikibase-entityid",
-                            },
-                        }
-                    ],
-                    "P813": [
-                        {
-                            "snaktype": "value",
-                            "property": "P813",
-                            "datavalue": {
-                                "value": {
-                                    "time": "+"
-                                    + str(datetime.date.today())
-                                    + "T00:00:00Z",
-                                    "timezone": 0,
-                                    "before": 0,
-                                    "after": 0,
-                                    "precision": 11,
-                                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
-                                },
-                                "type": "time",
-                            },
-                        }
-                    ],
-                }
-            }
-        ],
-    }
+    """Build a DPLA-authored SDC statement, returned as a wbeditentity
+    wire-format dict.
+
+    Constructed via ``pywikibot.Claim`` for type safety (the right
+    pywikibot value class is matched to the property's expected data
+    type at build time, not at POST time) and then serialised via
+    ``Claim.toJSON()`` so the result still plugs straight into the bulk
+    ``claims["claims"]`` accumulator that ``_post_new_claims`` submits.
+
+    Every statement carries the standard DPLA qualifier (P459=Q61848113,
+    determination method = "inferred from heuristic") and the 3-snak
+    DPLA reference (P854 source URL, P123 publisher=DPLA, P813 retrieved
+    date). The ``"somevalue"`` special case sets the mainsnak's
+    ``snaktype`` to ``"somevalue"`` and omits the datavalue — used for
+    claims where DPLA records that a value exists but doesn't know what
+    it is (e.g. ``add_date`` with a missing date).
+    """
+    repo = site.data_repository()
+    claim = pywikibot.Claim(site, prop)
 
     if value == "somevalue":
-        claim["mainsnak"].pop("datavalue")
-        claim["mainsnak"]["snaktype"] = "somevalue"
+        claim.setSnakType("somevalue")
+    else:
+        _set_claim_target(claim, repo, value, value_type)
 
-    return claim
+    # P459 = Q61848113 (determination method = inferred from heuristic).
+    # This is DPLA's universal "we set this" marker — `check()` and
+    # `_is_safe_to_amend_in_place` both depend on it to recognise
+    # DPLA-authored claims on read-back.
+    qualifier = pywikibot.Claim(site, "P459", is_qualifier=True)
+    qualifier.setTarget(pywikibot.ItemPage(repo, "Q61848113"))
+    claim.addQualifier(qualifier)
+
+    # Standard DPLA reference: P854 source URL + P123 publisher + P813
+    # retrieved date. ``_is_dpla_reference`` keys on the P123 publisher
+    # snak to recognise this reference shape on read-back.
+    ref_url = pywikibot.Claim(site, "P854", is_reference=True)
+    ref_url.setTarget(f"https://dp.la/item/{dpla_id}")
+    ref_publisher = pywikibot.Claim(site, "P123", is_reference=True)
+    ref_publisher.setTarget(pywikibot.ItemPage(repo, "Q2944483"))
+    today = datetime.date.today()
+    ref_retrieved = pywikibot.Claim(site, "P813", is_reference=True)
+    ref_retrieved.setTarget(
+        pywikibot.WbTime(year=today.year, month=today.month, day=today.day)
+    )
+    claim.addSources([ref_url, ref_publisher, ref_retrieved])
+
+    serialized = claim.toJSON()
+    # Strip the ``qualifiers-order`` and per-reference ``snaks-order``
+    # keys ``Claim.toJSON()`` produces. Several add_* helpers append
+    # extra inline qualifiers by mutating the returned dict
+    # (``claim["qualifiers"][P1932] = [...]`` etc.), which would leave
+    # the order keys out of sync with the actual qualifier set.
+    # Wikibase accepts dicts without order keys (the previous hand-built
+    # ``formattedclaim`` never produced them) and falls back to the
+    # natural dict iteration order, so stripping them is the
+    # lowest-risk way to keep the existing mutation pattern correct.
+    serialized.pop("qualifiers-order", None)
+    for ref in serialized.get("references", []):
+        ref.pop("snaks-order", None)
+    return serialized
 
 
 # Adds a missing qualifier to an existing claim via ``wbsetqualifier``.

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -14,7 +14,6 @@ import time
 import tomllib
 import urllib.parse
 from bs4 import BeautifulSoup
-from pywikibot.comms import http
 from pywikibot import pagegenerators
 from ingest_wikimedia.logs import setup_logging
 from ingest_wikimedia.slack import notify_phase_start, notify_sdc_complete
@@ -39,7 +38,6 @@ site: pywikibot.site.BaseSite
 hubs: dict
 rights: dict
 subject_ids: dict
-token: str
 _s3_partner: str | None = None
 _s3_client = None
 
@@ -120,13 +118,16 @@ def _build_parser() -> argparse.ArgumentParser:
 class _MissingEntityError(Exception):
     """Commons returned ``no-such-entity`` for the staged M-id.
 
-    Raised by the wbeditentity / wbremoveclaims POST helpers when Commons
-    reports the MediaInfo entity doesn't exist. This is not a failure of
-    the SDC phase — it just means the file page is gone (most commonly
-    because a Commons curator deleted it as a duplicate, or because this
-    is an SDC-only run for an M-id whose upload was never confirmed). The
-    per-ordinal handler in ``_run_partner_mode`` catches this distinctly
-    from generic ``Exception`` so it can:
+    Raised by the wbeditentity / wbremoveclaims POST helpers when
+    pywikibot's ``simple_request`` translates Commons'
+    ``{"error": {"code": "no-such-entity", ...}}`` response into an
+    ``APIError`` with ``code == "no-such-entity"``; the helpers
+    re-raise it as this dedicated class. This is not a failure of the
+    SDC phase — it just means the file page is gone (most commonly
+    because a Commons curator deleted it as a duplicate, or because
+    this is an SDC-only run for an M-id whose upload was never
+    confirmed). The per-ordinal handler in ``_run_partner_mode``
+    catches this distinctly from generic ``Exception`` so it can:
 
     - log at INFO instead of ERROR (it isn't an error to log against),
     - increment ``SDC_ORDINALS_SKIPPED_MISSING_ENTITY`` instead of
@@ -139,21 +140,6 @@ class _MissingEntityError(Exception):
     (upload phase, drift handling) — not something this phase can or
     should try to fix.
     """
-
-
-def _raise_if_missing_entity(post: dict, mediaid: str) -> None:
-    """Inspect a parsed wbeditentity / wbremoveclaims response and raise
-    ``_MissingEntityError`` if Commons reported ``no-such-entity``.
-
-    Must be called BEFORE accessing ``post["success"]`` — a response with
-    no ``success`` key (the shape of every Commons error response) would
-    otherwise raise ``KeyError`` and divert into the generic retry path,
-    masking the specific cause from the per-ordinal handler.
-    """
-    if isinstance(post, dict):
-        err = post.get("error") or {}
-        if err.get("code") == "no-such-entity":
-            raise _MissingEntityError(mediaid)
 
 
 def _truncate(text: str | None, limit: int = 500) -> str:
@@ -198,7 +184,7 @@ def _initialize() -> None:
     time. Kept out of import-time so `import tools.sdc_sync` (e.g. by the
     console-script entry point) does no I/O.
     """
-    global parser, args, method, dpla_api, site, hubs, rights, subject_ids, token
+    global parser, args, method, dpla_api, site, hubs, rights, subject_ids
     global _s3_partner, _s3_client
 
     parser = _build_parser()
@@ -211,11 +197,11 @@ def _initialize() -> None:
 
     site = pywikibot.Site()
     site.login()
-    # Fetch the wbeditentity CSRF token here so importing the module
-    # remains side-effect free — the helper post functions (_post_new_refs,
-    # _post_new_claims) read `token` at call time and refresh it
-    # themselves via `login()` on save failure.
-    token = login()
+    # CSRF tokens are managed by pywikibot's ``site.tokens["csrf"]`` —
+    # lazy-loaded on first read, refreshed automatically on ``badtoken``
+    # responses. No manual token fetch or relogin loops here; the
+    # ``_wbeditentity_via_pywikibot``, ``postqual``, and removals helpers
+    # all pull from the same auto-managed source at write time.
 
     # Hubs and subject mappings are fetched live from ingestion3 on every run,
     # by design: this sync exists precisely to propagate upstream changes to
@@ -326,53 +312,46 @@ def formattedclaim(prop, value, value_type, dpla_id):
     return claim
 
 
-# This is the function that will perform the POST to the Wikimedia Commons API, when passed all necessary parameters, to add a qualifier if it is missing for an existing claim. Currently, this is only used for P459. It creates a JSON object to send in the body of the request with the data to post and the login token.
+# Adds a missing qualifier to an existing claim via ``wbsetqualifier``.
+# Currently only used for P459 (determination method). The POST is
+# submitted through pywikibot's ``site.simple_request``, which manages
+# the CSRF token and retries on transient errors automatically.
 
 
 def postqual(claimid, prop, value):
-    global token
+    """Add a qualifier to an existing claim via ``wbsetqualifier``.
+
+    Routed through ``site.simple_request`` so pywikibot handles CSRF token
+    refresh, ``maxlag`` / ``Retry-After`` honoring, exponential backoff on
+    transient errors, and auto-relogin on ``badtoken`` — all automatically.
+    Replaces a hand-rolled refresh-token-and-retry-once pattern that didn't
+    cover ``maxlag`` or rate-limit signaling.
+
+    Best-effort: a final failure logs and continues; the partner is not
+    aborted for a missing qualifier amendment.
+    """
     summary = f"Adding [[:d:Property:{prop}]] to {claimid}."
-
-    postdata = {
-        "action": "wbsetqualifier",
-        "format": "json",
-        "claim": claimid,
-        "property": prop,
-        "snaktype": "value",
-        "value": value,
-        "token": token,
-        "bot": True,
-    }
-
     try:
-        json.loads(
-            http.fetch(
-                "https://commons.wikimedia.org/w/api.php", method="POST", data=postdata
-            ).text
-        )
+        site.simple_request(
+            action="wbsetqualifier",
+            claim=claimid,
+            property=prop,
+            snaktype="value",
+            value=value,
+            bot=True,
+            summary=summary,
+            token=site.tokens["csrf"],
+        ).submit()
         pywikibot.output(summary)
-
-    except Exception as e:
-        # Refresh the global token and retry once. The previous version only
-        # refreshed pywikibot's internal cache and didn't update the module
-        # `token` (used in postdata above) nor retry the POST, so qualifiers
-        # were silently dropped on any transient CSRF failure. Mirror the
-        # token-refresh pattern used by process_one().
-        print(repr(e))
-        print(" -- Refreshing CSRF token after API error and retrying...")
-        token = login()
-        postdata["token"] = token
-        try:
-            json.loads(
-                http.fetch(
-                    "https://commons.wikimedia.org/w/api.php",
-                    method="POST",
-                    data=postdata,
-                ).text
-            )
-            pywikibot.output(summary)
-        except Exception as retry_e:
-            print(f" -- Retry after token refresh failed: {repr(retry_e)}")
+    except pywikibot.exceptions.APIError as e:
+        # Log and continue — qualifier amends are best-effort, and pywikibot
+        # has already exhausted its built-in retry policy by the time an
+        # APIError surfaces here. Surface the Commons error code so it's
+        # diagnosable from the log without needing to enable verbose tracing.
+        print(
+            f" -- Failed to amend qualifier {prop} for {claimid}:"
+            f" {e.code} — {getattr(e, 'info', '')}"
+        )
 
 
 # This function performs an initial GET request on the given Wikimedia file to check if the statement we will be adding is already in the page. It returns a boolean, with True if the statement is not found and can be added. "qid" is passed as a tuple with both the value and the data type, so this check can handle the formatting for different data types. If statements are found in the entity with the prop and value, but no qualifiers, we return the statement id instead, so that the qualifier can be added to that statement instead of creating a new one using postqual().
@@ -1287,211 +1266,98 @@ def _build_expected_from_sdc(sdc_payload):
     return expected
 
 
-def _post_new_refs(mediaid, dpla_id):
-    """POST the accumulated `refclaims["claims"]` to wbeditentity.
+def _submit_sdc_write(action, mediaid, dpla_id, **params):
+    """Submit an SDC write (wbeditentity or wbremoveclaims) through
+    pywikibot's ``simple_request``.
 
-    Reads the module-global `refclaims` (populated by `add_ref` during the
-    per-claim check loop). No-op when nothing to post. Refreshes the
-    module-global `token` and retries once on save error.
+    Shared by the three write paths (``_post_new_refs``,
+    ``_post_new_claims``, removals in ``_reconcile_existing_claims``)
+    so they all get pywikibot's built-in behaviours for free:
+
+    - automatic CSRF token management (``site.tokens["csrf"]``);
+    - ``maxlag`` honoring (sleep ``lag + 1``, retry; default
+      ``Site.maxlag`` is 5s);
+    - ``Retry-After`` header honoring on 429/503;
+    - exponential backoff on ``internal_api_error_*`` / ``srvtimeout``;
+    - auto-relogin on ``badtoken``;
+    - structured ``APIError(code=..., info=...)`` instead of JSON
+      response inspection.
+
+    Raises :class:`_MissingEntityError` when Commons returns
+    ``no-such-entity`` (the entity doesn't exist; not the SDC phase's
+    problem — see PR #267). Other ``APIError`` codes propagate as a
+    ``RuntimeError`` carrying the code + info, which the per-ordinal
+    handler catches and treats as an ``SDC_ORDINALS_SKIPPED_ERROR``.
+
+    ``params`` is the per-action payload — for wbeditentity, the
+    serialized ``data``; for wbremoveclaims, the pipe-joined ``claim``
+    string. ``bot=True``, the CSRF token, and ``id=mediaid`` are
+    injected here so call sites stay focused on the action-specific
+    differences.
     """
-    global token
+    try:
+        site.simple_request(
+            action=action,
+            id=mediaid,
+            bot=True,
+            token=site.tokens["csrf"],
+            **params,
+        ).submit()
+    except pywikibot.exceptions.APIError as e:
+        if e.code == "no-such-entity":
+            raise _MissingEntityError(mediaid) from e
+        raise RuntimeError(
+            f"{action} failed for {mediaid} ({dpla_id}):"
+            f" {e.code} — {_truncate(getattr(e, 'info', ''))}"
+        ) from e
+
+
+def _post_new_refs(mediaid, dpla_id):
+    """POST the accumulated ``refclaims["claims"]`` to ``wbeditentity``.
+
+    Reads the module-global ``refclaims`` (populated by ``add_ref`` during
+    the per-claim check loop). No-op when nothing to post.
+    """
     if not refclaims["claims"]:
         return
     refs_to_post = len(refclaims["claims"])
-    postrefs = {
-        "action": "wbeditentity",
-        "format": "json",
-        "id": mediaid,
-        "data": json.dumps(refclaims),
-        "token": token,
-        "bot": True,
-        "summary": f"Added structured data references from [[COM:DPLA|DPLA]] item '[[dpla:{dpla_id}|{dpla_id}]]'. [[COM:DPLA/MOD|Leave feedback]]!",
-    }
-    try:
-        save = http.fetch(
-            "https://commons.wikimedia.org/w/api.php", method="POST", data=postrefs
-        )
-    except (requests.exceptions.ConnectionError, ConnectionError):
-        try:
-            save = http.fetch(
-                "https://commons.wikimedia.org/w/api.php",
-                method="POST",
-                data=postrefs,
-            )
-        except (requests.exceptions.ConnectionError, ConnectionError):
-            try:
-                save = http.fetch(
-                    "https://commons.wikimedia.org/w/api.php",
-                    method="POST",
-                    data=postrefs,
-                )
-            except (requests.exceptions.ConnectionError, ConnectionError) as final_e:
-                print(" --- Network error posting new refs: all retries failed.")
-                raise RuntimeError(
-                    f"Network error posting new refs for {mediaid} ({dpla_id}):"
-                    " all 3 ConnectionError retries failed"
-                ) from final_e
-    try:
-        post = json.loads(save.text)
-        _raise_if_missing_entity(post, mediaid)
-        if post["success"] == 1:
-            print(" --- Saved new refs!")
-            tracker.increment(Result.SDC_REFS_ADDED, refs_to_post)
-        else:
-            print(post)
-            print(" --- Error encountered on save.")
-            raise RuntimeError(
-                f"wbeditentity refs save returned non-success for"
-                f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
-            )
-    except (RuntimeError, _MissingEntityError):
-        # Our own structured failure — let the per-ordinal handler see it
-        # as-is rather than restarting the relogin path below.
-        # ``_MissingEntityError`` in particular must skip the relogin: the
-        # entity isn't coming back via a fresh token.
-        raise
-    except Exception:
-        try:
-            token = login()
-            postrefs["token"] = token
-            save = http.fetch(
-                "https://commons.wikimedia.org/w/api.php",
-                method="POST",
-                data=postrefs,
-            )
-            post = json.loads(save.text)
-            _raise_if_missing_entity(post, mediaid)
-            if post["success"] == 1:
-                print(" --- Saved new refs!")
-                tracker.increment(Result.SDC_REFS_ADDED, refs_to_post)
-                return
-            print(post)
-            print(" --- Error encountered on save.")
-            raise RuntimeError(
-                f"wbeditentity refs save still non-success after relogin for"
-                f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
-            )
-        except (RuntimeError, _MissingEntityError):
-            raise
-        except Exception as retry_e:
-            # `save` may not be bound if http.fetch raised before the response
-            # landed — guard with ``locals()`` so we don't mask the real cause
-            # with an UnboundLocalError. When ``save`` IS bound, the response
-            # body is the diagnostic we actually want (e.g. a Commons error
-            # like ``{"error": {"code": "permissiondenied", ...}}`` will raise
-            # KeyError on ``post["success"]`` above, but the response body
-            # itself names the cause).
-            print(f" --- Error encountered. 2: {retry_e!r}")
-            body_suffix = f": {_truncate(save.text)}" if "save" in locals() else ""
-            raise RuntimeError(
-                f"Refs relogin+save failed for {mediaid} ({dpla_id}){body_suffix}"
-            ) from retry_e
+    _submit_sdc_write(
+        "wbeditentity",
+        mediaid,
+        dpla_id,
+        data=json.dumps(refclaims),
+        summary=(
+            f"Added structured data references from [[COM:DPLA|DPLA]] item"
+            f" '[[dpla:{dpla_id}|{dpla_id}]]'."
+            f" [[COM:DPLA/MOD|Leave feedback]]!"
+        ),
+    )
+    print(" --- Saved new refs!")
+    tracker.increment(Result.SDC_REFS_ADDED, refs_to_post)
 
 
 def _post_new_claims(mediaid, dpla_id):
-    """POST the accumulated `claims["claims"]` to wbeditentity.
+    """POST the accumulated ``claims["claims"]`` to ``wbeditentity``.
 
-    Reads the module-global `claims` (populated by add_* helpers during the
-    per-claim check loop). No-op when nothing to post. Retries the initial
-    fetch up to three times on ConnectionError; refreshes the module-global
-    `token` and retries the whole save once on parse / save error.
+    Reads the module-global ``claims`` (populated by add_* helpers during
+    the per-claim check loop). No-op when nothing to post.
     """
-    global token
     if not claims["claims"]:
         return
     claims_to_post = len(claims["claims"])
-    postdata = {
-        "action": "wbeditentity",
-        "format": "json",
-        "id": mediaid,
-        "data": json.dumps(claims),
-        "token": token,
-        "bot": True,
-        "summary": f"Added structured data claims from [[COM:DPLA|DPLA]] item '[[dpla:{dpla_id}|{dpla_id}]]'. [[COM:DPLA/MOD|Leave feedback]]!",
-    }
-    try:
-        save = http.fetch(
-            "https://commons.wikimedia.org/w/api.php", method="POST", data=postdata
-        )
-    except (requests.exceptions.ConnectionError, ConnectionError):
-        try:
-            save = http.fetch(
-                "https://commons.wikimedia.org/w/api.php",
-                method="POST",
-                data=postdata,
-            )
-        except (requests.exceptions.ConnectionError, ConnectionError):
-            try:
-                save = http.fetch(
-                    "https://commons.wikimedia.org/w/api.php",
-                    method="POST",
-                    data=postdata,
-                )
-            except (requests.exceptions.ConnectionError, ConnectionError) as final_e:
-                print(" --- Network error posting new claims: all retries failed.")
-                raise RuntimeError(
-                    f"Network error posting new claims for {mediaid} ({dpla_id}):"
-                    " all 3 ConnectionError retries failed"
-                ) from final_e
-    try:
-        post = json.loads(save.text)
-        _raise_if_missing_entity(post, mediaid)
-        if post["success"] == 1:
-            print(" --- Saved new claims!")
-            tracker.increment(Result.SDC_CLAIMS_ADDED, claims_to_post)
-        else:
-            print(post)
-            print(" --- Error encountered on save.")
-            raise RuntimeError(
-                f"wbeditentity claims save returned non-success for"
-                f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
-            )
-    except (RuntimeError, _MissingEntityError):
-        raise
-    except Exception:
-        try:
-            token = login()
-            postdata["token"] = token
-            save = http.fetch(
-                "https://commons.wikimedia.org/w/api.php",
-                method="POST",
-                data=postdata,
-            )
-            post = json.loads(save.text)
-            _raise_if_missing_entity(post, mediaid)
-            if post["success"] == 1:
-                print(" --- Saved new claims!")
-                tracker.increment(Result.SDC_CLAIMS_ADDED, claims_to_post)
-                return
-            print(post)
-            print(" --- Error encountered on save.")
-            raise RuntimeError(
-                f"wbeditentity claims save still non-success after relogin for"
-                f" {mediaid} ({dpla_id}): {_truncate(save.text)}"
-            )
-        except (RuntimeError, _MissingEntityError):
-            raise
-        except Exception as retry_e:
-            # `post` may not be assigned yet if http.fetch / json.loads raised —
-            # referencing it directly would mask the real error with an
-            # UnboundLocalError. Log what we actually have.
-            #
-            # Bake ``save.text`` into the RuntimeError message (when bound) so
-            # the per-ordinal ``logging.exception`` captures the Commons error
-            # response body — the existing ``print(save.text)`` goes to stdout,
-            # which is block-buffered to a non-TTY and got dropped on
-            # ``sys.exit()``. The May 2026 NARA aborts ended with ``KeyError:
-            # 'success'`` propagating out of this block, which only happens
-            # when Commons returned ``{"error": {...}}`` (no ``success`` field)
-            # — the error code in that body is the missing diagnostic.
-            print(f" --- Retry after token refresh failed: {retry_e!r}")
-            if "save" in locals():
-                print(save.text)
-            print(" --- Error encountered. 3")
-            body_suffix = f": {_truncate(save.text)}" if "save" in locals() else ""
-            raise RuntimeError(
-                f"Claims relogin+save failed for {mediaid} ({dpla_id}){body_suffix}"
-            ) from retry_e
+    _submit_sdc_write(
+        "wbeditentity",
+        mediaid,
+        dpla_id,
+        data=json.dumps(claims),
+        summary=(
+            f"Added structured data claims from [[COM:DPLA|DPLA]] item"
+            f" '[[dpla:{dpla_id}|{dpla_id}]]'."
+            f" [[COM:DPLA/MOD|Leave feedback]]!"
+        ),
+    )
+    print(" --- Saved new claims!")
+    tracker.increment(Result.SDC_CLAIMS_ADDED, claims_to_post)
 
 
 def dpla_claims(
@@ -1732,42 +1598,19 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
             elif claim[prop]["value"] not in expected[prop]:
                 removals.append(claim[prop]["id"])
     if removals:
-        rmdata = {
-            "action": "wbremoveclaims",
-            "format": "json",
-            "id": mediaid,
-            "claim": "|".join(removals),
-            "token": token,
-            "bot": True,
-            "summary": f"Changing structured data claims from [[COM:DPLA|DPLA]] item '[[dpla:{dpla_id}|{dpla_id}]]'. [[COM:DPLA/MOD|Leave feedback]]!",
-        }
-        # Only count removals once we've seen `success: 1` on the
-        # wbremoveclaims response, matching what `_post_new_refs` and
-        # `_post_new_claims` do for their respective POSTs. Without this
-        # check, a rejected removal batch (bad token, replication lag,
-        # claim already gone, etc.) would silently inflate the counter.
-        rm_resp = http.fetch(
-            "https://commons.wikimedia.org/w/api.php", method="POST", data=rmdata
+        _submit_sdc_write(
+            "wbremoveclaims",
+            mediaid,
+            dpla_id,
+            claim="|".join(removals),
+            summary=(
+                f"Changing structured data claims from [[COM:DPLA|DPLA]]"
+                f" item '[[dpla:{dpla_id}|{dpla_id}]]'."
+                f" [[COM:DPLA/MOD|Leave feedback]]!"
+            ),
         )
-        try:
-            rm_post = json.loads(rm_resp.text)
-        except (ValueError, AttributeError) as parse_e:
-            print(" --- Could not parse removals response.")
-            raise RuntimeError(
-                f"wbremoveclaims response was not parseable JSON for"
-                f" {mediaid} ({dpla_id}): {_truncate(getattr(rm_resp, 'text', ''))}"
-            ) from parse_e
-        _raise_if_missing_entity(rm_post, mediaid)
-        if rm_post.get("success") == 1:
-            print(" --- Saved removals!")
-            tracker.increment(Result.SDC_REMOVALS, len(removals))
-        else:
-            print(rm_post)
-            print(" --- Error encountered on removals save.")
-            raise RuntimeError(
-                f"wbremoveclaims save returned non-success for"
-                f" {mediaid} ({dpla_id}): {_truncate(rm_resp.text)}"
-            )
+        print(" --- Saved removals!")
+        tracker.increment(Result.SDC_REMOVALS, len(removals))
 
 
 def _fetch_dpla_doc_from_api(dpla_id, dpla_api):
@@ -2019,15 +1862,6 @@ def _parse_dpla_doc(dpla, dpla_id):
     )
 
 
-def login():
-    tokenrequest = http.fetch(
-        "https://commons.wikimedia.org/w/api.php?action=query&meta=tokens&type=csrf&format=json"
-    )
-    tokendata = json.loads(tokenrequest.text)
-    token = tokendata.get("query").get("tokens").get("csrftoken")
-    return token
-
-
 def _resolve_dpla_id(title, dpla_api):
     """Return the DPLA item ID for a Commons file title.
 
@@ -2061,7 +1895,7 @@ def _resolve_dpla_id(title, dpla_api):
 
 def process_one(mediaid, dpla_id):
     """Fetch DPLA metadata and sync SDC claims for a single Commons file."""
-    global claims, refclaims, token
+    global claims, refclaims
 
     # Drop any stale cache from a prior file so check() always reads fresh state
     # for this mediaid.


### PR DESCRIPTION
## Summary

Follow-up to PR #268. The bulk POST helpers now route through pywikibot's `simple_request`, but `formattedclaim()` was still hand-building the wbeditentity wire-format dict directly. This PR replaces the body with `pywikibot.Claim` + `Claim.toJSON()`, getting type safety + idiom in the build step **without touching the 17 add_* callsites or the bulk-POST pipeline**.

## Scope chosen after probing

I started by probing `pywikibot.Claim.toJSON()` on EC2 to see what wire format pywikibot actually produces. Found two real differences that informed the design:

1. **Extra `datatype` per snak** — pywikibot auto-derives the property's Wikidata data type (e.g. `external-id` for P12109, `url` for P854, `wikibase-item` for P459) and emits it on every snak. The previous hand-built dict omitted this. Both forms are valid wbeditentity input; pywikibot's is more accurate.
2. **`qualifiers-order` and `snaks-order` keys** — pywikibot emits these to pin iteration order. The previous dict had no such keys.

The order keys are the problem: 11 callsites in `add_*` helpers mutate `claim["qualifiers"][prop] = [...]` after `formattedclaim()` returns to add inline extra qualifiers (P1932, P3831, P973, etc.). Each of those would leave the order list out of sync with the actual qualifier set. **Solution**: strip the order keys before returning. Wikibase falls back to dict iteration order, which is exactly what the previous hand-built version relied on. Verified the post-mutation output is still valid wbeditentity input.

## What stays the same

- `formattedclaim()`'s function-boundary contract: still `(prop, value, value_type, dpla_id) → wbeditentity wire-format dict`. **None of the 17 add_* callers change.**
- The standard DPLA qualifier (P459=Q61848113, determination method) and 3-snak DPLA reference (P854 URL + P123 publisher + P813 retrieved date) on every statement.
- The `"somevalue"` special case for claims where DPLA records the existence of a value but not its content (e.g. `add_date` with a missing date).
- The inline-qualifier mutation pattern (`claim["qualifiers"][prop] = [...]`).

## What changes

| File | Change |
|---|---|
| `tools/sdc_sync.py` `formattedclaim()` | ~70 line nested dict literal → ~25 line `pywikibot.Claim` build + `Claim.toJSON()` + order-key strip |
| `tools/sdc_sync.py` `_set_claim_target()` (new) | Helper centralising value-type → pywikibot type mapping. Raises `ValueError` on unsupported value_type. |

## Wire format diff per snak (sample)

```diff
  "mainsnak": {
+   "datatype": "wikibase-item",            ← pywikibot auto-derives from property
    "datavalue": { "type": "wikibase-entityid", "value": {"entity-type": "item", "numeric-id": 19652} },
    "property": "P6216",
    "snaktype": "value"
  },
- "qualifiers-order": ["P459"],             ← STRIPPED before return (incompatible with inline mutation pattern)
  "references": [{
    "snaks": {
      "P813": [{ "datavalue": {"value": {
-       "time": "+2026-05-30T00:00:00Z",     ← pywikibot uses long-year form
+       "time": "+00000002026-05-30T00:00:00Z",
        ... }}}]
    },
-   "snaks-order": ["P854","P123","P813"]   ← STRIPPED before return
  }]
```

Both forms are valid wbeditentity input — Commons normalises server-side.

## Tests

- `test_set_claim_target_dispatches_each_value_type` — for each of the 4 value_types the 17 add_* helpers use (`wikibase-entityid`, `string`, `monolingualtext`), assert `setTarget` is called with the right pywikibot type (`ItemPage(Q-id)`, raw string, `WbMonolingualText(text, language)`).
- `test_set_claim_target_rejects_unknown_value_type` — translator raises `ValueError` on `globe-coordinate` or raw `time` (the only `"time"` callsite passes `"somevalue"` and is handled by `formattedclaim` before reaching this translator). Prevents silent malformed-wire-data regressions if a new value_type slips into a callsite.

## Verification

Probed end-to-end on EC2 with pywikibot 9.4.1: all 4 value_type cases (`wikibase-entityid`, `string`, `monolingualtext`, `somevalue`) produce valid wbeditentity wire-format dicts after the order-key strip. The `add_date`-style inline qualifier mutation (`claim["qualifiers"]["P1932"] = [...]`) on a post-`formattedclaim()` dict still produces a valid claim.

## Test plan

- [ ] Pytest passes (CI)
- [ ] Smoke-test on EC2 with a single-item SDC sync (e.g. the Clinton item we tested for PR #268) and verify the resulting claims land on Commons identically to pre-merge runs
- [ ] If a real-world sync hits any unusual claim shape (e.g. monolingualtext with non-ASCII content), verify pywikibot encodes it correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR refactors SDC (Structured Data on Commons) write operations to use pywikibot for claim construction and to delegate HTTP/CSRF handling to pywikibot's request flow, replacing prior manual HTTP calls and token-refresh logic.

Key changes
- Request layer consolidation:
  - Adds _submit_sdc_write(action, mediaid, dpla_id, **params) to standardize Commons POST submissions (wbeditentity, wbremoveclaims, wbsetqualifier).
  - Uses site.simple_request(...).submit() and site.tokens["csrf"] (pywikibot-managed).
  - Maps Commons APIError(code="no-such-entity") → _MissingEntityError; other API errors are wrapped as RuntimeError with truncated messages via _truncate.
  - Removes manual token state and the old login()/token-refresh loops.
- Claim construction:
  - formattedclaim(prop, value, value_type, dpla_id) now builds claims via pywikibot.Claim + Claim.toJSON() instead of hand-building wbeditentity dicts.
  - Adds _set_claim_target(claim, repo, value, value_type) to centralize mapping of value_type → pywikibot target; raises ValueError for unsupported types.
  - Preserves prior behavior for the DPLA qualifier (P459), the 3-snak DPLA reference (P854, P123, P813), "somevalue" special-case handling, and the inline-qualifier mutation pattern.
  - Strips pywikibot-added ordering keys ("qualifiers-order", "snaks-order") from the claim dict before returning so callers that mutate claim["qualifiers"][prop] still behave as before (Wikibase will fall back to dict iteration order).
- Qualifiers update flow:
  - postqual() now uses site.simple_request(wbsetqualifier) and relies on pywikibot for CSRF handling; previous manual retry/login logic removed.
- Removals and helpers:
  - _raise_if_missing_entity() removed; behavior replaced by exception translation in _submit_sdc_write().
  - Module-level token variable removed.
- Tests and test-harness changes:
  - Tests now mock site.simple_request(...).submit() behavior; helper _install_module_globals signature changed to accept submit_side_effect/submit_return and returns a fake site.
  - New helper _api_error(code, info="") added for tests.
  - Tests added/updated to cover:
    - _post_new_refs/_post_new_claims error translation (APIError → RuntimeError or _MissingEntityError for no-such-entity).
    - That failures from _post_new_refs are raised as an Exception subclass (caught by per-ordinal except Exception:).
    - Success increments tracker counters by number of payload items.
    - _submit_sdc_write includes action name in RuntimeError messages and uses token + data in the request.
    - _set_claim_target dispatches for wikibase-entityid, string, monolingualtext and raises ValueError for unknown types.
  - Tests refactor: monkeypatching pywikibot.ItemPage to avoid MagicMock site issues.
- End-to-end verification:
  - Author ran an EC2 smoke-test with pywikibot 9.4.1 confirming valid wbeditentity output after stripping order keys.
  - CI pytest is the primary test plan.

Effects on infrastructure, secrets, DBs, and APIs
- No manual pipeline trigger or ECS redeployment required.
- No environment variable or AWS Secrets Manager changes.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM) or public-facing API response shapes/endpoints.

Security implications
- CSRF/token handling is consolidated under pywikibot (site.tokens) and the module-level token was removed. Reviewers should confirm site.token usage is correct at all callsites; no new secret storage or exposure is introduced.

Other notes
- Lines changed (manifest summary): approximately +225 / -381.
- Estimated review effort: Medium–High due to claim-construction and API error-translation changes and corresponding tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/ingest-wikimedia/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->