### PR TITLE
sdc: opportunistic structured time on P571 (self-healing migration)

### DIFF
--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -786,10 +786,21 @@ def parse_dpla_date(date_string: str) -> dict | None:
       * ``YYYY``         → precision 9 (year)
 
     Returns None for ranges (``1945-1950``), BC dates (``500 BC``), free
-    prose (``During the Gilded Age``), or any other shape — the
-    builder falls back to ``somevalue + P1932 stated-as`` for those, so
-    the original DPLA string is preserved verbatim regardless of parse
-    outcome.
+    prose (``During the Gilded Age``), era markers (``1945 AD``),
+    parenthesised forms (``(1945)``), month names (``January 1945``),
+    "before"/"after"/"between" prefixes, or any other shape that
+    leaves unrecognised text in the residue after decorator stripping
+    — the builder falls back to ``somevalue + P1932 stated-as`` for
+    those, so the original DPLA string is preserved verbatim
+    regardless of parse outcome.
+
+    Conservative-fallback contract: every regex above is anchored
+    (``^…$``), so ANY non-date text adjacent to a recognised pattern
+    forces a fallback. Decorator-stripping only removes the specific
+    markers we know how to encode as a P1480 qualifier; anything else
+    survives and breaks the regex match. There is no path where the
+    parser silently drops meaningful text and produces a false
+    precision.
 
     Year 0 returns None: proleptic Gregorian has no year 0, and
     ``datetime.date(0, …)`` would crash the calendar-arithmetic

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import datetime
 import json
 import logging
+import re
 import xml.etree.ElementTree as ET
 from collections.abc import Iterable
 from typing import Any
