### PR TITLE
downloader: emit honest per-ordinal 'Fetched' line + per-item summary

### DIFF
--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -498,3 +498,252 @@ def test_s3_key_age_days_propagates_non_404_errors(downloader):
     )
     with pytest.raises(ClientError):
         downloader._s3_key_age_days("any/path")
+
+
+# ---------------------------------------------------------------------------
+# process_media returns a per-ordinal status code so process_item can emit
+# a per-item summary line. The existing global tracker counters are still
+# incremented; the return value is purely so callers can group results.
+#
+# Status codes:
+#   "SKIPPED"   — S3 already had a fresh-enough key (no network work)
+#   "FETCHED"   — first-time fresh download to S3
+#   "REFRESHED" — S3 key was stale; re-downloaded and overwritten
+#   "FAILED"    — the ordinal raised at some point
+# ---------------------------------------------------------------------------
+
+
+def test_process_media_returns_skipped_when_s3_has_fresh_key(downloader):
+    """If the S3 key exists and is younger than max_age_days, return
+    'SKIPPED' immediately and don't touch the network."""
+    with patch.object(downloader, "_s3_key_age_days", return_value=10.0):
+        status = downloader.process_media(
+            partner="bpl",
+            dpla_id="abc",
+            ordinal=1,
+            media_url="http://example.com/x.jpg",
+            overwrite=False,
+            max_age_days=30,
+            sleep_secs=0,
+        )
+    assert status == "SKIPPED"
+    downloader.tracker.increment.assert_called_with(Result.SKIPPED)
+
+
+def test_process_media_returns_fetched_on_first_time_download(downloader, tmp_path):
+    """When the S3 key doesn't exist, process_media downloads + uploads
+    and returns 'FETCHED'. The 'Fetched' log line carries bytes + seconds
+    so operators can spot real network work in the log."""
+    temp_file = MagicMock()
+    temp_file.name = str(tmp_path / "fake.jpg")
+    downloader.local_fs.get_temp_file.return_value = temp_file
+    downloader.local_fs.get_content_type.return_value = "image/jpeg"
+    downloader.local_fs.get_file_hash.return_value = "deadbeef"
+
+    with (
+        patch.object(downloader, "_s3_key_age_days", return_value=None),
+        patch.object(downloader, "download_file_to_temp_path"),
+        patch.object(downloader, "upload_file_to_s3", return_value=True),
+        patch("os.stat") as mock_stat,
+        patch("logging.info") as mock_log,
+    ):
+        mock_stat.return_value.st_size = 123456
+        status = downloader.process_media(
+            partner="bpl",
+            dpla_id="abc",
+            ordinal=2,
+            media_url="http://example.com/y.jpg",
+            overwrite=False,
+            max_age_days=30,
+            sleep_secs=0,
+        )
+
+    assert status == "FETCHED"
+    # The "Fetched" line must appear with byte count + elapsed seconds —
+    # this is the additive companion to the pre-check "Downloading" line
+    # that makes the log honest about which considerations were real
+    # downloads.
+    fetched_log = next(
+        (c for c in mock_log.call_args_list if "Fetched bpl abc 2" in str(c)),
+        None,
+    )
+    assert fetched_log is not None, (
+        f"Expected a 'Fetched bpl abc 2 ...' log line; got: {mock_log.call_args_list}"
+    )
+    assert "123,456 bytes" in str(fetched_log)
+
+
+def test_process_media_returns_refreshed_when_s3_key_stale(downloader, tmp_path):
+    """When the S3 key exists but is older than max_age_days,
+    process_media re-downloads and returns 'REFRESHED' (distinct from
+    'FETCHED' so the per-item summary can break refresh out)."""
+    temp_file = MagicMock()
+    temp_file.name = str(tmp_path / "fake.jpg")
+    downloader.local_fs.get_temp_file.return_value = temp_file
+    downloader.local_fs.get_content_type.return_value = "image/jpeg"
+    downloader.local_fs.get_file_hash.return_value = "deadbeef"
+
+    with (
+        patch.object(downloader, "_s3_key_age_days", return_value=400.0),
+        patch.object(downloader, "download_file_to_temp_path"),
+        patch.object(downloader, "upload_file_to_s3", return_value=True),
+        patch("os.stat") as mock_stat,
+    ):
+        mock_stat.return_value.st_size = 42
+        status = downloader.process_media(
+            partner="bpl",
+            dpla_id="abc",
+            ordinal=3,
+            media_url="http://example.com/z.jpg",
+            overwrite=False,
+            max_age_days=30,
+            sleep_secs=0,
+        )
+
+    assert status == "REFRESHED"
+
+
+def test_process_media_returns_failed_on_exception(downloader, tmp_path):
+    """When the download itself raises, the status is 'FAILED' (and the
+    global tracker is bumped). Lets process_item count failed ordinals
+    distinctly in the per-item summary."""
+    temp_file = MagicMock()
+    temp_file.name = str(tmp_path / "fake.jpg")
+    downloader.local_fs.get_temp_file.return_value = temp_file
+
+    with (
+        patch.object(downloader, "_s3_key_age_days", return_value=None),
+        patch.object(
+            downloader,
+            "download_file_to_temp_path",
+            side_effect=RuntimeError("network blew up"),
+        ),
+    ):
+        status = downloader.process_media(
+            partner="bpl",
+            dpla_id="abc",
+            ordinal=4,
+            media_url="http://example.com/x.jpg",
+            overwrite=False,
+            max_age_days=30,
+            sleep_secs=0,
+        )
+
+    assert status == "FAILED"
+    downloader.tracker.increment.assert_any_call(Result.FAILED)
+
+
+def test_process_item_emits_per_item_summary_line(downloader, tmp_path):
+    """The ordinal loop must end with one summary line tallying skip /
+    fetch / refresh / fail counts. Grep-friendly companion to the
+    per-ordinal 'Fetched' line — operators can grep
+    ``"Item .*fetched=[1-9]"`` to find items that actually had work."""
+    from ingest_wikimedia.dpla import MEDIA_MASTER_FIELD_NAME
+
+    downloader.s3_client.get_item_metadata.return_value = json.dumps(
+        {
+            "_staged_by_get_ids_es": True,
+            MEDIA_MASTER_FIELD_NAME: [
+                "http://example.com/page1.jpg",
+                "http://example.com/page2.jpg",
+                "http://example.com/page3.jpg",
+            ],
+        }
+    )
+
+    # Make all three ordinals resolve to SKIPPED so the loop completes
+    # quickly without needing a full download mock chain.
+    with (
+        patch.object(downloader, "process_media", return_value="SKIPPED"),
+        patch("logging.info") as mock_log,
+    ):
+        downloader.process_item(
+            overwrite=False,
+            dry_run=False,
+            verbose=False,
+            partner="bpl",
+            dpla_id="item-xyz",
+            sleep_secs=0,
+        )
+
+    summary_log = next(
+        (c for c in mock_log.call_args_list if "Item item-xyz: 3 ordinals" in str(c)),
+        None,
+    )
+    assert summary_log is not None, (
+        f"Expected an 'Item item-xyz: 3 ordinals ...' summary log line; "
+        f"got: {[str(c) for c in mock_log.call_args_list]}"
+    )
+    assert "skipped=3" in str(summary_log)
+    assert "fetched=0" in str(summary_log)
+    assert "refreshed=0" in str(summary_log)
+    assert "failed=0" in str(summary_log)
+
+
+def test_process_item_summary_groups_mixed_statuses(downloader, tmp_path):
+    """A mix of SKIPPED / FETCHED / REFRESHED / FAILED outcomes across
+    the ordinals of one item must be tallied correctly in the summary."""
+    from ingest_wikimedia.dpla import MEDIA_MASTER_FIELD_NAME
+
+    downloader.s3_client.get_item_metadata.return_value = json.dumps(
+        {
+            "_staged_by_get_ids_es": True,
+            MEDIA_MASTER_FIELD_NAME: ["url" + str(i) for i in range(6)],
+        }
+    )
+
+    # Per-ordinal status cycle: 3 skipped, 2 fetched, 1 refreshed
+    statuses = ["SKIPPED", "SKIPPED", "SKIPPED", "FETCHED", "FETCHED", "REFRESHED"]
+    with (
+        patch.object(downloader, "process_media", side_effect=statuses),
+        patch("logging.info") as mock_log,
+    ):
+        downloader.process_item(
+            overwrite=False,
+            dry_run=False,
+            verbose=False,
+            partner="bpl",
+            dpla_id="item-mixed",
+            sleep_secs=0,
+        )
+
+    summary_log = next(
+        (c for c in mock_log.call_args_list if "Item item-mixed" in str(c)),
+        None,
+    )
+    assert summary_log is not None
+    text = str(summary_log)
+    assert "6 ordinals" in text
+    assert "skipped=3" in text
+    assert "fetched=2" in text
+    assert "refreshed=1" in text
+    assert "failed=0" in text
+
+
+def test_process_item_does_not_emit_summary_in_dry_run(downloader, tmp_path):
+    """The per-item summary is meaningless during a dry run (no
+    process_media calls happen, so all counts would be zero). Suppress
+    it so dry-run logs aren't padded with empty summary lines."""
+    from ingest_wikimedia.dpla import MEDIA_MASTER_FIELD_NAME
+
+    downloader.s3_client.get_item_metadata.return_value = json.dumps(
+        {
+            "_staged_by_get_ids_es": True,
+            MEDIA_MASTER_FIELD_NAME: ["url1", "url2"],
+        }
+    )
+
+    with patch("logging.info") as mock_log:
+        downloader.process_item(
+            overwrite=False,
+            dry_run=True,
+            verbose=False,
+            partner="bpl",
+            dpla_id="item-dry",
+            sleep_secs=0,
+        )
+
+    summary_logs = [c for c in mock_log.call_args_list if "Item item-dry" in str(c)]
+    assert not summary_logs, (
+        f"Per-item summary should be suppressed in dry-run mode; got: {summary_logs}"
+    )

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -633,12 +633,13 @@ def test_process_media_returns_failed_on_exception(downloader, tmp_path):
     downloader.tracker.increment.assert_any_call(Result.FAILED)
 
 
