### PR TITLE
launch: add #tech-alerts fallback for operational _slack_fail failures

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -70,9 +70,32 @@ def _parse_bool(value: str) -> bool:
     return value.lower() == "true"
 
 
-def _slack_fail(response_url: str, msg: str) -> NoReturn:
-    """Print msg to stderr, post ephemeral reply to response_url if set, then exit 1."""
+def _slack_fail(response_url: str, msg: str, *, operational: bool = False) -> NoReturn:
+    """Print msg to stderr, post ephemeral reply to response_url, then exit 1.
+
+    By default this is the ONLY delivery — appropriate for user-error
+    failures (typos, unparseable arguments, bad target syntax, ineligible
+    institution, mutually-exclusive flags). Those should stay private
+    between the runner and the user who issued the slash command; the
+    public `#tech-alerts` channel must not get flooded with them.
+
+    Pass ``operational=True`` for infrastructure-style failures (EC2
+    update timeout, mem/dir check failures, tmux launch failures, etc.)
+    — i.e. anything the user can't fix by re-typing the command. If the
+    response_url post fails for an operational error, fall back to
+    posting to `#tech-alerts` via ``DPLA_SLACK_BOT_TOKEN``. The fallback
+    uses ``api.slack.com/chat.postMessage`` (a different host and TLS
+    handshake than ``hooks.slack.com``), which buys some resilience to
+    correlated network failures from the GitHub runner — observed
+    behaviour: when the runner couldn't reach SSM, it also couldn't
+    reach hooks.slack.com, and the entire failure went unannounced.
+
+    The bot-token fallback is operational-only by design: user errors
+    are intentionally allowed to slip into silence rather than spam the
+    channel if the user's response_url happens to be flaky.
+    """
     print(msg, file=sys.stderr)
+    delivered = False
     if response_url:
         try:
             resp = requests.post(
@@ -81,8 +104,19 @@ def _slack_fail(response_url: str, msg: str) -> NoReturn:
                 timeout=5,
             )
             resp.raise_for_status()
+            delivered = True
         except Exception as e:
             logging.warning("Failed to post to Slack response_url: %s", e)
+    if not delivered and operational:
+        token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
+        if token:
+            try:
+                post_message(
+                    token,
+                    f"❌ Launch failure (response_url unreachable): {msg}",
+                )
+            except Exception as e:
+                logging.warning("Fallback post to #tech-alerts also failed: %s", e)
     sys.exit(1)
 
 
@@ -395,11 +429,12 @@ def main() -> None:
     try:
         out = ssm_run(ssm, update_cmd)
     except Exception as e:
-        _slack_fail(response_url, f"⚠️ Failed to update EC2 code: {e}")
+        _slack_fail(response_url, f"⚠️ Failed to update EC2 code: {e}", operational=True)
     if "UPDATE_DONE" not in out:
         _slack_fail(
             response_url,
             "⚠️ EC2 code update did not confirm completion. Check the GitHub Actions run for details.",
+            operational=True,
         )
     print("EC2 code updated.")
 
@@ -506,21 +541,34 @@ def main() -> None:
     try:
         mem_out = ssm_run(ssm, "free -m | awk 'NR==2{print $2, $7}'")
     except Exception as e:
-        _slack_fail(response_url, f"⚠️ Failed to check instance memory: {e}")
+        _slack_fail(
+            response_url,
+            f"⚠️ Failed to check instance memory: {e}",
+            operational=True,
+        )
     parts = mem_out.split()
     if len(parts) != 2:
-        _slack_fail(response_url, f"⚠️ Unexpected memory output: {mem_out!r}")
+        _slack_fail(
+            response_url,
+            f"⚠️ Unexpected memory output: {mem_out!r}",
+            operational=True,
+        )
     try:
         total_mb, available_mb = int(parts[0]), int(parts[1])
         pct_available = available_mb * 100 // total_mb
     except (ValueError, ZeroDivisionError) as e:
