### PR TITLE
sdc-sync: fix reconciler silently doing nothing (Wikimedia UA 403)

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1051,3 +1051,206 @@ def test_set_claim_target_rejects_unknown_value_type():
         sdc_sync._set_claim_target(claim, repo, "x", "globe-coordinate")
     with pytest.raises(ValueError, match="unsupported value_type"):
         sdc_sync._set_claim_target(claim, repo, {}, "time")
+
+
+# --------------------------------------------------------------------------
+# _reconcile_existing_claims — fetches Commons MediaInfo state and queues
+# wbremoveclaims for DPLA-referenced claims whose value isn't in `expected`.
+#
+# Critical regression history: until this fix, the reconciler used a bare
+# `requests.get(Special:EntityData/{mediaid}.json).json()` which Wikimedia
+# now (per phab T400119) rejects with HTTP 403 + "Please set a user-agent"
+# for the default `python-requests/X.Y` UA. The function's broad
+# `except Exception:` swallowed the JSONDecodeError, set file_claims to
+# an empty entity, and queued zero removals across every file. Routing
+# through `get_entity` reuses pywikibot's properly-configured session
+# (correct UA, CSRF, maxlag honoring) so this can't recur.
+# --------------------------------------------------------------------------
+
+
+def _stmt(stmt_id, prop, snaktype, value, qualifiers=None, references=None):
+    """Build a Commons statement dict in the shape Special:EntityData returns
+    (also matches wbgetentities). Used to construct entities for reconciler
+    test scenarios."""
+    if snaktype == "somevalue":
+        mainsnak = {"snaktype": "somevalue", "property": prop}
+    elif prop == "P760":
+        mainsnak = {
+            "snaktype": "value",
+            "property": prop,
+            "datavalue": {"value": value, "type": "string"},
+        }
+    else:
+        mainsnak = {
+            "snaktype": "value",
+            "property": prop,
+            "datavalue": {
+                "value": {
+                    "entity-type": "item",
+                    "numeric-id": int(value.replace("Q", "")),
+                    "id": value,
+                },
+                "type": "wikibase-entityid",
+            },
+        }
+    s = {"id": stmt_id, "mainsnak": mainsnak, "type": "statement", "rank": "normal"}
+    if qualifiers is not None:
+        s["qualifiers"] = qualifiers
+    if references is not None:
+        s["references"] = references
+    return s
+
+
+def test_reconciler_queues_removal_for_stale_p170_string():
+    """Production bug case (Cherokee Petition, M192627579): a DPLA-referenced
+    P170=somevalue claim's P2093 qualifier was written by an earlier
+    sdc-sync run with a different date stringification ("U.S. Senate.
+    3/4/1789") than the current sdc.json's value ("U.S. Senate.
+    (03/04/1789)"). The reconciler must recognize the existing claim's
+    qualifier value is not in `expected[P170]` and queue it for removal.
+
+    The pre-fix reconciler queued zero removals for this exact item
+    because its `requests.get(...)` was rejected with HTTP 403 by
+    Wikimedia and the resulting JSONDecodeError was silently swallowed
+    in an `except Exception:` block."""
+    from tools import sdc_sync
+
+    stale_stmt = _stmt(
+        stmt_id="M999$STALE",
+        prop="P170",
+        snaktype="somevalue",
+        value=None,
+        qualifiers={
+            "P459": _dpla_p459(),
+            "P2093": _qual_string("P2093", "U.S. Senate. 3/4/1789"),
+        },
+        references=[_dpla_reference()],
+    )
+    entity = {"pageid": 999, "statements": {"P170": [stale_stmt]}}
+    expected = {"P170": ["U.S. Senate. (03/04/1789)"]}
+
+    submit_calls = []
+
+    def fake_submit(action, mediaid, dpla_id, **params):
+        submit_calls.append((action, mediaid, params))
+
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(sdc_sync, "_submit_sdc_write", side_effect=fake_submit),
+    ):
+        sdc_sync._reconcile_existing_claims(
+            "M999", "abc1234567890abcdef1234567890abcd", expected
+        )
+
+    assert len(submit_calls) == 1
+    action, mediaid, params = submit_calls[0]
+    assert action == "wbremoveclaims"
+    assert mediaid == "M999"
+    assert params["claim"] == "M999$STALE", (
+        f"reconciler should queue the stale claim for removal; got {params['claim']!r}"
+    )
+
+
+def test_reconciler_keeps_claim_when_value_matches_expected():
+    """A DPLA-referenced claim whose P2093 value IS in `expected` must stay.
+    The fix must not have over-corrected into removing healthy claims."""
+    from tools import sdc_sync
+
+    good_stmt = _stmt(
+        stmt_id="M999$KEEP",
+        prop="P170",
+        snaktype="somevalue",
+        value=None,
+        qualifiers={
+            "P459": _dpla_p459(),
+            "P2093": _qual_string("P2093", "U.S. Senate. (03/04/1789)"),
+        },
+        references=[_dpla_reference()],
+    )
+    entity = {"pageid": 999, "statements": {"P170": [good_stmt]}}
+    expected = {"P170": ["U.S. Senate. (03/04/1789)"]}
+
+    submit_calls = []
+
+    def fake_submit(*args, **kwargs):
+        submit_calls.append((args, kwargs))
+
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(sdc_sync, "_submit_sdc_write", side_effect=fake_submit),
+    ):
+        sdc_sync._reconcile_existing_claims(
+            "M999", "abc1234567890abcdef1234567890abcd", expected
+        )
+
+    assert submit_calls == [], (
+        f"reconciler should not queue removal for a healthy claim; got {submit_calls!r}"
+    )
+
+
+def test_reconciler_ignores_foreign_claim_without_dpla_reference():
+    """Claims without a DPLA-publisher reference are not DPLA-authored and
+    must be left alone, even if their value isn't in expected. This is
+    the user-authored-statement invariant (also enforced by
+    `_is_safe_to_amend_in_place` on the write side)."""
+    from tools import sdc_sync
+
+    # Mainsnak matches a healthy DPLA claim's value, but no DPLA reference
+    # — a community editor's statement.
+    foreign_stmt = _stmt(
+        stmt_id="M999$FOREIGN",
+        prop="P170",
+        snaktype="somevalue",
+        value=None,
+        qualifiers={"P2093": _qual_string("P2093", "Some User's Author Name")},
+        references=[_foreign_reference()],
+    )
+    entity = {"pageid": 999, "statements": {"P170": [foreign_stmt]}}
+    expected = {"P170": ["U.S. Senate. (03/04/1789)"]}
+
+    submit_calls = []
+
+    def fake_submit(*args, **kwargs):
+        submit_calls.append((args, kwargs))
+
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(sdc_sync, "_submit_sdc_write", side_effect=fake_submit),
+    ):
+        sdc_sync._reconcile_existing_claims(
+            "M999", "abc1234567890abcdef1234567890abcd", expected
+        )
+
+    assert submit_calls == [], (
+        "reconciler must not touch foreign (non-DPLA-referenced) claims"
+    )
+
+
+def test_reconciler_propagates_get_entity_error():
+    """When the entity fetch raises (network failure, 403, etc.), the
+    reconciler must let the exception propagate to the per-ordinal
+    boundary in `_run_partner_mode` — NOT silently swallow it and
+    fall through with an empty entity, which would mean zero removals
+    queued for a working file."""
+    from tools import sdc_sync
+
+    def fake_get_entity(mediaid):
+        raise RuntimeError("simulated wbgetentities failure")
+
+    with (
+        patch.object(sdc_sync, "get_entity", side_effect=fake_get_entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+    ):
+        try:
+            sdc_sync._reconcile_existing_claims(
+                "M999", "abc1234567890abcdef1234567890abcd", {"P170": ["x"]}
+            )
+        except RuntimeError as e:
+            assert "simulated wbgetentities failure" in str(e)
+        else:
+            raise AssertionError(
+                "reconciler must propagate get_entity errors; got silent fallback"
+            )

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1053,25 +1053,12 @@ def test_set_claim_target_rejects_unknown_value_type():
         sdc_sync._set_claim_target(claim, repo, {}, "time")
 
 
-# --------------------------------------------------------------------------
-# _reconcile_existing_claims — fetches Commons MediaInfo state and queues
-# wbremoveclaims for DPLA-referenced claims whose value isn't in `expected`.
-#
-# Critical regression history: until this fix, the reconciler used a bare
-# `requests.get(Special:EntityData/{mediaid}.json).json()` which Wikimedia
-# now (per phab T400119) rejects with HTTP 403 + "Please set a user-agent"
-# for the default `python-requests/X.Y` UA. The function's broad
-# `except Exception:` swallowed the JSONDecodeError, set file_claims to
-# an empty entity, and queued zero removals across every file. Routing
-# through `get_entity` reuses pywikibot's properly-configured session
-# (correct UA, CSRF, maxlag honoring) so this can't recur.
-# --------------------------------------------------------------------------
+# Regression coverage for the Special:EntityData UA-403 silent-failure bug
+# in `_reconcile_existing_claims` (phab T400119).
 
 
 def _stmt(stmt_id, prop, snaktype, value, qualifiers=None, references=None):
-    """Build a Commons statement dict in the shape Special:EntityData returns
-    (also matches wbgetentities). Used to construct entities for reconciler
-    test scenarios."""
+    """Build a Commons statement dict in the wbgetentities shape."""
     if snaktype == "somevalue":
         mainsnak = {"snaktype": "somevalue", "property": prop}
     elif prop == "P760":
@@ -1102,17 +1089,7 @@ def _stmt(stmt_id, prop, snaktype, value, qualifiers=None, references=None):
 
 
 def test_reconciler_queues_removal_for_stale_p170_string():
-    """Production bug case (Cherokee Petition, M192627579): a DPLA-referenced
-    P170=somevalue claim's P2093 qualifier was written by an earlier
-    sdc-sync run with a different date stringification ("U.S. Senate.
-    3/4/1789") than the current sdc.json's value ("U.S. Senate.
-    (03/04/1789)"). The reconciler must recognize the existing claim's
-    qualifier value is not in `expected[P170]` and queue it for removal.
-
-    The pre-fix reconciler queued zero removals for this exact item
-    because its `requests.get(...)` was rejected with HTTP 403 by
-    Wikimedia and the resulting JSONDecodeError was silently swallowed
-    in an `except Exception:` block."""
+    """Stale DPLA-referenced P170 qualifier (value not in `expected`) is queued for wbremoveclaims."""
     from tools import sdc_sync
 
     stale_stmt = _stmt(
@@ -1153,8 +1130,7 @@ def test_reconciler_queues_removal_for_stale_p170_string():
 
 
 def test_reconciler_keeps_claim_when_value_matches_expected():
-    """A DPLA-referenced claim whose P2093 value IS in `expected` must stay.
-    The fix must not have over-corrected into removing healthy claims."""
+    """Healthy DPLA-referenced claim whose value is in `expected` is left alone."""
     from tools import sdc_sync
 
     good_stmt = _stmt(
@@ -1191,14 +1167,9 @@ def test_reconciler_keeps_claim_when_value_matches_expected():
 
 
 def test_reconciler_ignores_foreign_claim_without_dpla_reference():
-    """Claims without a DPLA-publisher reference are not DPLA-authored and
-    must be left alone, even if their value isn't in expected. This is
-    the user-authored-statement invariant (also enforced by
-    `_is_safe_to_amend_in_place` on the write side)."""
+    """Foreign (non-DPLA-referenced) claim is never queued for removal, even when its value isn't in `expected`."""
     from tools import sdc_sync
 
-    # Mainsnak matches a healthy DPLA claim's value, but no DPLA reference
-    # — a community editor's statement.
     foreign_stmt = _stmt(
         stmt_id="M999$FOREIGN",
         prop="P170",
@@ -1230,27 +1201,18 @@ def test_reconciler_ignores_foreign_claim_without_dpla_reference():
 
 
 def test_reconciler_propagates_get_entity_error():
-    """When the entity fetch raises (network failure, 403, etc.), the
-    reconciler must let the exception propagate to the per-ordinal
-    boundary in `_run_partner_mode` — NOT silently swallow it and
-    fall through with an empty entity, which would mean zero removals
-    queued for a working file."""
+    """Entity-fetch errors propagate (no silent fallback to an empty entity)."""
     from tools import sdc_sync
 
-    def fake_get_entity(mediaid):
-        raise RuntimeError("simulated wbgetentities failure")
-
     with (
-        patch.object(sdc_sync, "get_entity", side_effect=fake_get_entity),
+        patch.object(
+            sdc_sync,
+            "get_entity",
+            side_effect=RuntimeError("simulated wbgetentities failure"),
+        ),
         patch.object(sdc_sync, "invalidate_entity"),
+        pytest.raises(RuntimeError, match="simulated wbgetentities failure"),
     ):
-        try:
-            sdc_sync._reconcile_existing_claims(
-                "M999", "abc1234567890abcdef1234567890abcd", {"P170": ["x"]}
-            )
-        except RuntimeError as e:
-            assert "simulated wbgetentities failure" in str(e)
-        else:
-            raise AssertionError(
-                "reconciler must propagate get_entity errors; got silent fallback"
-            )
+        sdc_sync._reconcile_existing_claims(
+            "M999", "abc1234567890abcdef1234567890abcd", {"P170": ["x"]}
+        )

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1513,33 +1513,18 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
     `process_one_from_sdc` (PR 4 partner-mode path). Same removal logic;
     just different sources for `expected`.
     """
-    # Fetch the file's current MediaInfo state via pywikibot's
-    # wbgetentities, NOT a bare `requests.get(...)` to Special:EntityData.
-    # Wikimedia now (per phab T400119) returns HTTP 403 to any
-    # `python-requests/X.Y`-style default User-Agent, with body
-    # "Please set a user-agent and respect our robot policy". `.json()`
-    # on that body raises JSONDecodeError. The previous broad
-    # `except Exception:` silently swallowed every such failure and
-    # fell back to `{"entities": {mediaid: {"statements": {}}}}`,
-    # so the reconciler saw zero DPLA-referenced claims on every file
-    # and queued ZERO removals across every partner-mode SDC run.
-    # Stale claims (e.g. an older author-name-string formatting that
-    # has since been replaced in sdc.json) accumulate forever.
-    #
-    # Routing through `get_entity` reuses pywikibot's
-    # `Site.simple_request`, which sets the correct UA, manages
-    # CSRF tokens, honors maxlag/Retry-After, etc. We invalidate
-    # the per-process entity cache first so this read sees the
-    # post-write state from `_post_new_claims` above. Errors here
-    # propagate to the per-ordinal exception boundary in
-    # `_run_partner_mode` (logged + counted as
-    # SDC_ORDINALS_SKIPPED_ERROR) instead of silently masking a
-    # broken reconciler.
+    # Use pywikibot's wbgetentities (via get_entity) rather than a direct
+    # requests.get to Special:EntityData: Wikimedia rejects the default
+    # python-requests UA with HTTP 403 (phab T400119), and pywikibot's
+    # Site.simple_request sets a compliant UA plus maxlag/CSRF handling.
+    # Invalidate the cache so this read sees post-write state from
+    # `_post_new_claims` above; let errors propagate to the per-ordinal
+    # boundary in `_run_partner_mode`.
     print(f" -- Accessing Commons ID {mediaid}")
     invalidate_entity(mediaid)
     entity = get_entity(mediaid)
     print(f" -- Accessed Commons ID {mediaid}")
-    statements = entity.get("statements", {}) or {}
+    statements = entity.get("statements") or {}
     dpla_claim_list = []
     removals = []
     for prop in statements:

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1513,19 +1513,37 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
     `process_one_from_sdc` (PR 4 partner-mode path). Same removal logic;
     just different sources for `expected`.
     """
+    # Fetch the file's current MediaInfo state via pywikibot's
+    # wbgetentities, NOT a bare `requests.get(...)` to Special:EntityData.
+    # Wikimedia now (per phab T400119) returns HTTP 403 to any
+    # `python-requests/X.Y`-style default User-Agent, with body
+    # "Please set a user-agent and respect our robot policy". `.json()`
+    # on that body raises JSONDecodeError. The previous broad
+    # `except Exception:` silently swallowed every such failure and
+    # fell back to `{"entities": {mediaid: {"statements": {}}}}`,
+    # so the reconciler saw zero DPLA-referenced claims on every file
+    # and queued ZERO removals across every partner-mode SDC run.
+    # Stale claims (e.g. an older author-name-string formatting that
+    # has since been replaced in sdc.json) accumulate forever.
+    #
+    # Routing through `get_entity` reuses pywikibot's
+    # `Site.simple_request`, which sets the correct UA, manages
+    # CSRF tokens, honors maxlag/Retry-After, etc. We invalidate
+    # the per-process entity cache first so this read sees the
+    # post-write state from `_post_new_claims` above. Errors here
+    # propagate to the per-ordinal exception boundary in
+    # `_run_partner_mode` (logged + counted as
+    # SDC_ORDINALS_SKIPPED_ERROR) instead of silently masking a
+    # broken reconciler.
     print(f" -- Accessing Commons ID {mediaid}")
-    try:
-        file_claims = requests.get(
-            f"https://commons.wikimedia.org/wiki/Special:EntityData/{mediaid}.json",
-            timeout=30,
-        ).json()
-    except Exception:
-        file_claims = {"entities": {mediaid: {"statements": {}}}}
+    invalidate_entity(mediaid)
+    entity = get_entity(mediaid)
     print(f" -- Accessed Commons ID {mediaid}")
+    statements = entity.get("statements", {}) or {}
     dpla_claim_list = []
     removals = []
-    for prop in file_claims["entities"][mediaid]["statements"]:
-        for stmt in file_claims["entities"][mediaid]["statements"][prop]:
+    for prop in statements:
+        for stmt in statements[prop]:
             if stmt.get("references"):
                 if any(pubprop["snaks"].get("P123") for pubprop in stmt["references"]):
                     if any(


### PR DESCRIPTION
## Summary

`_reconcile_existing_claims` was fetching Commons MediaInfo state with a bare `requests.get(Special:EntityData/{mediaid}.json).json()`. Per phab T400119, Wikimedia now returns HTTP 403 + \"Please set a user-agent and respect our robot policy\" to the default `python-requests/X.Y` UA. `.json()` on that response raises `JSONDecodeError`; a broad `except Exception:` silently swallowed it and fell back to an empty entity. Effect: **the reconciler queued zero removals across every partner-mode SDC run since Wikimedia enforcement took effect**, leaving stale DPLA-authored claims accumulating on Commons (most visibly: duplicate P170 statements with old vs. new author-name-string formatters).

## How it was found

NARA Center for Legislative Archives' Cherokee Petition (`M192627579`) had two DPLA-referenced P170 statements after a re-run — May 27 with `P2093=\"U.S. Senate. 3/4/1789\"`, June 7 with `P2093=\"U.S. Senate. (03/04/1789)\"`. Manual trace of the reconciler logic correctly identified the stale claim for removal; a dry-run-wrapped live invocation of `_reconcile_existing_claims` against that item returned **zero** removals. Direct instrumentation confirmed the `requests.get` was 403'd; pywikibot's `Site.simple_request` (which sets a compliant UA) succeeds.

## Change

- Route the entity fetch through the existing `get_entity(mediaid)` helper, which calls `site.simple_request(action=\"wbgetentities\", ids=mediaid).submit()` — proper UA, CSRF, maxlag/Retry-After handling.
- Call `invalidate_entity(mediaid)` first so the read sees post-write state from `_post_new_claims`.
- Remove the silent `except Exception:` fallback so genuine API errors propagate to the per-ordinal exception boundary in `_run_partner_mode` (PR #252) — logged and counted as `SDC_ORDINALS_SKIPPED_ERROR` instead of silently masking a broken reconciler.

## Tests

Four new tests in `tests/test_sdc_sync.py`:
- `test_reconciler_queues_removal_for_stale_p170_string` — reproduces the Cherokee bug pattern (stale P170 qualifier value).
- `test_reconciler_keeps_claim_when_value_matches_expected` — healthy claim is not removed.
- `test_reconciler_ignores_foreign_claim_without_dpla_reference` — community-authored claims are untouched.
- `test_reconciler_propagates_get_entity_error` — entity-fetch errors are no longer silently swallowed.

## Follow-ups (deliberately out of scope)

Code review surfaced three real adjacent issues worth separate PRs:

1. **Legacy `--list`/`--files`/`--cat` entry points have no per-file try/except** around `process_one`. Now that the broad except is gone, a transient pywikibot APIError inside the reconciler will abort the whole WORKING-*.txt batch mid-run. Partner mode is protected by the per-ordinal boundary at line 2280; the legacy paths are not.
2. **`get_entity` does not translate `APIError(code='no-such-entity')` to `_MissingEntityError`.** Files deleted on Commons between upload and SDC sync now miscount as `SDC_ORDINALS_SKIPPED_ERROR` instead of `SDC_ORDINALS_SKIPPED_MISSING_ENTITY`. The translation lives in `_submit_sdc_write` (line ~1316) but should be in `get_entity` itself.
3. **No timeout bound on the pywikibot fetch path.** The deleted `requests.get(timeout=30)` had a 30s cap; pywikibot's defaults (max_retries=15, retry_wait up to 120s) allow a single `get_entity` call to stall ~30 minutes against an unresponsive endpoint.

Once this lands, the accumulated stale claims from runs predating the fix should be cleaned up — likely by scanning Commons for files with multiple DPLA-referenced claims of the same property.

## Test plan

- [ ] CI green (4 new tests pass; existing reconciler tests unaffected).
- [ ] After merge, re-run a small partner (e.g. `nara+center-for-legislative-archives`) and verify `SDC_REMOVALS` count is non-zero where stale claims exist.
- [ ] Confirm `M192627579` ends up with a single P170 claim matching the current sdc.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes a critical bug in `_reconcile_existing_claims` where the reconciler was silently failing to queue removals for stale DPLA-authored claims on Commons.

**Root Cause**: The function was directly calling `requests.get(Special:EntityData/{mediaid}.json)` to fetch entity data. Wikimedia began rejecting the default python-requests User-Agent with HTTP 403 (phab T400119). When the response body couldn't be parsed as JSON, a broad `except Exception:` clause silently caught the JSONDecodeError and treated the entity as empty, causing the reconciler to queue zero removals. This resulted in accumulation of stale duplicate claims (example: duplicate P170 statements with inconsistent author-name formatting on item M192627579).

**Solution**:
- Route entity fetches through the existing `get_entity(mediaid)` function, which uses pywikibot's `Site.simple_request()` with proper User-Agent headers, CSRF handling, and maxlag/Retry-After support
- Call `invalidate_entity(mediaid)` before the read to ensure fresh post-write state
- Remove the silent broad `except Exception:` fallback, allowing API errors to propagate to the per-ordinal exception boundary in `_run_partner_mode`, where they are logged and counted as `SDC_ORDINALS_SKIPPED_ERROR` instead of being silently ignored

**Tests**: Four new regression tests added (`test_reconciler_queues_removal_for_stale_p170_string`, `test_reconciler_keeps_claim_when_value_matches_expected`, `test_reconciler_ignores_foreign_claim_without_dpla_reference`, `test_reconciler_propagates_get_entity_error`) verify the reconciler correctly identifies and removes stale DPLA-referenced claims, preserves healthy ones, leaves foreign claims untouched, and properly propagates fetch errors.

**Changes**: +12/-9 in `tools/sdc_sync.py`; +165 in test additions to `tests/test_sdc_sync.py`.

**Deployment**: No manual pipeline trigger, ECS redeployment, environment variable changes, database migrations, shared infrastructure configuration changes, API shape modifications, or security implications. Takes effect on next standard deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->