### PR TITLE
sdc-sync: tighten reconciler error categorisation + bound pywikibot retries

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -441,6 +441,7 @@ def notify_sdc_complete(
             f"SKIPPED (no sidecar): {tracker.count(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR):,}",
             f"SKIPPED (mapping):    {tracker.count(Result.SDC_ITEMS_SKIPPED_MAPPING):,}",
             f"SKIPPED (error):      {tracker.count(Result.SDC_ITEMS_SKIPPED_ERROR):,}",
+            f"ORDINAL MISSING:      {tracker.count(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY):,}",
             f"ORDINAL ERRORS:       {tracker.count(Result.SDC_ORDINALS_SKIPPED_ERROR):,}",
             f"Runtime:              {runtime}",
         ],

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1216,3 +1216,172 @@ def test_reconciler_propagates_get_entity_error():
         sdc_sync._reconcile_existing_claims(
             "M999", "abc1234567890abcdef1234567890abcd", {"P170": ["x"]}
         )
+
+
+# ---------------------------------------------------------------------------
+# _raise_if_missing_entity / get_entity
+#
+# Reads are now expected to translate ``no-such-entity`` to
+# ``_MissingEntityError`` so the partner-mode boundary categorises deleted
+# files as MISSING_ENTITY rather than generic ERROR.
+# ---------------------------------------------------------------------------
+
+
+def test_raise_if_missing_entity_translates_no_such_entity():
+    """APIError(code='no-such-entity') becomes _MissingEntityError."""
+    from tools import sdc_sync
+
+    err = _api_error("no-such-entity", info="No entity")
+    with pytest.raises(sdc_sync._MissingEntityError):
+        sdc_sync._raise_if_missing_entity(err, "M999")
+
+
+def test_raise_if_missing_entity_silent_on_other_apierror():
+    """Other APIError codes pass through so the caller can wrap/re-raise."""
+    from tools import sdc_sync
+
+    # No raise → returns None implicitly.
+    assert sdc_sync._raise_if_missing_entity(_api_error("maxlag"), "M999") is None
+
+
+def test_get_entity_translates_no_such_entity(monkeypatch):
+    """When wbgetentities returns no-such-entity for a deleted Commons file,
+    get_entity must raise _MissingEntityError so the partner-mode boundary
+    increments SDC_ORDINALS_SKIPPED_MISSING_ENTITY (not _ERROR)."""
+    from tools import sdc_sync
+
+    fake_request = MagicMock()
+    fake_request.submit.side_effect = _api_error("no-such-entity")
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value = fake_request
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+    monkeypatch.setattr(sdc_sync, "_entity_cache", {}, raising=False)
+
+    with pytest.raises(sdc_sync._MissingEntityError):
+        sdc_sync.get_entity("M999")
+
+
+def test_get_entity_propagates_other_apierrors(monkeypatch):
+    """Non-missing APIErrors (maxlag, badtoken, etc.) propagate so the
+    per-ordinal boundary catches them as generic errors."""
+    import pywikibot.exceptions
+
+    from tools import sdc_sync
+
+    fake_request = MagicMock()
+    fake_request.submit.side_effect = _api_error("maxlag", info="DB lag")
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value = fake_request
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+    monkeypatch.setattr(sdc_sync, "_entity_cache", {}, raising=False)
+
+    with pytest.raises(pywikibot.exceptions.APIError, match="maxlag"):
+        sdc_sync.get_entity("M999")
+
+
+# ---------------------------------------------------------------------------
+# _safe_process_one — per-file exception boundary for the legacy
+# --list / --files / --cat loops, mirroring _run_partner_mode's
+# per-ordinal boundary. Unit-tested directly here; integration with main()
+# is exercised by hand against the three call sites.
+# ---------------------------------------------------------------------------
+
+
+def test_safe_process_one_passes_through_on_success(monkeypatch):
+    """No exception → no tracker increment."""
+    from tools import sdc_sync
+
+    fake_tracker = MagicMock()
+    monkeypatch.setattr(sdc_sync, "tracker", fake_tracker)
+    monkeypatch.setattr(sdc_sync, "process_one", lambda *a: None)
+
+    sdc_sync._safe_process_one("M1", "dpla-1")
+
+    fake_tracker.increment.assert_not_called()
+
+
+def test_safe_process_one_categorises_missing_entity(monkeypatch):
+    """_MissingEntityError → SDC_ORDINALS_SKIPPED_MISSING_ENTITY, not the
+    generic ERROR bucket. Without this branch, the new get_entity
+    translation (which can raise _MissingEntityError from process_one's
+    pre-warm at line 1950, OUTSIDE its own try/except at line 2015)
+    would be miscounted as a generic error."""
+    from tools import sdc_sync
+
+    fake_tracker = MagicMock()
+    monkeypatch.setattr(sdc_sync, "tracker", fake_tracker)
+
+    def raise_missing(*a):
+        raise sdc_sync._MissingEntityError("M1")
+
+    monkeypatch.setattr(sdc_sync, "process_one", raise_missing)
+
+    sdc_sync._safe_process_one("M1", "dpla-1")
+
+    fake_tracker.increment.assert_called_once_with(
+        Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY
+    )
+
+
+def test_safe_process_one_categorises_generic_error(monkeypatch):
+    """Any other Exception → SDC_ORDINALS_SKIPPED_ERROR + traceback logged
+    (so the loop continues to the next file)."""
+    from tools import sdc_sync
+
+    fake_tracker = MagicMock()
+    monkeypatch.setattr(sdc_sync, "tracker", fake_tracker)
+
+    def raise_other(*a):
+        raise RuntimeError("simulated APIError")
+
+    monkeypatch.setattr(sdc_sync, "process_one", raise_other)
+
+    # Should NOT propagate; loops upstream rely on this swallowing-and-continuing.
+    sdc_sync._safe_process_one("M1", "dpla-1")
+
+    fake_tracker.increment.assert_called_once_with(Result.SDC_ORDINALS_SKIPPED_ERROR)
+
+
+# ---------------------------------------------------------------------------
+# pywikibot retry budget — bounded by _initialize()
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_pins_pywikibot_retry_budget(monkeypatch, tmp_path):
+    """A hung Commons endpoint must not stall a single API call for the
+    ~30-minute pywikibot default. _initialize() pins max_retries +
+    retry_wait + retry_max to the module's _PYWIKIBOT_* constants so
+    the worst-case stall is bounded (~9 min)."""
+    import pywikibot
+
+    from tools import sdc_sync
+
+    # monkeypatch.setattr registers teardown BEFORE the mutation, so a
+    # mid-test failure can't leak polluted config to other tests.
+    monkeypatch.setattr(pywikibot.config, "max_retries", 15)
+    monkeypatch.setattr(pywikibot.config, "retry_wait", 5)
+    monkeypatch.setattr(pywikibot.config, "retry_max", 120)
+
+    # _initialize() reads config.toml + rights.json from _REPO_ROOT; stub both.
+    (tmp_path / "config.toml").write_text('dpla_api_key = "stub"\n')
+    (tmp_path / "rights.json").write_text("{}")
+    monkeypatch.setattr(sdc_sync, "_REPO_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        sdc_sync,
+        "_build_parser",
+        lambda: MagicMock(
+            parse_args=lambda: MagicMock(method=None, from_s3=None),
+        ),
+    )
+    monkeypatch.setattr(pywikibot, "Site", MagicMock)
+    monkeypatch.setattr(
+        sdc_sync.requests, "get", lambda *a, **k: MagicMock(json=lambda: {})
+    )
+
+    sdc_sync._initialize()
+
+    # Pin equality, not <=, so any future loosening of the constants is
+    # a deliberate edit reviewers see — not an invisible drift.
+    assert pywikibot.config.max_retries == sdc_sync._PYWIKIBOT_MAX_RETRIES
+    assert pywikibot.config.retry_wait == sdc_sync._PYWIKIBOT_RETRY_WAIT
+    assert pywikibot.config.retry_max == sdc_sync._PYWIKIBOT_RETRY_MAX

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -474,6 +474,7 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
             Result.SDC_ITEMS_SKIPPED_NO_SIDECAR: 2,
             Result.SDC_ITEMS_SKIPPED_MAPPING: 1,
             Result.SDC_ITEMS_SKIPPED_ERROR: 3,