-        _slack_fail(response_url, f"⚠️ Could not parse memory output ({mem_out!r}): {e}")
+        _slack_fail(
+            response_url,
+            f"⚠️ Could not parse memory output ({mem_out!r}): {e}",
+            operational=True,
+        )
     print(f"Memory: {pct_available}% available ({available_mb} MB of {total_mb} MB).")
     if pct_available < MEMORY_HEADROOM_PCT:
         _slack_fail(
             response_url,
             f"⚠️ Cannot launch `{session_name}`: only {pct_available}% memory available"
             f" ({available_mb} MB of {total_mb} MB). Threshold is {MEMORY_HEADROOM_PCT}%.",
+            operational=True,
         )
 
     # Verify every requested partner has a working directory on EC2. Pywikibot
@@ -539,7 +587,11 @@ def main() -> None:
     try:
         dir_check_out = ssm_run(ssm, check_cmd)
     except Exception as e:
-        _slack_fail(response_url, f"⚠️ Failed to check partner directories: {e}")
+        _slack_fail(
+            response_url,
+            f"⚠️ Failed to check partner directories: {e}",
+            operational=True,
+        )
     missing_dirs = sorted(
         line.split(":", 1)[1]
         for line in dir_check_out.splitlines()
@@ -556,6 +608,7 @@ def main() -> None:
                 f" `bpl` is missing on EC2. The bot relies on it as the source"
                 f" of pywikibot configuration when bootstrapping new partner"
                 f" directories. Manual setup required.",
+                operational=True,
             )
         print(f"Bootstrapping missing partner directories: {missing_dirs}")
         # Single SSM round-trip: mkdir + cp -np for each missing dir. -n
@@ -576,6 +629,7 @@ def main() -> None:
                 response_url,
                 f"⚠️ Cannot launch `{session_name}`: failed to bootstrap"
                 f" partner directories {missing_dirs}: {e}",
+                operational=True,
             )
         bootstrapped_list = ", ".join(f"`{d}`" for d in missing_dirs)
         print(f"Auto-bootstrapped partner directories: {bootstrapped_list}")
@@ -597,7 +651,11 @@ def main() -> None:
     try:
         tmux_list = ssm_run(ssm, "tmux ls 2>/dev/null || true")
     except Exception as e:
-        _slack_fail(response_url, f"⚠️ Failed to list tmux sessions: {e}")
+        _slack_fail(
+            response_url,
+            f"⚠️ Failed to list tmux sessions: {e}",
+            operational=True,
+        )
     label_conflicts: dict[str, list[str]] = {}
     for line in tmux_list.splitlines():
         existing_name = line.split(":")[0].strip()
@@ -664,7 +722,9 @@ def main() -> None:
                     ssm_run(ssm, f"tmux kill-session -t {shlex.quote(existing_name)}")
                 except Exception as e:
                     _slack_fail(
-                        response_url, f"⚠️ Failed to kill session `{existing_name}`: {e}"
+                        response_url,
+                        f"⚠️ Failed to kill session `{existing_name}`: {e}",
+                        operational=True,
                     )
         else:
             for label, existing_names in label_conflicts.items():
@@ -925,13 +985,16 @@ def main() -> None:
         )
     except Exception as e:
         _slack_fail(
-            response_url, f"⚠️ Failed to launch tmux session `{session_name}`: {e}"
+            response_url,
+            f"⚠️ Failed to launch tmux session `{session_name}`: {e}",
+            operational=True,
         )
     if "SESSION_STARTED" not in out:
         _slack_fail(
             response_url,
             f"⚠️ `{session_name}` failed to start — tmux could not create session."
             " Check the GitHub Actions run for details.",
+            operational=True,
         )
     print(f"Session {session_name} confirmed running.")
 

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -107,3 +107,143 @@ def test_parse_bool(value, expected):
     from scripts.wikimedia_launch import _parse_bool
 
     assert _parse_bool(value) is expected