@@ -681,15 +682,167 @@ def _build_creator_claim(
     return claim
 
 
+_GREGORIAN_CALENDAR = "http://www.wikidata.org/entity/Q1985727"
+
+# Wikibase time-datavalue precision codes used here:
+#   8  = decade  (e.g. "1940s"        → +1940-01-01)
+#   9  = year   (e.g. "1945"          → +1945-01-01)
+#   10 = month  (e.g. "1945-06"       → +1945-06-01)
+#   11 = day    (e.g. "1945-06-07"    → +1945-06-07)
+_PRECISION_DECADE = 8
+_PRECISION_YEAR = 9
+_PRECISION_MONTH = 10
+_PRECISION_DAY = 11
+
+# DPLA decorators stripped before pattern-matching. Repeat iteratively so
+# nested forms like "[1945?]" collapse cleanly.
+_DATE_PREFIX = re.compile(
+    r"^\s*(?:circa|c\.|ca\.|approximately|approx\.|~|\[)\s*", re.IGNORECASE
+)
+_DATE_SUFFIX = re.compile(r"\s*(?:\]|\?)\s*$")
+
+_ISO_DATE = re.compile(r"^(\d{1,4})-(\d{1,2})-(\d{1,2})$")
+_YEAR_MONTH = re.compile(r"^(\d{1,4})-(\d{1,2})$")
+_DECADE = re.compile(r"^(\d{1,4})s$")
+_YEAR_ONLY = re.compile(r"^(\d{1,4})$")
+
+
+def _wikibase_time(time_str: str, precision: int) -> dict:
+    """Construct the canonical ``value`` payload for a Wikibase time
+    datavalue. ``timezone``, ``before``, ``after``, and ``calendarmodel``
+    are pinned to constants — DPLA only emits proleptic Gregorian dates
+    with no explicit uncertainty bounds, and downstream consumers
+    (notably the reconciler's comparable key) treat any drift in those
+    fields as "different claim, rewrite it" — which would churn millions
+    of statements on every re-sync.
+    """
+    return {
+        "time": time_str,
+        "precision": precision,
+        "before": 0,
+        "after": 0,
+        "timezone": 0,
+        "calendarmodel": _GREGORIAN_CALENDAR,
+    }
+
+
+def _strip_date_decorators(s: str) -> str:
+    """Iteratively strip leading 'circa'/'['/'~' and trailing ']'/'?'
+    so nested patterns ('[1945?]', 'circa [1945]') collapse cleanly."""
+    prev = None
+    while prev != s:
+        prev = s
+        s = _DATE_PREFIX.sub("", s)
+        s = _DATE_SUFFIX.sub("", s)
+    return s.strip()
+
+
+def parse_dpla_date(date_string: str) -> dict | None:
+    """Parse a DPLA display-date string into a Wikibase time-datavalue
+    ``value`` dict, or ``None`` when the input is too messy to commit
+    to a structured time.
+
+    Recognised single-date shapes (after stripping ``circa``/``c.``/
+    ``ca.``/``approximately``/brackets/trailing ``?``):
+
+      * ``YYYY-MM-DD``   → precision 11 (day)
+      * ``YYYY-MM``      → precision 10 (month)
+      * ``YYYYs``        → precision 8 (decade), accepted only when the
+                            year is decade-aligned (e.g. ``1940s``, not
+                            ``1945s``)
+      * ``YYYY``         → precision 9 (year)
+
+    Returns None for ranges (``1945-1950``), BC dates (``500 BC``), free
+    prose (``During the Gilded Age``), or any other shape — the
+    builder falls back to ``somevalue + P1932 stated-as`` for those, so
+    the original DPLA string is preserved verbatim regardless of parse
+    outcome.
+
+    Year 0 returns None: proleptic Gregorian has no year 0, and ``datetime.date(0, …)``
+    would crash the calendar-arithmetic validation below.
+
+    The shape this returns must round-trip through
+    ``tools.sdc_sync._time_comparable`` to produce the canonical key the
+    reconciler matches Commons statements against. If the
+    Wikibase-time-datavalue shape changes here, mirror the change there.
+    """
+    if not date_string:
+        return None
+    s = _strip_date_decorators(date_string.strip())
+    if not s:
+        return None
+
+    m = _ISO_DATE.match(s)
+    if m:
+        y, mo, d = int(m[1]), int(m[2]), int(m[3])
+        if y == 0:
+            return None
+        try:
+            datetime.date(y, mo, d)
+        except ValueError:
+            pass
+        else:
+            return _wikibase_time(
+                f"+{y:04d}-{mo:02d}-{d:02d}T00:00:00Z", _PRECISION_DAY
+            )
+
+    m = _YEAR_MONTH.match(s)
+    if m:
+        y, mo = int(m[1]), int(m[2])
+        if y != 0 and 1 <= mo <= 12:
+            return _wikibase_time(f"+{y:04d}-{mo:02d}-01T00:00:00Z", _PRECISION_MONTH)
+
+    m = _DECADE.match(s)
+    if m:
+        y = int(m[1])
+        # Accept only decade-aligned years so "1945s" (almost certainly a
+        # typo for "1945") doesn't quietly become decade-precision.
+        if y != 0 and y % 10 == 0:
+            return _wikibase_time(f"+{y:04d}-01-01T00:00:00Z", _PRECISION_DECADE)
+
+    m = _YEAR_ONLY.match(s)
+    if m:
+        y = int(m[1])
+        if y != 0:
+            return _wikibase_time(f"+{y:04d}-01-01T00:00:00Z", _PRECISION_YEAR)
+
+    return None
+
+
 def _build_date_claim(
     date: str,
     dpla_id: str,
     retrieval_date: datetime.date,
 ) -> dict | None:
+    """Build a P571 (inception) claim from a DPLA display-date string.
+
+    When the string parses to a structured time value, emit a value-typed
+    P571 with a ``time`` datavalue at appropriate precision. When it
+    doesn't, fall back to ``somevalue`` with the raw string in a P1932
+    (stated as) qualifier — preserves today's behavior for any date the
+    parser can't commit to.
+
+    The P1932 qualifier is ALWAYS stamped, even on the value-typed
+    branch, so the original DPLA-supplied display string is recoverable
+    by readers (and so the template module can keep rendering whatever
+    text DPLA chose, rather than re-formatting from the structured
+    value).
+
+    Idempotency note: the reconciler treats the OLD somevalue claim and
+    the NEW value-typed claim as different (their comparable keys
+    differ — the somevalue's P1932 string vs. the value-typed time
+    canonical key), so a re-sync after this change cleanly migrates the
+    Commons statement from somevalue to value-typed in one cycle
+    (old removed, new added).
+    """
     normalized = _truncate(date)
     if not normalized:
         return None
-    claim = formattedclaim("P571", "somevalue", "time", dpla_id, retrieval_date)
+    parsed = parse_dpla_date(normalized)
+    if parsed is not None:
+        claim = formattedclaim("P571", parsed, "time", dpla_id, retrieval_date)
+    else:
+        claim = formattedclaim("P571", "somevalue", "time", dpla_id, retrieval_date)
     claim["qualifiers"]["P1932"] = [_qualifier_string_snak("P1932", normalized)]
     return claim
 

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -71,6 +71,15 @@ Q_CONTRIBUTING_INSTITUTION = "Q108296919"
 Q_NARA_ITEM = "Q11723795"
 Q_NARA_FILE_UNIT = "Q59221146"
 
+# https://www.wikidata.org/wiki/Q5727902 — the canonical value for the
+# ``sourcing circumstances`` (P1480) qualifier when a date is approximate
+# (circa / c. / ca. / ~ / brackets / trailing ?). Per
+# https://www.wikidata.org/wiki/Help:Dates#Inexact_dates, this is the
+# qualifier convention for inexact dates — distinct from year/decade
+# precision, which conveys "we know the year but not the day" rather
+# than "the year itself is approximate".
+Q_CIRCA = "Q5727902"
+
 # NARA-only mappings.
 NARA_ACCESS_CODES = {
     "10031403": "Q66739888",
@@ -726,24 +735,48 @@ def _wikibase_time(time_str: str, precision: int) -> dict:
     }
 
 
-def _strip_date_decorators(s: str) -> str:
-    """Iteratively strip leading 'circa'/'['/'~' and trailing ']'/'?'
-    so nested patterns ('[1945?]', 'circa [1945]') collapse cleanly."""
+def _strip_date_decorators(s: str) -> tuple[str, bool]:
+    """Iteratively strip leading ``circa``/``c.``/``ca.``/
+    ``approximately``/``~``/``[`` and trailing ``]``/``?`` so nested
+    patterns (``[1945?]``, ``circa [1945]``) collapse cleanly.
+
+    Returns the stripped string AND a flag recording whether any
+    decorator was actually removed — the flag drives the P1480
+    qualifier the builder stamps to mark the date as approximate."""
     prev = None
+    stripped = False
     while prev != s:
         prev = s
-        s = _DATE_PREFIX.sub("", s)
-        s = _DATE_SUFFIX.sub("", s)
-    return s.strip()
+        new = _DATE_PREFIX.sub("", s)
+        new = _DATE_SUFFIX.sub("", new)
+        if new != s:
+            stripped = True
+        s = new
+    return s.strip(), stripped
 
 
 def parse_dpla_date(date_string: str) -> dict | None:
-    """Parse a DPLA display-date string into a Wikibase time-datavalue
-    ``value`` dict, or ``None`` when the input is too messy to commit
-    to a structured time.
+    """Parse a DPLA display-date string into a structured representation,
+    or ``None`` when the input is too messy to commit to a Wikibase
+    time value.
 
-    Recognised single-date shapes (after stripping ``circa``/``c.``/
-    ``ca.``/``approximately``/brackets/trailing ``?``):
+    On success returns a dict::
+
+        {
+            "value": <Wikibase time-datavalue value dict>,
+            "approximate": bool,
+        }
+
+    ``approximate`` is True when the source string carried a
+    ``circa``/``c.``/``ca.``/``approximately``/``~``/``[…]``/``?``
+    decorator. The caller stamps a ``P1480 = Q5727902`` (sourcing
+    circumstances = circa) qualifier on the claim in that case, per
+    https://www.wikidata.org/wiki/Help:Dates#Inexact_dates — distinct
+    from year/decade precision (which conveys "we know the year but
+    not the day", a different shape of uncertainty than "the year
+    itself is approximate").
+
+    Recognised single-date shapes (after decorator stripping):
 
       * ``YYYY-MM-DD``   → precision 11 (day)
       * ``YYYY-MM``      → precision 10 (month)
@@ -758,19 +791,23 @@ def parse_dpla_date(date_string: str) -> dict | None:
     the original DPLA string is preserved verbatim regardless of parse
     outcome.
 
-    Year 0 returns None: proleptic Gregorian has no year 0, and ``datetime.date(0, …)``
-    would crash the calendar-arithmetic validation below.
+    Year 0 returns None: proleptic Gregorian has no year 0, and
+    ``datetime.date(0, …)`` would crash the calendar-arithmetic
+    validation below.
 
-    The shape this returns must round-trip through
+    The ``value`` payload must round-trip through
     ``tools.sdc_sync._time_comparable`` to produce the canonical key the
     reconciler matches Commons statements against. If the
     Wikibase-time-datavalue shape changes here, mirror the change there.
     """
     if not date_string:
         return None
-    s = _strip_date_decorators(date_string.strip())
+    s, approximate = _strip_date_decorators(date_string.strip())
     if not s:
         return None
+
+    def _ok(value: dict) -> dict:
+        return {"value": value, "approximate": approximate}
 
     m = _ISO_DATE.match(s)
     if m:
@@ -782,15 +819,17 @@ def parse_dpla_date(date_string: str) -> dict | None:
         except ValueError:
             pass
         else:
-            return _wikibase_time(
-                f"+{y:04d}-{mo:02d}-{d:02d}T00:00:00Z", _PRECISION_DAY
+            return _ok(
+                _wikibase_time(f"+{y:04d}-{mo:02d}-{d:02d}T00:00:00Z", _PRECISION_DAY)
             )
 
     m = _YEAR_MONTH.match(s)
     if m:
         y, mo = int(m[1]), int(m[2])
         if y != 0 and 1 <= mo <= 12:
-            return _wikibase_time(f"+{y:04d}-{mo:02d}-01T00:00:00Z", _PRECISION_MONTH)
+            return _ok(
+                _wikibase_time(f"+{y:04d}-{mo:02d}-01T00:00:00Z", _PRECISION_MONTH)
+            )
 
     m = _DECADE.match(s)
     if m:
@@ -798,13 +837,13 @@ def parse_dpla_date(date_string: str) -> dict | None:
         # Accept only decade-aligned years so "1945s" (almost certainly a
         # typo for "1945") doesn't quietly become decade-precision.
         if y != 0 and y % 10 == 0:
-            return _wikibase_time(f"+{y:04d}-01-01T00:00:00Z", _PRECISION_DECADE)
+            return _ok(_wikibase_time(f"+{y:04d}-01-01T00:00:00Z", _PRECISION_DECADE))
 
     m = _YEAR_ONLY.match(s)
     if m:
         y = int(m[1])
         if y != 0:
-            return _wikibase_time(f"+{y:04d}-01-01T00:00:00Z", _PRECISION_YEAR)
+            return _ok(_wikibase_time(f"+{y:04d}-01-01T00:00:00Z", _PRECISION_YEAR))
 
     return None
 
@@ -828,6 +867,14 @@ def _build_date_claim(
     text DPLA chose, rather than re-formatting from the structured
     value).
 
+    When the source carried a ``circa``/``c.``/``ca.``/brackets/``?``
+    decorator (parser ``approximate`` flag), the claim also gets a
+    ``P1480 = Q5727902`` (sourcing circumstances = circa) qualifier,
+    per https://www.wikidata.org/wiki/Help:Dates#Inexact_dates. The
+    structured year-precision time + P1480 qualifier together carry the
+    "approximate" semantic into Wikidata-shaped queries; the P1932
+    qualifier still preserves the verbatim source string for display.
+
     Idempotency note: the reconciler treats the OLD somevalue claim and
     the NEW value-typed claim as different (their comparable keys
     differ — the somevalue's P1932 string vs. the value-typed time
@@ -840,7 +887,9 @@ def _build_date_claim(
         return None
     parsed = parse_dpla_date(normalized)
     if parsed is not None:
-        claim = formattedclaim("P571", parsed, "time", dpla_id, retrieval_date)
+        claim = formattedclaim("P571", parsed["value"], "time", dpla_id, retrieval_date)
+        if parsed["approximate"]:
+            claim["qualifiers"]["P1480"] = [_qualifier_item_snak("P1480", Q_CIRCA)]
     else:
         claim = formattedclaim("P571", "somevalue", "time", dpla_id, retrieval_date)
     claim["qualifiers"]["P1932"] = [_qualifier_string_snak("P1932", normalized)]

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -323,6 +323,56 @@ def test_parse_rejects_empty_and_whitespace():
     assert parse_dpla_date(None) is None
 
 
+def test_parse_falls_back_when_residue_has_unrecognised_text():
+    """Conservative-fallback contract: any text the parser can't map to
+    either a recognised precision (year/month/day/decade) OR a
+    recognised qualifier (the circa-mappable decorators) MUST cause
+    the whole parse to fall back to ``None``. Otherwise we'd silently
+    strip meaningful text (era markers, month names, parens, "before",
+    free prose adjacent to a year) and emit a structured date that
+    doesn't actually represent the source.
+
+    The builder turns ``None`` into a ``somevalue + P1932`` claim with
+    the verbatim DPLA string preserved — so the template still
+    renders the original prose. Zero false-precision risk."""
+    cases = [
+        # Era markers — not stripped, not recognised in any regex.
+        "1945 AD",
+        "AD 1945",
+        "1945 BCE",
+        # Range-y / multi-date prose.
+        "1945 or 1946",
+        "1945 and 1946",
+        "before 1945",
+        "after 1945",
+        "between 1945 and 1950",
+        # Month-name prefixes / season markers — not stripped.
+        "January 1945",
+        "Jan 1945",
+        "Spring 1945",
+        "summer 1945",
+        # Parenthesised forms — parens not in the decorator list.
+        "(1945)",
+        "1945 (uncertain)",
+        "1945 (approximate)",
+        # Recognised decorator + UNRECOGNISED residue.
+        "circa unknown",
+        "ca. summer 1945",
+        "approximately 1945-1950",
+        "[1945 to 1950]",
+        # Numeric residue that ISN'T a date.
+        "1945.5",
+        "v.1945",
+        "1945abc",
+        # Decade with trailing non-decade text.
+        "1940s and 1950s",
+    ]
+    for src in cases:
+        assert parse_dpla_date(src) is None, (
+            f"{src!r} should fall back to somevalue, not produce a structured date"
+        )
+
+
 def test_build_date_claim_emits_value_typed_when_parseable():
     """Parser succeeds, no decorators → value-typed claim, NO P1480
     qualifier (the date is definite). P1932 always carries the

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -205,9 +205,9 @@ def test_all_documented_levels_round_trip():
 
 
 def test_parse_year_only():
-    """The most common DPLA date shape."""
-    v = parse_dpla_date("1945")
-    assert v == {
+    """The most common DPLA date shape — no decorators, so not approximate."""
+    parsed = parse_dpla_date("1945")
+    assert parsed["value"] == {
         "time": "+1945-01-01T00:00:00Z",
         "precision": 9,
         "before": 0,
@@ -215,25 +215,31 @@ def test_parse_year_only():
         "timezone": 0,
         "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
     }
+    assert parsed["approximate"] is False
 
 
 def test_parse_year_month():
-    v = parse_dpla_date("1945-06")
-    assert v["time"] == "+1945-06-01T00:00:00Z"
-    assert v["precision"] == 10
+    parsed = parse_dpla_date("1945-06")
+    assert parsed["value"]["time"] == "+1945-06-01T00:00:00Z"
+    assert parsed["value"]["precision"] == 10
+    assert parsed["approximate"] is False
 
 
 def test_parse_full_iso_date():
-    v = parse_dpla_date("1945-06-07")
-    assert v["time"] == "+1945-06-07T00:00:00Z"
-    assert v["precision"] == 11
+    parsed = parse_dpla_date("1945-06-07")
+    assert parsed["value"]["time"] == "+1945-06-07T00:00:00Z"
+    assert parsed["value"]["precision"] == 11
+    assert parsed["approximate"] is False
 
 
 def test_parse_decade():
-    """1940s → precision 8 (decade), time pinned to decade-start."""
-    v = parse_dpla_date("1940s")
-    assert v["time"] == "+1940-01-01T00:00:00Z"
-    assert v["precision"] == 8
+    """``1940s`` → precision 8, time pinned to decade-start. Decade
+    precision is structural (it says "this happened in the 1940s"), NOT
+    "approximate" in the P1480 sense — so ``approximate`` stays False."""
+    parsed = parse_dpla_date("1940s")
+    assert parsed["value"]["time"] == "+1940-01-01T00:00:00Z"
+    assert parsed["value"]["precision"] == 8
+    assert parsed["approximate"] is False
 
 
 def test_parse_decade_rejects_non_decade_year():
@@ -242,25 +248,35 @@ def test_parse_decade_rejects_non_decade_year():
     assert parse_dpla_date("1945s") is None
 
 
-def test_parse_strips_circa_prefix():
-    """Structured value drops the 'circa' marker — uncertainty is
-    encoded by year precision (9), not by setting before/after."""
-    v = parse_dpla_date("circa 1945")
-    assert v["time"] == "+1945-01-01T00:00:00Z"
-    assert v["precision"] == 9
+def test_parse_circa_marks_approximate():
+    """``circa`` (and equivalents) carry uncertainty into the structured
+    claim via the ``approximate`` flag — the caller stamps
+    ``P1480 = Q5727902`` on the resulting claim."""
+    parsed = parse_dpla_date("circa 1945")
+    assert parsed["value"]["time"] == "+1945-01-01T00:00:00Z"
+    assert parsed["value"]["precision"] == 9
+    assert parsed["approximate"] is True
 
 
-def test_parse_strips_c_and_ca_prefixes():
-    assert parse_dpla_date("c. 1945")["time"] == "+1945-01-01T00:00:00Z"
-    assert parse_dpla_date("ca. 1945")["time"] == "+1945-01-01T00:00:00Z"
-    assert parse_dpla_date("approximately 1945")["time"] == "+1945-01-01T00:00:00Z"
+def test_parse_strips_c_ca_approximately_tilde_marks_approximate():
+    """All circa-equivalent prefixes set the approximate flag."""
+    for src in ("c. 1945", "ca. 1945", "approximately 1945", "approx. 1945", "~1945"):
+        parsed = parse_dpla_date(src)
+        assert parsed["value"]["time"] == "+1945-01-01T00:00:00Z", src
+        assert parsed["approximate"] is True, (
+            f"{src!r} should mark the date approximate"
+        )
 
 
-def test_parse_strips_brackets_and_question_mark():
-    """Nested decorators collapse iteratively."""
-    assert parse_dpla_date("[1945]")["time"] == "+1945-01-01T00:00:00Z"
-    assert parse_dpla_date("[1945?]")["time"] == "+1945-01-01T00:00:00Z"
-    assert parse_dpla_date("1945?")["time"] == "+1945-01-01T00:00:00Z"
+def test_parse_brackets_and_question_mark_mark_approximate():
+    """Archival convention: bracketed dates (``[1945]``) and
+    trailing-question-mark dates (``1945?``) are both inexact —
+    treat them as approximate. Nested decorators collapse
+    iteratively."""
+    for src in ("[1945]", "[1945?]", "1945?"):
+        parsed = parse_dpla_date(src)
+        assert parsed["value"]["time"] == "+1945-01-01T00:00:00Z", src
+        assert parsed["approximate"] is True, src
 
 
 def test_parse_rejects_range():
@@ -308,10 +324,9 @@ def test_parse_rejects_empty_and_whitespace():
 
 
 def test_build_date_claim_emits_value_typed_when_parseable():
-    """Parser succeeds → value-typed claim (snaktype=value + time
-    datavalue). The original DPLA string is STILL preserved in the
-    P1932 qualifier so the template module can render whatever text
-    DPLA chose rather than reformatting from the structured value."""
+    """Parser succeeds, no decorators → value-typed claim, NO P1480
+    qualifier (the date is definite). P1932 always carries the
+    original DPLA string."""
     import datetime as _dt
 
     claim = _build_date_claim("1945", "abc123", _dt.date(2026, 6, 7))
@@ -319,6 +334,53 @@ def test_build_date_claim_emits_value_typed_when_parseable():
     assert claim["mainsnak"]["datavalue"]["type"] == "time"
     assert claim["mainsnak"]["datavalue"]["value"]["precision"] == 9
     assert claim["qualifiers"]["P1932"][0]["datavalue"]["value"] == "1945"
+    assert "P1480" not in claim["qualifiers"]
+
+
+def test_build_date_claim_stamps_p1480_for_circa():
+    """Parser flagged the date as approximate → claim gets a P1480
+    qualifier with value Q5727902 (circa), per Wikidata Help:Dates
+    convention for inexact dates. The structured time value AND the
+    P1480 marker together represent "around 1945" in a Wikidata-shaped
+    way; P1932 still carries the verbatim source string."""
+    import datetime as _dt
+
+    claim = _build_date_claim("circa 1945", "abc123", _dt.date(2026, 6, 7))
+    assert claim["mainsnak"]["snaktype"] == "value"
+    assert claim["mainsnak"]["datavalue"]["value"]["precision"] == 9
+    # P1932 preserves the verbatim source decoration.
+    assert claim["qualifiers"]["P1932"][0]["datavalue"]["value"] == "circa 1945"
+    # P1480 = Q5727902 (circa). _item_value uses numeric-id encoding.
+    p1480 = claim["qualifiers"]["P1480"][0]
+    assert p1480["property"] == "P1480"
+    assert p1480["datavalue"]["type"] == "wikibase-entityid"
+    assert p1480["datavalue"]["value"]["numeric-id"] == 5727902
+    assert p1480["datavalue"]["value"]["entity-type"] == "item"
+
+
+def test_build_date_claim_stamps_p1480_for_bracketed_and_question_mark():
+    """Brackets and trailing ? both indicate inexact dates → P1480."""
+    import datetime as _dt
+
+    for src in ("[1945]", "1945?", "[1945?]"):
+        claim = _build_date_claim(src, "abc123", _dt.date(2026, 6, 7))
+        assert "P1480" in claim["qualifiers"], (
+            f"{src!r} should produce a P1480 qualifier"
+        )
+        assert (
+            claim["qualifiers"]["P1480"][0]["datavalue"]["value"]["numeric-id"]
+            == 5727902
+        ), src
+
+
+def test_build_date_claim_no_p1480_for_decade():
+    """Decade precision is structural, not "approximate" in the P1480
+    sense — ``1940s`` stays without P1480."""
+    import datetime as _dt
+
+    claim = _build_date_claim("1940s", "abc123", _dt.date(2026, 6, 7))
+    assert claim["mainsnak"]["datavalue"]["value"]["precision"] == 8
+    assert "P1480" not in claim["qualifiers"]
 
 
 def test_build_date_claim_falls_back_to_somevalue_when_unparseable():

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -17,6 +17,8 @@ from ingest_wikimedia.sdc import (
     NARA_LEVELS,
     Q_NARA_FILE_UNIT,
     Q_NARA_ITEM,
+    _build_date_claim,
+    parse_dpla_date,
     parse_nara_access_level,
 )
 
@@ -192,3 +194,149 @@ def test_all_documented_levels_round_trip():
         assert level == expected_qid, (
             f"root {lvl_key} expected {expected_qid}, got {level}"
         )
+
+
+# ---------------------------------------------------------------------------
+# parse_dpla_date — opportunistic structured time extraction from DPLA's
+# free-text displayDate strings. A None return is a feature: the claim
+# builder falls back to somevalue + P1932 stated-as, preserving the
+# original DPLA prose for the wiki template to render verbatim.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_year_only():
+    """The most common DPLA date shape."""
+    v = parse_dpla_date("1945")
+    assert v == {
+        "time": "+1945-01-01T00:00:00Z",
+        "precision": 9,
+        "before": 0,
+        "after": 0,
+        "timezone": 0,
+        "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
+    }
+
+
+def test_parse_year_month():
+    v = parse_dpla_date("1945-06")
+    assert v["time"] == "+1945-06-01T00:00:00Z"
+    assert v["precision"] == 10
+
+
+def test_parse_full_iso_date():
+    v = parse_dpla_date("1945-06-07")
+    assert v["time"] == "+1945-06-07T00:00:00Z"
+    assert v["precision"] == 11
+
+
+def test_parse_decade():
+    """1940s → precision 8 (decade), time pinned to decade-start."""
+    v = parse_dpla_date("1940s")
+    assert v["time"] == "+1940-01-01T00:00:00Z"
+    assert v["precision"] == 8
+
+
+def test_parse_decade_rejects_non_decade_year():
+    """``1945s`` is almost certainly a typo for ``1945``. Refuse to
+    silently coerce it to decade precision."""
+    assert parse_dpla_date("1945s") is None
+
+
+def test_parse_strips_circa_prefix():
+    """Structured value drops the 'circa' marker — uncertainty is
+    encoded by year precision (9), not by setting before/after."""
+    v = parse_dpla_date("circa 1945")
+    assert v["time"] == "+1945-01-01T00:00:00Z"
+    assert v["precision"] == 9
+
+
+def test_parse_strips_c_and_ca_prefixes():
+    assert parse_dpla_date("c. 1945")["time"] == "+1945-01-01T00:00:00Z"
+    assert parse_dpla_date("ca. 1945")["time"] == "+1945-01-01T00:00:00Z"
+    assert parse_dpla_date("approximately 1945")["time"] == "+1945-01-01T00:00:00Z"
+
+
+def test_parse_strips_brackets_and_question_mark():
+    """Nested decorators collapse iteratively."""
+    assert parse_dpla_date("[1945]")["time"] == "+1945-01-01T00:00:00Z"
+    assert parse_dpla_date("[1945?]")["time"] == "+1945-01-01T00:00:00Z"
+    assert parse_dpla_date("1945?")["time"] == "+1945-01-01T00:00:00Z"
+
+
+def test_parse_rejects_range():
+    """``1945-1950`` is a range, not a single date. Wikibase has no
+    canonical single-time representation; fall back to somevalue+P1932
+    so the original string is preserved."""
+    assert parse_dpla_date("1945-1950") is None
+
+
+def test_parse_rejects_free_prose():
+    """The single biggest motivation for the somevalue fallback — DPLA
+    carries a long tail of un-coercable date strings that must still
+    surface in the template."""
+    assert parse_dpla_date("During the Gilded Age") is None
+    assert parse_dpla_date("could not be determined") is None
+    assert parse_dpla_date("unknown") is None
+
+
+def test_parse_rejects_year_zero():
+    """Proleptic Gregorian has no year zero; defensive guard."""
+    assert parse_dpla_date("0") is None
+    assert parse_dpla_date("0000") is None
+
+
+def test_parse_rejects_bc_year():
+    """BC years are out of the year-only regex's scope — fall back so
+    the original string survives. Could be added later if a hub
+    needs it."""
+    assert parse_dpla_date("-500") is None
+    assert parse_dpla_date("500 BC") is None
+
+
+def test_parse_rejects_invalid_iso_date():
+    """``datetime.date`` validation catches Feb 30 / month > 12; the
+    less-precise regexes don't accept this shape either, so the
+    result is None — not a silent fallback to a coarser precision."""
+    assert parse_dpla_date("2024-02-30") is None
+    assert parse_dpla_date("2024-13-01") is None
+
+
+def test_parse_rejects_empty_and_whitespace():
+    assert parse_dpla_date("") is None
+    assert parse_dpla_date("   ") is None
+    assert parse_dpla_date(None) is None
+
+
+def test_build_date_claim_emits_value_typed_when_parseable():
+    """Parser succeeds → value-typed claim (snaktype=value + time
+    datavalue). The original DPLA string is STILL preserved in the
+    P1932 qualifier so the template module can render whatever text
+    DPLA chose rather than reformatting from the structured value."""
+    import datetime as _dt
+
+    claim = _build_date_claim("1945", "abc123", _dt.date(2026, 6, 7))
+    assert claim["mainsnak"]["snaktype"] == "value"
+    assert claim["mainsnak"]["datavalue"]["type"] == "time"
+    assert claim["mainsnak"]["datavalue"]["value"]["precision"] == 9
+    assert claim["qualifiers"]["P1932"][0]["datavalue"]["value"] == "1945"
+
+
+def test_build_date_claim_falls_back_to_somevalue_when_unparseable():
+    """somevalue + P1932 fallback preserves DPLA's exact prose."""
+    import datetime as _dt
+
+    claim = _build_date_claim("During the Gilded Age", "abc123", _dt.date(2026, 6, 7))
+    assert claim["mainsnak"]["snaktype"] == "somevalue"
+    assert "datavalue" not in claim["mainsnak"]
+    assert (
+        claim["qualifiers"]["P1932"][0]["datavalue"]["value"] == "During the Gilded Age"
+    )
+
+
+def test_build_date_claim_returns_none_for_empty_input():
+    """Matches the pre-existing contract so the caller's
+    ``if c is not None`` loop short-circuits cleanly."""
+    import datetime as _dt
+
+    assert _build_date_claim("", "abc123", _dt.date(2026, 6, 7)) is None
+    assert _build_date_claim("   ", "abc123", _dt.date(2026, 6, 7)) is None

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1730,3 +1730,146 @@ def test_extract_comparable_value_returns_none_for_malformed_time():
         "references": [_dpla_reference()],
     }
     assert sdc_sync._extract_comparable_value(broken_claim) is None
+
+
+# ---------------------------------------------------------------------------
+# Circa-bit propagation in the comparable key (CodeRabbit Major finding):
+# without including P1480 presence in the comparable, a DPLA source-string
+# change "1945" ↔ "circa 1945" doesn't trigger the reconciler to add or
+# remove the P1480 qualifier on the existing Commons claim. The
+# _time_claim_comparable wrapper adds a "|circa" suffix when the claim
+# carries P1480 = Q5727902 so the two shapes have distinct identities.
+# ---------------------------------------------------------------------------
+
+
+def _value_typed_p571_with_circa(stmt_id, time_str, precision, stated_as):
+    """Build a value-typed P571 claim WITH the P1480 = Q5727902 (circa)
+    qualifier — the shape the new builder emits for approximate dates."""
+    claim = _value_typed_p571_claim(stmt_id, time_str, precision, stated_as)
+    claim["qualifiers"]["P1480"] = _qual_entity("P1480", "Q5727902")
+    return claim
+
+
+def test_circa_bit_distinguishes_otherwise_identical_claims():
+    """A circa-qualified and a definite claim with the SAME underlying
+    time + precision must produce DIFFERENT comparable keys, so the
+    reconciler can detect the migration in either direction."""
+    from tools import sdc_sync
+
+    plain = _value_typed_p571_claim("M$plain", "+1945-01-01T00:00:00Z", 9, "1945")
+    circa = _value_typed_p571_with_circa(
+        "M$circa", "+1945-01-01T00:00:00Z", 9, "circa 1945"
+    )
+
+    plain_key = sdc_sync._time_claim_comparable(plain)
+    circa_key = sdc_sync._time_claim_comparable(circa)
+
+    assert plain_key == "+1945-01-01T00:00:00Z|P9"
+    assert circa_key == "+1945-01-01T00:00:00Z|P9|circa"
+    assert plain_key != circa_key
+
+
+def test_reconciler_migrates_plain_to_circa_when_dpla_adds_decorator(monkeypatch):
+    """DPLA changes ``"1945"`` → ``"circa 1945"`` on a previously-migrated
+    item. The new sdc.json's expected key carries ``|circa``; the
+    existing Commons claim's comparable doesn't. Reconciler queues the
+    old (no-P1480) for removal so the new (with-P1480) can take its
+    place. Without the circa-bit in the comparable, both shapes
+    matched and the migration silently stalled — the bug CodeRabbit
+    flagged."""
+    from tools import sdc_sync
+
+    new_claim = _value_typed_p571_with_circa(
+        "M$NEW", "+1945-01-01T00:00:00Z", 9, "circa 1945"
+    )
+    expected = sdc_sync._build_expected_from_sdc({"claims": [new_claim]})
+    assert expected == {"P571": ["+1945-01-01T00:00:00Z|P9|circa"]}
+
+    on_commons = _value_typed_p571_claim(
+        "M999$EXACT", "+1945-01-01T00:00:00Z", 9, "1945"
+    )
+    entity = {"pageid": 999, "statements": {"P571": [on_commons]}}
+
+    submit_calls = []
+
+    def fake_submit(action, mediaid, dpla_id, **params):
+        submit_calls.append((action, params.get("claim")))
+
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(sdc_sync, "_submit_sdc_write", side_effect=fake_submit),
+    ):
+        sdc_sync._reconcile_existing_claims(
+            "M999", "abc1234567890abcdef1234567890abcd", expected
+        )
+
+    assert submit_calls == [("wbremoveclaims", "M999$EXACT")], submit_calls
+
+
+def test_check_time_kind_treats_circa_and_exact_as_distinct():
+    """``check()``'s time branch uses the circa-bit too. An exact claim
+    on Commons does NOT match a circa target — so the new circa
+    claim gets added, and the exact one gets reconciled away."""
+    from tools import sdc_sync
+
+    exact_on_commons = _value_typed_p571_claim(
+        "M999$EXACT", "+1945-01-01T00:00:00Z", 9, "1945"
+    )
+    entity = {"pageid": 999, "statements": {"P571": [exact_on_commons]}}
+
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        result = sdc_sync.check(
+            "M999", ("time", "+1945-01-01T00:00:00Z|P9|circa"), "P571"
+        )
+
+    # True = "add the new claim alongside" — the exact claim doesn't
+    # collide with the circa claim now.
+    assert result[0] is True
+
+
+# ---------------------------------------------------------------------------
+# Legacy `_build_expected_from_parsed` must protect BOTH shapes for P571
+# (CodeRabbit Major finding): otherwise a legacy --file/--cat/--list
+# rerun against a file that partner mode has migrated to value-typed
+# time would see the migrated claim's canonical comparable as
+# "unexpected" and queue it for removal.
+# ---------------------------------------------------------------------------
+
+
+def test_build_expected_from_parsed_includes_both_shapes_for_p571():
+    """The legacy expected map's P571 entry must include the raw
+    display-date string (for unmigrated somevalue+P1932 claims) AND
+    the canonical time-comparable key for the parseable subset (for
+    migrated value-typed claims), so a rerun after partner-mode
+    migration doesn't strip the migrated claim."""
+    from tools import sdc_sync
+
+    expected = sdc_sync._build_expected_from_parsed(
+        dpla_id="abcdef",
+        url="http://example.com/x",
+        descs=[],
+        dates=["1945", "circa 1929-10", "During the Gilded Age"],
+        titles=[],
+        hub="Q1",
+        local_ids=[],
+        institution="Q2",
+        rs="",
+        creators=[],
+        subjects=[],
+        naids=[],
+        access="",
+        level="",
+    )
+    p571 = expected["P571"]
+    # Raw strings preserved for old-shape somevalue+P1932 protection.
+    assert "1945" in p571
+    assert "circa 1929-10" in p571
+    assert "During the Gilded Age" in p571
+    # Canonical time keys added for the parseable subset.
+    assert "+1945-01-01T00:00:00Z|P9" in p571
+    assert "+1929-10-01T00:00:00Z|P10|circa" in p571
+    # Unparseable date contributes only the raw string (no canonical key).
+    canonical_keys = [v for v in p571 if v.startswith("+")]
+    # 2 parseables → exactly 2 canonical entries.
+    assert len(canonical_keys) == 2

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1676,6 +1676,41 @@ def test_reconciler_queues_removal_for_malformed_commons_time_value():
     assert submit_calls == [("wbremoveclaims", "M999$BORK")], submit_calls
 
 
+def test_check_time_kind_does_not_crash_on_malformed_commons_value():
+    """A Commons statement with snaktype=value and dtype=time but a
+    malformed value dict (missing ``precision``) must not crash
+    ``check()``. The KeyError would otherwise propagate past
+    ``process_one_from_sdc``'s APIError-only handler, abort the entire
+    ordinal, and prevent ``_reconcile_existing_claims`` from cleaning up
+    the malformed statement.
+
+    Expected behavior: ``check()`` treats the malformed statement as
+    non-matching, returns True (add the new claim), and the reconciler's
+    own defensive guard later queues the malformed statement for
+    removal."""
+    from tools import sdc_sync
+
+    malformed_stmt = {
+        "id": "M999$BORK",
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P571",
+            # datavalue type is "time" but inner value is missing "precision"
+            "datavalue": {"value": {"time": "+1945-01-01T00:00:00Z"}, "type": "time"},
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [_dpla_reference()],
+    }
+    entity = {"pageid": 999, "statements": {"P571": [malformed_stmt]}}
+
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        result = sdc_sync.check("M999", ("time", "+1945-01-01T00:00:00Z|P9"), "P571")
+
+    assert result[0] is True
+
+
 def test_extract_comparable_value_returns_none_for_malformed_time():
     """Parallel guard on the sdc.json side. If _wikibase_time ever
     regresses or a hand-crafted fixture omits a field, build_expected_from_sdc

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1837,13 +1837,19 @@ def test_check_time_kind_treats_circa_and_exact_as_distinct():
 # ---------------------------------------------------------------------------
 
 
-def test_build_expected_from_parsed_includes_both_shapes_for_p571():
+def test_build_expected_from_parsed_includes_both_shapes_for_p571(monkeypatch):
     """The legacy expected map's P571 entry must include the raw
     display-date string (for unmigrated somevalue+P1932 claims) AND
     the canonical time-comparable key for the parseable subset (for
     migrated value-typed claims), so a rerun after partner-mode
     migration doesn't strip the migrated claim."""
     from tools import sdc_sync
+
+    # `_build_expected_from_parsed` reads the module-global ``rights``
+    # (populated by ``_initialize()`` in production). Pin it explicitly
+    # so this test is self-contained — passes when run in isolation,
+    # under reordering, or under pytest-randomly.
+    monkeypatch.setattr(sdc_sync, "rights", {}, raising=False)
 
     expected = sdc_sync._build_expected_from_parsed(
         dpla_id="abcdef",

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1385,3 +1385,313 @@ def test_initialize_pins_pywikibot_retry_budget(monkeypatch, tmp_path):
     assert pywikibot.config.max_retries == sdc_sync._PYWIKIBOT_MAX_RETRIES
     assert pywikibot.config.retry_wait == sdc_sync._PYWIKIBOT_RETRY_WAIT
     assert pywikibot.config.retry_max == sdc_sync._PYWIKIBOT_RETRY_MAX
+
+
+# ---------------------------------------------------------------------------
+# Opportunistic date parsing — time-typed P571 claims and the migration
+# from old somevalue+P1932 statements. The reconciler/check side has to
+# treat the canonical (time, precision) key as DIFFERENT from any P1932
+# string so a re-sync after the parser ships removes the old somevalue
+# claim and adds the new value-typed one in a single cycle.
+# ---------------------------------------------------------------------------
+
+
+def _time_value(time_str, precision):
+    """Build a Wikibase time-datavalue ``value`` dict for tests."""
+    return {
+        "time": time_str,
+        "precision": precision,
+        "before": 0,
+        "after": 0,
+        "timezone": 0,
+        "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
+    }
+
+
+def _value_typed_p571_claim(stmt_id, time_str, precision, stated_as):
+    """Construct a value-typed P571 claim (the new shape) for tests."""
+    return {
+        "id": stmt_id,
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P571",
+            "datavalue": {"value": _time_value(time_str, precision), "type": "time"},
+        },
+        "qualifiers": {
+            "P459": _dpla_p459(),
+            "P1932": _qual_string("P1932", stated_as),
+        },
+        "references": [_dpla_reference()],
+    }
+
+
+def _somevalue_p571_claim(stmt_id, stated_as):
+    """Construct an old-shape P571 claim (somevalue + P1932) for tests."""
+    return _stmt(
+        stmt_id=stmt_id,
+        prop="P571",
+        snaktype="somevalue",
+        value=None,
+        qualifiers={
+            "P459": _dpla_p459(),
+            "P1932": _qual_string("P1932", stated_as),
+        },
+        references=[_dpla_reference()],
+    )
+
+
+def test_time_comparable_uses_only_time_and_precision():
+    """``timezone``, ``before``, ``after``, ``calendarmodel`` are constants
+    in DPLA's writes; including them in the comparable key would
+    silently churn statements on every re-sync if any drift crept in."""
+    from tools import sdc_sync
+
+    v = _time_value("+1945-01-01T00:00:00Z", 9)
+    assert sdc_sync._time_comparable(v) == "+1945-01-01T00:00:00Z|P9"
+
+
+def test_time_comparable_distinguishes_precision():
+    """Same time, different precision → different comparable. ``1945``
+    (year) and ``1945-01-01`` (day) must NOT collapse to the same key —
+    they're different facts about the same item."""
+    from tools import sdc_sync
+
+    year = sdc_sync._time_comparable(_time_value("+1945-01-01T00:00:00Z", 9))
+    day = sdc_sync._time_comparable(_time_value("+1945-01-01T00:00:00Z", 11))
+    assert year != day
+
+
+def test_extract_comparable_value_handles_value_typed_time():
+    """``_extract_comparable_value`` must produce the same canonical key
+    for sdc.json-side claims as the reconciler extracts from Commons
+    statements; otherwise expected/observed never line up and the
+    reconciler removes valid claims (or fails to remove stale ones)."""
+    from tools import sdc_sync
+
+    claim = _value_typed_p571_claim("Z$1", "+1945-01-01T00:00:00Z", 9, "1945")
+    assert sdc_sync._extract_comparable_value(claim) == "+1945-01-01T00:00:00Z|P9"
+
+
+def test_extract_comparable_value_still_handles_somevalue_p571():
+    """Backward-compatibility: existing somevalue+P1932 claims (still on
+    Commons until the migration completes) continue to compare by the
+    P1932 stated-as string."""
+    from tools import sdc_sync
+
+    claim = _somevalue_p571_claim("Z$2", "During the Gilded Age")
+    assert sdc_sync._extract_comparable_value(claim) == "During the Gilded Age"
+
+
+def test_reconciler_migrates_old_somevalue_to_new_value_typed(monkeypatch):
+    """End-to-end idempotency check the user called out explicitly:
+
+      * Commons currently holds the OLD somevalue+P1932="1945" claim
+        (DPLA-authored from a prior healthy run).
+      * The new sdc.json holds a value-typed P571 with the same
+        underlying date.
+      * The reconciler MUST queue the old somevalue claim for removal
+        (its comparable string "1945" is not in expected[P571], which
+        now carries the canonical time key).
+      * The matching ADD side (``_post_new_claims``) handles inserting
+        the new value-typed claim; the reconciler's job is purely to
+        clean up the stale half.
+
+    One reconcile cycle migrates the file cleanly without leaving a
+    duplicate date statement on Commons."""
+    from tools import sdc_sync
+
+    # sdc.json's expected map (built from a value-typed P571 claim).
+    new_claim = _value_typed_p571_claim(
+        "WILL_BE_FRESH$1", "+1945-01-01T00:00:00Z", 9, "1945"
+    )
+    expected = sdc_sync._build_expected_from_sdc({"claims": [new_claim]})
+    assert expected == {"P571": ["+1945-01-01T00:00:00Z|P9"]}
+
+    # Commons-side state: the OLD somevalue+P1932="1945" claim.
+    stale_old = _somevalue_p571_claim("M999$OLD", "1945")
+    entity = {"pageid": 999, "statements": {"P571": [stale_old]}}
+
+    submit_calls = []
+
+    def fake_submit(action, mediaid, dpla_id, **params):
+        submit_calls.append((action, params.get("claim")))
+
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(sdc_sync, "_submit_sdc_write", side_effect=fake_submit),
+    ):
+        sdc_sync._reconcile_existing_claims(
+            "M999", "abc1234567890abcdef1234567890abcd", expected
+        )
+
+    assert submit_calls == [("wbremoveclaims", "M999$OLD")], submit_calls
+
+
+def test_reconciler_leaves_value_typed_claim_alone_when_unchanged(monkeypatch):
+    """No-op after migration: a value-typed P571 on Commons matches the
+    same canonical key in expected, so the reconciler doesn't queue any
+    removal."""
+    from tools import sdc_sync
+
+    new_claim = _value_typed_p571_claim(
+        "WILL_BE_FRESH$1", "+1945-01-01T00:00:00Z", 9, "1945"
+    )
+    expected = sdc_sync._build_expected_from_sdc({"claims": [new_claim]})
+
+    on_commons = _value_typed_p571_claim(
+        "M999$LIVE", "+1945-01-01T00:00:00Z", 9, "1945"
+    )
+    entity = {"pageid": 999, "statements": {"P571": [on_commons]}}
+
+    submit_calls = []
+
+    def fake_submit(*a, **k):
+        submit_calls.append((a, k))
+
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(sdc_sync, "_submit_sdc_write", side_effect=fake_submit),
+    ):
+        sdc_sync._reconcile_existing_claims(
+            "M999", "abc1234567890abcdef1234567890abcd", expected
+        )
+
+    assert submit_calls == []
+
+
+def test_reconciler_removes_value_typed_claim_when_dpla_dropped_the_date(monkeypatch):
+    """When DPLA drops a date (sdc.json no longer carries that P571 at
+    all), the reconciler must clean up the prior value-typed claim too
+    — same contract as for somevalue claims. Regression guard against
+    the dtype=time branch in the value-side extraction loop being
+    forgotten."""
+    from tools import sdc_sync
+
+    # New sdc.json has NO P571 claim at all.
+    expected = sdc_sync._build_expected_from_sdc({"claims": []})
+    assert expected == {}
+
+    stale_live = _value_typed_p571_claim(
+        "M999$STALE", "+1945-01-01T00:00:00Z", 9, "1945"
+    )
+    entity = {"pageid": 999, "statements": {"P571": [stale_live]}}
+
+    submit_calls = []
+
+    def fake_submit(action, mediaid, dpla_id, **params):
+        submit_calls.append((action, params.get("claim")))
+
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(sdc_sync, "_submit_sdc_write", side_effect=fake_submit),
+    ):
+        sdc_sync._reconcile_existing_claims(
+            "M999", "abc1234567890abcdef1234567890abcd", expected
+        )
+
+    assert submit_calls == [("wbremoveclaims", "M999$STALE")], submit_calls
+
+
+def test_check_time_kind_recognises_existing_value_typed_match():
+    """When the new sdc.json's value-typed P571 already exists on
+    Commons with the same canonical key AND is DPLA-authored,
+    ``check()`` returns ``(False, ref)`` — i.e. "don't re-add". The
+    no-op behavior after migration relies on this."""
+    from tools import sdc_sync
+
+    existing = _value_typed_p571_claim("M999$LIVE", "+1945-01-01T00:00:00Z", 9, "1945")
+    entity = {"pageid": 999, "statements": {"P571": [existing]}}
+
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        result = sdc_sync.check("M999", ("time", "+1945-01-01T00:00:00Z|P9"), "P571")
+
+    assert result == (False, "")
+
+
+def test_check_time_kind_does_not_match_old_somevalue_claim():
+    """The migration relies on this: the new value-typed claim is added
+    even when an OLD somevalue+P1932 claim exists for the same date
+    (so ``_post_new_claims`` runs first to insert the new shape;
+    ``_reconcile_existing_claims`` then removes the old)."""
+    from tools import sdc_sync
+
+    old_somevalue = _somevalue_p571_claim("M999$OLD", "1945")
+    entity = {"pageid": 999, "statements": {"P571": [old_somevalue]}}
+
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        result = sdc_sync.check("M999", ("time", "+1945-01-01T00:00:00Z|P9"), "P571")
+
+    # First element True = "go ahead and add the new claim".
+    assert result[0] is True
+
+
+def test_reconciler_queues_removal_for_malformed_commons_time_value():
+    """Defensive: a community editor (or partial import) could leave a P571
+    statement with snaktype=value, type=time, but a value dict missing
+    ``time`` or ``precision``. Without the guard, ``_time_comparable``
+    raises KeyError, the for-loop unwinds, and the WHOLE reconciler
+    crashes for this file (and — in a fresh process — silently leaves
+    the remaining files in the batch unreconciled).
+
+    With the guard, the malformed statement is queued for removal
+    (matching the somevalue-missing-qualifier branch's behavior), the
+    loop continues, and the rest of the reconciler runs."""
+    from tools import sdc_sync
+
+    expected = {"P571": ["+1945-01-01T00:00:00Z|P9"]}
+    malformed_stmt = {
+        "id": "M999$BORK",
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P571",
+            # datavalue type is "time" but the inner value is missing "precision"
+            "datavalue": {"value": {"time": "+1945-01-01T00:00:00Z"}, "type": "time"},
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [_dpla_reference()],
+    }
+    entity = {"pageid": 999, "statements": {"P571": [malformed_stmt]}}
+
+    submit_calls = []
+
+    def fake_submit(action, mediaid, dpla_id, **params):
+        submit_calls.append((action, params.get("claim")))
+
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(sdc_sync, "_submit_sdc_write", side_effect=fake_submit),
+    ):
+        sdc_sync._reconcile_existing_claims(
+            "M999", "abc1234567890abcdef1234567890abcd", expected
+        )
+
+    assert submit_calls == [("wbremoveclaims", "M999$BORK")], submit_calls
+
+
+def test_extract_comparable_value_returns_none_for_malformed_time():
+    """Parallel guard on the sdc.json side. If _wikibase_time ever
+    regresses or a hand-crafted fixture omits a field, build_expected_from_sdc
+    must skip the broken claim rather than crash the whole expected-map
+    construction."""
+    from tools import sdc_sync
+
+    broken_claim = {
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P571",
+            "datavalue": {"value": {"time": "+1945-01-01T00:00:00Z"}, "type": "time"},
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [_dpla_reference()],
+    }
+    assert sdc_sync._extract_comparable_value(broken_claim) is None

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -444,13 +444,16 @@ def invalidate_entity(mediaid):
 #
 # Keep this aligned with the add_* functions in this file:
 #   * add_creator (P170)        — P2093 (author name string)