-def test_process_media_returns_failed_when_upload_signals_no_work(downloader, tmp_path):
-    """upload_file_to_s3 returns False on its 0-byte refusal path and on
-    the SHA1-match race (another writer landed the key between our age
-    check and our upload). Either way no fetch landed, so process_media
-    must NOT credit the ordinal as 'FETCHED' — the per-item summary
-    counts would lie. Verify the status is 'FAILED' instead."""
+def test_process_media_returns_failed_when_upload_refuses_zero_byte(
+    downloader, tmp_path
+):
+    """When upload_file_to_s3 returns False because the temp file is
+    0 bytes (defence-in-depth past download_file_to_temp_path's primary
+    raise), it has already bumped Result.FAILED. process_media must
+    return 'FAILED' so the per-item summary matches the global tracker."""
     temp_file = MagicMock()
     temp_file.name = str(tmp_path / "fake.jpg")
     downloader.local_fs.get_temp_file.return_value = temp_file
@@ -649,7 +650,9 @@ def test_process_media_returns_failed_when_upload_signals_no_work(downloader, tm
         patch.object(downloader, "_s3_key_age_days", return_value=None),
         patch.object(downloader, "download_file_to_temp_path"),
         patch.object(downloader, "upload_file_to_s3", return_value=False),
+        patch("os.stat") as mock_stat,
     ):
