### PR TITLE
get-ids-es: --single-id so /wikimedia-upload <id> re-stages sdc.json

### DIFF
--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -48,12 +48,15 @@ from __future__ import annotations
 import datetime
 import json
 import logging
+import os
 import re
 import xml.etree.ElementTree as ET
 from collections.abc import Iterable
 from typing import Any
 
 import requests
+
+from ingest_wikimedia.dpla import INSTITUTIONS_URL
 
 # Hardcoded Wikibase entities used across the SDC mapping. Centralized here
 # so any change has a single edit site.
@@ -153,7 +156,48 @@ TEXT_VALUE_LIMIT = 1499  # matches sdc-sync's longstanding truncation cap
 # strictly longer than 1500 is dropped.
 LOCAL_ID_MAX_LENGTH = 1500
 
+# DPLA subject → Wikidata Q-ID lookup table; sourced from dpla/ingestion3
+# alongside institutions_v2.json. Fetched fresh per run so upstream changes
+# land in the next sync without a redeploy.
+SUBJECTS_URL = (
+    "https://raw.githubusercontent.com/dpla/ingestion3/develop/"
+    "src/main/resources/subjects.json"
+)
+
+# Locate rights.json by walking up from this module's directory. sdc.py
+# lives at <repo>/ingest_wikimedia/sdc.py, so two dirname's above gives the
+# repo root.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
 logger = logging.getLogger(__name__)
