### PR TITLE
launch: make EC2-file-ownership heal step non-fatal on SSM timeout

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -364,10 +364,22 @@ def main() -> None:
         "chown -R ec2-user:ec2-user /home/ec2-user/ingest-wikimedia/ && "
         "(chown -R ec2-user:ec2-user /tmp/ingest-wikimedia-update 2>/dev/null || true)"
     )
+    # Non-fatal: the heal step is best-effort cleanup of incidental
+    # root-owned files. If it times out (SSM scheduling latency — observed
+    # ~5min queue time on a single-item launch where the chown itself ran
+    # in 0 seconds but SSM held the command pending past our polling
+    # window), or fails for any other reason, log a warning and proceed.
+    # If a previous root-owned file actually blocks the downstream update,
+    # `uv sync` will fail loudly with a specific permission error — which
+    # is more actionable than a generic "heal timed out" abort that
+    # forces the user to re-launch over an SSM-side hiccup.
     try:
         ssm_run(ssm, heal_cmd, as_root=True)
     except Exception as e:
-        _slack_fail(response_url, f"⚠️ Failed to heal EC2 file ownership: {e}")
+        logging.warning(
+            "EC2 file-ownership heal step failed or timed out (continuing): %s",
+            e,
+        )
 
     update_cmd = (
         "cd /tmp && rm -rf ingest-wikimedia-update && "


### PR DESCRIPTION
## Summary

Your single-item launch for `e939af1bdfd43c47bce97b996a1973fb` aborted with `⚠️ Failed to heal EC2 file ownership: SSM command 07a17bab-… did not complete within polling window`. Inspecting the SSM command directly shows it actually **succeeded** at the same instant our polling window expired (5 min):

```
$ aws ssm get-command-invocation --command-id 07a17bab-...
Status: Success
ExecutionStartDateTime: 2026-06-07T03:31:54.120Z
ExecutionEndDateTime:   2026-06-07T03:31:54.120Z
```

So the chown ran in 0 seconds — the latency was entirely SSM-side. The command sat in pending for ~5 minutes before SSM dispatched it to the agent, exactly hitting `ssm_run`'s 60×5s polling window.

## Fix

The heal step is best-effort cleanup of incidental root-owned files; it's not a hard prerequisite for the launch. Replace the `_slack_fail` on heal-step exception with a `logging.warning` so the launch proceeds. If a stale root-owned file genuinely blocks the downstream `uv sync`, that step will fail loudly with a specific permission error — far more actionable than aborting on a SSM scheduling hiccup.

Other launch steps (update, resolve, dir check, conflict check, the actual tmux launch) remain fatal because their failure modes are genuinely blocking. Only the heal step is structurally best-effort.

## What this doesn't change

- Polling window is still 5 min × 60 polls for all SSM calls — bumping it globally would trade SSM scheduling tolerance for slower detection of genuinely hung commands.
- If SSM scheduling latency starts hitting other steps too, we can address those individually (each has a different fatal-vs-recoverable judgment).

## Test plan

- [x] `ruff check` / `ruff format --check` clean.
- [ ] Re-run your single-item launch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Modified `scripts/wikimedia_launch.py` to make the EC2 file-ownership heal step non-fatal on SSM timeout.

**Rationale**: A single-item launch previously aborted when the heal step (a `chown` command to clean up incidental root-owned files) timed out waiting for an SSM command. Investigation revealed the command actually completed in 0 seconds but SSM's scheduling latency (~5 minutes queue time) caused it to miss the polling window deadline. The heal step is best-effort cleanup and not a hard prerequisite; when it fails or times out due to SSM scheduling issues, the launch now logs a warning and proceeds. If stale root-owned files genuinely block downstream work, later steps like `uv sync` will fail with specific, actionable permission errors rather than aborting over an SSM-side hiccup.

**Implementation**: Replaced the `_slack_fail()` call in the heal step exception handler with `logging.warning()`. The surrounding comments were updated to document the non-fatal behavior and expected timeout/failure handling.

**Scope unchanged**: 
- SSM polling window (60 polls × 5s) remains the same
- All other launch steps (update, resolve, directory check, conflict check, tmux launch) remain fatal
- No changes to SSM timeout configuration; broader scheduling issues should be addressed per-step if they arise

## Checklist Items

- **No manual pipeline trigger or ECS redeployment required** — the script change takes effect on the next launch invocation via the existing GitHub Actions workflow
- **No environment variables or AWS Secrets Manager keys added, removed, or renamed**
- **No database migrations**
- **No shared infrastructure configuration changes** (CodePipeline, CodeBuild, ECS, IAM)
- **No public API response shape changes or endpoint modifications**
- **No security implications** (auth and credential handling unchanged)

## Testing

Ruff checks/format validation passed locally. Full pipeline validation (single-item launch after merge) pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->