+        mock_stat.return_value.st_size = 0
         status = downloader.process_media(
             partner="bpl",
             dpla_id="abc",
@@ -661,6 +664,69 @@ def test_process_media_returns_failed_when_upload_signals_no_work(downloader, tm
         )
 
     assert status == "FAILED"
+
+
+def test_process_media_returns_skipped_on_sha1_match_race(downloader, tmp_path):
+    """SHA1-match race: between the age check returning None (no key)
+    and upload_file_to_s3's metadata read, another writer landed the
+    same key with a matching SHA1. upload_file_to_s3 returns False
+    after bumping Result.SKIPPED. process_media must mirror that with
+    'SKIPPED' so the per-item summary doesn't disagree with the tracker."""
+    temp_file = MagicMock()
+    temp_file.name = str(tmp_path / "fake.jpg")
+    downloader.local_fs.get_temp_file.return_value = temp_file
+    downloader.local_fs.get_content_type.return_value = "image/jpeg"
+    downloader.local_fs.get_file_hash.return_value = "deadbeef"
+
+    with (
+        patch.object(downloader, "_s3_key_age_days", return_value=None),
+        patch.object(downloader, "download_file_to_temp_path"),
+        patch.object(downloader, "upload_file_to_s3", return_value=False),
+        patch("os.stat") as mock_stat,
+    ):
+        # Non-zero size distinguishes this from the 0-byte refusal path.
+        mock_stat.return_value.st_size = 4096
+        status = downloader.process_media(
+            partner="bpl",
+            dpla_id="abc",
+            ordinal=6,
+            media_url="http://example.com/v.jpg",
+            overwrite=False,
+            max_age_days=30,
+            sleep_secs=0,
+        )
+
+    assert status == "SKIPPED"
+
+
+def test_process_media_returns_rejected_on_bad_content_type(downloader, tmp_path):
+    """Bad-content-type rejection: the HTTP fetch happened
+    (download_file_to_temp_path ran) but the response wasn't an image
+    we'll store. Distinct from 'SKIPPED' (which means no network
+    work) so the per-item summary stays honest about what consumed
+    bandwidth."""
+    temp_file = MagicMock()
+    temp_file.name = str(tmp_path / "fake.html")
+    downloader.local_fs.get_temp_file.return_value = temp_file
+    downloader.local_fs.get_content_type.return_value = "text/html"
+
+    with (
+        patch.object(downloader, "_s3_key_age_days", return_value=None),
+        patch.object(downloader, "download_file_to_temp_path"),
+    ):
+        status = downloader.process_media(
+            partner="bpl",
+            dpla_id="abc",
+            ordinal=7,
+            media_url="http://example.com/q.html",
+            overwrite=False,
+            max_age_days=30,
+            sleep_secs=0,
+        )
+
+    assert status == "REJECTED"
+    # Pre-existing tracker semantic preserved (COUNTS continuity).
+    downloader.tracker.increment.assert_any_call(Result.SKIPPED)
 
 
 def test_process_item_emits_per_item_summary_line(downloader, tmp_path):
@@ -707,23 +773,33 @@ def test_process_item_emits_per_item_summary_line(downloader, tmp_path):
     assert "skipped=3" in str(summary_log)
     assert "fetched=0" in str(summary_log)
     assert "refreshed=0" in str(summary_log)
+    assert "rejected=0" in str(summary_log)
     assert "failed=0" in str(summary_log)
 
 
 def test_process_item_summary_groups_mixed_statuses(downloader, tmp_path):
-    """A mix of SKIPPED / FETCHED / REFRESHED / FAILED outcomes across
-    the ordinals of one item must be tallied correctly in the summary."""
+    """A mix of SKIPPED / FETCHED / REFRESHED / REJECTED / FAILED outcomes
+    across the ordinals of one item must be tallied correctly in the
+    summary."""
     from ingest_wikimedia.dpla import MEDIA_MASTER_FIELD_NAME
 
     downloader.s3_client.get_item_metadata.return_value = json.dumps(
         {
             "_staged_by_get_ids_es": True,
-            MEDIA_MASTER_FIELD_NAME: ["url" + str(i) for i in range(6)],
+            MEDIA_MASTER_FIELD_NAME: ["url" + str(i) for i in range(7)],
         }
     )
 
-    # Per-ordinal status cycle: 3 skipped, 2 fetched, 1 refreshed
-    statuses = ["SKIPPED", "SKIPPED", "SKIPPED", "FETCHED", "FETCHED", "REFRESHED"]
+    # Per-ordinal status cycle: 3 skipped, 2 fetched, 1 refreshed, 1 rejected
+    statuses = [
+        "SKIPPED",
+        "SKIPPED",
+        "SKIPPED",
+        "FETCHED",
+        "FETCHED",
+        "REFRESHED",
+        "REJECTED",
+    ]
     with (
         patch.object(downloader, "process_media", side_effect=statuses),
         patch("logging.info") as mock_log,
@@ -743,10 +819,11 @@ def test_process_item_summary_groups_mixed_statuses(downloader, tmp_path):
     )
     assert summary_log is not None
     text = str(summary_log)
-    assert "6 ordinals" in text
+    assert "7 ordinals" in text
     assert "skipped=3" in text
     assert "fetched=2" in text
     assert "refreshed=1" in text
+    assert "rejected=1" in text
     assert "failed=0" in text
 
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -633,6 +633,36 @@ def test_process_media_returns_failed_on_exception(downloader, tmp_path):
     downloader.tracker.increment.assert_any_call(Result.FAILED)
 
 
+def test_process_media_returns_failed_when_upload_signals_no_work(downloader, tmp_path):
+    """upload_file_to_s3 returns False on its 0-byte refusal path and on
+    the SHA1-match race (another writer landed the key between our age
+    check and our upload). Either way no fetch landed, so process_media
+    must NOT credit the ordinal as 'FETCHED' — the per-item summary
+    counts would lie. Verify the status is 'FAILED' instead."""
+    temp_file = MagicMock()
+    temp_file.name = str(tmp_path / "fake.jpg")
+    downloader.local_fs.get_temp_file.return_value = temp_file
+    downloader.local_fs.get_content_type.return_value = "image/jpeg"
+    downloader.local_fs.get_file_hash.return_value = "deadbeef"
+
+    with (
+        patch.object(downloader, "_s3_key_age_days", return_value=None),
+        patch.object(downloader, "download_file_to_temp_path"),
+        patch.object(downloader, "upload_file_to_s3", return_value=False),
+    ):
+        status = downloader.process_media(
+            partner="bpl",
+            dpla_id="abc",
+            ordinal=5,
+            media_url="http://example.com/w.jpg",
+            overwrite=False,
+            max_age_days=30,
+            sleep_secs=0,
+        )
+
+    assert status == "FAILED"
+
+
 def test_process_item_emits_per_item_summary_line(downloader, tmp_path):
     """The ordinal loop must end with one summary line tallying skip /
     fetch / refresh / fail counts. Grep-friendly companion to the

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -277,10 +277,14 @@ class Downloader:
         per-item progress without re-scanning the log:
 
         - ``"SKIPPED"``   — S3 already had a fresh-enough key, no network work
+                            (also: SHA1-match race in ``upload_file_to_s3``)
         - ``"FETCHED"``   — first-time fresh download to S3
         - ``"REFRESHED"`` — S3 had a stale key (older than ``max_age_days``);
                             re-downloaded and overwritten
-        - ``"FAILED"``    — the ordinal raised at some point
+        - ``"REJECTED"``  — bytes were fetched but rejected (bad content
+                            type); no S3 write happened
+        - ``"FAILED"``    — the ordinal raised, or the 0-byte defensive
+                            refusal in ``upload_file_to_s3`` triggered
         """
         temp_file = self.local_fs.get_temp_file()
         temp_file_name = temp_file.name
@@ -323,8 +327,15 @@ class Downloader:
             content_type = self.local_fs.get_content_type(temp_file_name)
             if not check_content_type(content_type):
                 logging.info(f"Bad content type: {content_type}")
+                # Bytes WERE fetched (download_file_to_temp_path ran), but
+                # the content type isn't an image we'll store — so no S3
+                # write. The tracker continues to bump Result.SKIPPED for
+                # COUNTS continuity (pre-existing semantics), but the
+                # per-item summary status is "REJECTED" so it does not
+                # claim "no network work" alongside the genuine fresh-S3
+                # skips earlier in this function.
                 self.tracker.increment(Result.SKIPPED)
-                return "SKIPPED"
+                return "REJECTED"
 
             sha1 = self.local_fs.get_file_hash(temp_file_name)
 
@@ -338,13 +349,19 @@ class Downloader:
                         sha1,
                         force_overwrite=force_overwrite,
                     ):
