### PR TITLE
wikimedia: preserve assessment-class templates through metadata-rescue overwrite

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -595,9 +595,28 @@ def is_same_item_redirect_relic(
 #   parent page it was extracted from. Anchored anywhere in the text (including
 #   inside |other versions= of an {{Information}} template).
 # - Category links: [[Category:Name]] or [[Category:Name|sort key]].
+# - Assessment-class templates: status that Commons editors confer on a
+#   file outside of its bare description — Media/Picture of the day on a
+#   specific date, Featured/Quality/Valued image marks, or the bundled
+#   {{Assessments}} wrapper. These represent real curatorial work and must
+#   survive a metadata-rescue rewrite. Pattern is case-insensitive to handle
+#   the casing variants Commons editors use in practice ({{media of the day}}
+#   vs {{Media of the day}}). Optional `|params` covers the dated forms
+#   like {{Media of the day|2023|2|18}}.
 _PD_USGOV_RE = re.compile(r"\{\{PD-USGov(?:-[A-Za-z0-9_-]+)?(?:\|[^{}]*)?\}\}")
 _IMAGE_EXTRACTED_RE = re.compile(r"\{\{Image extracted\|[^{}]*\}\}", re.IGNORECASE)
 _CATEGORY_RE = re.compile(r"\[\[Category:[^\]\n]+\]\]")
+_ASSESSMENT_TEMPLATE_RE = re.compile(
+    r"\{\{\s*(?:"
+    r"Media of the day"
+    r"|Picture of the day"
+    r"|Featured picture"
+    r"|Quality image"
+    r"|Valued image"
+    r"|Assessments"
+    r")\s*(?:\|[^{}]*)?\}\}",
+    re.IGNORECASE,
+)
 
 
 def merge_preserved_wikitext(existing_text: str, new_artwork: str) -> str:
@@ -606,18 +625,32 @@ def merge_preserved_wikitext(existing_text: str, new_artwork: str) -> str:
     Used when the uploader rewrites a file description after a title-drift
     move or redirect-overwrite. The new {{Artwork}} wikitext is authoritative
     for the file's description, but page-level metadata that pre-existed —
-    PD-USGov license tags, Image-extracted parent links, and category
-    membership — must survive the rewrite.
+    PD-USGov license tags, Image-extracted parent links, category
+    membership, and assessment-class templates — must survive the rewrite.
 
-    Result order:
+    Result order (matches Commons page-structure convention):
         1. new_artwork (the freshly generated {{Artwork}} block)
-        2. preserved {{PD-USGov...}} templates (license, above categories)
-        3. preserved {{Image extracted|...}} templates (above categories)
-        4. preserved [[Category:...]] links
+        2. preserved Assessment block (=={{Assessment}}== header + any
+           {{Media of the day|...}}, {{Picture of the day|...}},
+           {{Featured picture}}, {{Quality image}}, {{Valued image}},
+           or {{Assessments|...}} templates from the original)
+        3. preserved {{PD-USGov...}} templates (license, above categories)
+        4. preserved {{Image extracted|...}} templates (above categories)
+        5. preserved [[Category:...]] links
+
+    The Assessment header is emitted unconditionally when any assessment
+    template is preserved — Commons convention is that these templates
+    live under that header for proper categorisation, and an MOTD-archive
+    scraper expecting that wrapper would miss a bare template.
 
     Duplicates within each preserved group are collapsed.
     """
     parts: list[str] = [new_artwork.rstrip()]
+    assessment = list(dict.fromkeys(_ASSESSMENT_TEMPLATE_RE.findall(existing_text)))
+    if assessment:
+        parts.append("")
+        parts.append("=={{Assessment}}==")
+        parts.extend(assessment)
     for pattern in (_PD_USGOV_RE, _IMAGE_EXTRACTED_RE, _CATEGORY_RE):
         group = list(dict.fromkeys(pattern.findall(existing_text)))
         if group:

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -402,6 +402,128 @@ def test_merge_preserved_wikitext_no_metadata_returns_artwork_unchanged():
     assert result == ARTWORK + "\n"
 
 
+# ---------------------------------------------------------------------------
+# Assessment-template preservation (Media of the day, etc.)
+# ---------------------------------------------------------------------------
+
+
+def test_merge_preserved_wikitext_preserves_media_of_the_day():
+    """Regression: {{Media of the day|YEAR|MONTH|DAY}} (and the
+    `=={{Assessment}}== ` header that wraps it) must survive the metadata
+    rescue overwrite. Earlier the rescue path silently dropped the entire
+    Assessment block — observed on the May-Ling Soong Chiang address
+    file (revid 1222566342), where the file lost its MOTD designation
+    for 2023-02-18 in a title-drift rewrite.
+    """
+    existing = (
+        "== {{int:filedesc}} ==\n"
+        "{{Information |description=...|date=1943-02-18 }}\n"
+        "\n"
+        "=={{Assessment}}==\n"
+        "{{Media of the day|2023|2|18}}\n"
+        "\n"
+        "=={{int:license-header}}==\n"
+        "{{PD-USGov-Congress}}\n"
+    )
+    result = merge_preserved_wikitext(existing, ARTWORK)
+
+    # The MOTD template survives with all three date components.
+    assert "{{Media of the day|2023|2|18}}" in result
+    # The Assessment header is emitted above it (Commons convention; an
+    # MOTD-archive scraper looking for that wrapper would miss a bare
+    # template).
+    assessment_idx = result.index("=={{Assessment}}==")
+    motd_idx = result.index("{{Media of the day|2023|2|18}}")
+    assert assessment_idx < motd_idx, (
+        "Assessment header must appear above the preserved MOTD template; "
+        f"got assessment_idx={assessment_idx}, motd_idx={motd_idx}"
+    )
+    # Assessment block goes BETWEEN the artwork and the license (matches
+    # Commons page-structure convention).
+    license_idx = result.index("{{PD-USGov-Congress}}")
+    artwork_end = len(ARTWORK)
+    assert artwork_end <= assessment_idx < license_idx, (
+        "Assessment block must go after artwork and before license; "
+        f"got artwork_end={artwork_end}, assessment_idx={assessment_idx}, "
+        f"license_idx={license_idx}"
+    )
+
+
+def test_merge_preserved_wikitext_preserves_picture_of_the_day():
+    """POTD has the same shape as MOTD and must round-trip identically."""
+    existing = (
+        "== {{int:filedesc}} ==\nold description\n{{Picture of the day|2024|6|15}}\n"
+    )
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert "{{Picture of the day|2024|6|15}}" in result
+    assert "=={{Assessment}}==" in result
+
+
+def test_merge_preserved_wikitext_preserves_quality_image_featured_valued():
+    """Status templates other than the time-stamped MOTD/POTD pair —
+    {{Featured picture}}, {{Quality image}}, {{Valued image}} — must
+    survive too. They're conferred by Commons editorial processes and
+    losing them in a rescue rewrite quietly demotes the file."""
+    existing = "{{Featured picture}}\n{{Quality image}}\n{{Valued image}}\n"
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert "{{Featured picture}}" in result
+    assert "{{Quality image}}" in result
+    assert "{{Valued image}}" in result
+    # Single Assessment header for the whole block, not one per template.
+    assert result.count("=={{Assessment}}==") == 1
+
+
+def test_merge_preserved_wikitext_preserves_assessments_bundle():
+    """The {{Assessments|...}} bundle template encodes multiple statuses
+    in one call (e.g. `{{Assessments|featured=1|quality=1}}`). Must be
+    preserved with its parameters intact."""
+    existing = "{{Assessments|featured=1|quality=1|com_nom=Foo.jpg}}"
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert "{{Assessments|featured=1|quality=1|com_nom=Foo.jpg}}" in result
+
+
+def test_merge_preserved_wikitext_assessment_template_case_insensitive():
+    """Commons editors use both `{{Media of the day|...}}` and the
+    lowercase `{{media of the day|...}}` variant. Both must be picked
+    up by the preservation pattern."""
+    existing = "{{media of the day|2023|2|18}}"
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert "{{media of the day|2023|2|18}}" in result
+
+
+def test_merge_preserved_wikitext_no_assessment_header_when_no_templates():
+    """When the existing page has no assessment-class templates at all,
+    no synthetic Assessment header must be added to the rewrite.
+    Otherwise every rescue would emit a dangling header above bare
+    license templates."""
+    existing = "{{PD-USGov}}\n[[Category:Foo]]"
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert "=={{Assessment}}==" not in result
+
+
+def test_merge_preserved_wikitext_dedupes_assessment_templates():
+    """Repeated MOTD designations (rare but possible if a file was
+    featured twice) must collapse to a single entry — same dedup
+    treatment as the other preserved-content groups."""
+    existing = "{{Media of the day|2023|2|18}}\n{{Media of the day|2023|2|18}}\n"
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    assert result.count("{{Media of the day|2023|2|18}}") == 1
+
+
+def test_merge_preserved_wikitext_assessment_does_not_false_match_other_templates():
+    """The pattern must not pick up unrelated templates whose names
+    happen to share a prefix (e.g. `{{Picture of the day request|...}}`
+    is NOT the same as `{{Picture of the day|...}}` and shouldn't be
+    preserved as if it were)."""
+    existing = "{{Picture of the day request|reason=test}}"
+    result = merge_preserved_wikitext(existing, ARTWORK)
+    # The whole template should not be picked up — it's a request, not a
+    # designation. (If it WERE matched, the Assessment header would also
+    # appear.)
+    assert "{{Picture of the day request" not in result
+    assert "=={{Assessment}}==" not in result
+
+
 def test_extract_page_ordinal_multipage():
     title = "Plant Life - DPLA - 002b0f7ad761858506721b83e3370c5f (page 17).jpg"
     assert extract_page_ordinal_from_commons_title(title) == 17


### PR DESCRIPTION
## Summary

Fixes the loss reported by Commons user [RoyZuo](https://commons.wikimedia.org/wiki/User:RoyZuo) on [User talk:DPLA bot](https://commons.wikimedia.org/w/index.php?title=User_talk:DPLA_bot&diff=prev&oldid=1222775465): the May-Ling Soong Chiang address file (diff [1222566342](https://commons.wikimedia.org/w/index.php?diff=1222566342)) lost its `{{Media of the day|2023|2|18}}` designation (and the wrapping `=={{Assessment}}==` header) when the uploader rewrote its description after a title-drift move.

The rescue path already preserved licenses (`{{PD-USGov-Congress}}`), `{{Image extracted|...}}` parent links, and categories — but the Assessment block wasn't on the preservation list and silently disappeared.

## Fix

Extend `merge_preserved_wikitext` to preserve six canonical Commons assessment-class templates:

| Template | Form |
|---|---|
| `{{Media of the day\|YEAR\|MONTH\|DAY}}` | dated MOTD designation |
| `{{Picture of the day\|YEAR\|MONTH\|DAY}}` | dated POTD designation |
| `{{Featured picture}}` | FP status, optional args |
| `{{Quality image}}` | QI status, optional args |
| `{{Valued image}}` | VI status, optional args |
| `{{Assessments\|...}}` | multi-status bundle |

They're emitted under a synthesised `=={{Assessment}}==` header (Commons convention; MOTD/POTD archive scrapers look for that wrapper) and placed BETWEEN the new Artwork and the preserved license — matching the canonical Commons page-structure order:

```
== {{int:filedesc}} ==
{{ Artwork | ... }}

=={{Assessment}}==
{{Media of the day|2023|2|18}}

{{PD-USGov-Congress}}

{{Image extracted|...}}

[[Category:...]]
```

Pattern is case-insensitive (catches `{{media of the day|...}}` variants) and uses a trailing `\}\}` anchor that prevents false matches on near-name templates like `{{Picture of the day request|...}}`.

## Test plan

Eight new tests in `tests/test_wikimedia.py`:

- **`test_merge_preserved_wikitext_preserves_media_of_the_day`** — pins the actual case from RoyZuo's report: MOTD with date preserved, Assessment header emitted, block sits between artwork and license.
- **`test_merge_preserved_wikitext_preserves_picture_of_the_day`** — POTD round-trip.
- **`test_merge_preserved_wikitext_preserves_quality_image_featured_valued`** — the three bare status templates together; single Assessment header for the whole block.
- **`test_merge_preserved_wikitext_preserves_assessments_bundle`** — `{{Assessments|featured=1|quality=1|...}}` parameters survive.
- **`test_merge_preserved_wikitext_assessment_template_case_insensitive`** — `{{media of the day|...}}` lowercase variant.
- **`test_merge_preserved_wikitext_no_assessment_header_when_no_templates`** — no dangling header when there's nothing to preserve.
- **`test_merge_preserved_wikitext_dedupes_assessment_templates`** — repeated entries collapse to one (matches the existing dedup behavior of the other groups).
- **`test_merge_preserved_wikitext_assessment_does_not_false_match_other_templates`** — `{{Picture of the day request|...}}` does NOT trigger preservation.

Verified locally against the actual diff content — output matches the desired structure exactly.

- [x] ruff check / format clean
- [ ] Next title-drift rescue that touches an MOTD/POTD/FP/QI/VI file should keep its assessment metadata.

## Out of scope (for follow-up if needed)

The same diff also lost the Ukrainian translated `description` (a `{{uk|...}}` block) embedded in the original `{{Information}}` template — but that's inside a field we intentionally rewrite (the new `{{Artwork}}` provides authoritative description). Preserving multi-lingual descriptions through the rewrite is a separate, larger problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)