+            Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY: 5,
             Result.SDC_ORDINALS_SKIPPED_ERROR: 7,
         },
     )
@@ -485,6 +486,7 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
     assert any("SKIPPED (no sidecar)" in s and "2" in s for s in stats)
     assert any("SKIPPED (mapping)" in s and "1" in s for s in stats)
     assert any("SKIPPED (error)" in s and "3" in s for s in stats)
+    assert any("ORDINAL MISSING:" in s and "5" in s for s in stats)
     assert any("ORDINAL ERRORS:" in s and "7" in s for s in stats)
     assert any("Runtime:" in s and "42s" in s for s in stats)
 

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -195,6 +195,18 @@ def _initialize() -> None:
     with open(os.path.join(_REPO_ROOT, "config.toml"), "rb") as f:
         dpla_api = tomllib.load(f)["dpla_api_key"]
 
+    # Bound pywikibot's retry budget. Defaults let a single hung Commons
+    # endpoint stall ``simple_request().submit()`` for ~30 minutes
+    # (max_retries=15 × retry_max=120s backoff). One stuck connection
+    # then holds up the whole 50K-file partner batch behind it. The
+    # values below cap worst-case stall at ~9 min and still ride through
+    # the 1-2 retries needed for transient blips. Applies process-wide,
+    # including to ``site.login()`` immediately below and to all
+    # subsequent ``simple_request`` / ``FilePage.touch`` calls.
+    pywikibot.config.max_retries = _PYWIKIBOT_MAX_RETRIES
+    pywikibot.config.retry_wait = _PYWIKIBOT_RETRY_WAIT
+    pywikibot.config.retry_max = _PYWIKIBOT_RETRY_MAX
+
     site = pywikibot.Site()
     site.login()
     # CSRF tokens are managed by pywikibot's ``site.tokens["csrf"]`` —