+
+
+def fetch_institutions_v2() -> dict:
+    """Fetch the full institutions_v2.json document used for hub/institution
+    eligibility and (in the SDC pre-compute pass) Wikidata-ID resolution."""
+    resp = requests.get(INSTITUTIONS_URL, timeout=15)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_subjects_json() -> dict:
+    """Fetch the DPLA-subject → Wikidata-ID map used to populate P921.
+
+    Sourced from dpla/ingestion3 alongside institutions_v2.json; fetched
+    fresh per run so upstream changes land in the next sync without a
+    redeploy.
+    """
+    resp = requests.get(SUBJECTS_URL, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def load_rights_json() -> dict:
+    """Load rights.json from the repo root and normalize its keys for
+    scheme-and-slash-insensitive lookup."""
+    with open(os.path.join(_REPO_ROOT, "rights.json")) as f:
+        raw = json.load(f)
+    return {normalize_rights_uri(k): v for k, v in raw.items()}
 
 
 def normalize_rights_uri(uri: str) -> str:

--- a/ingest_wikimedia/staging.py
+++ b/ingest_wikimedia/staging.py
@@ -12,7 +12,7 @@ import threading
 from collections.abc import Callable
 from concurrent.futures import Future
 
-from .s3 import S3Client
+from .s3 import APPLICATION_JSON, SDC_FILENAME, S3Client
 
 _QUEUE_DEPTH_MULTIPLIER = 4
 
@@ -26,6 +26,20 @@ def stage_item_to_s3(
     future.exception() in the done callback.
     """
     s3_client.write_item_metadata(partner, dpla_id, json.dumps(source))
+
+
+def stage_sdc_to_s3(
+    s3_client: S3Client, partner: str, dpla_id: str, sdc_payload: dict
+) -> None:
+    """Write the per-item sdc.json sidecar to the partner's item prefix.
+
+    Shared by get-ids-es and get-ids-nara (and any future tool that
+    pre-computes SDC claims). Raises on failure so the caller's
+    ThreadPoolExecutor can observe it via future.exception().
+    """
+    s3_client.write_item_file(
+        partner, dpla_id, json.dumps(sdc_payload), SDC_FILENAME, APPLICATION_JSON
+    )
 
 
 def make_s3_stage_context(

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -499,29 +499,32 @@ def main() -> None:
         _slack_fail(response_url, f"No valid targets to launch.{detail}")
 
     # `--sdc-only` is meaningful only for targets whose ID-generation step
-    # re-stages sdc.json. Two target types use a different path:
-    #   * Single-item DPLA IDs — the launcher writes the one ID via `printf`
-    #     to skip the enumeration phase; `resolve-dpla-ids` (run at startup)
-    #     stages `dpla-map.json` but NOT `sdc.json`.
+    # re-stages sdc.json. One target type doesn't:
     #   * NARA hub-level — uses `get-ids-nara` (NARA catalog enumeration,
-    #     not ingestion3 ES), which also doesn't write `sdc.json`.
+    #     not ingestion3 ES), which doesn't write `sdc.json`.
     # For these, sdc-sync will replay whatever sidecar the *original* upload
-    # run wrote. That's fine for re-running PR-#251-style code changes
-    # against a known item, but operators backfilling for upstream mapping
-    # changes need to know they won't pick up. Warn loudly rather than
-    # silently using stale data.
+    # run wrote. That's fine for re-running known-code regressions against a
+    # known item, but operators backfilling for upstream mapping changes need
+    # to know they won't pick up. Warn loudly rather than silently using
+    # stale data.
+    # (Single-item DPLA IDs used to land in this bucket too — they wrote
+    # the CSV via `printf` and skipped get-ids-es entirely. They now invoke
+    # ``get-ids-es --single-id`` instead, which re-stages sdc.json with the
+    # latest mapping code; so single-item targets are NOT included in the
+    # stale-sdc warning anymore.)
     if sdc_only:
         stale_sdc_target_labels = [
             lbl
             for canonical, institutions, lbl, dpla_id, _ in targets
-            if dpla_id is not None or (canonical == "nara" and not institutions)
+            if dpla_id is None and canonical == "nara" and not institutions
         ]
         if stale_sdc_target_labels:
             print(
-                "Warning: --sdc-only with single-item DPLA IDs or NARA"
-                " hub-level targets will use the existing sdc.json sidecars"
-                " (last written by get-ids-es during the original upload"
-                " run). These targets cannot re-stage sdc.json. Affected:"
+                "Warning: --sdc-only with NARA hub-level targets will use the"
+                " existing sdc.json sidecars (last written by get-ids-es"
+                " during the original upload run). get-ids-nara enumerates"
+                " the NARA catalog directly and does not write sdc.json, so"
+                " these targets cannot re-stage. Affected:"
                 f" {', '.join(stale_sdc_target_labels)}.",
                 file=sys.stderr,
             )
@@ -802,9 +805,21 @@ def main() -> None:
         # collection-level sessions don't clobber each other's ID lists.
         csv_file = f"{session_label}.csv"
         if dpla_id is not None:
-            # Single-item target: metadata was already staged to S3 by resolve-dpla-ids.
-            # Write the one ID directly to the CSV; no ID-generation phase needed.
-            get_ids_cmd = f"printf '%s\\n' {shlex.quote(dpla_id)} > {csv_file}"
+            # Single-item target: re-run get-ids-es in ``--single-id`` mode so
+            # dpla-map.json AND sdc.json are staged with the latest mapping
+            # code before the downloader/uploader/sdc-sync chain reads them.
+            # Without this re-staging, sdc-sync would diff against whatever
+            # sdc.json the partner's last full run produced — silently missing
+            # any subsequent ingest_wikimedia.sdc changes (e.g. PR #279's
+            # opportunistic date parsing, PR #278's NARA stdlib XML).
+            # ``resolve-dpla-ids`` (the pre-launch eligibility check) is
+            # still useful because it short-circuits ineligible IDs with a
+            # clean Slack message before the tmux session is even launched,
+            # but the per-item S3 staging it does is superseded here.
+            get_ids_cmd = (
+                f"get-ids-es {canonical}"
+                f" --single-id {shlex.quote(dpla_id)} > {csv_file}"
+            )
         elif canonical == "nara" and not institutions:
             get_ids_cmd = f"get-ids-nara > {csv_file}"
         else:

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -498,42 +498,20 @@ def main() -> None:
         detail = ("\n• " + "\n• ".join(skipped_warnings)) if skipped_warnings else ""
         _slack_fail(response_url, f"No valid targets to launch.{detail}")
 
-    # `--sdc-only` is meaningful only for targets whose ID-generation step
-    # re-stages sdc.json. One target type doesn't:
-    #   * NARA hub-level — uses `get-ids-nara` (NARA catalog enumeration,
-    #     not ingestion3 ES), which doesn't write `sdc.json`.
-    # For these, sdc-sync will replay whatever sidecar the *original* upload
-    # run wrote. That's fine for re-running known-code regressions against a
-    # known item, but operators backfilling for upstream mapping changes need
-    # to know they won't pick up. Warn loudly rather than silently using
-    # stale data.
-    # (Single-item DPLA IDs used to land in this bucket too — they wrote
-    # the CSV via `printf` and skipped get-ids-es entirely. They now invoke
-    # ``get-ids-es --single-id`` instead, which re-stages sdc.json with the
-    # latest mapping code; so single-item targets are NOT included in the
-    # stale-sdc warning anymore.)
-    if sdc_only:
-        stale_sdc_target_labels = [
-            lbl
-            for canonical, institutions, lbl, dpla_id, _ in targets
-            if dpla_id is None and canonical == "nara" and not institutions
-        ]
-        if stale_sdc_target_labels:
-            print(
-                "Warning: --sdc-only with NARA hub-level targets will use the"
-                " existing sdc.json sidecars (last written by get-ids-es"
-                " during the original upload run). get-ids-nara enumerates"
-                " the NARA catalog directly and does not write sdc.json, so"
-                " these targets cannot re-stage. Affected:"
-                f" {', '.join(stale_sdc_target_labels)}.",
-                file=sys.stderr,
-            )
-        if max_age_days is not None:
-            print(
-                "Warning: --max-age-days is ignored in --sdc-only mode"
-                " (no download phase runs).",
-                file=sys.stderr,
-            )
+    # `--sdc-only` re-runs the ID-generation step (which now re-stages
+    # sdc.json for every target type — get-ids-es for hub/institution and
+    # single-item, get-ids-nara for NARA hub-level) so operators
+    # backfilling for upstream mapping changes pick up the latest claims.
+    # Previously NARA hub-level and single-item DPLA-ID targets
+    # short-circuited their respective Phase 3 (sdc.json staging) — that
+    # gap was closed in this PR, so no "stale sdc.json" warning is needed
+    # anymore.
+    if sdc_only and max_age_days is not None:
+        print(
+            "Warning: --max-age-days is ignored in --sdc-only mode"
+            " (no download phase runs).",
+            file=sys.stderr,
+        )
 
     # Session name uses + as separator (unambiguous since slugs/institution names use -).
     # Institution-level targets include the hub slug as a prefix so the status script

--- a/tests/test_get_ids_es.py
+++ b/tests/test_get_ids_es.py
@@ -200,6 +200,12 @@ def _invoke_single_id(single_id, hits):
         patch.object(get_ids_es, "post_es", return_value=fake_response) as post_es_mock,
         patch.object(get_ids_es, "check_es_response"),
         patch.object(get_ids_es, "stage_item_to_s3"),
+        # Phase 3 stages sdc.json via this helper — mock it explicitly,
+        # otherwise the real S3Client tries an actual write and the CI
+        # job exits 1 with "1 sdc.json writes failed" before any
+        # assertion runs (the failure mode CodeRabbit caught on the
+        # earlier push of this PR).
+        patch.object(get_ids_es, "stage_sdc_to_s3"),
         patch.object(get_ids_es.Banlist, "is_banned", return_value=False),
         patch.object(get_ids_es, "reconcile_subjects", return_value={}),
         patch.object(get_ids_es, "build_claims_for_doc", return_value={"claims": []}),
@@ -234,7 +240,10 @@ def test_single_id_builds_term_query_not_paginated_filter():
     # built by build_query (which would include rightsCategory /
     # eligible-dp-names filters that single-id is meant to bypass).
     sent_query = post_es_mock.call_args[0][0]
-    assert sent_query == {"query": {"term": {"id": fake_id}}, "size": 1}
+    # ``size: 2`` (not 1) so the in-process ``len(hits) != 1`` defense
+    # is actually reachable — see the matching comment in get_ids_es.py
+    # where the query is built.
+    assert sent_query == {"query": {"term": {"id": fake_id}}, "size": 2}
 
 
 def test_single_id_exits_nonzero_when_es_has_no_match():

--- a/tests/test_get_ids_es.py
+++ b/tests/test_get_ids_es.py
@@ -129,3 +129,188 @@ def test_unknown_institution_rejected_with_clear_message():
     assert result.exit_code == 1, result.output
     assert "not upload-eligible" in result.output
     assert "Nonexistent Institution" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --single-id mode — re-stage one DPLA item's sidecars so the per-item
+# launch path (``/wikimedia-upload <dpla-id>``) actually exercises the
+# latest mapping code, instead of diffing sdc-sync against whatever
+# sdc.json the partner's last full run produced.
+# ---------------------------------------------------------------------------
+
+
+def test_single_id_rejects_combined_with_institution():
+    """--single-id targets exactly one doc by ID; combining it with
+    --institution makes no sense (the institution filter would be
+    ignored or would unexpectedly hide the requested ID)."""
+    result = _invoke(
+        "bpl",
+        "--single-id",
+        "deadbeefcafe00000000000000000000",
+        "--institution",
+        "Boston Public Library",
+    )
+    assert result.exit_code == 1, result.output
+    assert "cannot be combined with --institution" in result.output
+
+
+def test_single_id_rejects_combined_with_collection():
+    """Same defense for --collection."""
+    result = _invoke(
+        "bpl",
+        "--single-id",
+        "deadbeefcafe00000000000000000000",
+        "--collection",
+        "Some Collection",
+    )
+    assert result.exit_code == 1, result.output
+    assert "cannot be combined with --institution or --collection" in result.output
+
+
+def _invoke_single_id(single_id, hits):
+    """Invoke get-ids-es with --single-id, mocking out ES + S3 + reconci.link
+    so the test exercises validation, query construction, and the
+    not-found vs found code paths without external calls."""
+    from unittest.mock import MagicMock
+
+    from tools import get_ids_es
+
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"hits": {"hits": hits}}
+    fake_response.raise_for_status.return_value = None
+
+    with (
+        patch.object(get_ids_es.DPLA, "check_partner", return_value=None),
+        patch.object(get_ids_es, "notify_phase_start"),
+        patch.object(get_ids_es, "PARTNER_HUBS", {"bpl": "Digital Commonwealth"}),
+        patch.object(
+            get_ids_es,
+            "fetch_institutions_v2",
+            return_value={
+                "Digital Commonwealth": {
+                    "Wikidata": "Q12345",
+                    "institutions": {
+                        "Boston Public Library": {"upload": True, "Wikidata": "Q1001"},
+                    },
+                }
+            },
+        ),
+        patch.object(get_ids_es, "load_rights_json", return_value={}),
+        patch.object(get_ids_es, "fetch_subjects_json", return_value={}),
+        patch.object(get_ids_es, "post_es", return_value=fake_response) as post_es_mock,
+        patch.object(get_ids_es, "check_es_response"),
+        patch.object(get_ids_es, "stage_item_to_s3"),
+        patch.object(get_ids_es.Banlist, "is_banned", return_value=False),
+        patch.object(get_ids_es, "reconcile_subjects", return_value={}),
+        patch.object(get_ids_es, "build_claims_for_doc", return_value={"claims": []}),
+        patch("ingest_wikimedia.s3.S3Client.get_item_metadata", return_value="{}"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(get_ids_es.main, ["bpl", "--single-id", single_id])
+        return result, post_es_mock
+
+
+def test_single_id_builds_term_query_not_paginated_filter():
+    """--single-id must query ES by exact DPLA-ID term, NOT via
+    ``build_query``'s hub-wide filter. Otherwise the rightsCategory /
+    institution-upload-flag gates could silently hide the requested ID,
+    defeating the operator's explicit single-item invocation."""
+    fake_id = "deadbeefcafe00000000000000000000"
+    fake_hit = {
+        "_source": {
+            "id": fake_id,
+            "provider": {"name": "Digital Commonwealth"},
+            "dataProvider": {"name": "Boston Public Library"},
+            "mediaMaster": ["http://example.org/img.jpg"],
+            "sourceResource": {"title": ["x"]},
+        }
+    }
+    result, post_es_mock = _invoke_single_id(fake_id, [fake_hit])
+
+    assert result.exit_code == 0, result.output
+    # The single document was printed.
+    assert fake_id in result.output
+    # The ES query was a one-shot term lookup, not a paginated filter
+    # built by build_query (which would include rightsCategory /
+    # eligible-dp-names filters that single-id is meant to bypass).
+    sent_query = post_es_mock.call_args[0][0]
+    assert sent_query == {"query": {"term": {"id": fake_id}}, "size": 1}
+
+
+def test_single_id_exits_nonzero_when_es_has_no_match():
+    """ID not in ES → exit code 1 with a clear error message. The launch
+    script's tmux chain relies on the non-zero exit to short-circuit
+    the downstream downloader/uploader/sdc-sync (which would otherwise
+    run against an empty CSV and produce confusing 0-item summaries)."""
+    fake_id = "deadbeefcafe00000000000000000000"
+    result, _ = _invoke_single_id(fake_id, [])
+    assert result.exit_code == 1, result.output
+    assert fake_id in result.output
+    assert "no document" in result.output
+
+
+def test_single_id_banlist_hit_gets_distinct_error():
+    """A banlisted ID must produce a ``banlist``-specific error message,
+    not the generic ``no document from ES`` one. Operationally distinct:
+    fixing a banlist hit is a one-line edit to dpla-id-banlist.txt,
+    whereas a missing-from-ES hit needs an indexing investigation. The
+    Slack failure handler surfaces this message verbatim, so the wording
+    has to point on-call at the right remediation."""
+    from unittest.mock import MagicMock
+
+    from tools import get_ids_es
+
+    fake_id = "deadbeefcafe00000000000000000000"
+    # post_es should NEVER be called when the banlist check short-circuits.
+    post_es_mock = MagicMock(
+        side_effect=AssertionError("ES round-trip skipped on banlist hit")
+    )
+    with (
+        patch.object(get_ids_es.DPLA, "check_partner", return_value=None),
+        patch.object(get_ids_es, "notify_phase_start"),
+        patch.object(get_ids_es, "PARTNER_HUBS", {"bpl": "Digital Commonwealth"}),
+        patch.object(
+            get_ids_es,
+            "fetch_institutions_v2",
+            return_value={
+                "Digital Commonwealth": {
+                    "Wikidata": "Q12345",
+                    "institutions": {
+                        "Boston Public Library": {"upload": True, "Wikidata": "Q1001"},
+                    },
+                }
+            },
+        ),
+        patch.object(get_ids_es, "load_rights_json", return_value={}),
+        patch.object(get_ids_es, "fetch_subjects_json", return_value={}),
+        patch.object(get_ids_es.Banlist, "is_banned", return_value=True),
+        patch.object(get_ids_es, "post_es", post_es_mock),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(get_ids_es.main, ["bpl", "--single-id", fake_id])
+
+    assert result.exit_code == 1, result.output
+    assert "banlist" in result.output
+    assert fake_id in result.output
+
+
+def test_single_id_rejects_mismatched_id_from_es():
+    """Defense-in-depth: if ES returns a document whose ``_source.id``
+    differs from the queried ID (would indicate either an index
+    normalization regression or stale-replica weirdness), refuse to
+    stage under the wrong key. The dpla-map.json S3 path is keyed by
+    the source ID; staging under a mismatched key would orphan the
+    object from the downstream downloader/uploader."""
+    queried = "deadbeefcafe00000000000000000000"
+    returned_id = "aaaabbbbccccddddeeeeffff00000000"
+    hit = {
+        "_source": {
+            "id": returned_id,
+            "provider": {"name": "Digital Commonwealth"},
+            "dataProvider": {"name": "Boston Public Library"},
+        }
+    }
+    result, _ = _invoke_single_id(queried, [hit])
+    assert result.exit_code == 1, result.output
+    assert "mismatched" in result.output
+    assert returned_id in result.output

--- a/tests/test_get_ids_nara.py
+++ b/tests/test_get_ids_nara.py
@@ -8,10 +8,19 @@ timestamp on S3 against the get-ids-nara run time" — this test pins the
 in-process call graph so a future refactor that drops Phase 3 surfaces
 as a test failure rather than a Slack-message-shaped surprise on the
 next operator run.
+
+Uses ``contextlib.ExitStack`` rather than the parenthesized ``with (A,
+B, C):`` form — CodeQL's ``py/unused-import`` query has a known false-
+positive class with the parenthesized form
+(https://github.com/github/codeql/issues/9657) and flags ``patch``,
+``CliRunner``, and the iteration source as "unused" even though
+ruff's F401/F841 confirm they are. The ExitStack pattern keeps every
+reference at top-level statement scope where the analyzer can trace it.
 """
 
 from __future__ import annotations
 
+import contextlib
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -45,41 +54,63 @@ def test_main_runs_sdc_phase_after_enumeration():
             }
         },
     ]
+    paginate_iter = iter(fake_hits)
 
-    with (
+    with contextlib.ExitStack() as stack:
         # No remote ES calls during the build_*_queries phases.
-        patch.object(get_ids_nara, "build_format_queries", return_value=[]),
-        patch.object(get_ids_nara, "build_language_queries", return_value=[]),
-        patch.object(get_ids_nara, "notify_phase_start"),
+        stack.enter_context(
+            patch.object(get_ids_nara, "build_format_queries", return_value=[])
+        )
+        stack.enter_context(
+            patch.object(get_ids_nara, "build_language_queries", return_value=[])
+        )
+        stack.enter_context(patch.object(get_ids_nara, "notify_phase_start"))
         # Phase 1: yield the two fake hits across whatever filter is passed.
-        patch.object(get_ids_nara, "_paginate", return_value=iter(fake_hits)),
+        stack.enter_context(
+            patch.object(get_ids_nara, "_paginate", return_value=paginate_iter)
+        )
         # Phase 1 staging: don't actually write to S3.
-        patch.object(get_ids_nara, "stage_item_to_s3") as stage_item_mock,
+        stage_item_mock = stack.enter_context(
+            patch.object(get_ids_nara, "stage_item_to_s3")
+        )
         # SDC-input loaders: cheap stubs.
-        patch.object(
-            get_ids_nara,
-            "fetch_institutions_v2",
-            return_value={
-                "National Archives and Records Administration": {
-                    "Wikidata": "Q518155",
-                    "institutions": {},
-                }
-            },
-        ),
-        patch.object(get_ids_nara, "load_rights_json", return_value={}),
-        patch.object(get_ids_nara, "fetch_subjects_json", return_value={}),
-        patch.object(get_ids_nara, "reconcile_subjects", return_value={}),
-        # S3Client used to read dpla-map.json back in Phase 3. Return the
-        # source doc verbatim — build_claims_for_doc handles it from there.
-        patch.object(get_ids_nara, "S3Client") as s3_class_mock,
+        stack.enter_context(
+            patch.object(
+                get_ids_nara,
+                "fetch_institutions_v2",
+                return_value={
+                    "National Archives and Records Administration": {
+                        "Wikidata": "Q518155",
+                        "institutions": {},
+                    }
+                },
+            )
+        )
+        stack.enter_context(
+            patch.object(get_ids_nara, "load_rights_json", return_value={})
+        )
+        stack.enter_context(
+            patch.object(get_ids_nara, "fetch_subjects_json", return_value={})
+        )
+        stack.enter_context(
+            patch.object(get_ids_nara, "reconcile_subjects", return_value={})
+        )
+        # S3Client used to read dpla-map.json back in Phase 3.
+        s3_class_mock = stack.enter_context(patch.object(get_ids_nara, "S3Client"))
         # build_claims_for_doc: stub return so Phase 3 actually calls stage_sdc_to_s3.
-        patch.object(
-            get_ids_nara, "build_claims_for_doc", return_value={"claims": []}
-        ) as build_mock,
+        build_mock = stack.enter_context(
+            patch.object(
+                get_ids_nara, "build_claims_for_doc", return_value={"claims": []}
+            )
+        )
         # Phase 3 staging: capture the calls.
-        patch.object(get_ids_nara, "stage_sdc_to_s3") as stage_sdc_mock,
-        patch.object(get_ids_nara.Banlist, "is_banned", return_value=False),
-    ):
+        stage_sdc_mock = stack.enter_context(
+            patch.object(get_ids_nara, "stage_sdc_to_s3")
+        )
+        stack.enter_context(
+            patch.object(get_ids_nara.Banlist, "is_banned", return_value=False)
+        )
+
         # Wire S3Client().get_item_metadata to return each fake hit's source
         # doc as JSON so Phase 3's re-read succeeds.
         s3_instance = s3_class_mock.return_value
@@ -94,7 +125,6 @@ def test_main_runs_sdc_phase_after_enumeration():
             '"sourceResource":{"title":["y"]},"mediaMaster":["http://example.org/y.jpg"]}',
         ]
 
-        # Run main() and wait for the ThreadPoolExecutors to finish.
         runner = CliRunner()
         # Click's main() exits via SystemExit; standalone_mode=False
         # surfaces any non-zero exit code through the result.

--- a/tests/test_get_ids_nara.py
+++ b/tests/test_get_ids_nara.py
@@ -1,0 +1,116 @@
+"""CLI-level test for tools/get_ids_nara.py — specifically that the SDC
+pre-compute pass added in this PR runs after Phase 1 enumeration. Without
+it, NARA hub-level runs leave sdc.json stale (last written by the
+previous upload run) and sdc-sync silently misses any
+ingest_wikimedia.sdc mapping changes shipped in the interim. The
+matching production observability is "diff the sdc.json LastModified
+timestamp on S3 against the get-ids-nara run time" — this test pins the
+in-process call graph so a future refactor that drops Phase 3 surfaces
+as a test failure rather than a Slack-message-shaped surprise on the
+next operator run.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+
+def test_main_runs_sdc_phase_after_enumeration():
+    """The Phase 1 enumeration (stage_item_to_s3 for each hit) must be
+    followed by a Phase 3 SDC staging pass (stage_sdc_to_s3 for each
+    enumerated DPLA ID). Without Phase 3, NARA hub-level runs leave
+    sdc.json stale on every item they enumerate — the exact gap this
+    PR closes."""
+    from tools import get_ids_nara
+
+    fake_hits = [
+        {
+            "_source": {
+                "id": "nara0000000000000000000000000001",
+                "provider": {"name": "National Archives and Records Administration"},
+                "dataProvider": {"name": "NARA — Some Library"},
+                "sourceResource": {"title": ["x"]},
+                "mediaMaster": ["http://example.org/x.jpg"],
+            }
+        },
+        {
+            "_source": {
+                "id": "nara0000000000000000000000000002",
+                "provider": {"name": "National Archives and Records Administration"},
+                "dataProvider": {"name": "NARA — Another Library"},
+                "sourceResource": {"title": ["y"]},
+                "mediaMaster": ["http://example.org/y.jpg"],
+            }
+        },
+    ]
+
+    with (
+        # No remote ES calls during the build_*_queries phases.
+        patch.object(get_ids_nara, "build_format_queries", return_value=[]),
+        patch.object(get_ids_nara, "build_language_queries", return_value=[]),
+        patch.object(get_ids_nara, "notify_phase_start"),
+        # Phase 1: yield the two fake hits across whatever filter is passed.
+        patch.object(get_ids_nara, "_paginate", return_value=iter(fake_hits)),
+        # Phase 1 staging: don't actually write to S3.
+        patch.object(get_ids_nara, "stage_item_to_s3") as stage_item_mock,
+        # SDC-input loaders: cheap stubs.
+        patch.object(
+            get_ids_nara,
+            "fetch_institutions_v2",
+            return_value={
+                "National Archives and Records Administration": {
+                    "Wikidata": "Q518155",
+                    "institutions": {},
+                }
+            },
+        ),
+        patch.object(get_ids_nara, "load_rights_json", return_value={}),
+        patch.object(get_ids_nara, "fetch_subjects_json", return_value={}),
+        patch.object(get_ids_nara, "reconcile_subjects", return_value={}),
+        # S3Client used to read dpla-map.json back in Phase 3. Return the
+        # source doc verbatim — build_claims_for_doc handles it from there.
+        patch.object(get_ids_nara, "S3Client") as s3_class_mock,
+        # build_claims_for_doc: stub return so Phase 3 actually calls stage_sdc_to_s3.
+        patch.object(
+            get_ids_nara, "build_claims_for_doc", return_value={"claims": []}
+        ) as build_mock,
+        # Phase 3 staging: capture the calls.
+        patch.object(get_ids_nara, "stage_sdc_to_s3") as stage_sdc_mock,
+        patch.object(get_ids_nara.Banlist, "is_banned", return_value=False),
+    ):
+        # Wire S3Client().get_item_metadata to return each fake hit's source
+        # doc as JSON so Phase 3's re-read succeeds.
+        s3_instance = s3_class_mock.return_value
+        s3_instance.get_item_metadata.side_effect = [
+            '{"id":"nara0000000000000000000000000001",'
+            '"provider":{"name":"National Archives and Records Administration"},'
+            '"dataProvider":{"name":"NARA — Some Library"},'
+            '"sourceResource":{"title":["x"]},"mediaMaster":["http://example.org/x.jpg"]}',
+            '{"id":"nara0000000000000000000000000002",'
+            '"provider":{"name":"National Archives and Records Administration"},'
+            '"dataProvider":{"name":"NARA — Another Library"},'
+            '"sourceResource":{"title":["y"]},"mediaMaster":["http://example.org/y.jpg"]}',
+        ]
+
+        # Run main() and wait for the ThreadPoolExecutors to finish.
+        runner = CliRunner()
+        # Click's main() exits via SystemExit; standalone_mode=False
+        # surfaces any non-zero exit code through the result.
+        result = runner.invoke(get_ids_nara.main, [], standalone_mode=False)
+
+    # If get_ids_nara raises during main(), Click captures the exception.
+    assert result.exception is None, f"Unexpected exception: {result.exception!r}"
+
+    # Phase 1 staged both items.
+    assert stage_item_mock.call_count == 2
+    # Phase 3 ran build_claims_for_doc for each item.
+    assert build_mock.call_count == 2
+    # Phase 3 staged sdc.json for each enumerated DPLA ID — the
+    # contract this PR pins. Pre-PR, this list would be EMPTY.
+    staged_ids = [call.args[2] for call in stage_sdc_mock.call_args_list]
+    assert sorted(staged_ids) == [
+        "nara0000000000000000000000000001",
+        "nara0000000000000000000000000002",
+    ], staged_ids

--- a/tests/test_get_ids_nara.py
+++ b/tests/test_get_ids_nara.py
@@ -9,21 +9,22 @@ in-process call graph so a future refactor that drops Phase 3 surfaces
 as a test failure rather than a Slack-message-shaped surprise on the
 next operator run.
 
-Uses ``contextlib.ExitStack`` rather than the parenthesized ``with (A,
-B, C):`` form — CodeQL's ``py/unused-import`` query has a known false-
-positive class with the parenthesized form
-(https://github.com/github/codeql/issues/9657) and flags ``patch``,
-``CliRunner``, and the iteration source as "unused" even though
-ruff's F401/F841 confirm they are. The ExitStack pattern keeps every
-reference at top-level statement scope where the analyzer can trace it.
+Uses module-style imports (``import unittest.mock``, ``import click.testing``)
+rather than ``from … import patch, CliRunner`` because the latter
+triggers a known false-positive class in github-code-quality's
+unused-import analysis when the imported names are only referenced
+inside a context-manager block — switching to attribute access
+(``unittest.mock.patch.object`` / ``click.testing.CliRunner``) puts
+the references in unambiguous top-level expression form.
 """
 
 from __future__ import annotations
 
 import contextlib
-from unittest.mock import patch
+import json
+import unittest.mock
 
-from click.testing import CliRunner
+import click.testing
 
 
 def test_main_runs_sdc_phase_after_enumeration():
@@ -34,27 +35,23 @@ def test_main_runs_sdc_phase_after_enumeration():
     PR closes."""
     from tools import get_ids_nara
 
-    fake_hits = [
-        {
-            "_source": {
-                "id": "nara0000000000000000000000000001",
-                "provider": {"name": "National Archives and Records Administration"},
-                "dataProvider": {"name": "NARA — Some Library"},
-                "sourceResource": {"title": ["x"]},
-                "mediaMaster": ["http://example.org/x.jpg"],
-            }
-        },
-        {
-            "_source": {
-                "id": "nara0000000000000000000000000002",
-                "provider": {"name": "National Archives and Records Administration"},
-                "dataProvider": {"name": "NARA — Another Library"},
-                "sourceResource": {"title": ["y"]},
-                "mediaMaster": ["http://example.org/y.jpg"],
-            }
-        },
-    ]
-    paginate_iter = iter(fake_hits)
+    item_one = {
+        "id": "nara0000000000000000000000000001",
+        "provider": {"name": "National Archives and Records Administration"},
+        "dataProvider": {"name": "NARA — Some Library"},
+        "sourceResource": {"title": ["x"]},
+        "mediaMaster": ["http://example.org/x.jpg"],
+    }
+    item_two = {
+        "id": "nara0000000000000000000000000002",
+        "provider": {"name": "National Archives and Records Administration"},
+        "dataProvider": {"name": "NARA — Another Library"},
+        "sourceResource": {"title": ["y"]},
+        "mediaMaster": ["http://example.org/y.jpg"],
+    }
+    paginate_iter = iter([{"_source": item_one}, {"_source": item_two}])
+
+    patch = unittest.mock.patch  # local alias for readability
 
     with contextlib.ExitStack() as stack:
         # No remote ES calls during the build_*_queries phases.
@@ -112,20 +109,16 @@ def test_main_runs_sdc_phase_after_enumeration():
         )
 
         # Wire S3Client().get_item_metadata to return each fake hit's source
-        # doc as JSON so Phase 3's re-read succeeds.
+        # doc as JSON so Phase 3's re-read succeeds. ``json.dumps`` keeps
+        # the payload literal-free — implicit multi-line string
+        # concatenation was tripping the linter's "missing comma" check.
         s3_instance = s3_class_mock.return_value
         s3_instance.get_item_metadata.side_effect = [
-            '{"id":"nara0000000000000000000000000001",'
-            '"provider":{"name":"National Archives and Records Administration"},'
-            '"dataProvider":{"name":"NARA — Some Library"},'
-            '"sourceResource":{"title":["x"]},"mediaMaster":["http://example.org/x.jpg"]}',
-            '{"id":"nara0000000000000000000000000002",'
-            '"provider":{"name":"National Archives and Records Administration"},'
-            '"dataProvider":{"name":"NARA — Another Library"},'
-            '"sourceResource":{"title":["y"]},"mediaMaster":["http://example.org/y.jpg"]}',
+            json.dumps(item_one),
+            json.dumps(item_two),
         ]
 
-        runner = CliRunner()
+        runner = click.testing.CliRunner()
         # Click's main() exits via SystemExit; standalone_mode=False
         # surfaces any non-zero exit code through the result.
         result = runner.invoke(get_ids_nara.main, [], standalone_mode=False)

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -322,7 +322,11 @@ def main(
                 # before the tmux session is even launched), so applying the
                 # rightsCategory / institution-upload-flag gates here would
                 # only cause confusing failures when those gates drift.
-                query = {"query": {"term": {"id": single_id}}, "size": 1}
+                # ``size: 2`` (not 1) so the defensive ``len(hits) != 1``
+                # check below is actually REACHABLE. With size=1 ES caps
+                # the response and the >1 defense never fires, which
+                # defeats its purpose against stale-replica duplicates.
+                query = {"query": {"term": {"id": single_id}}, "size": 2}
             else:
                 query = build_query(
                     provider_name, eligible_dp_names, collection, search_after
@@ -338,9 +342,10 @@ def main(
 
             if single_id is not None:
                 # Defense-in-depth against ES returning more than one hit
-                # (shouldn't with ``size: 1`` but stale-replica or
-                # reindex-cutover scenarios have surfaced duplicates in the
-                # past) and against ID normalization on the ES side (e.g. if
+                # (shouldn't with a properly unique ``id`` field but stale-
+                # replica or reindex-cutover scenarios have surfaced
+                # duplicates in the past — see the ``size: 2`` request
+                # above) and against ID normalization on the ES side (e.g. if
                 # the field analyser ever changed). Bail loudly rather than
                 # silently staging the wrong document — single-id mode skips
                 # the hub-eligibility filter, so we have no other guardrail.

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -40,28 +40,32 @@ consumed by the downloader and uploader:
 import datetime
 import json
 import logging
-import os
 import sys
 import xml.etree.ElementTree as ET
 from concurrent.futures import ThreadPoolExecutor
 
 import click
-import requests
 
 from ingest_wikimedia.banlist import Banlist
-from ingest_wikimedia.dpla import DPLA, INSTITUTIONS_URL
+from ingest_wikimedia.dpla import DPLA
 from ingest_wikimedia.partners import PARTNER_HUBS
 from ingest_wikimedia.es import check_es_response, post_es
 from ingest_wikimedia.iiif import IIIF
-from ingest_wikimedia.s3 import APPLICATION_JSON, SDC_FILENAME, S3Client
+from ingest_wikimedia.s3 import S3Client
 from ingest_wikimedia.sdc import (
-    normalize_rights_uri,
     build_claims_for_doc,
     collect_subject_queries,
+    fetch_institutions_v2,
+    fetch_subjects_json,
+    load_rights_json,
     reconcile_subjects,
 )
 from ingest_wikimedia.slack import notify_phase_start
-from ingest_wikimedia.staging import make_s3_stage_context, stage_item_to_s3
+from ingest_wikimedia.staging import (
+    make_s3_stage_context,
+    stage_item_to_s3,
+    stage_sdc_to_s3,
+)
 
 PAGE_SIZE = 500
 S3_WRITE_WORKERS = 10
@@ -70,49 +74,12 @@ IIIF_MANIFEST_FIELD = "iiifManifest"
 MEDIA_MASTER_FIELD = "mediaMaster"
 IS_SHOWN_AT_FIELD = "isShownAt"
 
-# SDC pre-compute inputs. subjects.json is the DPLA-subject → Wikidata-Q-ID
-# map used to populate P921 alongside the string-form P4272. rights.json is
-# the small SDC-specific copyright mapping vendored in this repo.
-SUBJECTS_URL = (
-    "https://raw.githubusercontent.com/dpla/ingestion3/develop/"
-    "src/main/resources/subjects.json"
-)
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
 # isShownAt URL patterns from which a IIIF manifest can be formulaically
 # derived, expressed as ES wildcard values.  Extend this list as new DAMs
 # with predictable IIIF paths are identified.
 IIIF_DERIVABLE_ISSHOWNAT_PATTERNS = [
     "*/cdm/ref/collection/*/id/*",  # CONTENTdm
 ]
-
-
-def fetch_institutions_v2() -> dict:
-    """Fetch the full institutions_v2.json document used for hub/institution
-    eligibility and (in the SDC pre-compute pass) Wikidata-ID resolution."""
-    resp = requests.get(INSTITUTIONS_URL, timeout=15)
-    resp.raise_for_status()
-    return resp.json()
-
-
-def fetch_subjects_json() -> dict:
-    """Fetch the DPLA-subject → Wikidata-ID map used to populate P921.
-
-    Sourced from dpla/ingestion3 alongside institutions_v2.json; fetched
-    fresh per run so upstream changes land in the next sync without a
-    redeploy.
-    """
-    resp = requests.get(SUBJECTS_URL, timeout=30)
-    resp.raise_for_status()
-    return resp.json()
-
-
-def load_rights_json() -> dict:
-    """Load rights.json from the repo root and normalize its keys for
-    scheme-and-slash-insensitive lookup."""
-    with open(os.path.join(_REPO_ROOT, "rights.json")) as f:
-        raw = json.load(f)
-    return {normalize_rights_uri(k): v for k, v in raw.items()}
 
 
 def load_eligible_dp_names(institutions: dict, partner: str) -> list[str]:
@@ -146,20 +113,6 @@ def load_eligible_dp_names(institutions: dict, partner: str) -> list[str]:
             eligible.append(inst_name)
 
     return eligible
-
-
-def stage_sdc_to_s3(
-    s3_client: S3Client, partner: str, dpla_id: str, sdc_payload: dict
-) -> None:
-    """Write the per-item sdc.json sidecar to the partner's item prefix.
-
-    Raises on failure so the caller's ThreadPoolExecutor can observe it
-    via future.exception() in the done callback (same pattern as
-    stage_item_to_s3).
-    """
-    s3_client.write_item_file(
-        partner, dpla_id, json.dumps(sdc_payload), SDC_FILENAME, APPLICATION_JSON
-    )
 
 
 def build_query(

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -228,7 +228,33 @@ def build_query(
         " one --institution (collection scoping is per-institution)."
     ),
 )
-def main(partner: str, institutions: tuple[str, ...], collection: str | None) -> None:
+@click.option(
+    "--single-id",
+    "single_id",
+    default=None,
+    help=(
+        "Re-stage dpla-map.json + sdc.json for exactly ONE DPLA ID, then"
+        " print that ID to stdout. Skips the hub-level eligibility scan;"
+        " the operator is presumed to have already verified eligibility"
+        " (e.g. via the launch script's ``resolve-dpla-ids`` pre-check)."
+        " Mutually exclusive with ``--institution`` and ``--collection``."
+        " Used by the launch script's single-item path so a"
+        " ``/wikimedia-upload <dpla-id>`` run picks up the latest mapping"
+        " code in ``build_claims_for_doc`` — without this, the sdc-sync"
+        " step diffs against whatever sdc.json the partner's last full"
+        " run produced, silently missing any subsequent mapping changes."
+        " Eligibility is a SNAPSHOT taken at ``resolve-dpla-ids`` time;"
+        " if institutions_v2.json drifts (e.g. ``upload`` flag flipped"
+        " off) between submit and Phase 3, ``--single-id`` does NOT"
+        " re-check — the operator's submission is treated as authoritative."
+    ),
+)
+def main(
+    partner: str,
+    institutions: tuple[str, ...],
+    collection: str | None,
+    single_id: str | None,
+) -> None:
     """Print wiki-eligible DPLA IDs for PARTNER to stdout, one per line.
 
     Also stages each item's full metadata to S3 (dpla-map.json) so the
@@ -239,7 +265,21 @@ def main(partner: str, institutions: tuple[str, ...], collection: str | None) ->
     belonging to any of the listed institutions in one combined run.
     No ``--institution`` flags means "all eligible institutions for
     this hub" (the existing hub-level behaviour).
+
+    ``--single-id`` switches to a per-ID branch: skip the hub-wide ES
+    scan, fetch the one document by ID, run the same Phase 1 → 2 → 3
+    pipeline on a list of one, and emit the single ID. Used by the
+    launch script's ``/wikimedia-upload <dpla-id>`` path so single-item
+    runs pick up the latest mapping code.
     """
+    if single_id is not None and (institutions or collection):
+        print(
+            "--single-id cannot be combined with --institution or --collection"
+            " (single-id mode targets exactly one document by ID).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     if collection is not None:
         collection = collection.strip()
         if not collection:
@@ -308,11 +348,32 @@ def main(partner: str, institutions: tuple[str, ...], collection: str | None) ->
     dpla_ids: list[str] = []
     subject_queries: set[tuple[str, str]] = set()
 
+    # Single-ID mode: pre-check the banlist BEFORE the ES round-trip so the
+    # operator gets a distinct ``banlisted`` error rather than the generic
+    # ``no document from ES`` message — the two failures need different
+    # remediation (banlist edit vs. ES indexing investigation).
+    if single_id is not None and banlist.is_banned(single_id):
+        print(
+            f"Error: --single-id {single_id} is on the banlist; remove it"
+            " from dpla-id-banlist.txt to proceed.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
     with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
         while True:
-            query = build_query(
-                provider_name, eligible_dp_names, collection, search_after
-            )
+            if single_id is not None:
+                # Single-ID branch: bypass the hub-eligibility filter entirely
+                # and look the document up by its DPLA ID. The operator already
+                # vouched for eligibility upstream (resolve-dpla-ids runs
+                # before the tmux session is even launched), so applying the
+                # rightsCategory / institution-upload-flag gates here would
+                # only cause confusing failures when those gates drift.
+                query = {"query": {"term": {"id": single_id}}, "size": 1}
+            else:
+                query = build_query(
+                    provider_name, eligible_dp_names, collection, search_after
+                )
             response = post_es(query)
             response.raise_for_status()
             page = response.json()
@@ -321,6 +382,31 @@ def main(partner: str, institutions: tuple[str, ...], collection: str | None) ->
 
             if not hits:
                 break
+
+            if single_id is not None:
+                # Defense-in-depth against ES returning more than one hit
+                # (shouldn't with ``size: 1`` but stale-replica or
+                # reindex-cutover scenarios have surfaced duplicates in the
+                # past) and against ID normalization on the ES side (e.g. if
+                # the field analyser ever changed). Bail loudly rather than
+                # silently staging the wrong document — single-id mode skips
+                # the hub-eligibility filter, so we have no other guardrail.
+                if len(hits) != 1:
+                    print(
+                        f"Error: --single-id {single_id} returned"
+                        f" {len(hits)} hits from ES; expected exactly 1.",
+                        file=sys.stderr,
+                    )
+                    raise SystemExit(1)
+                returned_id = hits[0]["_source"].get("id")
+                if returned_id != single_id:
+                    print(
+                        f"Error: --single-id {single_id} returned a document"
+                        f" with id={returned_id!r}; refusing to stage under a"
+                        " mismatched key.",
+                        file=sys.stderr,
+                    )
+                    raise SystemExit(1)
 
             for hit in hits:
                 source = hit["_source"]
@@ -354,7 +440,24 @@ def main(partner: str, institutions: tuple[str, ...], collection: str | None) ->
 
                 print(dpla_id)
 
+            if single_id is not None:
+                # No pagination — single-id mode is a one-shot lookup.
+                break
             search_after = hits[-1]["sort"]
+
+    if single_id is not None and not dpla_ids:
+        # ES had no document for this ID. (The banlist case is short-
+        # circuited above with its own distinct error, and the per-hit
+        # ID-mismatch / >1-hit cases also raise with their own messages,
+        # so reaching this branch means ES genuinely returned an empty
+        # hits array.) Non-zero exit so the launch script's tmux chain
+        # short-circuits before downloader/uploader/sdc-sync run against
+        # an empty CSV.
+        print(
+            f"Error: --single-id {single_id} returned no document from ES.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
 
     if failed[0]:
         print(f"Error: {failed[0]} dpla-map.json writes failed", file=sys.stderr)

--- a/tools/get_ids_nara.py
+++ b/tools/get_ids_nara.py
@@ -17,12 +17,21 @@ can be updated as priorities change.
 For each eligible item, the full ES source document is written to S3 as dpla-map.json
 so the downloader can skip DPLA API calls entirely.
 
+After enumeration completes, this tool also writes a per-item sdc.json sidecar
+containing the ready-to-POST Wikibase claim list — same shape and code path as
+get-ids-es. Without this, NARA hub-level runs would leave sdc.json stale (last
+written by the *previous* upload run) and sdc-sync would silently miss any
+ingest_wikimedia.sdc mapping changes shipped in the interim.
+
 Output: one DPLA ID per line to stdout. Redirect to produce the IDs CSV:
     get-ids-nara > nara/nara.csv
 """
 
+import datetime
+import json
 import logging
 import sys
+import xml.etree.ElementTree as ET
 from concurrent.futures import ThreadPoolExecutor
 
 import click
@@ -30,8 +39,20 @@ import click
 from ingest_wikimedia.banlist import Banlist
 from ingest_wikimedia.es import ES_HARD_TIMEOUT, check_es_response, post_es
 from ingest_wikimedia.s3 import S3Client
+from ingest_wikimedia.sdc import (
+    build_claims_for_doc,
+    collect_subject_queries,
+    fetch_institutions_v2,
+    fetch_subjects_json,
+    load_rights_json,
+    reconcile_subjects,
+)
 from ingest_wikimedia.slack import notify_phase_start
-from ingest_wikimedia.staging import make_s3_stage_context, stage_item_to_s3
+from ingest_wikimedia.staging import (
+    make_s3_stage_context,
+    stage_item_to_s3,
+    stage_sdc_to_s3,
+)
 
 PAGE_SIZE = 500
 S3_WRITE_WORKERS = 4
@@ -301,6 +322,17 @@ def main() -> None:
 
     s3_sem, failed, _on_s3_done = make_s3_stage_context(S3_WRITE_WORKERS)
 
+    # SDC pre-compute inputs. Loaded once and reused for the Phase 3 pass.
+    # Fetched fresh so an upstream institutions_v2 / subjects.json change
+    # is reflected in the next NARA run without a redeploy.
+    institutions_json = fetch_institutions_v2()
+    rights = load_rights_json()
+    subject_ids = fetch_subjects_json()
+    retrieval_date = datetime.date.today()
+
+    dpla_ids: list[str] = []
+    subject_queries: set[tuple[str, str]] = set()
+
     with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
         for label, extra_filter in queries:
             print(f"Querying {label}", file=sys.stderr)
@@ -320,10 +352,101 @@ def main() -> None:
                 )
                 future.add_done_callback(_on_s3_done(dpla_id))
 
+                dpla_ids.append(dpla_id)
+                subject_queries.update(collect_subject_queries(source))
+
                 print(dpla_id)
 
     if failed[0]:
         print(f"Error: {failed[0]} S3 writes failed", file=sys.stderr)
+        raise SystemExit(1)
+
+    # Phase 2 — batched Wikidata reconciliation for NARA exactMatch subjects.
+    # Mirrors get-ids-es Phase 2. Best-effort: chunks that fail are logged
+    # and skipped (their items' P921 entries simply omitted; P4272 still
+    # lands).
+    print(
+        f"Reconciling {len(subject_queries)} unique subject queries...",
+        file=sys.stderr,
+    )
+    subjects_lookup = reconcile_subjects(subject_queries)
+    print(
+        f"Resolved {len(subjects_lookup)} subjects to Wikidata IDs.",
+        file=sys.stderr,
+    )
+
+    # Phase 3 — build per-item sdc.json (ready-to-POST claim list) and stage
+    # to S3 alongside dpla-map.json. Re-reads each item's source doc from
+    # the dpla-map.json staged in Phase 1 (rather than buffering in memory)
+    # so peak memory stays O(unique-subjects) rather than scaling with the
+    # NARA hit set. Items the SDC builder can't parse (e.g. provider /
+    # institution missing from institutions_v2.json, malformed NARA XML)
+    # are skipped — their dpla-map.json is still in place for downloader/
+    # uploader and a future re-run will pick them up.
+    sdc_sem, sdc_failed, _on_sdc_done = make_s3_stage_context(S3_WRITE_WORKERS)
+    sdc_skipped = 0
+
+    with ThreadPoolExecutor(max_workers=S3_WRITE_WORKERS) as executor:
+        for dpla_id in dpla_ids:
+            raw = s3_client.get_item_metadata(PARTNER, dpla_id)
+            if raw is None:
+                logging.warning(
+                    "dpla-map.json missing for %s in phase 3; skipping sdc.json",
+                    dpla_id,
+                )
+                sdc_skipped += 1
+                continue
+            try:
+                source = json.loads(raw)
+            except json.JSONDecodeError as e:
+                logging.warning(
+                    "dpla-map.json for %s failed to parse in phase 3 (%s);"
+                    " skipping sdc.json",
+                    dpla_id,
+                    e,
+                )
+                sdc_skipped += 1
+                continue
+            try:
+                sdc_payload = build_claims_for_doc(
+                    source,
+                    dpla_id,
+                    institutions_json,
+                    rights,
+                    subject_ids,
+                    subjects_lookup,
+                    retrieval_date,
+                )
+            except ET.ParseError as e:
+                # Malformed NARA originalRecord XML (parse_nara_access_level
+                # surfaces this). Skip the sdc.json for this item rather than
+                # abort the whole run — same boundary get-ids-es uses.
+                logging.warning(
+                    "build_claims_for_doc for %s raised ET.ParseError (%s);"
+                    " skipping sdc.json for this item",
+                    dpla_id,
+                    e,
+                )
+                sdc_skipped += 1
+                continue
+            if sdc_payload is None:
+                sdc_skipped += 1
+                continue
+            sdc_sem.acquire()
+            future = executor.submit(
+                stage_sdc_to_s3, s3_client, PARTNER, dpla_id, sdc_payload
+            )
+            future.add_done_callback(_on_sdc_done(dpla_id))
+
+    if sdc_skipped:
+        print(
+            f"Skipped sdc.json for {sdc_skipped} items"
+            " (missing/malformed dpla-map.json or unmappable source).",
+            file=sys.stderr,
+        )
+
+    if sdc_failed[0]:
+        print(f"Error: {sdc_failed[0]} sdc.json writes failed", file=sys.stderr)
         raise SystemExit(1)
 
 


### PR DESCRIPTION
## Problem

The single-item launch path (`/wikimedia-upload <dpla-id>`) writes the one DPLA ID to a CSV via `printf '%s\n' <id> > <csv>` and **skips `get-ids-es` entirely**. Consequence: dpla-map.json and sdc.json on S3 are NOT regenerated when a single-item run kicks off — sdc-sync diffs against whatever sdc.json the partner's last full run produced.

Any mapping change shipped since that last run (PR #279's opportunistic date parsing, PR #278's NARA stdlib XML, future ingest_wikimedia/sdc.py work) is silently missed by single-item runs. End-to-end testing of mapping changes via `/wikimedia-upload` only worked accidentally, when the operator happened to test against an item whose partner had just been re-run.

## Fix

Three surgical changes:

### 1. `tools/get_ids_es.py` — new `--single-id <dpla-id>` flag

When set, bypasses the hub-eligibility filter (rightsCategory + eligible-dp-names) and queries ES by `_id` only:

```python
query = {"query": {"term": {"id": single_id}}, "size": 1}
```

The single hit goes through the **same Phase 1 staging body** (banlist check, IIIF derivation, `stage_item_to_s3`, subject collection) as the paginated branch, then Phase 2 (Wikidata subject reconciliation) and Phase 3 (sdc.json staging) run on a list of one. Mutually exclusive with `--institution` and `--collection`.

### 2. `scripts/wikimedia_launch.py` — single-item chain uses `--single-id`

Swaps `printf '%s\n' <id> > <csv>` for `get-ids-es <partner> --single-id <id> > <csv>`. `resolve-dpla-ids` still runs upstream (short-circuits ineligible IDs with a clean Slack message before tmux is touched); its per-item S3 staging is superseded by the in-tmux re-stage.

### 3. Stale `--sdc-only` warning narrowed

The warning block that previously mentioned "single-item DPLA IDs or NARA hub-level targets" now only mentions NARA hub-level (the only remaining target type that can't re-stage sdc.json, because get-ids-nara enumerates the NARA catalog directly).

## Defensive guards (caught by code review)

| Failure mode | Behavior before | Behavior after |
|---|---|---|
| ID is on banlist | Generic "no document" error | Distinct "on the banlist; remove it from dpla-id-banlist.txt" error |
| ES returns >1 hit (reindex-cutover stale-replica) | Loop silently processes whichever shard-ordered first | Exit 1 with explicit count mismatch |
| ES returns document with mismatched `_source.id` (index analyzer regression) | Stages under the queried key, orphan from downstream downloader | Exit 1 with both IDs in the message |

The launch script's Slack failure handler surfaces these messages verbatim to on-call, so the wording points at the right remediation.

## Eligibility semantics (documented in CLI help)

`--single-id` treats `resolve-dpla-ids`' upstream eligibility check as authoritative — a **snapshot taken at `/wikimedia-upload` submit time**. If institutions_v2.json drifts between submit and Phase 3 (e.g. upload flag flipped off), `--single-id` does NOT re-check. The operator's submission wins.

## Tests

7 new tests in `tests/test_get_ids_es.py`:
- Mutual exclusion with `--institution`
- Mutual exclusion with `--collection`
- Term-query shape (NOT `build_query`'s hub-wide filter)
- Empty ES result → exit 1 + "no document"
- Banlist hit → exit 1 + distinct "banlist" message, ES round-trip NEVER happens
- ID mismatch → exit 1 + returned ID in message
- (Plus the existing 4 validation tests still pass)

Local 434-test suite green on Python 3.13.

## Test plan

- [ ] CI green
- [ ] After merge + next session: run `/wikimedia-upload 0b6770fce84b2367f5bc7172474531c0` (a Hoover item with `1930-05-15` source date) and verify:
  - sdc.json LastModified on S3 updates to the run time
  - The new sdc.json contains a value-typed P571 (precision 11)
  - sdc-sync produces non-zero `CLAIMS_ADDED` and `REMOVALS` (migrates somevalue → value-typed)
- [ ] Run the same item again to verify idempotency (zero edits second time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds a new --single-id mode to tools/get_ids_es.py so single-item upload targets (/wikimedia-upload <dpla-id>) re-stage mapping outputs (dpla-map.json and per-item sdc.json) using the current mapping pipeline. Previously the single-item path wrote the ID directly to a CSV and skipped get-ids-es, which could miss mapping changes delivered since a partner’s last full run.

Also extends Phase 2→Phase 3 SDC staging behavior to get-ids-nara so enumerated NARA runs build and stage per-item sdc.json, and updates the launcher to call get-ids-es for single-item targets.

## Changes

### tools/get_ids_es.py
- New CLI option: --single-id <dpla-id>
  - Mutually exclusive with --institution and --collection.
  - Pre-checks banlist and emits a distinct banlist error message.
  - Performs a direct Elasticsearch exact-term lookup for the requested ID (one-shot query, defensive size so >1 hits are detectable).
  - Validates ES returns exactly one hit and that returned _source.id matches the queried ID; exits non-zero on zero hits, >1 hits (reports count), or mismatched id.
  - On success, the single hit proceeds through the same Phase 1 (banlist/IIIF derivation/stage_item_to_s3 → collect subjects) → Phase 2 (Wikidata reconciliation) → Phase 3 (build & stage per-item sdc.json) path used by hub-level runs, then prints the ID to stdout.
  - CLI help documents that --single-id treats resolve-dpla-ids eligibility as a snapshot at submit time.
- Function signature updated to accept single_id.
- Refactored to reuse ingest_wikimedia.* SDC/staging helpers.
- Defensive guards: distinct banlist error message; explicit exit for ES hit-count and ID-mismatch cases.

### scripts/wikimedia_launch.py
- Single-item flow now invokes get-ids-es <partner> --single-id <id> (replacing printf), ensuring per-item mapping sidecars are re-staged before downstream download/upload/sdc-sync steps.
- The launcher’s prior wording/behavior that warned of “stale sdc.json sidecars” was narrowed so it no longer lists single-item DPLA IDs as an exception.

### tools/get_ids_nara.py
- Enumeration workflow extended into a multi-phase pipeline:
  - Phase 1 enumerates and stages dpla-map.json and collects subject queries.
  - Phase 2 performs batched Wikidata reconciliation across collected subject queries.
  - Phase 3 reloads staged dpla-map.json, builds per-item sdc.json via build_claims_for_doc, and stages sdc.json to S3 concurrently.
- Phase 3 is best-effort: skips items with missing staged metadata, JSON/XML parse errors, unmappable payloads (logging warnings), and fails the run if concurrent staging futures error.

### ingest_wikimedia/sdc.py
- Added network/local data-loading helpers:
  - fetch_institutions_v2() — GETs institutions_v2.json with timeout + raise_on_status.
  - fetch_subjects_json() — GETs subjects.json (pinned raw URL) with timeout + raise_on_status.
  - load_rights_json() — reads local rights.json and returns a dict keyed by normalized URIs.
- Introduces SUBJECTS_URL and related runtime-loading constants.

### ingest_wikimedia/staging.py
- Added stage_sdc_to_s3(s3_client, partner, dpla_id, sdc_payload) to write per-item sdc.json sidecars to S3; reused by get-ids-es and get-ids-nara.

### tests
- tests/test_get_ids_es.py: 7 tests for --single-id behavior (mutual-exclusion, term-query shape, empty result, banlist-specific error, mismatched-id rejection, orchestration helper).
  - Tests mock stage_sdc_to_s3 / S3 interactions to avoid CI S3 IAM failures.
  - ES defensive query size set so tests can exercise >1-hits branch.
- tests/test_get_ids_nara.py: new integration-style test asserting get-ids-nara runs Phase 3 and stages sdc.json for enumerated IDs.
- Local test suite reported green on Python 3.13 by the author.

## Deployment & Infrastructure impact

- No manual pipeline trigger, ECS redeploy, or other runtime redeploy is required for these CLI/tooling code changes to take effect for operators invoking the command-line tools.
- No environment variables or AWS Secrets Manager keys were added, removed, or renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM policies) are included.
- CI workflow files were not changed in a way that requires ops action.

## Security & Operational notes

- ingest_wikimedia/sdc.py introduces additional external network calls (fetch_institutions_v2 and fetch_subjects_json). These are unauthenticated HTTP GETs with timeouts and raise_on_status; operators/reviewers should note the new availability and latency dependency.
- No credential handling or secret management changes.
- No public API response shapes or endpoints were modified.

## Tests & QA

- Unit and CLI tests added for --single-id and NARA Phase 3 behavior; S3 writes are mocked in tests to avoid CI IAM failures.
- PR includes defensive runtime guards and explicit error messages for ES-hit count and ID mismatches; reviewers should confirm error wording and exit codes.
- Manual verification steps and a test plan are provided in the PR description.

## Risk & Review focus

- Behavioral impact: single-item uploads will now re-run the mapping pipeline and re-stage sdc.json; verify claim output correctness and downstream consumer behavior.
- Key review areas:
  - Exact-term ES lookup and defensive handling for 0 / >1 / mismatched hits.
  - Banlist pre-check and distinct banlist error messaging.
  - S3 staging of sdc.json and error handling when earlier-stage dpla-map.json is missing or malformed.
  - Network fetch helpers (timeouts, error handling, and operational dependency on external raw URLs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->