-#   * add_date (P571)           — P1932 (stated as)
+#   * add_date (P571)           — P1932 (stated as), P1480 (circa marker
+#                                  when the source carried a
+#                                  circa/[]/?/~/c./ca./approximately
+#                                  decorator)
 #   * add_contributed (P9126)   — P3831 (object has role)
 #   * add_local_id (P217)       — P195 (collection)
 #   * add_source (P7482)        — P973 (described at URL), P137 (operator)
 _DPLA_EXTRA_QUALIFIER_PROPS = {
     "P170": {"P2093"},
-    "P571": {"P1932"},
+    "P571": {"P1932", "P1480"},
     "P9126": {"P3831"},
     "P217": {"P195"},
     "P7482": {"P973", "P137"},

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -703,6 +703,59 @@ def check(mediaid, qid, prop):
                 return True, ref
         except KeyError:
             return True, ref
+    if qid[0] == "time":
+        # Mirrors the item/string/somevalue branches above for value-typed
+        # time claims (P571 when ``parse_dpla_date`` succeeded). Compares
+        # canonical (time, precision) keys via ``_time_comparable``.
+        #
+        # A Commons statement with the OLD somevalue+P1932 shape does NOT
+        # match here, so the new value-typed claim is added; the
+        # corresponding old somevalue claim will be queued for removal by
+        # ``_reconcile_existing_claims`` (its P1932 string isn't in
+        # ``expected`` once the sdc.json carries the value-typed
+        # equivalent). One reconcile cycle migrates the file from old to
+        # new without leaving the date duplicated.
+        target = qid[1]
+
+        def _statement_value_time_matches(statement) -> bool:
+            if statement["mainsnak"].get("snaktype") != "value":
+                return False
+            dv = statement["mainsnak"].get("datavalue") or {}
+            if dv.get("type") != "time":
+                return False
+            return _time_comparable(dv["value"]) == target
+
+        for statement in statements:
+            if (
+                _statement_value_time_matches(statement)
+                and not statement.get("references")
+                and _is_safe_to_amend_in_place(statement, prop)
+            ):
+                ref = statement["id"]
+                break
+        for statement in statements:
+            if _statement_value_time_matches(statement) and not statement.get(
+                "qualifiers"
+            ):
+                return add_det(mediaid, statement["id"]), ref
+
+        if any(
+            _statement_value_time_matches(statement)
+            and _is_safe_to_amend_in_place(statement, prop)
+            for statement in statements
+        ):
+            print(
+                f" -- There already exists a DPLA-authored statement with a {prop} > {target} claim for {mediaid}."
+            )
+            return False, ref
+
+        if any(_statement_value_time_matches(statement) for statement in statements):
+            print(
+                f" -- A foreign {prop} > {target} statement exists for {mediaid}; adding the DPLA-authored statement alongside."
+            )
+            return True, ""
+
+        return True, ref
     if qid[0] == "source":
         try:
             if any(
@@ -1245,7 +1298,7 @@ def add_ref(claimid, claim):
 
 
 def _check_kind_for_claim(claim):
-    """Return the 'kind' tag (item|string|monolingualtext|somevalue|source)
+    """Return the 'kind' tag (item|string|monolingualtext|somevalue|source|time)
     that `check()` uses to dispatch its per-type matcher against existing
     Commons statements.
     """
@@ -1263,6 +1316,26 @@ def _check_kind_for_claim(claim):
     return dtype
 
 
+def _time_comparable(value):
+    """Canonical comparable key for a Wikibase time datavalue.
+
+    Used wherever a P571 (or other time-typed) claim's value needs to
+    compare equal to another for "is this the same fact?" purposes.
+    Includes only the salient identity fields — ``time`` and
+    ``precision``. ``timezone``, ``before``, ``after``, and
+    ``calendarmodel`` are constants in DPLA's writes; any drift in
+    those would have been a user-edit, and ``_is_safe_to_amend_in_place``
+    keeps user-edited statements out of this code path anyway.
+
+    Distinct from any P1932 stated-as string a somevalue claim could
+    produce, so the migration from ``somevalue+P1932="1945"`` to a
+    value-typed ``time("+1945-01-01T00:00:00Z", precision=9)`` is
+    correctly detected as a different fact by the reconciler
+    (old removed, new added in one cycle).
+    """
+    return f"{value['time']}|P{value['precision']}"
+
+
 def _extract_comparable_value(claim):
     """Pull the comparable scalar value out of a precomputed sdc.json claim.
 
@@ -1272,6 +1345,7 @@ def _extract_comparable_value(claim):
       * Q-ID string for wikibase-entityid (e.g. "Q19652")
       * the raw string for string-typed claims (P760, P217, etc.)
       * the text body for monolingualtext claims (P1476, P10358)
+      * the canonical time key for time-typed claims (P571 when parseable)
       * the P1932/P2093 qualifier value for somevalue claims (P571, P170)
       * the P973 qualifier value for the P7482 source-catalog claim
       * None when the claim shape isn't one we know how to compare
@@ -1302,6 +1376,15 @@ def _extract_comparable_value(claim):
         return datavalue["value"]
     if dtype == "monolingualtext":
         return datavalue["value"]["text"]
+    if dtype == "time":
+        try:
+            return _time_comparable(datavalue["value"])
+        except (KeyError, TypeError):
+            # Malformed time datavalue (missing "time" or "precision" key).
+            # Skip rather than crash the whole expected-build; the
+            # corresponding Commons-side extraction has the same guard
+            # so the two sides stay symmetric.
+            return None
     return None
 
 
@@ -1632,6 +1715,36 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
                                         }
                                     }
                                 )