@@ -367,6 +379,14 @@ def postqual(claimid, prop, value):
 # This function performs an initial GET request on the given Wikimedia file to check if the statement we will be adding is already in the page. It returns a boolean, with True if the statement is not found and can be added. "qid" is passed as a tuple with both the value and the data type, so this check can handle the formatting for different data types. If statements are found in the entity with the prop and value, but no qualifiers, we return the statement id instead, so that the qualifier can be added to that statement instead of creating a new one using postqual().
 
 
+# Pywikibot retry budget — applied process-wide in ``_initialize()``.
+# Worst-case single-call stall ≈ max_retries × (read_timeout + retry_max)
+# = 5 × (45s + 60s) ≈ 9 min, vs pywikibot's ~30-min default.
+_PYWIKIBOT_MAX_RETRIES = 5
+_PYWIKIBOT_RETRY_WAIT = 5
+_PYWIKIBOT_RETRY_MAX = 60
+
+
 # Per-file cache for wbgetentities, populated at the start of process_one()
 # and consulted by check() for all subsequent add_* calls. Avoids ~25 redundant
 # round-trips per file. Invalidate when claims change to keep the read-after-write
@@ -375,13 +395,39 @@ def postqual(claimid, prop, value):
 _entity_cache = {}
 
 
+def _raise_if_missing_entity(error, mediaid):
+    """Raise :class:`_MissingEntityError` for ``APIError(code='no-such-entity')``;
+    return silently otherwise.
+
+    The partner-mode boundary catches ``_MissingEntityError`` distinctly
+    so deleted-file skips can be counted as
+    ``SDC_ORDINALS_SKIPPED_MISSING_ENTITY`` instead of folded into the
+    generic error bucket. Callers MUST be inside an
+    ``except pywikibot.exceptions.APIError`` block and MUST follow the
+    silent-return path with their own ``raise`` (re-raise the original)
+    or ``raise SomeRuntimeError(...) from error`` — otherwise the
+    non-missing APIError is silently swallowed."""
+    if (
+        isinstance(error, pywikibot.exceptions.APIError)
+        and error.code == "no-such-entity"
+    ):
+        raise _MissingEntityError(mediaid) from error
+
+
 def get_entity(mediaid):
     """Return the wbgetentities response for mediaid, caching per process_one run."""
     cached = _entity_cache.get(mediaid)
     if cached is not None:
         return cached
