### PR TITLE
ssm: stage tmux launch scripts via base64 to avoid SSM "command too long"

### DIFF
--- a/ingest_wikimedia/ssm.py
+++ b/ingest_wikimedia/ssm.py
@@ -1,5 +1,7 @@
 """Shared SSM helpers for Wikimedia pipeline scripts."""
 
+import base64
+import hashlib
 import shlex
 import time
 
@@ -50,3 +52,43 @@ def ssm_run(client, cmd: str, *, as_root: bool = False) -> str:
                 f"SSM command {cmd_id} ended with {status}: {stderr or 'no stderr'}"
             )
     raise TimeoutError(f"SSM command {cmd_id} did not complete within polling window")
+
+
+def stage_and_launch_tmux(client, *, script: str, session_name: str, cwd: str) -> str:
+    """Stage `script` to a file on the instance, then launch a detached
+    tmux session that runs it. Returns whatever ssm_run returns (stdout).
+
+    Use this instead of an inline ``tmux new-session ... "PIPELINE_CMD"``
+    SSM call when ``script`` may be long.  SSM's per-command size limit
+    (the agent rejects with "command too long" once exceeded — observed
+    on a 22-target batch of ~25KB) bites when long batch pipelines or
+    institution-rich target lists get serialised inline, especially
+    once shlex.quote'ing many embedded single quotes inflates them
+    further.  Base64 adds only ~33% overhead vs the 2-3x growth from
+    quote-escaping, and the base64 alphabet (``[A-Za-z0-9+/=]``) has no
+    characters that need shell escaping, so the SSM payload stays
+    compact regardless of script content.
+
+    Side benefit: the staged script runs in a fresh bash via
+    ``bash <path>``, so its variable references see raw ``$?`` / ``$rc``
+    / ``$0`` etc. without needing backslash escapes that were only
+    necessary when the pipeline was embedded as a double-quoted
+    argument to an outer bash through tmux.  Callers should pass the
+    raw, unescaped script form.
+
+    The script filename is derived from a SHA-1 of ``session_name`` so
+    two concurrent launches with different sessions don't collide on
+    ``/tmp``, but the same launch retried after a transient error
+    overwrites cleanly.
+    """
+    script_id = hashlib.sha1(session_name.encode()).hexdigest()[:12]
+    script_path = f"/tmp/wm-pipeline-{script_id}.sh"
+    script_b64 = base64.b64encode(script.encode()).decode()
+    staged_cmd = (
+        f"echo {script_b64} | base64 -d > {script_path} && "
+        f"chmod +x {script_path} && "
+        f"tmux new-session -d -s {shlex.quote(session_name)} "
+        f"-c {shlex.quote(cwd)} 'bash {script_path}' && "
+        "echo SESSION_STARTED"
+    )
+    return ssm_run(client, staged_cmd)

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -44,7 +44,7 @@ from ingest_wikimedia.partners import (
     slugify_session_label_component,
 )
 from ingest_wikimedia.slack import post_message
-from ingest_wikimedia.ssm import REGION, ssm_run
+from ingest_wikimedia.ssm import REGION, ssm_run, stage_and_launch_tmux
 
 # Each ingest session peaks at ~300–500 MB; 30% of 7.6 GB leaves headroom for 4–5 concurrent sessions.
 MEMORY_HEADROOM_PCT = 30
@@ -629,23 +629,14 @@ def main() -> None:
     # target (|| handler + ; separator).
     # The cd is required because config.toml is read from CWD.
     #