+                            elif dtype == "time":
+                                # Same canonical key as
+                                # `_extract_comparable_value` produces on
+                                # the sdc.json side. Without this branch,
+                                # a value-typed P571 on Commons would be
+                                # silently ignored by the reconciler
+                                # (left in dpla_claim_list as a missing
+                                # entry), and a sdc.json that no longer
+                                # includes that date would never trigger
+                                # the corresponding removal.
+                                try:
+                                    comparable = _time_comparable(
+                                        stmt["mainsnak"]["datavalue"]["value"]
+                                    )
+                                except (KeyError, TypeError):
+                                    # Malformed Commons time datavalue
+                                    # (missing "time" or "precision"); queue
+                                    # the statement for removal — mirrors
+                                    # the somevalue-missing-qualifier
+                                    # branch below.
+                                    removals.append(stmt["id"])
+                                else:
+                                    dpla_claim_list.append(
+                                        {
+                                            stmt["mainsnak"]["property"]: {
+                                                "id": stmt["id"],
+                                                "value": comparable,
+                                            }
+                                        }
+                                    )
                         if stmt["mainsnak"]["snaktype"] == "somevalue":
                             p = "P1932" if prop == "P571" else "P2093"
                             try:

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -723,7 +723,19 @@ def check(mediaid, qid, prop):
             dv = statement["mainsnak"].get("datavalue") or {}
             if dv.get("type") != "time":
                 return False