-    request = site.simple_request(action="wbgetentities", ids=mediaid)
-    raw = request.submit()
+    try:
+        raw = site.simple_request(action="wbgetentities", ids=mediaid).submit()
+    except pywikibot.exceptions.APIError as e:
+        # A file deleted between upload and SDC sync surfaces here as
+        # ``no-such-entity``; without the translation it would bubble
+        # up as a generic Exception and be miscounted as an error in
+        # the partner-mode Slack summary.
+        _raise_if_missing_entity(e, mediaid)
+        raise
     entity = raw.get("entities", {}).get(mediaid, {})
     _entity_cache[mediaid] = entity
     return entity
@@ -1314,8 +1360,7 @@ def _submit_sdc_write(action, mediaid, dpla_id, **params):
             **params,
         ).submit()
     except pywikibot.exceptions.APIError as e:
-        if e.code == "no-such-entity":
-            raise _MissingEntityError(mediaid) from e
+        _raise_if_missing_entity(e, mediaid)
         raise RuntimeError(
             f"{action} failed for {mediaid} ({dpla_id}):"
             f" {e.code} — {_truncate(getattr(e, 'info', ''))}"
@@ -2377,6 +2422,35 @@ def _run_partner_mode(partner, ids_file):
 # We can use a PWB generator to programatically make the list of files we are working on based on a set of criteria. Here, we are generating the page titles from a Wikimedia Commons search and categories. For other types of available page generators, see <https://doc.wikimedia.org/pywikibot/master/api_ref/pywikibot.html#module-pywikibot.pagegenerators>. As an additional step, we take the pageid provided by the generator and prepend "M" for the mediaid needed for posting SDC statements.
 
 
+def _safe_process_one(mediaid: str, dpla_id: str) -> None:
+    """Run ``process_one`` with the per-file exception boundary the
+    legacy ``--list`` / ``--files`` / ``--cat`` loops need.
+
+    Without this, a transient pywikibot APIError on any one file
+    aborts the entire loop — and on ``--list``, leaves WORKING-*.txt
+    unrenamed so the rest of the manifest is silently abandoned.
+    Mirrors ``_run_partner_mode``'s per-ordinal boundary at
+    line ~2294.
+
+    Catches ``_MissingEntityError`` separately because ``process_one``
+    pre-warms via ``get_entity`` BEFORE its own internal handler at
+    line 2015 — so a deleted file's ``_MissingEntityError`` bypasses
+    that handler and surfaces here. Categorise it as MISSING_ENTITY
+    (clean skip) instead of folding it into the generic ERROR bucket.
+    """
+    try:
+        process_one(mediaid, dpla_id)
+    except _MissingEntityError:
+        logging.info(
+            f" -- {mediaid} for {dpla_id}: Commons MediaInfo entity"
+            " does not exist; skipping (not an error)."
+        )
+        tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY)
+    except Exception:
+        logging.exception(f" -- {mediaid} for {dpla_id}: SDC sync failed; skipping.")
+        tracker.increment(Result.SDC_ORDINALS_SKIPPED_ERROR)
+
+
 def main() -> None:
     """Entry point for the `sdc-sync` console script.
 
@@ -2408,7 +2482,7 @@ def main() -> None:
                 print("\n" + str(file).replace('""', '"'))
                 mediaid = "M" + str(file.pageid)
                 dpla_id = _resolve_dpla_id(str(file), dpla_api)
-                process_one(mediaid, dpla_id)
+                _safe_process_one(mediaid, dpla_id)
 
             os.rename(working_file, os.path.join(args.lists, "COMPLETE-" + lists[x]))
 
@@ -2438,7 +2512,7 @@ def main() -> None:
             dpla_id = _resolve_dpla_id(title, dpla_api)
             count += 1
             print(f"{count}: {mediaid}")
-            process_one(mediaid, dpla_id)
+            _safe_process_one(mediaid, dpla_id)
 
     elif args.cat:
         category = pywikibot.Category(site, args.cat)
@@ -2452,7 +2526,7 @@ def main() -> None:
             dpla_id = _resolve_dpla_id(title, dpla_api)
             count += 1
             print(f"{count}: {mediaid}")
-            process_one(mediaid, dpla_id)
+            _safe_process_one(mediaid, dpla_id)
             if args.limit and count >= args.limit:
                 print(f" -- Reached --limit {args.limit}, stopping.")
                 break


### PR DESCRIPTION
## Summary

Three follow-ups to PR #273 (the Wikimedia UA-403 reconciler fix), shipped together because they're in the same code area (the reconciler's `get_entity` call site, `_submit_sdc_write`'s error translation, and the legacy CLI loops in `main()`).

All three are real but bounded: none of them block correctness of in-flight partner runs. They make failure modes legible in the Slack summary and stop one hung connection from holding up an entire 50K-file batch.

## 1. Categorise deleted-file APIErrors correctly on the read path

Extract `_raise_if_missing_entity(error, mediaid)` helper. Use it in both `get_entity` and `_submit_sdc_write` to translate `APIError(code='no-such-entity')` → the dedicated `_MissingEntityError`.

Before this PR, the translation lived only in `_submit_sdc_write` (write path). The reconciler's new `get_entity` call could surface a deleted-file APIError that the partner-mode boundary caught at its generic `except Exception` arm and miscounted as `SDC_ORDINALS_SKIPPED_ERROR` instead of `SDC_ORDINALS_SKIPPED_MISSING_ENTITY`. Operators reading the Slack summary couldn't distinguish 'file deleted upstream' (clean) from 'real error' (alarming).

## 2. Per-file exception boundary for the legacy CLI loops

Extract `_safe_process_one(mediaid, dpla_id)` helper. Replaces three byte-identical try/except sites in the `--list`, `--files`, `--cat` loops. Mirrors `_run_partner_mode`'s per-ordinal boundary.

Before this PR, the legacy loops had no try/except around `process_one`. After PR #273 removed the broad `except` in `_reconcile_existing_claims`, a single transient APIError on one file aborted the entire `--list` batch — and worse, left the `WORKING-*.txt` manifest unrenamed, silently orphaning the rest of the files.

The helper catches `_MissingEntityError` separately from generic `Exception` because `process_one` pre-warms via `get_entity` at line 1950 — OUTSIDE its own `_MissingEntityError` handler at line 2015 — so a deleted file's exception bypasses the inner handler and surfaces at the loop level.

## 3. Bound pywikibot's retry budget

Pin `pywikibot.config.max_retries = 5`, `retry_wait = 5`, `retry_max = 60` at `_initialize()` time, via `_PYWIKIBOT_*` module constants.

Pywikibot's defaults (`max_retries=15`, `retry_wait=5`, `retry_max=120`) let a single hung Commons endpoint stall one `simple_request().submit()` call for ~30 minutes (15 retries × up to 120s backoff each). The new cap is ~9 min worst case — still robust against transient blips that resolve in 1-2 retries, but no more 30-min stalls holding up a 50K-file partner batch.

Applies process-wide, including to `site.login()` and `FilePage.touch()`. Comment in `_initialize` calls this out.

## Tests

- `_raise_if_missing_entity` — translates `no-such-entity`, silent-returns on other APIErrors
- `get_entity` — translates `no-such-entity`, propagates other APIErrors (e.g. maxlag)
- `_safe_process_one` — three branches: success (no increment), `_MissingEntityError` → MISSING_ENTITY counter, generic exception → ERROR counter
- `_initialize` — pins all three pywikibot.config knobs to the `_PYWIKIBOT_*` constants via equality (any future loosening is a visible, reviewed edit, not invisible drift)

## Out of scope

- The "legacy-mode tracker counter increments are silently dropped" issue (the legacy paths don't call `notify_sdc_complete`). Pre-existing; not introduced by this PR. Worth fixing if operators start running legacy CLI commands often.
- Possible dead-code-ness of `get_entity`'s translation if pywikibot's `wbgetentities` returns `{"missing": ""}` HTTP 200 rather than raising APIError for deleted M-ids. Harmless defensive code either way; the helper is still real on the write path.

## Test plan

- [ ] CI green (new tests pass; existing tests unaffected)
- [ ] After merge, run a partner with at least one known-deleted M-id and confirm the Slack summary shows `SDC_ORDINALS_SKIPPED_MISSING_ENTITY` increment matching the deleted file count
- [ ] If any future partner run hits a hung Commons endpoint, confirm the log shows a stall bounded under ~10 minutes rather than ~30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Three follow-up fixes to the SDC reconciler (PR `#275`)

Summary
- Error translation and exception boundaries: Adds _raise_if_missing_entity() and uses it in read and write paths (get_entity and _submit_sdc_write) so pywikibot.exceptions.APIError(code="no-such-entity") is translated into the dedicated _MissingEntityError. This prevents deleted-file (missing MediaInfo) cases from being misclassified as generic errors in Slack summaries and metrics.
- Per-file exception isolation: Adds _safe_process_one() and updates legacy CLI loops (--list, --files, --cat) to call it, creating a per-file exception boundary mirroring partner-mode behavior. _MissingEntityError is treated as a clean skip (increments Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY and logs at INFO); other Exceptions increment Result.SDC_ORDINALS_SKIPPED_ERROR and are swallowed so a single file error does not abort batches or leave WORKING-*.txt manifests orphaned.
- Pywikibot retry caps: Pins pywikibot.config.max_retries, retry_wait, and retry_max at initialization via module constants (_PYWIKIBOT_MAX_RETRIES = 5, _PYWIKIBOT_RETRY_WAIT = 5, _PYWIKIBOT_RETRY_MAX = 60). This bounds process-wide pywikibot retry stalls (site.login(), simple_request(), FilePage.touch(), etc.) to ~9 minutes worst-case instead of ~30 minutes while preserving transient retry behavior.
- Tests: Adds unit tests for _raise_if_missing_entity, get_entity, _safe_process_one (success / missing entity / generic exception branches and tracker increments), and _initialize (verifies pywikibot config pins).

Operational / infra / security checklist
- Manual pipeline trigger / ECS redeploy required: No (normal deploy of updated code only).
- Environment variables / AWS Secrets Manager keys added/removed/renamed: No.
- Database migrations: None.
- Shared infra changes (CodePipeline/CodeBuild/ECS task defs/IAM): None.
- Public-facing API shape or endpoints changed: No.
- Security implications: No new credentials or auth flows introduced. The only runtime-affecting change is bounding pywikibot retry behaviour; authentication semantics are unchanged.

Files touched (summary)
- tools/sdc_sync.py: centralised missing-entity translation, added _safe_process_one, and pinned pywikibot retry constants. (~+81/-7)
- tests/test_sdc_sync.py: new tests for missing-entity translation, _safe_process_one branches, and _initialize. (+169)
- ingest_wikimedia/slack.py and tests/test_slack.py: add Slack summary line for missing-entity skips and extend tests to assert it. (+1, +2)

Estimated review effort: Medium–High (changes affect error classification, retry behaviour, and CLI control flow).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->