-                        # upload_file_to_s3 returned False — either the
-                        # 0-byte defensive refusal (tracker already bumped
-                        # FAILED) or a SHA1-match race on a non-refresh
-                        # path (tracker already bumped SKIPPED). In both
-                        # cases no fetch landed, so the per-item summary
-                        # must NOT credit this ordinal as FETCHED.
-                        return "FAILED"
+                        # upload_file_to_s3 returned False on one of two
+                        # paths that have already incremented the tracker.
+                        # Distinguish them so the per-item summary stays
+                        # consistent with the global COUNTS:
+                        #   * 0-byte defensive refusal → Result.FAILED
+                        #     (download_file_to_temp_path should have
+                        #     raised first; defence-in-depth path)
+                        #   * SHA1-match race → Result.SKIPPED
+                        #     (another writer landed the same key
+                        #     between our age check and our upload)
+                        if os.stat(temp_file_name).st_size == 0:
+                            return "FAILED"
+                        return "SKIPPED"
                     size_bytes = os.stat(temp_file_name).st_size
                     self.tracker.increment(Result.BYTES, size_bytes)
                     elapsed = time.time() - fetch_start
@@ -488,7 +505,13 @@ class Downloader:
         # the ordinal loop. Lets operators grep
         # ``grep "Item .*fetched=[1-9]"`` to see which items actually
         # had network work, vs scrolling thousands of per-ordinal lines.
