### PR TITLE
launch: collapse a single QID's multi-institution resolution into one session

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -425,7 +425,15 @@ def main() -> None:
                         f"DPLA ID `{item_id}`: not eligible ({reason})."
                     )
                 elif status.startswith("HUB="):
-                    _add_target(status.removeprefix("HUB="), None, dpla_id=item_id)
+                    # DPLA-ID single-item target: no institution filter.
+                    # ``institutions=()`` is the new "hub-level / no filter"
+                    # signal — passing ``None`` would crash because the
+                    # body iterates ``institutions``.
+                    _add_target(
+                        status.removeprefix("HUB="),
+                        institutions=(),
+                        dpla_id=item_id,
+                    )
                 elif status.startswith("ERROR:"):
                     skipped_warnings.append(
                         f"DPLA ID `{item_id}`: resolve error — {status.removeprefix('ERROR:')}."

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -137,7 +137,11 @@ def main() -> None:
         _slack_fail(response_url, f"Could not parse --partner: {e}")
 
     # Validate each target and build
-    # (canonical, institution_or_None, label, dpla_id_or_None, collection_or_None) tuples.
+    # (canonical, institutions_tuple, label, dpla_id_or_None, collection_or_None) tuples.
+    # ``institutions_tuple`` is ``()`` for hub-level, ``(name,)`` for single-
+    # institution, or ``(n1, n2, …)`` for a combined session covering multiple
+    # institutions under one hub (used when a single Wikidata QID resolves to
+    # multiple institutions in the same hub).
     # Dedup by full target string so the same hub may appear with different institutions
     # (e.g. two QIDs that both resolve into the same hub but different institutions).
     seen_target_strs: set[str] = set()
@@ -145,7 +149,7 @@ def main() -> None:
     seen_session_labels: dict[
         str, None
     ] = {}  # insertion-ordered; drives session naming
-    targets: list[tuple[str, str | None, str, str | None, str | None]] = []
+    targets: list[tuple[str, tuple[str, ...], str, str | None, str | None]] = []
     # DPLA item ID tokens collected separately; resolved via EC2 before target building.
     dpla_id_tokens: list[str] = []
     # Per-target validation warnings; populated by _add_target and the conflict
@@ -155,21 +159,36 @@ def main() -> None:
 
     def _add_target(
         canonical: str,
-        institution: str | None,
+        institutions: tuple[str, ...] = (),
         dpla_id: str | None = None,
         collection: str | None = None,
     ) -> None:
-        if collection is not None and institution is None:
+        # ``institutions`` semantics:
+        #   ``()``         → hub-level (no institution filter at get-ids-es time)
+        #   ``(name,)``    → single institution (the historical / pipe-target case)
+        #   ``(n1, n2, …)`` → combined session covering multiple institutions
+        #                     under the same hub. Used when a single Wikidata
+        #                     QID resolves to N institutions in one hub; the
+        #                     pipeline runs ONE ``get-ids-es`` (with N
+        #                     ``--institution`` flags), one downloader, one
+        #                     uploader, one sdc-sync — so the operator sees
+        #                     one tmux session and one set of Slack
+        #                     notifications instead of N chained sessions.
+        if collection is not None and len(institutions) != 1:
             skipped_warnings.append(
-                f"Collection '{collection}' specified without an institution."
+                f"Collection '{collection}' requires exactly one institution"
+                " (collection scoping is per-institution)."
             )
             return
-        if institution is not None:
-            institution = institution.strip()
-            if not institution:
+        stripped: list[str] = []
+        for name in institutions:
+            name = name.strip()
+            if not name:
                 skipped_warnings.append(f"'{canonical}|': empty institution name.")
                 return
-        if dpla_id is None and canonical != "nara" and institution is None:
+            stripped.append(name)
+        institutions = tuple(stripped)
+        if dpla_id is None and canonical != "nara" and not institutions:
             # Hub-level target: check that any institution in the hub is eligible.
             # Skipped for DPLA item ID targets — item-level eligibility (rights
             # statement + media presence) was already verified by resolve-dpla-ids.
@@ -190,9 +209,16 @@ def main() -> None:
                 )
                 return
         if collection is not None:
-            target_str = f"{canonical}|{institution}|{collection}"
-        elif institution is not None:
-            target_str = f"{canonical}|{institution}"
+            target_str = f"{canonical}|{institutions[0]}|{collection}"
+        elif len(institutions) == 1:
+            target_str = f"{canonical}|{institutions[0]}"
+        elif institutions:
+            # Multi-institution: dedup key joins all names so two different
+            # institution sets under the same hub produce two different
+            # sessions, but the same QID resolved twice in one command
+            # produces a "duplicate target" warning rather than two
+            # near-identical sessions.
+            target_str = f"{canonical}|" + "+".join(institutions)
         elif dpla_id is not None:
             target_str = dpla_id
         else:
@@ -207,13 +233,21 @@ def main() -> None:
             # This is long enough to distinguish concurrent single-item sessions for
             # the same hub while keeping session names readable.
             inst_label: str | None = dpla_id[:8]
-        elif institution is not None:
-            inst_label = _slugify(institution)
-            if not inst_label:
+        elif institutions:
+            first_slug = _slugify(institutions[0])
+            if not first_slug:
                 skipped_warnings.append(
-                    f"'{canonical}|{institution}': institution name normalizes to an empty slug."
+                    f"'{canonical}|{institutions[0]}': institution name normalizes to an empty slug."
                 )
                 return
+            if len(institutions) == 1:
+                inst_label = first_slug
+            else:
+                # Multi-institution session label: keep it short and parseable.
+                # ``-and-N-more`` is human-readable in tmux ls output and in
+                # Slack notifications, and the leading slug pins which hub +
+                # at-least-one-institution this session is for.
+                inst_label = f"{first_slug}-and-{len(institutions) - 1}-more"
         else:
             inst_label = None
         if collection is not None:
@@ -232,7 +266,7 @@ def main() -> None:
             )
             return
         seen_session_labels[label] = None
-        targets.append((canonical, institution, label, dpla_id, collection))
+        targets.append((canonical, institutions, label, dpla_id, collection))
 
     for token in target_tokens:
         if is_wikidata_id(token):
@@ -242,8 +276,34 @@ def main() -> None:
                     f"Wikidata ID {token!r}: not found in institutions_v2.json."
                 )
                 continue
+            # Group resolved pairs by canonical hub so multiple institutions
+            # under the same hub collapse into a single combined session
+            # (one tmux session, one get-ids-es with N --institution flags,
+            # one downloader / uploader / sdc-sync run, one set of Slack
+            # notifications). Cross-hub QIDs — rare; same QID present under
+            # institutions in different hubs — still produce one session per
+            # hub, but each of those sessions is itself combined across all
+            # institutions matching the QID in that hub.
+            by_hub: dict[str, list[str | None]] = {}
             for canonical, institution in resolved:
-                _add_target(canonical, institution)
+                by_hub.setdefault(canonical, []).append(institution)
+            for canonical, inst_list in by_hub.items():
+                if None in inst_list:
+                    # The QID matched the hub itself — that's strictly broader
+                    # than any per-institution match, so the hub-level scope
+                    # wins (no --institution filter, all eligible institutions
+                    # processed).
+                    _add_target(canonical, institutions=())
+                else:
+                    # All matches are institution-level; combine them.
+                    # ``inst_list`` only contains non-None strings at this
+                    # branch, so the cast is safe.
+                    _add_target(
+                        canonical,
+                        institutions=tuple(
+                            name for name in inst_list if name is not None
+                        ),
+                    )
         elif is_dpla_id(token):
             # Collect for batch resolution via EC2 after local parsing is done.
             # Normalise to lowercase — ES and S3 paths expect the canonical form.