-            return _time_comparable(dv["value"]) == target
+            try:
+                return _time_comparable(dv.get("value") or {}) == target
+            except (KeyError, TypeError):
+                # Malformed Commons time datavalue (missing ``time`` or
+                # ``precision``). Treat as non-matching so check()
+                # returns True and the new claim is still added —
+                # ``_reconcile_existing_claims`` will queue the malformed
+                # statement for removal via its own defensive guard.
+                # Without this, the KeyError would bubble past check()'s
+                # APIError-only handler in ``process_one_from_sdc`` and
+                # abort the whole ordinal, leaving the bad statement
+                # on Commons.
+                return False
 
         for statement in statements:
             if (

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -15,7 +15,7 @@ import tomllib
 import urllib.parse
 from pywikibot import pagegenerators
 from ingest_wikimedia.logs import setup_logging
-from ingest_wikimedia.sdc import parse_nara_access_level
+from ingest_wikimedia.sdc import parse_dpla_date, parse_nara_access_level
 from ingest_wikimedia.slack import notify_phase_start, notify_sdc_complete
 from ingest_wikimedia.tracker import Result, Tracker
 from ingest_wikimedia.wikimedia import extract_dpla_id_from_commons_title
@@ -727,7 +727,7 @@ def check(mediaid, qid, prop):
             if dv.get("type") != "time":
                 return False
             try:
-                return _time_comparable(dv.get("value") or {}) == target
+                return _time_claim_comparable(statement) == target
             except (KeyError, TypeError):
                 # Malformed Commons time datavalue (missing ``time`` or
                 # ``precision``). Treat as non-matching so check()
@@ -1351,6 +1351,47 @@ def _time_comparable(value):
     return f"{value['time']}|P{value['precision']}"
 
 
+def _claim_has_circa_marker(claim):
+    """True iff the claim carries a ``P1480 = Q5727902`` (circa)
+    qualifier — the sourcing-circumstances marker the builder stamps
+    when a DPLA display-date had a ``circa``/``[…]``/``?``-style
+    decorator."""
+    for q in claim.get("qualifiers", {}).get("P1480") or []:
+        if q.get("snaktype") != "value":
+            continue
+        dv = q.get("datavalue") or {}
+        if dv.get("type") != "wikibase-entityid":
+            continue
+        v = dv.get("value") or {}
+        if not isinstance(v, dict):
+            continue
+        qid = v.get("id") or (f"Q{v['numeric-id']}" if "numeric-id" in v else None)
+        if qid == "Q5727902":
+            return True
+    return False
+
+
+def _time_claim_comparable(claim):
+    """Canonical comparable key for a *value-typed time* claim, including
+    the circa-bit derived from the P1480 qualifier.
+
+    Without including the circa-bit, a DPLA source change
+    ``"1945"`` → ``"circa 1945"`` (the time canonical key
+    ``+1945-01-01T00:00:00Z|P9`` is unchanged) would not trigger the
+    reconciler to add the new P1480 qualifier to the existing Commons
+    claim. With the circa-bit suffix, the two versions have different
+    comparables and the reconciler correctly queues old-without-P1480
+    for removal so the new-with-P1480 (or vice versa) can be written
+    in its place.
+
+    Wraps :func:`_time_comparable`; the inner call may still raise
+    ``KeyError`` / ``TypeError`` on a malformed datavalue, which
+    callers handle as before.
+    """
+    base = _time_comparable(claim["mainsnak"]["datavalue"]["value"])
+    return f"{base}|circa" if _claim_has_circa_marker(claim) else base
+
+
 def _extract_comparable_value(claim):
     """Pull the comparable scalar value out of a precomputed sdc.json claim.
 
@@ -1393,7 +1434,7 @@ def _extract_comparable_value(claim):
         return datavalue["value"]["text"]
     if dtype == "time":
         try:
-            return _time_comparable(datavalue["value"])
+            return _time_claim_comparable(claim)
         except (KeyError, TypeError):
             # Malformed time datavalue (missing "time" or "precision" key).
             # Skip rather than crash the whole expected-build; the
@@ -1571,6 +1612,15 @@ def _build_expected_from_parsed(
     The legacy partner-API path (parsed() → process_one → dpla_claims) uses
     this. The new partner mode (PR 4) reads sdc.json from S3 and uses
     `_build_expected_from_sdc` instead — same shape, different source.
+
+    P571 entries: include BOTH the raw DPLA display-date string AND
+    the canonical time-comparable key the partner-mode path produces
+    when ``parse_dpla_date`` succeeds. This way a legacy ``--file`` /
+    ``--cat`` / ``--list`` rerun against a file that partner mode has
+    already migrated from ``somevalue+P1932`` to value-typed time
+    won't see the migrated claim's comparable as ``unexpected`` and
+    queue it for removal. Both old-shape and new-shape Commons claims
+    representing the same date are protected.
     """
     rightsprop = "P6216"
     rightsvalue = ""
@@ -1615,6 +1665,20 @@ def _build_expected_from_parsed(
     # All values are lists so the `value not in expected[prop]` reconciliation
     # below behaves consistently (a bare string would degrade `not in` into a
     # substring check and let real DPLA claims look "unexpected").
+    # P571: include both the raw DPLA strings (for OLD-shape
+    # somevalue+P1932 claims) AND the canonical time-comparable keys
+    # for the parseable subset (for NEW-shape value-typed claims).
+    # See docstring above — legacy reruns must protect both shapes.
+    p571_expected = list(dates)
+    for date in dates:
+        parsed = parse_dpla_date(date)
+        if parsed is None:
+            continue
+        base = f"{parsed['value']['time']}|P{parsed['value']['precision']}"
+        if parsed["approximate"]:
+            base = f"{base}|circa"
+        p571_expected.append(base)
+
     expected = {
         "P217": local_ids,
         "P760": [dpla_id],
@@ -1624,7 +1688,7 @@ def _build_expected_from_parsed(
         "P9126": ["Q2944483", hub, institution],
         "P7482": [url],
         "P4272": subjects,
-        "P571": dates,
+        "P571": p571_expected,
         "P10358": descs,
         "P1225": naids,
         "P6224": [level],
@@ -1741,9 +1805,7 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
                                 # includes that date would never trigger
                                 # the corresponding removal.
                                 try:
-                                    comparable = _time_comparable(
-                                        stmt["mainsnak"]["datavalue"]["value"]
-                                    )
+                                    comparable = _time_claim_comparable(stmt)
                                 except (KeyError, TypeError):
                                     # Malformed Commons time datavalue
                                     # (missing "time" or "precision"); queue


### PR DESCRIPTION
## Summary

Today every DPLA date is emitted as a `P571 somevalue` statement with the original DPLA string in a `P1932` (stated as) qualifier. That handles non-standard prose (\"During the Gilded Age\", \"could not be determined\") cleanly but hides parseable dates from any Wikidata/SDC consumer that expects a structured time value.

This PR adds **opportunistic** time parsing — when the DPLA display-date string is clean enough to commit to a Wikibase time value, we emit it as such; otherwise behavior is byte-identical to before. The P1932 stated-as qualifier carrying the original DPLA string is preserved on both branches so the wiki template module can keep rendering whatever text DPLA chose.

## Parser scope (`parse_dpla_date`)

Stdlib-only (regex + `datetime.date` for day-of-month validation).

| Input | Output |
|---|---|
| `YYYY` | precision 9 (year) |
| `YYYY-MM` | precision 10 (month) |
| `YYYY-MM-DD` | precision 11 (day) |
| `YYYYs` (decade-aligned) | precision 8 (decade) |
| `circa YYYY` / `c. YYYY` / `ca. YYYY` / `approximately YYYY` / `[YYYY]` / `[YYYY?]` / `YYYY?` | strip decorators iteratively, then re-match |
| ranges (`1945-1950`), free prose, BC years, year 0, malformed ISO dates | `None` → caller falls back to today's somevalue+P1932 path |

## Self-healing idempotency

The user explicitly called this out: existing Commons files carry millions of old-shape `somevalue+P1932=\"…\"` P571 statements. After this PR ships, a re-sync must NOT leave duplicates.

**One reconcile cycle migrates a file:**

1. New sdc.json has value-typed P571 with time `+1945-01-01T00:00:00Z` (precision 9) AND P1932=\"1945\".
2. `expected[P571] = [\"+1945-01-01T00:00:00Z|P9\"]` (the new canonical time key).
3. `check()` for the new claim: the old somevalue claim on Commons doesn't match by time value → `_post_new_claims` inserts the new value-typed claim.
4. `_reconcile_existing_claims` walks the Commons P571 statements: the old somevalue's comparable (its P1932 string \"1945\") isn't in `expected[P571]` → queued for removal.
5. End state: one value-typed P571 claim. Old removed, new added, no duplicate.

Re-running the same partner against the now-migrated file is a no-op: the value-typed claim's canonical key matches expected, `check()` returns False (\"already there\"), reconciler removes nothing.

## Architecture changes

| File | Change |
|---|---|
| `ingest_wikimedia/sdc.py` | New `parse_dpla_date()` + `_wikibase_time()` + `_strip_date_decorators()` helpers. `_build_date_claim` calls the parser and branches on success/failure. |
| `tools/sdc_sync.py` | New `_time_comparable()` helper producing the canonical `\"+YYYY-…|PN\"` key. `_extract_comparable_value` and `_reconcile_existing_claims`'s inline extraction grow `dtype==\"time\"` branches calling it. `_check_kind_for_claim` returns `\"time\"` for value-typed time claims. `check()` grows a new `\"time\"` kind branch mirroring the existing item/string/somevalue branches' amend/add-alongside logic. |

## Defensive guards (caught by code review)

The new `time` branches in both `_extract_comparable_value` and the reconciler's inline extraction wrap `_time_comparable` in `try / except (KeyError, TypeError)`. A community-edited or partially-imported Commons P571 statement could have a malformed time datavalue (missing `time` or `precision`); without the guard the whole reconciler would crash for that file. With the guard, the malformed statement is queued for removal — matches the existing somevalue-missing-qualifier branch's behavior. Covered by a dedicated test.

## Tests

21 new across two files. Local Python-3.13 full suite: **417 passed**.

- `tests/test_sdc.py` (+13): parser shapes, decorator stripping, decade alignment, year 0 / BC / malformed ISO rejection, builder value-typed vs somevalue branches, P1932 preservation on both branches, empty-input contract.
- `tests/test_sdc_sync.py` (+8): `_time_comparable` canonical form, precision distinction, `_extract_comparable_value` time and somevalue parity, reconciler migration scenario (old somevalue → new value-typed in one cycle), no-op on already-migrated state, removal when DPLA drops the date entirely, `check()` time-kind match/no-match across old vs new shapes, malformed Commons-side time datavalue defensively queued for removal.

## Out of scope

- BC dates / very-early-year sanity bounds — DPLA's content range goes back to medieval manuscripts; tightening at all would need data first.
- Date-RANGE structuring (`1945-1950` → P1319/P1326 qualifiers or P580/P582). The somevalue+P1932 fallback still preserves the string for the wiki template.
- Named periods (`\"Gilded Age\"` → P2348 lookup against Wikidata). Same — preserved verbatim.
- The transient mid-cycle window where Commons briefly holds both the old somevalue and the new value-typed claim, between the `_post_new_claims` and `_reconcile_existing_claims` phases of `process_one_from_sdc`. Reviewer flagged this as theoretically observable but acceptable (matches the existing semantics for every other value update).

## Test plan

- [ ] CI green on Python 3.13
- [ ] After merge + EC2 code-update, kick off a small NARA partner re-sync; confirm Slack summary shows non-zero `CLAIMS ADDED` (new value-typed P571 inserts) AND non-zero `REMOVALS` (old somevalue cleanup) on the same partner.
- [ ] Spot-check 2-3 NARA files on Commons: history should show one wbeditentity adding a value-typed P571 and one wbremoveclaims removing the old somevalue P571, ~seconds apart.
- [ ] Second run on the same partner: zero `CLAIMS ADDED` for P571, zero `REMOVALS` (idempotent no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds opportunistic structured parsing of DPLA display-date strings and reconciler support to emit and manage Wikibase time datavalues for P571 (inception) when the DPLA string is reliably parseable; otherwise the pipeline preserves the existing somevalue mainsnak + P1932 ("stated as") behavior. The original DPLA string is always preserved in P1932.

What changed
- ingest_wikimedia/sdc.py
  - Added Q_CIRCA = Q5727902 and parse_dpla_date(date_string: str) -> dict | None.
  - parse_dpla_date (stdlib-only: regex + datetime.date) iteratively strips repeated inexact-date decorators (circa / c. / ca. / approximately / ~, brackets, trailing ?) and flags decorator-originated inexactness (approximate). It accepts only anchored single-date shapes after stripping: YYYY (precision P9), YYYY-MM (P10), YYYY-MM-DD (P11), and decade-aligned YYYYs (P8). It validates calendar components (rejects year 0) and returns None for ranges, BC years, malformed ISO dates, free prose, or other unsupported shapes.
  - _build_date_claim now uses parse_dpla_date: on success it emits a value-typed P571 time datavalue at the parsed precision and adds P1480 = Q5727902 when approximate; on failure it falls back to a legacy somevalue mainsnak. P1932 is always added with the original DPLA string.
  - Added helpers: _strip_date_decorators, _wikibase_time, and related small helpers.

- tools/sdc_sync.py
  - Added _time_comparable(value) producing a canonical comparable key (time string + precision); _time_claim_comparable(claim) appends a "|circa" suffix when P1480 = Q5727902 is present; added _claim_has_circa_marker.
  - _extract_comparable_value and partner-mode expected-building logic now handle value-typed time mainsnaks and produce canonical time keys; malformed Commons-side time datavalues are skipped or queued for removal rather than crashing.
  - check(...) gained a "time" kind branch: it matches canonical time keys against Commons statements and mirrors existing amend-in-place / DPLA-stamping semantics (including capturing an amend target and stamping P459 when appropriate).
  - _reconcile_existing_claims/expected-building extended so a reconcile cycle can migrate legacy somevalue+P1932 claims to value-typed P571 and remove stale/malformed claims.
  - Tightened amend-in-place safety for P571 by treating P1480 (circa) as a DPLA-owned qualifier alongside P1932.
  - Imports updated to include parse_dpla_date.

Tests
- tests/test_sdc.py: added unit tests for parse_dpla_date (supported shapes, decorator stripping, approximate flag) and _build_date_claim behavior (value-typed vs somevalue fallback, P1932 preservation, P1480 stamping rules, empty input).
- tests/test_sdc_sync.py: added tests for _time_comparable, _extract_comparable_value (value-typed and legacy somevalue handling), reconciliation/migration behavior (migrating legacy somevalue→value-typed, idempotency, removal when DPLA drops the date), check() semantics for time kind, circa-vs-exact distinction, and defensive handling/queuing of malformed Commons-side time datavalues.
- Author-reported local run: full suite 417 passed.

Backward compatibility and behavior
- Conservative fallback: parse_dpla_date returns None rather than producing a structured date for unsupported/adjacent unrecognized text; code falls back to legacy somevalue + P1932. P1932 is preserved in all cases.
- Reconciler migration: sync logic can migrate legacy somevalue+P1932 claims to the new value-typed P571 and de-duplicate appropriately. Circa-qualified vs exact time claims are treated as distinct comparable keys.
- Defensive handling prevents malformed Commons-side time datavalues from crashing reconciliation; such statements are queued for removal.

Operational / security notes (explicit)
- No manual pipeline trigger or ECS redeployment is required beyond standard code deployment.
- No environment variables or AWS Secrets Manager keys were added, removed, or renamed.
- No database migrations.
- No shared infrastructure changes (CodePipeline, CodeBuild, ECS task definitions, IAM).
- No public-facing API changes or new endpoints.
- No security-sensitive changes to authentication or credential handling.

Files changed (high level)
- ingest_wikimedia/sdc.py — parse_dpla_date, Q_CIRCA, _build_date_claim updates, decorator stripping helpers.
- tools/sdc_sync.py — _time_comparable, _time_claim_comparable, _claim_has_circa_marker, extraction/reconcile/check updates, P1480 treated as DPLA-owned qualifier.
- tests/test_sdc.py, tests/test_sdc_sync.py — new tests exercising parsing and reconciliation behavior.

Notes and scope
- The parser intentionally rejects ranges, BC dates, year zero, and malformed ISO dates; those remain handled by the legacy somevalue + P1932 flow.
- A follow-up commit documented and enforced the parser’s conservative contract (parser returns None on adjacent unrecognized text) and added a regression test covering many negative cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->