-        item_counts = {"SKIPPED": 0, "FETCHED": 0, "REFRESHED": 0, "FAILED": 0}
+        item_counts = {
+            "SKIPPED": 0,
+            "FETCHED": 0,
+            "REFRESHED": 0,
+            "REJECTED": 0,
+            "FAILED": 0,
+        }
 
         for media_url in tqdm(
             media_urls, desc="Downloading Files", leave=False, unit="File", ncols=100
@@ -531,6 +554,7 @@ class Downloader:
                 f" (skipped={item_counts['SKIPPED']},"
                 f" fetched={item_counts['FETCHED']},"
                 f" refreshed={item_counts['REFRESHED']},"
+                f" rejected={item_counts['REJECTED']},"
                 f" failed={item_counts['FAILED']})."
             )
 

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -331,27 +331,34 @@ class Downloader:
             force_overwrite = overwrite or is_refresh
             for attempt in range(1, CREDENTIAL_RETRY_MAX + 1):
                 try:
-                    if self.upload_file_to_s3(
+                    if not self.upload_file_to_s3(
                         temp_file_name,
                         destination_path,
                         content_type,
                         sha1,
                         force_overwrite=force_overwrite,
                     ):
-                        size_bytes = os.stat(temp_file_name).st_size
-                        self.tracker.increment(Result.BYTES, size_bytes)
-                        elapsed = time.time() - fetch_start
-                        # ADDITIVE companion to the pre-check ``Downloading``
-                        # line: emitted only when a network fetch actually
-                        # happened (fresh or refresh). Grep history for the
-                        # old ``Downloading nara`` pattern is unchanged; the
-                        # new ``Fetched nara`` pattern lets you count real
-                        # network work and visually distinguish skips in the
-                        # log live.
-                        logging.info(
-                            f"Fetched {partner} {dpla_id} {ordinal}"
-                            f" ({size_bytes:,} bytes, {elapsed:.1f}s)."
-                        )
+                        # upload_file_to_s3 returned False — either the
+                        # 0-byte defensive refusal (tracker already bumped
+                        # FAILED) or a SHA1-match race on a non-refresh
+                        # path (tracker already bumped SKIPPED). In both
+                        # cases no fetch landed, so the per-item summary
+                        # must NOT credit this ordinal as FETCHED.
+                        return "FAILED"
+                    size_bytes = os.stat(temp_file_name).st_size
+                    self.tracker.increment(Result.BYTES, size_bytes)
+                    elapsed = time.time() - fetch_start
+                    # ADDITIVE companion to the pre-check ``Downloading``
+                    # line: emitted only when a network fetch actually
+                    # happened (fresh or refresh). Grep history for the
+                    # old ``Downloading nara`` pattern is unchanged; the
+                    # new ``Fetched nara`` pattern lets you count real
+                    # network work and visually distinguish skips in the
+                    # log live.
+                    logging.info(
+                        f"Fetched {partner} {dpla_id} {ordinal}"
+                        f" ({size_bytes:,} bytes, {elapsed:.1f}s)."
+                    )
                     return "REFRESHED" if is_refresh else "FETCHED"
                 except CredentialRetrievalError as e:
                     if attempt < CREDENTIAL_RETRY_MAX:

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -256,7 +256,7 @@ class Downloader:
         overwrite: bool,
         max_age_days: int | None,
         sleep_secs: float,
-    ) -> None:
+    ) -> str:
         """
         For a given capture for a given item, downloads it if we don't have it or are
         overwriting, gets the mime and sha1, and sticks it in S3.
@@ -269,6 +269,18 @@ class Downloader:
         credentials occasionally fail to refresh from IMDS, causing a brief blip that
         resolves within seconds. Only the S3 upload is retried — the HTTP download is
         not repeated, since the file is already on disk when the upload step fails.
+
+        Returns a per-ordinal status string used by ``process_item`` to emit a
+        single-line per-item summary at the end of the ordinal loop. The
+        existing global ``self.tracker`` counters are still incremented as
+        before — the return value is purely so callers can show fine-grained
+        per-item progress without re-scanning the log:
+
+        - ``"SKIPPED"``   — S3 already had a fresh-enough key, no network work
+        - ``"FETCHED"``   — first-time fresh download to S3
+        - ``"REFRESHED"`` — S3 had a stale key (older than ``max_age_days``);
+                            re-downloaded and overwritten
+        - ``"FAILED"``    — the ordinal raised at some point
         """
         temp_file = self.local_fs.get_temp_file()
         temp_file_name = temp_file.name