-    # notify_fail_cmd uses single-quoted Python inside a double-quoted tmux argument.
-    # Single quotes are literal characters inside double-quoted bash strings, so the
-    # inner Python code reaches the interpreter verbatim without needing any escaping.
-    #
-    # The `$?` and `$rc` references DO need backslash-escaping. pipeline_cmd is
-    # embedded as `"{pipeline_cmd}"` in tmux_cmd below — a double-quoted argument
-    # — and the outer bash on EC2 expands unescaped `$` references inside double
-    # quotes BEFORE tmux ever sees the command string. Without the escapes the
-    # inner shell ends up with `rc=0; WIKIMEDIA_LAST_EXIT= python3 -c '...'`
-    # (outer $? = 0 from the previous tmux launch, outer $rc undefined), so
-    # WIKIMEDIA_LAST_EXIT is always empty in the Slack message — losing the
-    # exit-code suffix that decodes signals like 137 (SIGKILL / probable OOM)
-    # and 143 (SIGTERM). With `\$?` and `\$rc`, the outer bash leaves the `$`
-    # literal and the inner shell evaluates the references against the actual
-    # failing step's exit status.
+    # notify_fail_cmd captures the failing step's exit code via `rc=$?` so the
+    # Slack message can decode signals like 137 (SIGKILL / probable OOM) and
+    # 143 (SIGTERM). No backslash escaping needed on `$?` / `$rc`: pipeline_cmd
+    # is staged to a script file via stage_and_launch_tmux below and read
+    # directly by bash, so the inner shell sees raw `$?` / `$rc` and expands
+    # them at runtime against the actual failing step.
     notify_fail_cmd = (
-        r"rc=\$?; WIKIMEDIA_LAST_EXIT=\$rc python3 -c "
+        "rc=$?; WIKIMEDIA_LAST_EXIT=$rc python3 -c "
         "'from ingest_wikimedia.slack import notify_pipeline_fail; notify_pipeline_fail()'"
     )
     setup = " && ".join(
@@ -818,17 +809,22 @@ def main() -> None:
             logging.warning("Slack notification failed: %s", e)
 
     print(f"Launching {session_name} pipeline...")
-    # Use double quotes around the pipeline so single-quoted institution names inside are
-    # preserved when the outer shell (bash -c) processes the tmux command. The sentinel
-    # echo runs immediately after tmux creates the detached session — before any pipeline
-    # commands execute — so it is not subject to a race with fast-completing pipelines.
-    tmux_cmd = (
-        f"tmux new-session -d -s {shlex.quote(session_name)} -c /home/ec2-user/ingest-wikimedia/"
-        f' "{pipeline_cmd}" && echo SESSION_STARTED'
-    )
+    # Stage pipeline_cmd to a script file on EC2 and launch tmux against it
+    # rather than inlining as a `"PIPELINE_CMD"` argument to tmux. The
+    # inline form ran into SSM's per-command size limit ("command too long"
+    # on a 22-target batch — single-quoted institution names plus the
+    # shlex.quote multiplier add up fast). stage_and_launch_tmux base64-
+    # encodes the script and decodes it on the instance, keeping the SSM
+    # payload compact regardless of pipeline length. See ssm.py for the
+    # full rationale.
     out = ""
     try:
-        out = ssm_run(ssm, tmux_cmd)
+        out = stage_and_launch_tmux(
+            ssm,
+            script=pipeline_cmd,
+            session_name=session_name,
+            cwd="/home/ec2-user/ingest-wikimedia/",
+        )
     except Exception as e:
         _slack_fail(
             response_url, f"⚠️ Failed to launch tmux session `{session_name}`: {e}"

--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -22,7 +22,7 @@ import requests
 
 from ingest_wikimedia.partners import PARTNER_DIR, resolve_slug
 from ingest_wikimedia.slack import post_message
-from ingest_wikimedia.ssm import REGION, ssm_run
+from ingest_wikimedia.ssm import REGION, ssm_run, stage_and_launch_tmux
 
 RETRY_DIR = "/home/ec2-user/ingest-wikimedia/retry"
 MEMORY_HEADROOM_PCT = 30
@@ -224,19 +224,12 @@ def main() -> None:
         session_name += f"-{partner}"
 
     # `rc=$?` captures the failing step's exit code so the Slack message can
-    # decode signals like 137 (SIGKILL / probable OOM) and 143 (SIGTERM).
-    #
-    # The `$?` and `$rc` references MUST be backslash-escaped. notify_fail_cmd
-    # is embedded inside a `"{pipeline_cmd}"` double-quoted argument when the
-    # tmux command is built (see the launch path below), and the outer bash on
-    # EC2 expands unescaped `$` references inside double quotes before tmux
-    # sees the command. Without the escapes the inner shell ends up with
-    # `rc=0; WIKIMEDIA_LAST_EXIT= python3 -c '...'` and Slack failure
-    # notifications silently lose their exit-code suffix. With `\$?` and
-    # `\$rc` the outer bash leaves the `$` literal and the inner shell
-    # evaluates the references against the actual failing step's status.
+    # decode signals like 137 (SIGKILL / probable OOM) and 143 (SIGTERM). No
+    # backslash escaping needed: pipeline_cmd is staged to a script file via
+    # stage_and_launch_tmux below and read directly by bash, so `$?` / `$rc`
+    # are expanded at runtime against the actual failing step.
     notify_fail_cmd = (
-        r"rc=\$?; WIKIMEDIA_LAST_EXIT=\$rc python3 -c "
+        "rc=$?; WIKIMEDIA_LAST_EXIT=$rc python3 -c "
         "'from ingest_wikimedia.slack import notify_pipeline_fail; notify_pipeline_fail()'"
     )
     setup = " && ".join(
@@ -336,23 +329,13 @@ def main() -> None:
             combined_csv = f"{RETRY_DIR}/{slug}-retry-{days}d-combined.csv"
             # `awk '!seen[$0]++'` is the standard idempotent dedup-while-
             # preserving-order one-liner.  Each retry CSV is one DPLA ID
-            # per line, so per-line uniqueness is the right grain.
-            #
-            # The `$0` MUST be backslash-escaped.  pipeline_cmd is embedded
-            # as `"{pipeline_cmd}"` in tmux_cmd below — a double-quoted
-            # argument — and the outer bash on EC2 expands unescaped `$0`
-            # inside double quotes before tmux ever sees the command. `$0`
-            # would resolve to the outer shell's argv[0] (typically the
-            # string "bash"), so awk would dedupe by that literal string
-            # on every line — producing a single-line output and silently
-            # losing 99% of the retry IDs.  Same class of bug as PR #246's
-            # `\$?`/`\$rc` escapes in notify_fail_cmd.  With `\$0` the
-            # outer bash leaves the `$` literal and awk evaluates `$0` as
-            # the current input line.
+            # per line, so per-line uniqueness is the right grain.  No
+            # backslash escaping on `$0` — pipeline_cmd is staged to a
+            # script file via stage_and_launch_tmux below and read
+            # directly by bash, so awk's `$0` reaches awk verbatim and
+            # evaluates as the current input line as intended.
             cat_args = " ".join(shlex.quote(c) for c in upload_inputs)
-            steps.append(
-                rf"awk '!seen[\$0]++' {cat_args} > {shlex.quote(combined_csv)}"
-            )
+            steps.append(f"awk '!seen[$0]++' {cat_args} > {shlex.quote(combined_csv)}")
             steps.append(f"uploader {shlex.quote(combined_csv)} {slug}")
         target_steps = " && ".join(steps)
         target_blocks.append(
@@ -374,17 +357,30 @@ def main() -> None:
         except Exception as e:
             logging.warning("Slack notification failed: %s", e)
 
-    # Kill any existing session with the same name (retries are idempotent) and launch.
+    # Kill any existing session with the same name (retries are idempotent),
+    # then stage the pipeline as a script file and launch tmux against it.
+    # See stage_and_launch_tmux for why we don't inline pipeline_cmd as a
+    # `"{pipeline_cmd}"` argument to tmux: SSM's per-command size limit was
+    # being hit on large batches once shlex.quote'ing of many institution
+    # names inflated the inline form.
     print(f"Launching {session_name}...")
-    tmux_cmd = (
-        f"tmux kill-session -t {shlex.quote(session_name)} 2>/dev/null || true; "
-        f"tmux new-session -d -s {shlex.quote(session_name)}"
-        " -c /home/ec2-user/ingest-wikimedia/"
-        f' "{pipeline_cmd}" && echo SESSION_STARTED'
-    )
+    try:
+        ssm_run(
+            ssm,
+            f"tmux kill-session -t {shlex.quote(session_name)} 2>/dev/null || true",
+        )
+    except Exception as e:
+        # kill-session failing is non-fatal — the session might not exist yet,
+        # and `|| true` should swallow that. Log and proceed to the launch.
+        logging.warning("kill-session pre-launch step failed (continuing): %s", e)
     tmux_out = ""
     try:
-        tmux_out = ssm_run(ssm, tmux_cmd)
+        tmux_out = stage_and_launch_tmux(
+            ssm,
+            script=pipeline_cmd,
+            session_name=session_name,
+            cwd="/home/ec2-user/ingest-wikimedia/",
+        )
     except Exception as e:
         _slack_fail(
             response_url, f"⚠️ Failed to launch tmux session `{session_name}`: {e}"

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -1,8 +1,10 @@
 """Tests for ingest_wikimedia/ssm.py — the AWS SSM wrapper helper."""
 
+import base64
+import re
 from unittest.mock import MagicMock
 
-from ingest_wikimedia.ssm import ssm_run
+from ingest_wikimedia.ssm import ssm_run, stage_and_launch_tmux
 
 
 def _make_client_returning(stdout: str) -> MagicMock:
@@ -56,3 +58,114 @@ def test_ssm_run_returns_stripped_stdout():
     client = _make_client_returning("  hello world  \n")
     result = ssm_run(client, "echo")
     assert result == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# stage_and_launch_tmux: base64-staged pipeline launcher
+# ---------------------------------------------------------------------------
+
+
+def _extract_staged_script(ssm_cmd: str) -> str:
+    """Reverse the staging wire format: pull the base64 payload and decode."""
+    m = re.search(
+        r"echo ([A-Za-z0-9+/=]+) \| base64 -d > /tmp/wm-pipeline-",
+        ssm_cmd,
+    )
+    assert m is not None, f"no base64 stage step found in: {ssm_cmd!r}"
+    return base64.b64decode(m.group(1)).decode()
+
+
+def test_stage_and_launch_tmux_emits_base64_stage_then_tmux_launch():
+    """The staged form must (1) base64-decode the script to /tmp, (2)
+    chmod +x it, and (3) launch tmux that runs the staged file. All
+    three steps need to be present and chained with `&&` so a failure
+    at any step short-circuits before the launch."""
+    client = _make_client_returning("SESSION_STARTED")
+    script = (
+        "cd /home/ec2-user/ingest-wikimedia/northwest-heritage && "
+        "get-ids-es northwest-heritage --institution 'Foo' > out.csv && "
+        "downloader out.csv northwest-heritage"
+    )
+    stage_and_launch_tmux(
+        client,
+        script=script,
+        session_name="wikimedia-northwest-heritage",
+        cwd="/home/ec2-user/ingest-wikimedia/",
+    )
+    sent = client.send_command.call_args.kwargs["Parameters"]["commands"][0]
+
+    assert "base64 -d > /tmp/wm-pipeline-" in sent, sent
+    assert "chmod +x /tmp/wm-pipeline-" in sent, sent
+    assert "tmux new-session -d -s" in sent, sent
+    assert "'bash /tmp/wm-pipeline-" in sent, sent
+    assert "echo SESSION_STARTED" in sent, sent
+
+    # And the decoded script equals exactly what the caller passed in.
+    decoded = _extract_staged_script(sent)
+    assert decoded == script, f"decoded script does not roundtrip; got: {decoded!r}"
+
+
+def test_stage_and_launch_tmux_keeps_ssm_payload_small_for_large_scripts():
+    """Regression: a 25-target batch (the kind of workload that hit
+    SSM's "command too long" limit when serialised inline) must produce
+    an SSM payload well within agent limits.
+
+    The inline form would balloon to >25KB once shlex.quote'd through
+    bash -c; the staged form should be roughly base64-overhead (~33%)
+    of the script size plus a fixed wrapper. Cap the assertion at 50KB
+    so we have headroom but still fail loudly if a future refactor
+    silently re-introduces the inline payload.
+    """
+    client = _make_client_returning("SESSION_STARTED")
+    # ~25KB script, similar in shape to a 22-target pipeline (sprinkle in
+    # single quotes so we'd see the bash-quote-escaping multiplier in the
+    # naive form).
+    big_script = (
+        "cd /home/ec2-user/ingest-wikimedia/foo && "
+        "get-ids-es foo --institution 'Some Institution Name' > out.csv\n"
+    ) * 200
+    assert len(big_script) > 20_000  # ensures we're actually exercising a big payload
+
+    stage_and_launch_tmux(
+        client,
+        script=big_script,
+        session_name="wikimedia-foo",
+        cwd="/home/ec2-user/ingest-wikimedia/",
+    )
+    sent = client.send_command.call_args.kwargs["Parameters"]["commands"][0]
+
+    # Sanity: payload includes the full base64 of the script. Worst case
+    # ~4/3 the script size plus the tmux wrapper.
+    assert len(sent) < 50_000, (
+        f"staged SSM payload unexpectedly large ({len(sent)} bytes) for a "
+        f"{len(big_script)}-byte script — staging should keep this well "
+        "under SSM's per-command limit."
+    )
+    # And the decoded script still roundtrips exactly.
+    decoded = _extract_staged_script(sent)
+    assert decoded == big_script
+
+
+def test_stage_and_launch_tmux_script_filename_is_deterministic_per_session():
+    """Same session_name → same staged-script path. Different session
+    names → different paths (so concurrent launches don't collide on
+    /tmp)."""
+    client = _make_client_returning("SESSION_STARTED")
+    stage_and_launch_tmux(client, script="x", session_name="wikimedia-A", cwd="/tmp")
+    sent_A1 = client.send_command.call_args.kwargs["Parameters"]["commands"][0]
+    stage_and_launch_tmux(client, script="x", session_name="wikimedia-A", cwd="/tmp")
+    sent_A2 = client.send_command.call_args.kwargs["Parameters"]["commands"][0]
+    stage_and_launch_tmux(client, script="x", session_name="wikimedia-B", cwd="/tmp")
+    sent_B = client.send_command.call_args.kwargs["Parameters"]["commands"][0]
+
+    path_re = re.compile(r"/tmp/wm-pipeline-[a-f0-9]+\.sh")
+    path_A1 = path_re.search(sent_A1).group(0)
+    path_A2 = path_re.search(sent_A2).group(0)
+    path_B = path_re.search(sent_B).group(0)
+
+    assert path_A1 == path_A2, (
+        f"same session name should produce same script path: {path_A1} vs {path_A2}"
+    )
+    assert path_A1 != path_B, (
+        f"different session names must produce different paths: {path_A1} vs {path_B}"
+    )

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -146,6 +146,70 @@ def test_stage_and_launch_tmux_keeps_ssm_payload_small_for_large_scripts():
     assert decoded == big_script
 
 
+def test_stage_and_launch_tmux_handles_apostrophe_in_script_content():
+    """Regression: a minnesota launch for `College of Saint Benedict & Saint
+    John's University` failed with `bash: -c: line 1: unexpected EOF while
+    looking for matching '` under the inline-tmux form. shlex.quote of the
+    institution name produces `'College of Saint Benedict & Saint
+    John'"'"'s University'` — three single quotes and TWO literal " chars
+    used to escape the inner apostrophe — and embedding that as a
+    `"PIPELINE_CMD"` double-quoted tmux argument was broken: the inner
+    " characters terminated the outer double quote, leaving bash with
+    unbalanced quotes.
+
+    The staged form base64-encodes the script body before it hits SSM, so
+    apostrophes/quotes/braces all become base64 alphabet characters with
+    no shell-parsing significance. The decoded script is then read by bash
+    from a file, where shlex.quote's output is the standard, correct way
+    to encode the institution name.
+
+    This test exercises the full apostrophe-institution case end-to-end:
+    the staged SSM command must (a) have no literal apostrophes/quotes
+    inside its base64 payload, and (b) decode to a script that bash can
+    actually parse (verified by running bash -n on the decoded script).
+    """
+    import shlex
+    import subprocess
+
+    institution = "College of Saint Benedict & Saint John's University"
+    script = f"printf %s {shlex.quote(institution)}"
+    session = "wikimedia-minnesota+college-of-saint-benedict--saint-johns-university"
+
+    client = _make_client_returning("SESSION_STARTED")
+    stage_and_launch_tmux(client, script=script, session_name=session, cwd="/tmp")
+    sent = client.send_command.call_args.kwargs["Parameters"]["commands"][0]
+
+    # The base64 payload itself must not contain any apostrophes or quotes
+    # that could disturb the surrounding shell layer.
+    m = re.search(
+        r"echo ([A-Za-z0-9+/=]+) \| base64 -d > /tmp/wm-pipeline-",
+        sent,
+    )
+    assert m is not None, f"no stage step found in: {sent!r}"
+    payload = m.group(1)
+    assert "'" not in payload and '"' not in payload, (
+        "base64 payload must contain only [A-Za-z0-9+/=] — quotes would "
+        f"re-introduce the shell-parsing bug we're guarding against: {payload!r}"
+    )
+
+    # The decoded script must parse cleanly under bash (bash -n flags any
+    # syntax error including unmatched quotes).  Roundtrip the institution
+    # too: bash must reconstruct the original apostrophe-containing name.
+    decoded = base64.b64decode(payload).decode()
+    syntax = subprocess.run(
+        ["bash", "-n", "-c", decoded], capture_output=True, text=True
+    )
+    assert syntax.returncode == 0, (
+        f"decoded script does not parse under bash: {syntax.stderr!r}\n"
+        f"script: {decoded!r}"
+    )
+    run = subprocess.run(["bash", "-c", decoded], capture_output=True, text=True)
+    assert run.returncode == 0
+    assert run.stdout == institution, (
+        f"bash reconstruction lost the apostrophe; got {run.stdout!r}"
+    )
+
+
 def test_stage_and_launch_tmux_script_filename_is_deterministic_per_session():
     """Same session_name → same staged-script path. Different session
     names → different paths (so concurrent launches don't collide on

--- a/tests/test_wikimedia_retry.py
+++ b/tests/test_wikimedia_retry.py
@@ -1,6 +1,46 @@
 """Tests for scripts/wikimedia_retry.py."""
 
+import base64
+import re
 from unittest.mock import MagicMock, patch
+
+
+def _decode_staged_script(ssm_cmd: str) -> str:
+    """Extract the base64-encoded pipeline script from an SSM staging
+    command and return its decoded text. Returns the raw ssm_cmd
+    unchanged if no `echo <b64> | base64 -d > /tmp/wm-pipeline-` step
+    is present (e.g. a non-launch command like the scan or memory
+    check).
+
+    See ingest_wikimedia.ssm.stage_and_launch_tmux for the staging
+    wire format. Tests that assert on pipeline *content* (downloader
+    args, env exports, awk dedup step) need to decode this — the
+    surrounding SSM command only contains the base64 plus the tmux
+    wrapper.
+    """
+    m = re.search(
+        r"echo ([A-Za-z0-9+/=]+) \| base64 -d > /tmp/wm-pipeline-",
+        ssm_cmd,
+    )
+    if not m:
+        return ssm_cmd
+    return base64.b64decode(m.group(1)).decode()
+
+
+def _find_pipeline_script(commands: list[str]) -> str:
+    """Locate the staged-launch SSM command in `commands` and return the
+    decoded pipeline script. Asserts the staging step is present so a
+    refactor that accidentally drops it surfaces immediately."""
+    staged = [c for c in commands if "tmux new-session" in c]
+    assert staged, (
+        f"no tmux launch command found in captured SSM commands; got: {commands!r}"
+    )
+    decoded = _decode_staged_script(staged[0])
+    assert decoded != staged[0], (
+        "expected the launch command to be base64-staged but found no "
+        f"`echo <b64> | base64 -d > /tmp/wm-pipeline-` step: {staged[0]!r}"
+    )
+    return decoded
 
 
 def _run_main_and_capture_ssm_commands(argv: list[str]) -> list[str]:
@@ -32,6 +72,11 @@ def _run_main_and_capture_ssm_commands(argv: list[str]) -> list[str]:
 
     with (
         patch("scripts.wikimedia_retry.ssm_run", side_effect=fake_ssm_run),
+        # stage_and_launch_tmux (in ingest_wikimedia.ssm) calls ssm_run via
+        # the module namespace, so the patch on scripts.wikimedia_retry's
+        # local import doesn't intercept those. Patch the module-level
+        # function too so the staged-launch SSM command lands in `captured`.
+        patch("ingest_wikimedia.ssm.ssm_run", side_effect=fake_ssm_run),
         patch("scripts.wikimedia_retry.boto3.client", return_value=MagicMock()),
         patch("sys.argv", argv),
         patch.dict("os.environ", {}, clear=False),
@@ -124,6 +169,11 @@ def _run_main_and_capture_full_pipeline(argv: list[str]) -> list[str]:
 
     with (
         patch("scripts.wikimedia_retry.ssm_run", side_effect=fake_ssm_run),
+        # stage_and_launch_tmux (in ingest_wikimedia.ssm) calls ssm_run via
+        # the module namespace, so the patch on scripts.wikimedia_retry's
+        # local import doesn't intercept those. Patch the module-level
+        # function too so the staged-launch SSM command lands in `captured`.
+        patch("ingest_wikimedia.ssm.ssm_run", side_effect=fake_ssm_run),
         patch("scripts.wikimedia_retry.boto3.client", return_value=MagicMock()),
         patch("scripts.wikimedia_retry.post_message"),  # no real Slack
         patch("sys.argv", argv),
@@ -167,9 +217,7 @@ def test_retry_passes_max_age_days_one_to_downloader():
         ["wikimedia_retry.py", "--days", "30", "--partner", "si"]
     )
 
-    pipeline_cmds = [c for c in commands if "tmux new-session" in c]
-    assert pipeline_cmds, f"No tmux new-session command was issued; saw: {commands!r}"
-    pipeline_cmd = pipeline_cmds[0]
+    pipeline_cmd = _find_pipeline_script(commands)
 
     assert "downloader --max-age-days 1" in pipeline_cmd, (
         f"The retry's downloader call must pass `--max-age-days 1` so "
@@ -209,7 +257,7 @@ def test_retry_pipeline_does_not_export_download_log_via_pwd_subshell():
     commands = _run_main_and_capture_full_pipeline(
         ["wikimedia_retry.py", "--days", "30", "--partner", "si"]
     )
-    pipeline_cmd = next(c for c in commands if "tmux new-session" in c)
+    pipeline_cmd = _find_pipeline_script(commands)
 
     assert "WIKIMEDIA_RETRY_DOWNLOAD_LOG" not in pipeline_cmd, (
         "pipeline must not export WIKIMEDIA_RETRY_DOWNLOAD_LOG — the "
@@ -231,39 +279,37 @@ def test_retry_pipeline_does_not_export_download_log_via_pwd_subshell():
     )
 
 
-def test_retry_pipeline_escapes_dollar_in_notify_fail_cmd():
-    r"""Regression guard: the failure handler must use `\$?` and `\$rc`, not
-    `$?` and `$rc`, when capturing the failing step's exit code.
-
-    The whole pipeline_cmd is sent to tmux as a `"{pipeline_cmd}"`
-    double-quoted argument. Inside double quotes the outer bash on EC2
-    expands `$?` and `$rc` *before* tmux ever sees the command — using
-    its own (unrelated) last-command status and undefined `$rc`. Without
-    the backslashes the inner shell ends up with literal
-    `rc=0; WIKIMEDIA_LAST_EXIT= python3 -c '...'`, so every Slack failure
-    notification silently loses the exit-code suffix that decodes signals
-    like 137 (SIGKILL / probable OOM).
+def test_retry_pipeline_uses_raw_dollar_in_notify_fail_cmd():
+    r"""The failure handler in the *script* (post base64 decode) must use
+    raw `rc=$?` / `WIKIMEDIA_LAST_EXIT=$rc`. The earlier `\$?` / `\$rc`
+    form existed only to survive the double-quote layer of an inline
+    `tmux new-session "..."` argument; with stage_and_launch_tmux the
+    script is base64-decoded into a file and read directly by bash, so
+    raw `$?` and `$rc` are evaluated against the actual failing step at
+    runtime (which is what we want). A backslash-escaped `\$?` here
+    would be interpreted as a literal `$` by bash and `rc` would get the
+    string `$?` — defeating the exit-code capture entirely.
     """
     commands = _run_main_and_capture_full_pipeline(
         ["wikimedia_retry.py", "--days", "30", "--partner", "si"]
     )
-    pipeline_cmd = next(c for c in commands if "tmux new-session" in c)
+    pipeline_cmd = _find_pipeline_script(commands)
 
-    assert r"rc=\$?" in pipeline_cmd, (
-        "notify_fail_cmd must use `rc=\\$?` (backslash-escaped) so the outer "
-        "bash leaves the `$` literal and the inner shell evaluates `$?` "
-        f"against the failing step; got: {pipeline_cmd!r}"
-    )
-    assert r"WIKIMEDIA_LAST_EXIT=\$rc" in pipeline_cmd, (
-        "notify_fail_cmd must use `WIKIMEDIA_LAST_EXIT=\\$rc` (backslash-"
-        "escaped) so $rc is read by the inner shell, not the outer one; "
+    assert "rc=$?" in pipeline_cmd, (
+        "notify_fail_cmd in the staged script must use raw `rc=$?`; "
         f"got: {pipeline_cmd!r}"
     )
-    # Defence: make sure the UNESCAPED form isn't hiding somewhere else in
-    # the command. If it ever reappears the silent-loss bug returns.
-    assert "rc=$?" not in pipeline_cmd, (
-        "found unescaped `rc=$?` in pipeline_cmd; outer bash will expand "
-        f"$? prematurely. Use `rc=\\$?`. Got: {pipeline_cmd!r}"
+    assert "WIKIMEDIA_LAST_EXIT=$rc" in pipeline_cmd, (
+        "notify_fail_cmd must use `WIKIMEDIA_LAST_EXIT=$rc` so the inner "
+        f"shell reads the captured exit code; got: {pipeline_cmd!r}"
+    )
+    # Defence: the backslash-escaped form would now be a bug — `\$?` in
+    # a script context reads as literal `$?` (not as the exit code), so
+    # if a future refactor brings it back the capture silently breaks.
+    assert r"\$?" not in pipeline_cmd, (
+        r"found backslash-escaped `\$?` in the staged script; in a script "
+        r"file bash reads `\$` as literal `$` so the exit-code capture "
+        f"fails. Use raw `$?`. Got: {pipeline_cmd!r}"
     )
 
 
@@ -288,6 +334,11 @@ def _run_main_with_csvs(argv: list[str], csv_paths: list[str]) -> list[str]:
 
     with (
         patch("scripts.wikimedia_retry.ssm_run", side_effect=fake_ssm_run),
+        # stage_and_launch_tmux (in ingest_wikimedia.ssm) calls ssm_run via
+        # the module namespace, so the patch on scripts.wikimedia_retry's
+        # local import doesn't intercept those. Patch the module-level
+        # function too so the staged-launch SSM command lands in `captured`.
+        patch("ingest_wikimedia.ssm.ssm_run", side_effect=fake_ssm_run),
         patch("scripts.wikimedia_retry.boto3.client", return_value=MagicMock()),
         patch("scripts.wikimedia_retry.post_message"),
         patch("sys.argv", argv),
@@ -324,34 +375,33 @@ def test_retry_merges_download_and_upload_csvs_into_single_uploader_call():
             "/home/ec2-user/ingest-wikimedia/retry/nara-upload-retry.csv",
         ],
     )
-    pipeline_cmd = next(c for c in commands if "tmux new-session" in c)
+    pipeline_cmd = _find_pipeline_script(commands)
 
     # The combined CSV merge step must be present and feed the (single)
-    # uploader invocation.  The `$0` in the awk program MUST be
-    # backslash-escaped — pipeline_cmd is embedded into the tmux launch
-    # as `"{pipeline_cmd}"` (double-quoted), and the outer bash on EC2
-    # would expand an unescaped `$0` before tmux ever sees the command.
-    # See the comment in scripts/wikimedia_retry.py around the awk step
-    # for the full rationale (same class of bug as PR #246).
+    # uploader invocation. The `$0` in the awk program is now raw (not
+    # backslash-escaped): the staged script is read directly by bash from
+    # /tmp/wm-pipeline-<id>.sh, so `$0` reaches awk verbatim and awk
+    # evaluates it as the current input line. A backslash-escaped `\$0`
+    # would now be the bug — bash would interpret `\$` as literal `$`,
+    # passing `awk '!seen[$0]++'` to awk after a quoting layer that
+    # already collapsed the backslash.
     expected_combined = (
         "/home/ec2-user/ingest-wikimedia/retry/nara-retry-1d-combined.csv"
     )
     assert (
-        r"awk '!seen[\$0]++' "
+        "awk '!seen[$0]++' "
         "/home/ec2-user/ingest-wikimedia/retry/nara-download-retry.csv "
         "/home/ec2-user/ingest-wikimedia/retry/nara-upload-retry.csv "
         f"> {expected_combined}"
     ) in pipeline_cmd, (
         f"expected awk merge step missing or malformed; got: {pipeline_cmd!r}"
     )
-    # Defence: the UNESCAPED form must not appear anywhere in the
-    # pipeline command.  If it ever reappears the silent-loss bug
-    # returns — awk would dedupe by the outer shell's argv[0] (typically
-    # the string "bash"), collapsing every retry CSV to a single line.
-    assert "awk '!seen[$0]++'" not in pipeline_cmd, (
-        f"found unescaped `$0` in pipeline_cmd; outer bash will expand "
-        f"$0 to its argv[0] before tmux sees the command. Use `\\$0`. "
-        f"Got: {pipeline_cmd!r}"
+    # Defence: the backslash-escaped form must NOT appear in the staged
+    # script — it'd be interpreted as literal `$` and break the dedup.
+    assert r"awk '!seen[\$0]++'" not in pipeline_cmd, (
+        r"found backslash-escaped `\$0` in the staged script; bash will "
+        r"read `\$` as literal `$` and awk's dedup will be wrong. "
+        f"Use raw `$0`. Got: {pipeline_cmd!r}"
     )
 
     # Exactly ONE `uploader` invocation, pointing at the combined CSV.
@@ -387,7 +437,7 @@ def test_retry_download_only_csv_runs_uploader_once_without_merge_step():
         ["wikimedia_retry.py", "--days", "30", "--partner", "si"],
         ["/home/ec2-user/ingest-wikimedia/retry/smithsonian-download-retry.csv"],
     )
-    pipeline_cmd = next(c for c in commands if "tmux new-session" in c)
+    pipeline_cmd = _find_pipeline_script(commands)
 
     assert "awk '!seen" not in pipeline_cmd, (
         f"no merge step expected when only one retry CSV is present; "
@@ -413,7 +463,7 @@ def test_retry_upload_only_csv_runs_uploader_once_without_merge_step():
         ["wikimedia_retry.py", "--days", "30", "--partner", "si"],
         ["/home/ec2-user/ingest-wikimedia/retry/smithsonian-upload-retry.csv"],
     )
-    pipeline_cmd = next(c for c in commands if "tmux new-session" in c)
+    pipeline_cmd = _find_pipeline_script(commands)
 
     assert "awk '!seen" not in pipeline_cmd
     assert "-retry-30d-combined.csv" not in pipeline_cmd


### PR DESCRIPTION
## Summary

Fixes the launch failure you saw on the 22-target nwdh batch:

> ⚠️ Failed to launch tmux session wikimedia-northwest-heritage+city-of-colfax-washington+…+whitman-hospital-and-medical-center: SSM command 88c8ebc2… ended with Failed: command too long

The launch script was inlining the entire pipeline as a `"PIPELINE_CMD"` double-quoted argument to `tmux new-session`. With 22 institution labels and the shlex.quote multiplier on embedded single quotes (each `'` in an institution name expands to `'\''` four chars), the SSM payload blew past the agent's per-command size limit. The retry script had the identical shape and was at risk of the same failure.

## Fix

Add `stage_and_launch_tmux` to `ingest_wikimedia/ssm.py`:

1. Base64-encode the pipeline script
2. SSM command: `echo <b64> | base64 -d > /tmp/wm-pipeline-<hash>.sh && chmod +x /tmp/wm-pipeline-<hash>.sh && tmux new-session -d -s <name> -c <cwd> 'bash /tmp/wm-pipeline-<hash>.sh' && echo SESSION_STARTED`
3. The instance reconstructs the script from base64 and tmux runs it directly

Base64 overhead is ~33% vs the 2-3x explosion from `shlex.quote`-ing many embedded single quotes. The base64 alphabet (`[A-Za-z0-9+/=]`) has no chars that need shell escaping, so the SSM payload size scales linearly with script size regardless of content. A 25KB pipeline now produces a ~34KB SSM command (far below SSM agent limits) vs the inline form's ~70-80KB.

The script filename is derived from `sha1(session_name)[:12]`, so two concurrent launches with different sessions don't collide on `/tmp`.

## Side benefit: dropped the `\$?` / `\$rc` / `\$0` escapes

PRs #246 and #257 had to backslash-escape every `$` in the pipeline because the inline form put pipeline_cmd inside a double-quoted argument where the outer EC2 bash would eagerly expand. With the staged form, the script is read directly by bash from a file — `$?` / `$rc` / `$0` reach the interpreter raw and expand at runtime. The escapes were not just unnecessary in the new form — they would actively *break* the script (bash reads `\$` as literal `$` in a script-file context, so `rc=\$?` would assign the literal string `$?` to rc).

Removed in both launch and retry scripts.

## Test plan

Three new tests in `tests/test_ssm.py`:
- **`test_stage_and_launch_tmux_emits_base64_stage_then_tmux_launch`** — pins the wire format (base64 stage + chmod + tmux + SESSION_STARTED) and verifies the script roundtrips.
- **`test_stage_and_launch_tmux_keeps_ssm_payload_small_for_large_scripts`** — regression guard: a 20KB+ script produces an SSM payload < 50KB.
- **`test_stage_and_launch_tmux_script_filename_is_deterministic_per_session`** — same session_name produces the same path (so retries don't litter /tmp), different session_names get different paths (no concurrent-launch collisions).

Existing retry tests in `tests/test_wikimedia_retry.py` updated to decode the base64 from the staged SSM command and assert against the decoded script content. The escape-related tests were inverted:
- `test_retry_pipeline_uses_raw_dollar_in_notify_fail_cmd` (was `_escapes_dollar_`) — now asserts raw `$?` / `$rc`, with the backslash form as a failure mode.
- The awk merge test now asserts raw `$0`, not `\$0`.

- [x] `ruff check` / `ruff format --check` clean
- [ ] Re-launch the 22-target nwdh batch after merge to verify the actual SSM call succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes SSM "command too long" and quote/escaping failures when launching long or quote-heavy pipeline commands by staging the pipeline script as a base64-encoded file on the EC2 instance and then running it under tmux, instead of inlining the pipeline as a double-quoted tmux argument.

Key points:
- New helper ingest_wikimedia/ssm.py::stage_and_launch_tmux(client, *, script: str, session_name: str, cwd: str) that:
  - base64-encodes the provided script,
  - sends an SSM command which echoes the base64, decodes it to /tmp/wm-pipeline-<sha1[:12]>.sh, chmod +x, and launches tmux to run it via bash,
  - returns the stdout from ssm_run (caller checks for "SESSION_STARTED").
- Script filename uses sha1(session_name)[:12] to avoid /tmp collisions while keeping names deterministic for the same session_name.
- Removed prior backslash-escaping of dollar variables (`\$?`, `\$rc`, `\$0`) in launch and retry pipeline scripts because the staged script is executed directly by bash and must use raw `$` expansions.
- Tests:
  - Added/updated tests in tests/test_ssm.py and tests/test_wikimedia_retry.py to extract and decode staged base64 payloads and assert:
    - correct staging + tmux launch wire format,
    - payload-size regression (keeps SSM command <50KB for large scripts),
    - deterministic per-session staged filename,
    - end-to-end regression for apostrophe/quote-heavy content (ensures base64 payload has only base64 chars, decoded script parses under bash -n, and reproduces apostrophe-containing strings).
  - Existing retry tests updated to decode staged scripts and assert on decoded content (e.g., notify-failure uses raw `$?`, awk dedup uses raw `$0`).
- Call sites updated:
  - scripts/wikimedia_launch.py and scripts/wikimedia_retry.py now call stage_and_launch_tmux() instead of inlining the pipeline into tmux.

Operational and impact notes (explicitly called out):
- Manual pipeline trigger: The PR includes a note that a manual re-launch of the originally problematic 22-target batch is pending to validate the fix in production. A manual run is required to confirm the runtime behavior on EC2.
- Environment variables / AWS Secrets Manager: No environment variables or Secrets Manager keys were added, removed, or renamed.
- Database migrations: None.
- Shared infrastructure configuration: No changes to CodePipeline, CodeBuild, ECS task definitions, or IAM policies are included in this PR.
- Public API surface: No public-facing API responses or endpoints were added/changed.
- Security implications: No authentication or credential-handling changes. The change stages scripts via base64 and runs them on the instance; this does not introduce new external inputs beyond the existing pipeline content. Callers should continue to ensure pipeline script content is trusted for execution on EC2.

Files/areas touched (high level):
- ingest_wikimedia/ssm.py: added stage_and_launch_tmux (new base64 staging flow).
- scripts/wikimedia_launch.py, scripts/wikimedia_retry.py: use stage_and_launch_tmux and remove prior dollar-escaping.
- tests/test_ssm.py, tests/test_wikimedia_retry.py: added/updated tests for staging, size regression, deterministic filenames, and apostrophe/quote regression.

Developer notes:
- The staged SSM command emits "echo SESSION_STARTED" after tmux launch; callers continue to assert on that marker to verify success.
- The base64 staging approach keeps SSM payload growth to ~33% and avoids the 2–3× inflation caused by shlex.quote of many embedded single quotes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->