@@ -257,16 +317,18 @@ def main() -> None:
                 continue
             if len(token_parts) == 3:
                 _, institution, collection = token_parts
-                _add_target(canonical, institution, collection=collection)
+                _add_target(
+                    canonical, institutions=(institution,), collection=collection
+                )
             else:
                 _, institution = token_parts
-                _add_target(canonical, institution)
+                _add_target(canonical, institutions=(institution,))
         else:
             canonical = resolve_slug(token)
             if canonical is None:
                 skipped_warnings.append(f"'{token}': unknown hub slug.")
                 continue
-            _add_target(canonical, None)
+            _add_target(canonical, institutions=())
 
     slack_token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
     ssm = boto3.client("ssm", region_name=REGION)
@@ -396,8 +458,8 @@ def main() -> None:
     if sdc_only:
         stale_sdc_target_labels = [
             lbl
-            for canonical, institution, lbl, dpla_id, _ in targets
-            if dpla_id is not None or (canonical == "nara" and institution is None)
+            for canonical, institutions, lbl, dpla_id, _ in targets
+            if dpla_id is not None or (canonical == "nara" and not institutions)
         ]
         if stale_sdc_target_labels:
             print(
@@ -522,8 +584,8 @@ def main() -> None:
         if not existing_name.startswith("wikimedia-"):
             continue
         existing_labels = set(parse_session_labels(existing_name[len("wikimedia-") :]))
-        for canonical, institution, label, dpla_id, collection in targets:
-            if institution is None and dpla_id is None:
+        for canonical, institutions, label, dpla_id, collection in targets:
+            if not institutions and dpla_id is None:
                 # Hub-level request conflicts with any existing session touching this hub
                 # (hub-level, institution-level, or collection-level for the same hub).
                 conflicts_this = any(
@@ -539,21 +601,25 @@ def main() -> None:
                 #   3. An existing session for the exact same collection label
                 # A collection does NOT conflict with a different collection from the
                 # same institution — those are independent, disjoint subsets.
-                inst_label = f"{canonical}+{_slugify(institution)}"
+                # ``institutions`` is exactly one element when collection is set
+                # (enforced by _add_target).
+                inst_label = f"{canonical}+{_slugify(institutions[0])}"
                 conflicts_this = (
                     canonical in existing_labels
                     or inst_label in existing_labels
                     or label in existing_labels
                 )
             elif dpla_id is None:
-                # Institution-level requests conflict with:
+                # Institution-level (or multi-institution-combined) requests
+                # conflict with:
                 #   1. An existing hub-level session for the same hub
-                #   2. An existing session for the exact same institution label
-                #   3. Any existing collection-level session for the same institution
+                #   2. An existing session for the exact same label
+                #   3. Any existing collection-level session for the same label
                 #      (the collection is a strict subset; the institution run would
                 #      duplicate work on those items, symmetric with collection→institution)
-                # Two institution-level sessions for different institutions within
-                # the same hub do NOT conflict.
+                # Two institution-level sessions for different institution sets
+                # within the same hub do NOT conflict — combined and single sets
+                # are treated symmetrically.
                 conflicts_this = (
                     canonical in existing_labels
                     or label in existing_labels
@@ -647,7 +713,7 @@ def main() -> None:
     )
     target_blocks = []
     last_idx = len(targets) - 1
-    for idx, (canonical, institution, session_label, dpla_id, collection) in enumerate(
+    for idx, (canonical, institutions, session_label, dpla_id, collection) in enumerate(
         targets
     ):
         pdir = PARTNER_DIR.get(canonical, canonical)
@@ -659,12 +725,15 @@ def main() -> None:
             # Single-item target: metadata was already staged to S3 by resolve-dpla-ids.
             # Write the one ID directly to the CSV; no ID-generation phase needed.
             get_ids_cmd = f"printf '%s\\n' {shlex.quote(dpla_id)} > {csv_file}"
-        elif canonical == "nara" and institution is None:
+        elif canonical == "nara" and not institutions:
             get_ids_cmd = f"get-ids-nara > {csv_file}"
         else:
             get_ids_cmd = f"get-ids-es {canonical}"
-            if institution is not None:
-                get_ids_cmd += f" --institution {shlex.quote(institution)}"
+            # ``--institution`` is repeated per name when the QID resolved
+            # to multiple institutions under this hub; get-ids-es ORs them
+            # in the Elasticsearch dataProvider filter.
+            for inst in institutions:
+                get_ids_cmd += f" --institution {shlex.quote(inst)}"
             if collection is not None:
                 get_ids_cmd += f" --collection {shlex.quote(collection)}"
             get_ids_cmd += f" > {csv_file}"
@@ -735,12 +804,21 @@ def main() -> None:
 
     if slack_token:
 
-        def _target_label(c: str, i: str | None, col: str | None) -> str:
-            """Format a batch target as the pipe-separated string shown in Slack."""
+        def _target_label(c: str, insts: tuple[str, ...], col: str | None) -> str:
+            """Format a batch target as the pipe-separated string shown in Slack.
+
+            For a combined-institution target (multiple institutions from a
+            single QID under one hub), shows the first institution + a
+            ``(+N more)`` hint — full list would blow up the Slack message
+            width for QIDs with many sub-institutions.
+            """
             if col:
-                return f"`{c}|{i}|{col}`"
-            if i:
-                return f"`{c}|{i}`"
+                # Collection-level is always single-institution by construction.
+                return f"`{c}|{insts[0]}|{col}`"
+            if len(insts) == 1:
+                return f"`{c}|{insts[0]}`"
+            if insts:
+                return f"`{c}|{insts[0]} (+{len(insts) - 1} more)`"
             return f"`{c}`"
 
         single_item_targets = [

--- a/tests/test_get_ids_es.py
+++ b/tests/test_get_ids_es.py
@@ -59,7 +59,14 @@ def _invoke(*args: str):
         patch.object(get_ids_es, "load_rights_json", return_value={}),
     ):
         runner = CliRunner()
-        return runner.invoke(get_ids_es.main, list(args), catch_exceptions=False)
+        # ``catch_exceptions=True`` (the default) puts unhandled
+        # exceptions into ``result.exception`` instead of re-raising —
+        # that's how ``test_multiple_institutions_pass_validation_and_combine``
+        # reads the sentinel ``RuntimeError`` from the stubbed
+        # ``fetch_subjects_json``. With ``catch_exceptions=False`` the
+        # runner re-raises into the test body, killing it before the
+        # assertion runs.
+        return runner.invoke(get_ids_es.main, list(args))
 
 
 def test_collection_requires_exactly_one_institution_zero():

--- a/tests/test_get_ids_es.py
+++ b/tests/test_get_ids_es.py
@@ -1,0 +1,110 @@
+"""CLI-level tests for tools/get_ids_es.py.
+
+Focused on the new multi-``--institution`` + ``--collection`` argument
+validation contract added when launch.py grew QID-combine support. The
+ES query construction and S3 staging paths are exercised end-to-end by
+the actual partner runs — only the validation surface that can silently
+ship a wrong CLI is unit-tested here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+
+def _invoke(*args: str):
+    """Invoke get-ids-es's Click app with monkey-patched DPLA.check_partner
+    so we don't need a config.toml. Stops further execution after
+    validation by patching everything that follows."""
+    from tools import get_ids_es
+
+    with (
+        patch.object(get_ids_es.DPLA, "check_partner", return_value=None),
+        patch.object(get_ids_es, "notify_phase_start"),
+        patch.object(get_ids_es, "PARTNER_HUBS", {"bpl": "Digital Commonwealth"}),
+        patch.object(
+            get_ids_es,
+            "fetch_institutions_v2",
+            return_value={
+                "Digital Commonwealth": {
+                    "institutions": {
+                        "Boston Public Library": {"upload": True},
+                        "Boston City Archives": {"upload": True},
+                    }
+                }
+            },
+        ),
+        # Short-circuit AFTER validation by raising at the next external call.
+        patch.object(
+            get_ids_es,
+            "fetch_subjects_json",
+            side_effect=RuntimeError("stop-after-validation"),
+        ),
+        patch.object(get_ids_es, "load_rights_json", return_value={}),
+    ):
+        runner = CliRunner()
+        return runner.invoke(get_ids_es.main, list(args), catch_exceptions=False)
+
+
+def test_collection_requires_exactly_one_institution_zero():
+    """``--collection`` with no ``--institution`` must fail validation
+    (collection scoping is per-institution)."""
+    result = _invoke(
+        "bpl",
+        "--collection",
+        "Some Collection",
+    )
+    assert result.exit_code == 1, result.output
+    assert "exactly one --institution" in result.output
+
+
+def test_collection_requires_exactly_one_institution_many():
+    """``--collection`` with multiple ``--institution`` values must fail
+    validation — combining a collection scope across institutions is
+    not meaningful."""
+    result = _invoke(
+        "bpl",
+        "--institution",
+        "Boston Public Library",
+        "--institution",
+        "Boston City Archives",
+        "--collection",
+        "Some Collection",
+    )
+    assert result.exit_code == 1, result.output
+    assert "exactly one --institution" in result.output
+
+
+def test_multiple_institutions_pass_validation_and_combine():
+    """Multiple ``--institution`` values without ``--collection`` must
+    pass validation and reach the ID-generation path (where our stubbed
+    ``fetch_subjects_json`` raises a known sentinel — proving the run
+    got past validation rather than rejecting the inputs upfront)."""
+    result = _invoke(
+        "bpl",
+        "--institution",
+        "Boston Public Library",
+        "--institution",
+        "Boston City Archives",
+    )
+    assert isinstance(result.exception, RuntimeError)
+    assert "stop-after-validation" in str(result.exception)
+
+
+def test_unknown_institution_rejected_with_clear_message():
+    """An institution name that isn't in the hub's eligible set must be
+    rejected explicitly, naming the offender — this is the safety net
+    that prevents the launch script from silently asking ES for an
+    institution that doesn't exist."""
+    result = _invoke(
+        "bpl",
+        "--institution",
+        "Boston Public Library",
+        "--institution",
+        "Nonexistent Institution",
+    )
+    assert result.exit_code == 1, result.output
+    assert "not upload-eligible" in result.output
+    assert "Nonexistent Institution" in result.output

--- a/tests/test_get_ids_es.py
+++ b/tests/test_get_ids_es.py
@@ -27,12 +27,26 @@ def _invoke(*args: str):
         patch.object(
             get_ids_es,
             "fetch_institutions_v2",
+            # ``load_eligible_dp_names`` only counts an institution as
+            # eligible when BOTH the hub and the institution carry a
+            # ``Wikidata`` field — that's how the production data
+            # excludes records that haven't been fully onboarded.
+            # Stubbed values are arbitrary QIDs; they exist solely to
+            # pass the eligibility gate so the tests can exercise the
+            # CLI-validation contract we actually care about.
             return_value={
                 "Digital Commonwealth": {
+                    "Wikidata": "Q12345",
                     "institutions": {
-                        "Boston Public Library": {"upload": True},
-                        "Boston City Archives": {"upload": True},
-                    }
+                        "Boston Public Library": {
+                            "upload": True,
+                            "Wikidata": "Q1001",
+                        },
+                        "Boston City Archives": {
+                            "upload": True,
+                            "Wikidata": "Q1002",
+                        },
+                    },
                 }
             },
         ),

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -210,28 +210,45 @@ def build_query(
 @click.argument("partner")
 @click.option(
     "--institution",
-    default=None,
-    help="Restrict to a single institution name (must be upload-eligible).",
+    "institutions",
+    multiple=True,
+    help=(
+        "Restrict to a specific institution name (must be upload-eligible)."
+        " May be passed multiple times to combine several institutions into"
+        " one ID-generation run — used by the launch script when a single"
+        " Wikidata QID resolves to multiple institutions under one hub."
+    ),
 )
 @click.option(
     "--collection",
     default=None,
-    help="Restrict to items in a specific collection title (requires --institution).",
+    help=(
+        "Restrict to items in a specific collection title. Requires exactly"
+        " one --institution (collection scoping is per-institution)."
+    ),
 )
-def main(partner: str, institution: str | None, collection: str | None) -> None:
+def main(partner: str, institutions: tuple[str, ...], collection: str | None) -> None:
     """Print wiki-eligible DPLA IDs for PARTNER to stdout, one per line.
 
     Also stages each item's full metadata to S3 (dpla-map.json) so the
     downloader can skip DPLA API calls entirely.
+
+    Multiple ``--institution`` flags are ORed together in the
+    Elasticsearch ``dataProvider`` filter, so the output covers items
+    belonging to any of the listed institutions in one combined run.
+    No ``--institution`` flags means "all eligible institutions for
+    this hub" (the existing hub-level behaviour).
     """
     if collection is not None:
         collection = collection.strip()
         if not collection:
             print("--collection cannot be empty.", file=sys.stderr)
             sys.exit(1)
-        if institution is None:
+        if len(institutions) != 1:
             print(
-                "--collection requires --institution to be specified.", file=sys.stderr
+                "--collection requires exactly one --institution to be specified"
+                " (collection scoping is per-institution).",
+                file=sys.stderr,
             )
             sys.exit(1)
 
@@ -245,8 +262,8 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
 
     # Load institutions_v2.json once and reuse it for both eligibility
     # filtering and the SDC pre-compute pass.
-    institutions = fetch_institutions_v2()
-    eligible_dp_names = load_eligible_dp_names(institutions, partner)
+    institutions_json = fetch_institutions_v2()
+    eligible_dp_names = load_eligible_dp_names(institutions_json, partner)
     if not eligible_dp_names:
         print(
             f"No eligible institutions found for {partner} in institutions_v2.json",
@@ -254,14 +271,15 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
         )
         sys.exit(0)
 
-    if institution is not None:
-        if institution not in eligible_dp_names:
+    if institutions:
+        ineligible = [name for name in institutions if name not in eligible_dp_names]
+        if ineligible:
             print(
-                f"Institution '{institution}' is not upload-eligible for {partner}.",
+                f"Institution(s) not upload-eligible for {partner}: {ineligible}.",
                 file=sys.stderr,
             )
             sys.exit(1)
-        eligible_dp_names = [institution]
+        eligible_dp_names = list(institutions)
 
     # SDC pre-compute inputs.
     rights = load_rights_json()
@@ -391,7 +409,7 @@ def main(partner: str, institution: str | None, collection: str | None) -> None:
             sdc_payload = build_claims_for_doc(
                 source,
                 dpla_id,
-                institutions,
+                institutions_json,
                 rights,
                 subject_ids,
                 subjects_lookup,


### PR DESCRIPTION
## Problem

When a single Wikidata QID resolves to multiple institutions under the same hub (the common shape — e.g. \`Q12345\` mapping to \"University of Minnesota Libraries\" + Kautz Family YMCA Archives + Berman Upper Midwest Jewish Archives + Northwest Architectural Archives), \`launch.py\` was iterating the resolved list and emitting one target per institution. Each became its own pipeline session, each posting its own \`starting id-generation\` → \`starting download\` → \`Refresh Complete\` Slack notifications — a wall of effectively-duplicate messages for what the operator wanted as one logical run.

The screenshot that motivated this PR shows ~4 chained refresh sessions for the same Minnesota Q-id back-to-back, each posting separate id-generation + download + completion notifications.

## Fix

Group the QID resolver's output by canonical hub and emit ONE target per (hub, set-of-institutions). The pipeline then runs ONE \`get-ids-es\` (with N \`--institution\` flags), one downloader, one uploader, one sdc-sync — so the operator sees one tmux session and one set of Slack notifications instead of N chained ones.

The cross-hub case (same QID under institutions in different hubs — rare) still produces one session per hub, but each of those sessions is itself combined across all institutions matching the QID in that hub. Architectural decision intentional: combining ACROSS hubs would require partner-per-row CSVs touching downloader/uploader/sdc-sync (~3 binaries, much bigger change for a rare case).

Hub-level QID match still wins precedence: if a QID matches at the hub level AND on per-institution entries under the same hub, the hub-level scope wins (strictly broader — no \`--institution\` filter, all eligible institutions processed).

## Changes

### \`tools/get_ids_es.py\`
- \`--institution\` becomes \`multiple=True\`. Multiple values OR-filter the ES \`dataProvider\` term.
- \`--collection\` is now restricted to exactly one \`--institution\` (collection scoping is per-institution and isn't meaningful across an institution set).
- Local variable \`institutions\` (the parsed institutions_v2.json dict) renamed to \`institutions_json\` to avoid name-clashing the new Click parameter; fixes the corresponding \`build_claims_for_doc\` call.

### \`scripts/wikimedia_launch.py\`
- \`_add_target\` takes \`institutions: tuple[str, ...]\` instead of \`institution: str | None\`:
  - \`()\` → hub-level (no \`--institution\` filter)
  - \`(name,)\` → single institution (the historical \`hub|inst\` case)
  - \`(n1, n2, ...)\` → combined session
- Target tuple shape, conflict-detection loop, build loop, Slack \`_target_label\`, type annotations all updated.
- QID-handling block in the token loop now groups by canonical hub before calling \`_add_target\`.
- Session label for combined sessions: \`<hub>+<first-slug>-and-N-more\` (e.g. \`minnesota+university-of-minnesota-libraries-and-3-more\`).
- Slack label for combined sessions: \`<hub>|<first-name> (+N more)\`.

### \`tests/test_get_ids_es.py\` (new)
CLI-level validation tests:
- \`--collection\` with zero institutions → rejected
- \`--collection\` with multiple institutions → rejected  
- Multiple \`--institution\` flags without \`--collection\` → passes validation
- Unknown institution name → rejected with the offender named

## What's NOT changed

- Hub-only targets (\`/wikimedia-upload bpl\`)
- Single-institution targets (\`/wikimedia-upload \"indiana|Indiana State Library\"\`)
- Collection-level targets (\`/wikimedia-upload \"bpl|Digital Commonwealth|Boston City Archives\"\`)
- DPLA item ID targets
- NARA hub-level targets

All of those follow the same code paths as before, just with the new tuple shape passed through.

## Test plan

- [ ] Pytest passes (CI)
- [ ] After merge: \`/wikimedia-upload <qid-that-resolves-to-multiple-institutions-in-one-hub>\` produces ONE tmux session (e.g. \`wikimedia-minnesota+university-of-minnesota-libraries-and-3-more\`) and ONE set of phase Slack notifications
- [ ] \`/wikimedia-upload <qid>\` where the QID matches only one institution still produces a normal single-institution session (no \"and-N-more\" suffix)
- [ ] \`/wikimedia-upload bpl\` (hub-only) still works
- [ ] \`/wikimedia-upload \"indiana|Indiana State Library\"\` (single hub|inst) still works
- [ ] \`/wikimedia-upload \"bpl|Digital Commonwealth|Boston City Archives\"\` (hub|inst|coll) still works
- [ ] The COUNTS dump from a combined session covers items across all the constituent institutions
- [ ] If a QID resolves across multiple hubs (rare), N chained sessions are produced (one per hub), each combined across that hub's institutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR collapses Wikidata QID resolutions that map to multiple institutions within the same hub into a single combined ingest session, reducing duplicate id-generation/download/upload/sdc-sync runs, tmux sessions, and Slack notifications.

It also fixes a runtime crash in the DPLA-item resolution path by ensuring hub-level DPLA targets call _add_target with institutions=() instead of None.

## Changes

- scripts/wikimedia_launch.py
  - Targets now represent institutions as tuple[str, ...]: hub-level as (), single-institution as (name,), multi-institution as (n1, n2, ...).
  - Wikidata QID handling groups resolved (canonical, institution) pairs by canonical hub. For each hub: a hub-level match (None) wins and produces institutions=(); otherwise all institution matches in that hub are combined into one target (institutions=tuple(...)).
  - _add_target updated to validate collection requires exactly one institution, normalize/strip institution names, build dedup keys for multi-institution sets, and generate session labels that shorten multi-institution labels (slug + "-and-N-more").
  - Session overlap/conflict detection, deduplication, build loop, and type annotations adjusted for the new institutions tuple shape.
  - Pipeline command generation now emits one --institution flag per institution for get-ids-es; NARA hub-level behavior (get-ids-nara) remains unchanged.
  - DPLA ID handling updated to call _add_target(..., institutions=()) for hub-level DPLA item targets (fixes a TypeError crash).

- tools/get_ids_es.py
  - CLI: --institution is now repeatable (multiple=True) and collected as institutions: tuple[str, ...].
  - --collection now requires exactly one --institution; validation and error messages updated.
  - institutions_v2.json is fetched once into institutions_json; eligible dataProvider names are computed from it. If --institution values are supplied they are validated against upload-eligible institutions and then used to restrict the ES dataProvider filter (OR semantics).
  - Per-item SDC claim-builder updated to receive institutions_json.
  - Function signature changed to main(partner: str, institutions: tuple[str, ...], collection: str | None).

- tests/test_get_ids_es.py
  - New CLI-level unit tests for get-ids-es validating:
    - --collection requires exactly one --institution (zero or many fails).
    - Multiple --institution values without --collection pass validation and proceed.
    - Unknown / non-upload-eligible institution is rejected with a clear message naming the offender.
  - Tests stub partner/config dependencies and short-circuit execution after validation.

## Behavior

- A single-hub QID that matches multiple institutions now produces one pipeline session combining those institutions (one get-ids-es with multiple --institution flags, one downloader, one uploader, one sdc-sync) and one set of Slack notifications.
- A QID resolving across multiple hubs produces one combined session per hub.
- If a QID matches both a hub-level entry and per-institution entries within the same hub, the hub-level match wins (no --institution filter).
- Hub-only targets, single-institution targets, collection-level targets, DPLA item ID targets, and existing NARA hub-level behavior remain unchanged.
- Fixed: DPLA-item resolution no longer crashes due to None being passed for institutions; uses institutions=() for hub-level DPLA targets.

## Deployment Notes / Impact (explicit checks)

- Manual pipeline trigger / ECS redeployment: Not required beyond the project's normal deployment procedure. No infra or runtime orchestration changes in this PR that demand a special redeploy.
- Environment variables / AWS Secrets Manager: No additions, removals, or renames.
- Database migrations: None.
- Shared infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM): No changes.
- Public-facing API / endpoints: No changes.
- Security implications: No authentication model changes, credential handling changes, or new secret management introduced.

## Tests / Validation

- CI: pytest coverage expected to pass; new unit tests added for get-ids-es argument validation.
- Manual validation described: combined QID produces one tmux session and one set of Slack notifications; combined session counts include all constituent institutions; cross-hub QID yields one session per hub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->