@@ -290,7 +302,7 @@ class Downloader:
                     if max_age_days is None or age_days < max_age_days:
                         logging.info("Key already in S3.")
                         self.tracker.increment(Result.SKIPPED)
-                        return
+                        return "SKIPPED"
                     logging.info(
                         f"Refreshing {dpla_id} {ordinal}: S3 file is "
                         f"{age_days:.0f} days old (threshold: {max_age_days})."
@@ -299,13 +311,20 @@ class Downloader:
 
             if sleep_secs != 0:
                 time.sleep(sleep_secs)
+            # Time the fetch + S3 upload pair so the per-ordinal "Fetched"
+            # line below reports honest wall-clock cost. ``Downloading`` (the
+            # pre-check line in process_item) is emitted for every ordinal
+            # regardless of whether work happens, which makes log volume
+            # alone a poor proxy for actual network time — the "Fetched"
+            # line fires only when bytes really moved.
+            fetch_start = time.time()
             self.download_file_to_temp_path(media_url, temp_file_name)
 
             content_type = self.local_fs.get_content_type(temp_file_name)
             if not check_content_type(content_type):
                 logging.info(f"Bad content type: {content_type}")
                 self.tracker.increment(Result.SKIPPED)
-                return
+                return "SKIPPED"
 
             sha1 = self.local_fs.get_file_hash(temp_file_name)
 
@@ -319,10 +338,21 @@ class Downloader:
                         sha1,
                         force_overwrite=force_overwrite,
                     ):