+
+
+# ---------------------------------------------------------------------------
+# _slack_fail: ephemeral-by-default with operational fallback
+# ---------------------------------------------------------------------------
+
+
+def _raise_connect_timeout(*_args, **_kwargs):
+    raise Exception("connect timeout")
+
+
+def test_slack_fail_user_error_stays_ephemeral_only(monkeypatch):
+    """Default `_slack_fail` call (no operational flag) goes ONLY to the
+    slash command's response_url. User-error failures must stay private
+    between the runner and the user; the public `#tech-alerts` channel
+    must NEVER see typo / bad-arg failures even if the response_url
+    delivery happens to fail. Regression guard for the design choice
+    that the bot-token fallback is operational-only.
+    """
+    from scripts import wikimedia_launch
+
+    posted_to_channel: list[tuple[str, str]] = []
+
+    monkeypatch.setenv("DPLA_SLACK_BOT_TOKEN", "fake-token")
+    # Simulate response_url being unreachable — would trigger the
+    # fallback if `operational=True` were set. User-error path must NOT
+    # call post_message (which goes to #tech-alerts).
+    monkeypatch.setattr(wikimedia_launch.requests, "post", _raise_connect_timeout)
+    monkeypatch.setattr(
+        wikimedia_launch,
+        "post_message",
+        lambda token, text: posted_to_channel.append((token, text)),
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        wikimedia_launch._slack_fail(
+            "https://hooks.slack.com/commands/T/N/X",
+            "Could not parse --partner: bad token",
+        )
+    assert excinfo.value.code == 1
+    assert posted_to_channel == [], (
+        "user-error _slack_fail must NOT post to #tech-alerts, even when "
+        f"response_url fails; got: {posted_to_channel!r}"
+    )
+
+
+def test_slack_fail_operational_falls_back_to_channel_when_response_url_fails(
+    monkeypatch,
+):
+    """Operational `_slack_fail` call (operational=True) tries the
+    response_url first, then falls back to posting to `#tech-alerts`
+    via DPLA_SLACK_BOT_TOKEN when response_url is unreachable.
+
+    Regression for the network-blackout case where the GH runner
+    couldn't reach hooks.slack.com (and AWS SSM); user got no Slack
+    notification of the launch failure because the only delivery path
+    was via the same hostname class that was down.
+    """
+    from scripts import wikimedia_launch
+
+    posted_to_channel: list[tuple[str, str]] = []
+
+    monkeypatch.setenv("DPLA_SLACK_BOT_TOKEN", "fake-token")
+    monkeypatch.setattr(wikimedia_launch.requests, "post", _raise_connect_timeout)
+    monkeypatch.setattr(
+        wikimedia_launch,
+        "post_message",
+        lambda token, text: posted_to_channel.append((token, text)),
+    )
+
+    with pytest.raises(SystemExit):
+        wikimedia_launch._slack_fail(
+            "https://hooks.slack.com/commands/T/N/X",
+            "⚠️ Failed to update EC2 code: connect timeout",
+            operational=True,
+        )
+    assert len(posted_to_channel) == 1, (
+        "operational _slack_fail must fall back to #tech-alerts when "
+        f"response_url fails; got: {posted_to_channel!r}"
+    )
+    token, text = posted_to_channel[0]
+    assert token == "fake-token"
+    assert "response_url unreachable" in text
+    assert "⚠️ Failed to update EC2 code" in text
+
+
+def test_slack_fail_operational_skips_fallback_when_response_url_succeeds(
+    monkeypatch,
+):
+    """If response_url delivery succeeded, the operational fallback must
+    NOT also post to `#tech-alerts` — that would duplicate the
+    notification (private to the user AND public). The fallback only
+    fires when the primary delivery actually failed."""
+    from scripts import wikimedia_launch
+
+    posted_to_channel: list[tuple[str, str]] = []
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setenv("DPLA_SLACK_BOT_TOKEN", "fake-token")
+    monkeypatch.setattr(
+        wikimedia_launch.requests, "post", lambda *a, **kw: _FakeResponse()
+    )
+    monkeypatch.setattr(
+        wikimedia_launch,
+        "post_message",
+        lambda token, text: posted_to_channel.append((token, text)),
+    )
+
+    with pytest.raises(SystemExit):
+        wikimedia_launch._slack_fail(
+            "https://hooks.slack.com/commands/T/N/X",
+            "⚠️ Failed to launch tmux session: connect timeout",
+            operational=True,
+        )
+    assert posted_to_channel == [], (
+        "fallback must NOT fire when response_url delivery succeeded; "
+        f"got duplicate channel post: {posted_to_channel!r}"
+    )
+
+
+def test_slack_fail_operational_silent_when_no_bot_token(monkeypatch):
+    """If DPLA_SLACK_BOT_TOKEN is unset AND response_url fails, the
+    operational `_slack_fail` should still exit cleanly (logging a
+    warning) rather than crash trying to call post_message with an
+    empty token."""
+    from scripts import wikimedia_launch
+
+    monkeypatch.delenv("DPLA_SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.setattr(wikimedia_launch.requests, "post", _raise_connect_timeout)
+
+    with pytest.raises(SystemExit) as excinfo:
+        wikimedia_launch._slack_fail(
+            "https://hooks.slack.com/commands/T/N/X",
+            "⚠️ Failed to update EC2 code: connect timeout",
+            operational=True,
+        )
+    assert excinfo.value.code == 1  # still exits 1, no traceback

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -233,12 +233,22 @@ def test_slack_fail_operational_skips_fallback_when_response_url_succeeds(
 def test_slack_fail_operational_silent_when_no_bot_token(monkeypatch):
     """If DPLA_SLACK_BOT_TOKEN is unset AND response_url fails, the
     operational `_slack_fail` should still exit cleanly (logging a
-    warning) rather than crash trying to call post_message with an
-    empty token."""
+    warning) — and must NOT attempt the fallback post_message call
+    with an empty token. A future refactor that lost the empty-token
+    guard would crash with a Slack `invalid_auth` error; this test
+    locks in the "silent when no token" contract by asserting
+    post_message is never invoked."""
     from scripts import wikimedia_launch
+
+    posted_to_channel: list[tuple[str, str]] = []
 
     monkeypatch.delenv("DPLA_SLACK_BOT_TOKEN", raising=False)
     monkeypatch.setattr(wikimedia_launch.requests, "post", _raise_connect_timeout)
+    monkeypatch.setattr(
+        wikimedia_launch,
+        "post_message",
+        lambda token, text: posted_to_channel.append((token, text)),
+    )
 
     with pytest.raises(SystemExit) as excinfo:
         wikimedia_launch._slack_fail(
@@ -247,3 +257,7 @@ def test_slack_fail_operational_silent_when_no_bot_token(monkeypatch):
             operational=True,
         )
     assert excinfo.value.code == 1  # still exits 1, no traceback
+    assert posted_to_channel == [], (
+        "fallback must NOT attempt post_message with an empty token; "
+        f"got: {posted_to_channel!r}"
+    )


### PR DESCRIPTION
## Summary

Last night's run #27082177818 surfaced a delivery gap. The GH-hosted runner couldn't reach either `ssm.us-east-1.amazonaws.com` (so the EC2 code-update step timed out) OR `hooks.slack.com` (so the `_slack_fail` post about that timeout also failed) — and the user got no Slack notification at all. The only signal was the Actions log.

In-pipeline runtime failures (`notify_pipeline_fail`) deliver via `DPLA_SLACK_BOT_TOKEN` to `#tech-alerts` over a different endpoint (`api.slack.com/chat.postMessage`), so they would have been visible even when `hooks.slack.com` was down. Launch-time errors had no such fallback.

## Design choice: bifurcate by error class

You correctly pointed out that just posting all launch failures to `#tech-alerts` is wrong — that public channel would fill with user typos and bad-arg messages. So:

| Class | Examples | Delivery |
|---|---|---|
| **User error** (default) | bad `--max-age-days`, unparseable `--partner`, unknown slug, ineligible institution, mutually-exclusive flags, no valid targets | `response_url` only — fail silently if unreachable. **No channel pollution from typos.** |
| **Operational** (`operational=True`) | EC2 update timeout, mem/dir/conflict-check failures, tmux launch failures, bootstrap failures, kill-session failures | `response_url` first → fallback to `#tech-alerts` via bot token if response_url fails. |

The operational fallback uses `api.slack.com/chat.postMessage` — a different host and TLS handshake than `hooks.slack.com`, which buys some resilience to the correlated network failures that motivated this PR.

## Marking the call sites

All 13 `⚠️`-prefixed `_slack_fail` calls now pass `operational=True`. The 5 user-error sites (no `⚠️` prefix) keep the default. A small audit script verified the classification matches the `⚠️` heuristic.

## Tests

Four new tests in `tests/test_wikimedia_launch.py`:

- **`test_slack_fail_user_error_stays_ephemeral_only`** — pins the privacy contract: user-error failures don't post to `#tech-alerts` even when response_url is unreachable.
- **`test_slack_fail_operational_falls_back_to_channel_when_response_url_fails`** — regression guard for the network-blackout scenario: with `operational=True` + a failing response_url, the launcher posts to `#tech-alerts` via the bot token.
- **`test_slack_fail_operational_skips_fallback_when_response_url_succeeds`** — no duplicate notification when the primary delivery worked.
- **`test_slack_fail_operational_silent_when_no_bot_token`** — exits 1 cleanly when the fallback can't fire either.

## What this does NOT change

- The slash-command `response_url` is still the primary delivery for everything — users see their errors in the same DM/ephemeral context as today.
- User-error failures still don't leak to `#tech-alerts` ever — even when response_url is unreachable.
- The fallback ONLY fires when (a) the error is operational AND (b) the primary delivery failed AND (c) `DPLA_SLACK_BOT_TOKEN` is set. Realistic frequency: rare.

## Test plan

- [x] ruff check / format clean
- [x] 4 new unit tests covering both classes + both delivery paths
- [ ] Next operational launch failure (if any) should show up in `#tech-alerts` rather than going silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR enhances scripts/wikimedia_launch.py's failure notification behavior by adding an operational-only Slack fallback for launch-time `_slack_fail` notifications:

- Behavior change:
  - Default (user-error): unchanged — attempt ephemeral reply to the provided slash-command `response_url` only; if that fails, do not post publicly.
  - Operational (operational=True): try `response_url` first; if that fails and DPLA_SLACK_BOT_TOKEN is set, fall back to posting a message to `#tech-alerts` via api.slack.com/chat.postMessage (uses post_message, different host than hooks.slack.com).
- Scope: 13 call sites were marked operational=True (infrastructure/operational failures such as EC2 update timeouts, SSM/memory checks, tmux session/manage/bootstrap failures). 5 user-error call sites remain ephemeral-only. An audit script validated classifications.
- Tests: adds four unit tests in tests/test_wikimedia_launch.py covering user-error ephemerality, operational fallback on response_url failure, no duplicate when primary succeeds, and silent exit when bot token is unset. A follow-up commit tightens the "no post_message with empty token" assertion.
- Code impact: scripts/wikimedia_launch.py modified (~+73/-10 lines); tests expanded (+154 lines). Overall PR includes many additional files (see commit stats), but the change described is confined to the launcher and its tests.

Does this require deployment or infra changes?
- No manual pipeline trigger, ECS redeploy, database migration, or shared-infrastructure config change is required for this behavior to take effect in code. The change becomes effective when the updated code is deployed/run (e.g., the GitHub Actions workflow that invokes the launcher runs the new script).

Environment variables / secrets:
- No new environment variables or Secrets Manager keys were added. The PR relies on the existing optional DPLA_SLACK_BOT_TOKEN to enable the operational fallback. If the token is unset, operational fallbacks will not attempt a channel post (the launcher exits with code 1 and logs a warning).

Shared infra / API changes:
- No changes to shared infra (CodePipeline/CodeBuild/ECS task defs/IAM) or public API response shapes or endpoints.
- The fallback uses the existing Slack bot-token flow (api.slack.com/chat.postMessage via ingest_wikimedia.post_message).

Security implications:
- The launcher now conditionally reads and uses DPLA_SLACK_BOT_TOKEN for operational fallbacks. The implementation only reads the token when the response_url delivery fails and only for operational errors, reducing unnecessary exposure. Tests explicitly assert that no post_message call is made when the token is absent.
- Review of credential handling is recommended when deploying the updated code to ensure the bot token remains stored and managed securely (it was already used elsewhere in the repo).

Other notes:
- Primary delivery remains the slash-command `response_url`. User-error failures will never post to `#tech-alerts`. The fallback triggers only when (a) operational=True, (b) the response_url POST failed, and (c) DPLA_SLACK_BOT_TOKEN is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->