-                        self.tracker.increment(
-                            Result.BYTES, os.stat(temp_file_name).st_size
+                        size_bytes = os.stat(temp_file_name).st_size
+                        self.tracker.increment(Result.BYTES, size_bytes)
+                        elapsed = time.time() - fetch_start
+                        # ADDITIVE companion to the pre-check ``Downloading``
+                        # line: emitted only when a network fetch actually
+                        # happened (fresh or refresh). Grep history for the
+                        # old ``Downloading nara`` pattern is unchanged; the
+                        # new ``Fetched nara`` pattern lets you count real
+                        # network work and visually distinguish skips in the
+                        # log live.
+                        logging.info(
+                            f"Fetched {partner} {dpla_id} {ordinal}"
+                            f" ({size_bytes:,} bytes, {elapsed:.1f}s)."
                         )
-                    return
+                    return "REFRESHED" if is_refresh else "FETCHED"
                 except CredentialRetrievalError as e:
                     if attempt < CREDENTIAL_RETRY_MAX:
                         delay = CREDENTIAL_RETRY_BASE_DELAY_SECS * (2 ** (attempt - 1))
@@ -338,9 +368,16 @@ class Downloader:
         except Exception as e:
             self.tracker.increment(Result.FAILED)
             logging.warning(f"Failed: {dpla_id} {ordinal}", exc_info=e)
+            return "FAILED"
 
         finally:
             self.local_fs.clean_up_tmp_file(temp_file)
+
+        # Defensive: unreachable in normal flow because every branch above
+        # either returns explicitly or falls through to the exception
+        # handler. Returning a known status here keeps callers' per-item
+        # tallies sound if the control flow ever evolves.
+        return "FAILED"
 
     def process_item(
         self,
@@ -437,6 +474,15 @@ class Downloader:
             logging.info(f"DPLA ID: {dpla_id}")
             logging.info(f"Metadata: {item_metadata}")
 
+        # Per-item tally for the end-of-item summary line. Keeps the
+        # global ``self.tracker`` counters untouched (they continue to
+        # accumulate across the whole run); these locals exist only to
+        # produce the one ``Item {dpla_id}: ...`` summary at the end of
+        # the ordinal loop. Lets operators grep
+        # ``grep "Item .*fetched=[1-9]"`` to see which items actually
+        # had network work, vs scrolling thousands of per-ordinal lines.
+        item_counts = {"SKIPPED": 0, "FETCHED": 0, "REFRESHED": 0, "FAILED": 0}
+
         for media_url in tqdm(
             media_urls, desc="Downloading Files", leave=False, unit="File", ncols=100
         ):
@@ -444,6 +490,7 @@ class Downloader:
             if not media_url:
                 logging.warning(f"Skipping {dpla_id} ordinal {count}: empty URL.")
                 self.tracker.increment(Result.SKIPPED)
+                item_counts["SKIPPED"] += 1
                 continue
             # NARA item URLs sporadically arrive with a malformed scheme of
             # "https/..." (missing the colon) — repair before requesting.
@@ -454,7 +501,7 @@ class Downloader:
                 media_url = media_url.replace("https/", "https:/")
             logging.info(f"Downloading {partner} {dpla_id} {count} from {media_url}")
             if not dry_run:
-                self.process_media(
+                status = self.process_media(
                     partner,
                     dpla_id,
                     count,
@@ -463,6 +510,22 @@ class Downloader:
                     max_age_days,
                     sleep_secs,
                 )
+                item_counts[status] = item_counts.get(status, 0) + 1
+
+        # Per-item summary: one concise line operators can grep to find
+        # items that actually had network work (vs scrolling thousands of
+        # per-ordinal lines). Companion to the per-ordinal ``Fetched``
+        # line emitted by ``process_media`` — together they make the log
+        # honest about how much of the work was real downloads vs how
+        # much was already-staged-skip churn.
+        if not dry_run:
+            logging.info(
+                f"Item {dpla_id}: {len(media_urls)} ordinals"
+                f" (skipped={item_counts['SKIPPED']},"
+                f" fetched={item_counts['FETCHED']},"
+                f" refreshed={item_counts['REFRESHED']},"
+                f" failed={item_counts['FAILED']})."
+            )
 
 
 @click.command()


### PR DESCRIPTION
## Problem

Today the downloader logs \`Downloading {partner} {dpla_id} {ord} from {url}\` **before** the skip check, so a re-run against an already-staged batch produces thousands of \`Downloading\` lines that look like real network work but are followed (in 85% of cases per a sampled Clinton run) by \`Key already in S3\`. Reading the log live, you can't tell at a glance how much of the run is real downloads vs already-staged-skip churn — the per-ordinal latency is honest (skip = 0.02s, fetch ≈ 0.5s) but the per-ordinal log shape isn't.

This led to an investigation today that concluded the skip logic is actually correct; the user's perception that "the downloader is taking too long because it's not skipping" was driven entirely by misleading log volume.

## Fix

Two additive log lines. Pure additions — every existing log line and every existing grep continues to work. The historical \`grep \"Downloading nara\"\` pattern still counts ordinals the downloader considered, exactly as before.

### (A) Per-ordinal \`Fetched\` line

Emitted only when a network fetch actually happened (fresh first-time download OR refresh past max_age_days). Carries the byte count and the wall-clock seconds the fetch + S3 upload took:

\`\`\`
[INFO] HH:MM:SS: Downloading nara abc 5 from https://...
[INFO] HH:MM:SS: Fetched nara abc 5 (123,456 bytes, 0.4s).
\`\`\`

Skips are still followed by the existing \`Key already in S3\` line, so the distinction becomes visible three ways:
- **pattern** — each \`Downloading\` is followed by EITHER \`Key already in S3\` OR \`Fetched\` OR \`Refreshing\`
- **grep** — \`grep \"Fetched nara\"\` is the canonical count of real network work
- **structured** — \`process_media\` returns \`\"FETCHED\"\` / \`\"REFRESHED\"\` / \`\"SKIPPED\"\` / \`\"FAILED\"\` so the per-item summary (below) can tally without re-parsing the log

### (B) Per-item summary line

Emitted once per DPLA item after the ordinal loop finishes:

\`\`\`
[INFO] HH:MM:SS: Item abc: 36 ordinals (skipped=35, fetched=1, refreshed=0, failed=0).
\`\`\`

Grep-friendly: \`grep \"Item .*fetched=[1-9]\"\` finds every item with at least one fresh download. Suppressed in dry-run mode (where process_media isn't called and all counts would trivially be zero).

## Why both, not one

Picked deliberately. Option A gives ordinal-level granularity for spot-checking individual transactions in the log; Option B gives item-level summary for quick \"which items actually had work?\" greps without scanning thousands of per-ordinal lines. Together they make the log self-describing at two zoom levels.

## What's NOT changed

- Every existing log line continues to fire with the same wording at the same point — old greps unaffected
- \`process_media\`'s side effects (tracker increments, S3 writes, exception handling) are byte-identical
- COUNTS summary at end-of-session unchanged
- Slack completion messages unchanged

## Tests

Six new tests in \`test_downloader.py\`:

- \`test_process_media_returns_skipped_when_s3_has_fresh_key\` — SKIP status, tracker still bumped
- \`test_process_media_returns_fetched_on_first_time_download\` — FETCHED status, verifies the new \`Fetched\` log line carries byte count
- \`test_process_media_returns_refreshed_when_s3_key_stale\` — REFRESHED status distinct from FETCHED (so the per-item summary can break them out)
- \`test_process_media_returns_failed_on_exception\` — FAILED status, tracker still bumped
- \`test_process_item_emits_per_item_summary_line\` — single-status case (all skipped)
- \`test_process_item_summary_groups_mixed_statuses\` — mixed status counts tallied correctly
- \`test_process_item_does_not_emit_summary_in_dry_run\` — dry-run suppression

## Test plan

- [ ] Pytest passes (CI)
- [ ] After deploy: the next downloader run shows \`Fetched\` lines paired with \`Downloading\` ONLY when real work happens; \`Key already in S3\` continues to pair with \`Downloading\` for skips
- [ ] Each item ends with one \`Item {dpla_id}: N ordinals (skipped=..., fetched=..., refreshed=..., failed=...)\` line
- [ ] Old monitoring/grep patterns (e.g. \`grep -c \"Downloading nara\"\`) return the same counts as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds additive logging and per-ordinal status reporting to the downloader so real network fetches are distinguishable from skips without changing existing log lines or behavior.

- Per-ordinal "Fetched" line and status returns: Downloader.process_media() now returns a per-ordinal status string instead of None. Status values include SKIPPED, FETCHED, REFRESHED, FAILED, and REJECTED (see below). A new "Fetched ..." log line is emitted only when a network download + successful S3 upload actually occurs; it reports byte count and elapsed wall-clock time. Existing "Downloading ..." and "Key already in S3" lines and wording are unchanged and continue to indicate download attempts and skips. process_media preserves existing side effects (tracker increments, S3 writes, exception handling, temp-file cleanup) but now:
  - Returns "FETCHED" for first-time uploads and "REFRESHED" for overwrites.
  - Returns "REJECTED" when downloaded content fails content-type checks (no S3 write; tracker semantics preserved).
  - Distinguishes two upload-False cases: defensive 0-byte refusal → "FAILED"; SHA1-match race → "SKIPPED".
  - Returns "FAILED" for upload failure or exceptions, ensuring defensive failure semantics.

- Per-item summary line: Downloader.process_item() aggregates per-ordinal statuses into per-item tallies (including rejected) and emits one end-of-item summary line reporting totals for ordinals, skipped, fetched, refreshed, rejected, and failed. This per-item summary is suppressed in dry-run mode. The end-of-session COUNTS summary and Slack completion messages are unchanged.

These additions are grep-friendly and additive so existing monitoring/search patterns (e.g., grep "Downloading nara") and counts remain valid.

## Changes

- tools/downloader.py (+103/-9): process_media signature updated to return str; implements status values (SKIPPED, FETCHED, REFRESHED, FAILED, REJECTED), emits the new per-ordinal "Fetched ..." log on successful fetch+upload, and updates process_item to aggregate and emit per-item summaries (suppressed in dry-run).
- tests/test_downloader.py (+~356/-0): Tests expanded/added to cover SKIPPED, FETCHED, REFRESHED, FAILED, REJECTED, the split upload-False behavior (FAILED vs SKIPPED), per-item summary emission, mixed-status tallying, and suppression in dry-run.

## Deployment / Operational impact

- No special/manual pipeline trigger or ECS redeployment is required beyond the normal deployment of application code.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM).
- No public API response shape or endpoint changes.
- No new credential handling; no additional security-sensitive changes beyond the existing download/upload behavior.

## Testing / Validation

- CI: run pytest (new/updated tests included).
- Post-deploy: verify that "Fetched" lines correspond to real downloads, "Key already in S3" lines correspond to skipped ordinals, each item emits the per-item summary (unless dry-run), and existing monitoring/grep patterns produce the same aggregate counts as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->