### PR TITLE
sdc: stamp P2699 + P6108 qualifiers on P7482 (idempotent for existing claims)

### DIFF
--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -694,8 +694,26 @@ def _build_source_claim(
     url: str,
     dpla_id: str,
     retrieval_date: datetime.date,
+    iiif_manifest_url: str | None = None,
 ) -> dict:
-    """Build the P7482 (described at) claim with P973 + P137 qualifiers."""
+    """Build the P7482 (described at) claim with its qualifier bundle.
+
+    Qualifiers, all DPLA-authored (the ``_is_safe_to_amend_in_place`` gate
+    considers a P7482 statement still "ours" only when every qualifier is
+    in this list; see ``_DPLA_EXTRA_QUALIFIER_PROPS`` in tools/sdc_sync.py):
+
+      * ``P973``  — described-at URL (the partner catalog page for this
+                    DPLA item, ``edm:isShownAt``)
+      * ``P137``  — operator (the hub's Wikidata QID)
+      * ``P6108`` — IIIF manifest URL (only when the source DPLA record
+                    has ``iiifManifest``; per-DPLA-item, identical across
+                    every ordinal)
+
+    The per-ordinal ``P2699`` qualifier (direct file download URL) is NOT
+    stamped here — it differs per Commons file and is materialized at
+    sdc-sync write time from ``file-list.txt``. See
+    ``process_one_from_sdc`` in tools/sdc_sync.py.
+    """
     claim = formattedclaim(
         "P7482",
         _item_value(Q_SOURCE_CATALOG),
@@ -705,6 +723,10 @@ def _build_source_claim(
     )
     claim["qualifiers"]["P973"] = [_qualifier_string_snak("P973", url, datatype="url")]
     claim["qualifiers"]["P137"] = [_qualifier_item_snak("P137", hub)]
+    if iiif_manifest_url:
+        claim["qualifiers"]["P6108"] = [
+            _qualifier_string_snak("P6108", iiif_manifest_url, datatype="url")
+        ]
     return claim
 
 
@@ -1076,8 +1098,27 @@ def build_claims_for_doc(
     # P9126 — maintained by chain.
     claims.extend(_build_contributed_claims(hub, institution, dpla_id, retrieval_date))
 
-    # P7482 — described at source catalog.
-    claims.append(_build_source_claim(hub, url, dpla_id, retrieval_date))
+    # P7482 — described at source catalog. P6108 (IIIF manifest URL) is
+    # added as a qualifier here when the source carries a usable
+    # iiifManifest; P2699 (per-ordinal download URL) is added downstream
+    # by sdc-sync. Defensive URL validation: some hubs ship the literal
+    # string "null", whitespace, or malformed fragments in iiifManifest;
+    # stamping that as P6108 would require manual Commons cleanup later.
+    iiif_manifest_raw = doc.get("iiifManifest") or ""
+    iiif_manifest_url = (
+        iiif_manifest_raw.strip() if isinstance(iiif_manifest_raw, str) else ""
+    )
+    if not iiif_manifest_url.startswith(("http://", "https://")):
+        iiif_manifest_url = None
+    claims.append(
+        _build_source_claim(
+            hub,
+            url,
+            dpla_id,
+            retrieval_date,
+            iiif_manifest_url=iiif_manifest_url,
+        )
+    )
 
     # P217 — local identifier (non-NARA; per-value, with P195 qualifier).
     for local_id in local_ids:

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -18,6 +18,7 @@ from ingest_wikimedia.sdc import (
     Q_NARA_FILE_UNIT,
     Q_NARA_ITEM,
     _build_date_claim,
+    _build_source_claim,
     parse_dpla_date,
     parse_nara_access_level,
 )
@@ -452,3 +453,122 @@ def test_build_date_claim_returns_none_for_empty_input():
 
     assert _build_date_claim("", "abc123", _dt.date(2026, 6, 7)) is None
     assert _build_date_claim("   ", "abc123", _dt.date(2026, 6, 7)) is None
+
+
+# ---------------------------------------------------------------------------
+# _build_source_claim — P7482 (described at) with its qualifier bundle.
+# P6108 (IIIF manifest URL) is the new per-item qualifier in this PR;
+# P2699 is per-ordinal and gets materialized in sdc-sync, NOT here.
+# ---------------------------------------------------------------------------
+
+
+def test_build_source_claim_omits_p6108_when_no_iiif_manifest():
+    """Items without iiifManifest in the source doc → no P6108 qualifier.
+    Default behavior — preserves the pre-PR shape for the long tail of
+    non-IIIF partners."""
+    import datetime as _dt
+
+    claim = _build_source_claim(
+        "Q12345", "https://example.org/item/1", "abc", _dt.date(2026, 6, 7)
+    )
+    quals = claim["qualifiers"]
+    assert "P973" in quals  # described-at URL still there
+    assert "P137" in quals  # operator still there
+    assert "P6108" not in quals
+
+
+def test_build_source_claim_stamps_p6108_when_iiif_manifest_provided():
+    """When the source carries a IIIF manifest URL, build it into the
+    P7482 statement as a P6108 qualifier (per-item). sdc.json now carries
+    the value; sdc-sync handles backfill of existing P7482 statements
+    via ``_amend_p7482_url_qualifiers``."""
+    import datetime as _dt
+
+    manifest_url = "https://example.org/iiif/abc/manifest.json"
+    claim = _build_source_claim(
+        "Q12345",
+        "https://example.org/item/1",
+        "abc",
+        _dt.date(2026, 6, 7),
+        iiif_manifest_url=manifest_url,
+    )
+    p6108 = claim["qualifiers"]["P6108"][0]
+    assert p6108["property"] == "P6108"
+    assert p6108["datavalue"]["value"] == manifest_url
+    assert p6108["datavalue"]["type"] == "string"
+    assert p6108["datatype"] == "url"
+
+
+def test_build_claims_for_doc_rejects_junky_iiif_manifest_values():
+    """``doc["iiifManifest"]`` arrives from upstream DPLA records that
+    occasionally carry junk — literal string "null", whitespace, schemes
+    we don't recognise. Stamping any of those as P6108 on Commons would
+    require manual cleanup. Pin the defense: only stamp when the value
+    is a real http(s) URL after stripping."""
+    from ingest_wikimedia.sdc import build_claims_for_doc
+
+    def _doc(iiif_value):
+        return {
+            "id": "abc1234567890",
+            "provider": {"name": "Digital Commonwealth"},
+            "dataProvider": {"name": "Boston Public Library"},
+            "sourceResource": {
+                "title": ["A title"],
+                "date": [{"displayDate": "1945"}],
+            },
+            "isShownAt": "https://example.org/item/abc",
+            "rights": "http://rightsstatements.org/vocab/InC/1.0/",
+            "iiifManifest": iiif_value,
+        }
+
+    hubs = {
+        "Digital Commonwealth": {
+            "Wikidata": "Q1",
+            "institutions": {"Boston Public Library": {"Wikidata": "Q2"}},
+        }
+    }
+    import datetime as _dt
+
+    for junk in (None, "", "   ", "null", "ftp://example.org/x", "not a url"):
+        out = build_claims_for_doc(
+            _doc(junk), "abc1234567890", hubs, {}, {}, {}, _dt.date(2026, 6, 7)
+        )
+        p7482 = next(c for c in out["claims"] if c["mainsnak"]["property"] == "P7482")
+        assert "P6108" not in p7482["qualifiers"], (
+            f"{junk!r} should not produce a P6108 qualifier"
+        )
+
+    # Valid http/https URLs DO get stamped, with surrounding whitespace
+    # tolerated.
+    for valid in (
+        "https://example.org/iiif/manifest.json",
+        "  https://example.org/iiif/manifest.json  ",
+        "http://example.org/iiif/manifest.json",
+    ):
+        out = build_claims_for_doc(
+            _doc(valid), "abc1234567890", hubs, {}, {}, {}, _dt.date(2026, 6, 7)
+        )
+        p7482 = next(c for c in out["claims"] if c["mainsnak"]["property"] == "P7482")
+        assert "P6108" in p7482["qualifiers"], (
+            f"{valid!r} should produce a P6108 qualifier"
+        )
+        # Stamped value is the stripped form.
+        assert p7482["qualifiers"]["P6108"][0]["datavalue"]["value"] == valid.strip()
+
+
+def test_build_source_claim_never_stamps_p2699():
+    """``P2699`` is per-ordinal — different ordinals of the same DPLA
+    item have different download URLs, so the qualifier can't be baked
+    into sdc.json. It gets injected by ``process_one_from_sdc`` at sync
+    time. Pin the contract that ``_build_source_claim`` does NOT emit
+    it, even speculatively."""
+    import datetime as _dt
+
+    claim = _build_source_claim(
+        "Q12345",
+        "https://example.org/item/1",
+        "abc",
+        _dt.date(2026, 6, 7),
+        iiif_manifest_url="https://example.org/iiif/abc/manifest.json",
+    )
+    assert "P2699" not in claim["qualifiers"]

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -16,6 +16,7 @@ A claim that contains any user-authored qualifier or reference is
 NOT safe — the wbeditentity round-trip would erase that data.
 """
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1879,3 +1880,232 @@ def test_build_expected_from_parsed_includes_both_shapes_for_p571(monkeypatch):
     canonical_keys = [v for v in p571 if v.startswith("+")]
     # 2 parseables → exactly 2 canonical entries.
     assert len(canonical_keys) == 2
+
+
+# ---------------------------------------------------------------------------
+# P2699 / P6108 qualifiers on P7482 (PR description in
+# tools/sdc_sync.py::_amend_p7482_url_qualifiers).
+#
+# Test surface:
+#   * per-ordinal P2699 injection in process_one_from_sdc
+#   * idempotent amend of existing DPLA-authored P7482 statements
+#     (missing → POST wbsetqualifier; already present → no-op)
+#   * eligibility gate: don't amend foreign-shaped P7482 statements
+#   * reconciler treats P2699/P6108 as DPLA-owned (doesn't queue removal)
+# ---------------------------------------------------------------------------
+
+
+def _p7482_stmt(stmt_id, p973_value, extra_qualifiers=None):
+    """A DPLA-authored P7482 statement with the standard P973/P137/P459
+    qualifier set. ``extra_qualifiers`` is a dict merged in on top
+    (used by tests that need to set P2699 / P6108 to pre-existing
+    values)."""
+    qualifiers = {
+        "P459": _dpla_p459(),
+        "P973": _qual_string("P973", p973_value),
+        "P137": _qual_entity("P137", "Q12345"),
+    }
+    if extra_qualifiers:
+        qualifiers.update(extra_qualifiers)
+    return {
+        "id": stmt_id,
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P7482",
+            "datavalue": {
+                "value": {
+                    "entity-type": "item",
+                    "numeric-id": 74228490,
+                    "id": "Q74228490",
+                },
+                "type": "wikibase-entityid",
+            },
+        },
+        "qualifiers": qualifiers,
+        "references": [_dpla_reference()],
+    }
+
+
+def _sdc_payload_with_p7482(catalog_url, iiif_manifest_url=None):
+    """Build a sdc.json shape with a single P7482 claim — what
+    ``_amend_p7482_url_qualifiers`` reads to learn what should be there."""
+    p7482 = {
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P7482",
+            "datavalue": {
+                "value": {"entity-type": "item", "numeric-id": 74228490},
+                "type": "wikibase-entityid",
+            },
+        },
+        "qualifiers": {
+            "P459": _dpla_p459(),
+            "P973": _qual_string("P973", catalog_url),
+            "P137": _qual_entity("P137", "Q12345"),
+        },
+        "references": [_dpla_reference()],
+    }
+    if iiif_manifest_url is not None:
+        p7482["qualifiers"]["P6108"] = _qual_string("P6108", iiif_manifest_url)
+    return {"claims": [p7482]}
+
+
+def test_amend_p7482_adds_missing_p2699_and_p6108(monkeypatch):
+    """Existing DPLA-authored P7482 with only P973/P137/P459 — the
+    common case for every file uploaded before this PR. Sdc-sync should
+    POST wbsetqualifier for each missing qualifier and stop."""
+    from tools import sdc_sync
+
+    catalog_url = "https://example.org/item/abc"
+    download_url = "https://example.org/files/abc-page1.jpg"
+    iiif_url = "https://example.org/iiif/abc/manifest.json"
+
+    legacy_stmt = _p7482_stmt("M999$P7482", catalog_url)
+    entity = {"pageid": 999, "statements": {"P7482": [legacy_stmt]}}
+    payload = _sdc_payload_with_p7482(catalog_url, iiif_manifest_url=iiif_url)
+
+    postqual_calls = []
+
+    def fake_postqual(claimid, prop, value):
+        postqual_calls.append((claimid, prop, value))
+
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(sdc_sync, "postqual", side_effect=fake_postqual),
+    ):
+        sdc_sync._amend_p7482_url_qualifiers(
+            "M999", "abcdef", payload, download_url=download_url
+        )
+
+    # Both qualifiers were posted; both targeted the same existing claim.
+    by_prop = {c[1]: c for c in postqual_calls}
+    assert "P2699" in by_prop, postqual_calls
+    assert "P6108" in by_prop, postqual_calls
+    assert by_prop["P2699"][0] == "M999$P7482"
+    assert by_prop["P6108"][0] == "M999$P7482"
+    # Values are JSON-encoded strings (matches add_det's wbsetqualifier value).
+    assert json.loads(by_prop["P2699"][2]) == download_url
+    assert json.loads(by_prop["P6108"][2]) == iiif_url
+
+
+def test_amend_p7482_noop_when_qualifiers_already_match(monkeypatch):
+    """Already-present qualifiers with the matching values → zero
+    wbsetqualifier calls. Re-running the same partner against an
+    already-migrated file is silent."""
+    from tools import sdc_sync
+
+    catalog_url = "https://example.org/item/abc"
+    download_url = "https://example.org/files/abc-page1.jpg"
+    iiif_url = "https://example.org/iiif/abc/manifest.json"
+
+    already_migrated = _p7482_stmt(
+        "M999$P7482",
+        catalog_url,
+        extra_qualifiers={
+            "P2699": _qual_string("P2699", download_url),
+            "P6108": _qual_string("P6108", iiif_url),
+        },
+    )
+    entity = {"pageid": 999, "statements": {"P7482": [already_migrated]}}
+    payload = _sdc_payload_with_p7482(catalog_url, iiif_manifest_url=iiif_url)
+
+    postqual_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync, "postqual", side_effect=lambda *a: postqual_calls.append(a)
+        ),
+    ):
+        sdc_sync._amend_p7482_url_qualifiers(
+            "M999", "abcdef", payload, download_url=download_url
+        )
+
+    assert postqual_calls == []
+
+
+def test_amend_p7482_skips_when_no_existing_statement(monkeypatch):
+    """When Commons has no P7482 yet (newly uploaded file), the standard
+    ``_post_new_claims`` path is responsible for adding it with all the
+    qualifiers already in place. ``_amend_p7482_url_qualifiers`` should
+    not POST anything — no claim id to target."""
+    from tools import sdc_sync
+
+    entity = {"pageid": 999, "statements": {}}  # no P7482
+    payload = _sdc_payload_with_p7482("https://example.org/item/abc")
+
+    postqual_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync, "postqual", side_effect=lambda *a: postqual_calls.append(a)
+        ),
+    ):
+        sdc_sync._amend_p7482_url_qualifiers(
+            "M999",
+            "abcdef",
+            payload,
+            download_url="https://example.org/files/abc.jpg",
+        )
+
+    assert postqual_calls == []
+
+
+def test_amend_p7482_does_not_touch_foreign_statements(monkeypatch):
+    """A P7482 statement carrying user-added qualifiers (or a non-DPLA
+    publisher reference) must be left alone — the
+    ``_is_safe_to_amend_in_place`` gate keeps community-edited statements
+    out of the amend path. Re-running shouldn't drag in our P2699/P6108
+    next to someone else's data."""
+    from tools import sdc_sync
+
+    catalog_url = "https://example.org/item/abc"
+    foreign_stmt = _p7482_stmt(
+        "M999$FOREIGN",
+        catalog_url,
+        extra_qualifiers={
+            # P1001 isn't in _DPLA_EXTRA_QUALIFIER_PROPS for P7482 →
+            # _is_safe_to_amend_in_place returns False.
+            "P1001": _qual_entity("P1001", "Q30"),
+        },
+    )
+    entity = {"pageid": 999, "statements": {"P7482": [foreign_stmt]}}
+    payload = _sdc_payload_with_p7482(catalog_url)
+
+    postqual_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync, "postqual", side_effect=lambda *a: postqual_calls.append(a)
+        ),
+    ):
+        sdc_sync._amend_p7482_url_qualifiers(
+            "M999", "abcdef", payload, download_url="https://example.org/files/abc.jpg"
+        )
+
+    assert postqual_calls == []
+
+
+def test_dpla_extra_qualifier_props_p7482_includes_new_url_quals():
+    """``_DPLA_EXTRA_QUALIFIER_PROPS["P7482"]`` must include both P2699
+    and P6108 so the reconciler's amend-safety check counts them as
+    DPLA-owned. Without this, a P7482 statement carrying our own
+    P2699/P6108 would look 'foreign' to ``_is_safe_to_amend_in_place``
+    and the reconciler would refuse to clean it up if DPLA's catalog
+    URL ever changed."""
+    from tools import sdc_sync
+
+    allowed = sdc_sync._DPLA_EXTRA_QUALIFIER_PROPS["P7482"]
+    assert "P2699" in allowed
+    assert "P6108" in allowed
+    # Keep the existing qualifiers in the set too — regression guard
+    # against an accidental overwrite.
+    assert "P973" in allowed
+    assert "P137" in allowed

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1328,19 +1328,29 @@ def _amend_p7482_url_qualifiers(mediaid, dpla_id, sdc_payload, download_url):
     succeeding, and the next sync attempt will retry the missing
     qualifier.
 
-    Limitations:
-      * P973 match is exact-string. Real-world catalog URLs drift
-        (http → https, trailing slash, percent-encoding). If a legacy
-        Commons P7482's P973 doesn't byte-match the new sdc.json's
-        P973, ``check()`` will also miss (same exact-match comparison)
-        and add a SECOND P7482 alongside the legacy one. Worth a
-        normalization helper here and in ``check()`` someday;
-        consciously out of scope for this PR.
+    Design notes:
+      * DPLA-authored P7482 statements reference the partner's source
+        metadata; they semantically belong to that reference. Any
+        community-added qualifiers on those specific statements are
+        out of band — a community contributor wanting to assert a
+        fact about the file should add their own statement with their
+        own reference, not graft onto DPLA's. So when URL drift
+        triggers a remove-and-re-add cycle (via the reconciler's
+        normal "P973 mismatch → not our statement → add a new one"
+        path), discarding any stray user additions on the old
+        DPLA-referenced statement is correct, not lossy.
+      * That said, P973 matching is exact-string today. Real-world
+        catalog URLs drift over time (http → https, trailing slash,
+        percent-encoding) and each drift causes an unnecessary
+        remove+re-add churn even though both URLs point to the same
+        resource. A normalization helper here and in ``check()``
+        would be a pure efficiency win; consciously out of scope
+        for this PR.
       * The in-memory P2699 augmentation in ``process_one_from_sdc``
-        only takes effect when ``check()`` decides to ADD a new
-        P7482 statement (the new-upload path). For the much more
-        common existing-statement case, this helper is the path
-        that lands P2699/P6108 onto Commons.
+        only fires on the new-upload path (when ``check()`` decides
+        to ADD a P7482). For the far more common existing-statement
+        case, this helper is the path that lands P2699/P6108 onto
+        Commons.
     """
     # Find sdc.json's P7482 claim to learn the expected catalog URL +
     # IIIF manifest URL (if any). sdc.json has at most one P7482 entry.

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -450,13 +450,19 @@ def invalidate_entity(mediaid):
 #                                  decorator)
 #   * add_contributed (P9126)   — P3831 (object has role)
 #   * add_local_id (P217)       — P195 (collection)
-#   * add_source (P7482)        — P973 (described at URL), P137 (operator)
+#   * add_source (P7482)        — P973 (described at URL), P137 (operator),
+#                                  P2699 (direct file download URL — per-
+#                                  ordinal; materialized by sdc-sync from
+#                                  file-list.txt at write time),
+#                                  P6108 (IIIF manifest URL — per-item;
+#                                  emitted by build_claims_for_doc when
+#                                  the source carries iiifManifest)
 _DPLA_EXTRA_QUALIFIER_PROPS = {
     "P170": {"P2093"},
     "P571": {"P1932", "P1480"},
     "P9126": {"P3831"},
     "P217": {"P195"},
-    "P7482": {"P973", "P137"},
+    "P7482": {"P973", "P137", "P2699", "P6108"},
 }
 
 
@@ -1285,6 +1291,130 @@ def add_det(mediaid, claimid):
         # to an existing claim). Drop the cached snapshot so any subsequent
         # check() call for the same mediaid in this run reads the fresh
         # post-write state instead of repeating the qualifier write.
+        invalidate_entity(mediaid)
+
+
+def _amend_p7482_url_qualifiers(mediaid, dpla_id, sdc_payload, download_url):
+    """For an EXISTING DPLA-authored P7482 statement on Commons, stamp
+    any missing ``P2699`` (download URL) or ``P6108`` (IIIF manifest URL)
+    qualifier via wbsetqualifier.
+
+    Why this exists: every file uploaded before this code shipped has a
+    P7482 with only P973 / P137 / P459 qualifiers. The normal ``check()``
+    path for source claims finds the existing statement, returns False
+    ("don't add a duplicate"), and never gets a chance to add the new
+    qualifiers. This function fills that gap — it's the same shape as
+    :func:`add_det` (which stamps P459 onto bare claims), generalized to
+    two new qualifier properties.
+
+    Match-and-amend logic, in order:
+
+      1. Look for a P7482 statement on Commons whose P973 qualifier
+         matches the sdc.json's P973 (the partner catalog URL — uniquely
+         identifies "our" P7482 vs. a community editor's).
+      2. Confirm it's safe to amend in place (``_is_safe_to_amend_in_place``
+         — every qualifier on the statement is one DPLA writes, every
+         reference carries the DPLA publisher marker).
+      3. For each of P2699 (when ``download_url`` is supplied) and
+         P6108 (when the sdc.json carries one), check if a qualifier
+         with the matching value is already present. Skip if yes; POST
+         wbsetqualifier if not.
+
+    Idempotent: re-running the same call against the same Commons state
+    sends zero requests once both qualifiers are present.
+
+    Best-effort: a postqual that fails just logs (postqual's own error
+    handler) and continues — the reconciler doesn't depend on this pass
+    succeeding, and the next sync attempt will retry the missing
+    qualifier.
+
+    Limitations:
+      * P973 match is exact-string. Real-world catalog URLs drift
+        (http → https, trailing slash, percent-encoding). If a legacy
+        Commons P7482's P973 doesn't byte-match the new sdc.json's
+        P973, ``check()`` will also miss (same exact-match comparison)
+        and add a SECOND P7482 alongside the legacy one. Worth a
+        normalization helper here and in ``check()`` someday;
+        consciously out of scope for this PR.
+      * The in-memory P2699 augmentation in ``process_one_from_sdc``
+        only takes effect when ``check()`` decides to ADD a new
+        P7482 statement (the new-upload path). For the much more
+        common existing-statement case, this helper is the path
+        that lands P2699/P6108 onto Commons.
+    """
+    # Find sdc.json's P7482 claim to learn the expected catalog URL +
+    # IIIF manifest URL (if any). sdc.json has at most one P7482 entry.
+    sdc_p7482 = next(
+        (
+            c
+            for c in sdc_payload.get("claims", [])
+            if c["mainsnak"]["property"] == "P7482"
+        ),
+        None,
+    )
+    if sdc_p7482 is None:
+        return
+
+    def _first_qual_value(claim, prop):
+        for q in claim.get("qualifiers", {}).get(prop, []) or []:
+            if q.get("snaktype") == "value":
+                dv = q.get("datavalue") or {}
+                if "value" in dv:
+                    return dv["value"]
+        return None
+
+    expected_p973 = _first_qual_value(sdc_p7482, "P973")
+    expected_p6108 = _first_qual_value(sdc_p7482, "P6108")
+
+    # _post_new_refs / _post_new_claims (called just before this helper)
+    # don't invalidate the entity cache after writing — same shape as
+    # the pre-existing invalidate-before-reconcile pattern elsewhere
+    # in this file. Drop the cached snapshot so we read the
+    # post-write state and don't see a phantom-absent P7482 when one
+    # was just created.
+    invalidate_entity(mediaid)
+    entity = get_entity(mediaid)
+    existing_p7482 = (entity.get("statements") or {}).get("P7482") or []
+
+    # Find the DPLA-authored statement whose P973 matches our expectation.
+    target_stmt = None
+    for stmt in existing_p7482:
+        if not _is_safe_to_amend_in_place(stmt, "P7482"):
+            continue
+        if _first_qual_value(stmt, "P973") == expected_p973:
+            target_stmt = stmt
+            break
+    if target_stmt is None:
+        # No existing match — either no P7482 yet (``_post_new_claims``
+        # already handled it), or only foreign / unsafe-to-amend
+        # statements exist. Either way, nothing to backfill.
+        return
+
+    claimid = target_stmt["id"]
+    existing_p2699_values = [
+        q["datavalue"]["value"]
+        for q in (target_stmt.get("qualifiers", {}).get("P2699") or [])
+        if q.get("snaktype") == "value" and q.get("datavalue")
+    ]
+    existing_p6108_values = [
+        q["datavalue"]["value"]
+        for q in (target_stmt.get("qualifiers", {}).get("P6108") or [])
+        if q.get("snaktype") == "value" and q.get("datavalue")
+    ]
+
+    amended = False
+    if download_url and download_url not in existing_p2699_values:
+        postqual(claimid, "P2699", json.dumps(download_url))
+        amended = True
+    if expected_p6108 and expected_p6108 not in existing_p6108_values:
+        postqual(claimid, "P6108", json.dumps(expected_p6108))
+        amended = True
+
+    if amended:
+        # Drop the cached snapshot so any subsequent code in this
+        # process_one_from_sdc cycle (notably ``_reconcile_existing_claims``
+        # immediately below the caller) reads the freshly-amended state
+        # — same invariant ``add_det`` maintains for P459.
         invalidate_entity(mediaid)
 
 
@@ -2221,7 +2351,7 @@ def process_one(mediaid, dpla_id):
         return
 
 
-def process_one_from_sdc(mediaid, dpla_id, sdc_payload):
+def process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url=None):
     """Sync SDC for a single Commons file against a precomputed claim list.
 
     Reads the claim envelope produced by `build_claims_for_doc` and staged
@@ -2236,6 +2366,15 @@ def process_one_from_sdc(mediaid, dpla_id, sdc_payload):
     walk. Reuses the existing `check()` per-property matcher, the shared
     `_post_new_refs`/`_post_new_claims` POST helpers, and the shared
     `_reconcile_existing_claims` removal logic.
+
+    ``download_url`` is the per-ordinal direct file URL (from
+    file-list.txt). When supplied, the P7482 (described at) claim gets
+    a P2699 (URL) qualifier with that value before being posted —
+    different ordinals of the same DPLA item have different download
+    URLs, so the qualifier must be materialized per-call here rather
+    than baked into the per-item sdc.json. For existing P7482
+    statements on Commons that lack P2699, ``_amend_p7482_url_qualifiers``
+    POSTs the missing qualifier via wbsetqualifier (idempotent).
     """
     global claims, refclaims
 
@@ -2260,6 +2399,20 @@ def process_one_from_sdc(mediaid, dpla_id, sdc_payload):
         # would inherit ordinal N-1's per-mediaid claim IDs and references.
         claim = copy.deepcopy(source_claim)
         prop = claim["mainsnak"]["property"]
+
+        # Materialize the per-ordinal P2699 qualifier on the P7482 claim.
+        # build_claims_for_doc can't do this — sdc.json is per-DPLA-item
+        # and a multi-page item's ordinals have different download URLs.
+        if prop == "P7482" and download_url:
+            claim.setdefault("qualifiers", {})["P2699"] = [
+                {
+                    "snaktype": "value",
+                    "property": "P2699",
+                    "datavalue": {"value": download_url, "type": "string"},
+                    "datatype": "url",
+                }
+            ]
+
         kind = _check_kind_for_claim(claim)
         comparable = _extract_comparable_value(claim)
         if comparable is None:
@@ -2287,6 +2440,15 @@ def process_one_from_sdc(mediaid, dpla_id, sdc_payload):
 
     _post_new_refs(mediaid, dpla_id)
     _post_new_claims(mediaid, dpla_id)
+
+    # Backfill P2699/P6108 qualifiers onto any pre-existing DPLA-authored
+    # P7482 statement that lacks them. Every file uploaded BEFORE this PR
+    # shipped has a P7482 with only P973/P137/P459 — without this pass,
+    # ``check()`` finds the existing statement, returns False (no
+    # duplicate), and the new qualifiers never land on Commons. Idempotent
+    # by design: a qualifier whose value already matches what sdc.json (+
+    # per-ordinal download_url) says is silently skipped.
+    _amend_p7482_url_qualifiers(mediaid, dpla_id, sdc_payload, download_url)
 
     expected = _build_expected_from_sdc(sdc_payload)
     _reconcile_existing_claims(mediaid, dpla_id, expected)
@@ -2386,6 +2548,22 @@ def _run_partner_mode(partner, ids_file):
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
                 continue
 
+            # file-list.txt maps ordinal-1 (zero-indexed) → download URL.
+            # Used to populate the per-ordinal P2699 qualifier on the
+            # P7482 (described at) claim — every file gets one, but the
+            # URL differs per ordinal so it can't live in the per-item
+            # sdc.json. A missing or empty file-list.txt is non-fatal:
+            # P2699 simply isn't materialized for those ordinals (the
+            # rest of the SDC pass still runs).
+            try:
+                file_list = s3.get_file_list(partner, dpla_id)
+            except ClientError as e:
+                logging.warning(
+                    f" -- S3 error reading file-list.txt for {dpla_id}: {e!r};"
+                    " continuing without P2699 qualifiers."
+                )
+                file_list = []
+
             ordinals = upload_result.get("ordinals", {})
             # Guard the type of `ordinals` before iteration — if the JSON
             # sidecar is corrupt or its schema drifts (null, list, scalar),
@@ -2471,8 +2649,25 @@ def _run_partner_mode(partner, ids_file):
                 # `logging.exception` writes the full traceback into
                 # the SDC log file so notify_pipeline_fail's
                 # `_summarize_log` can surface it in Slack.
+                # Look up this ordinal's download URL from file-list.txt
+                # (zero-indexed; ord_str is "1"-indexed). Used to stamp the
+                # per-ordinal P2699 qualifier on the P7482 statement.
+                # Explicit range guard — Python's negative indexing would
+                # silently grab the LAST entry for ord_str == "0", planting
+                # the wrong URL on a real Commons claim via wbsetqualifier.
                 try:
-                    process_one_from_sdc(mediaid, dpla_id, sdc_payload)
+                    ord_num = int(ord_str)
+                except ValueError:
+                    download_url = None
+                else:
+                    if 1 <= ord_num <= len(file_list):
+                        download_url = file_list[ord_num - 1] or None
+                    else:
+                        download_url = None
+                try:
+                    process_one_from_sdc(
+                        mediaid, dpla_id, sdc_payload, download_url=download_url
+                    )
                 except _MissingEntityError:
                     # Commons says the MediaInfo entity at this M-id doesn't
                     # exist. Almost always means the file page was deleted

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1401,16 +1401,19 @@ def _amend_p7482_url_qualifiers(mediaid, dpla_id, sdc_payload, download_url):
         return
 
     claimid = target_stmt["id"]
-    existing_p2699_values = [
-        q["datavalue"]["value"]
-        for q in (target_stmt.get("qualifiers", {}).get("P2699") or [])
-        if q.get("snaktype") == "value" and q.get("datavalue")
-    ]
-    existing_p6108_values = [
-        q["datavalue"]["value"]
-        for q in (target_stmt.get("qualifiers", {}).get("P6108") or [])
-        if q.get("snaktype") == "value" and q.get("datavalue")
-    ]
+
+    def _qual_values(stmt, prop):
+        out = []
+        for q in stmt.get("qualifiers", {}).get(prop, []) or []:
+            if q.get("snaktype") != "value":
+                continue
+            dv = q.get("datavalue")
+            if isinstance(dv, dict) and "value" in dv:
+                out.append(dv["value"])
+        return out
+
+    existing_p2699_values = _qual_values(target_stmt, "P2699")
+    existing_p6108_values = _qual_values(target_stmt, "P6108")
 
     amended = False
     if download_url and download_url not in existing_p2699_values:


### PR DESCRIPTION
## Summary

Per the design discussion: every DPLA upload should carry a **P2699 (URL)** qualifier on its **P7482 (described at)** statement — the direct download URL for that specific Commons file. IIIF-sourced uploads also carry a **P6108 (IIIF manifest URL)** qualifier on the same P7482. Both are "URLs that explain where the file is found on the internet."

**Idempotency contract:** every existing DPLA upload on Commons already has a P7482 with P973/P137/P459 but no P2699/P6108. The first sync after this ships **backfills** the new qualifiers onto those existing statements without creating duplicates. Subsequent syncs are no-ops.

## How

| File | What |
|---|---|
| `ingest_wikimedia/sdc.py` | `_build_source_claim` takes optional `iiif_manifest_url`, emits P6108 qualifier when provided. `build_claims_for_doc` extracts `doc["iiifManifest"]` and validates it (stripped http/https) before passing — guards against `"null"` / whitespace / non-URL junk seen in upstream hub data. |
| `tools/sdc_sync.py::_run_partner_mode` | Reads `file-list.txt` (per-item, one URL per ordinal). Looks up each ordinal's URL with an explicit `1 <= n <= len(file_list)` range check (Python's negative indexing would otherwise silently grab the LAST file for `ord_str="0"`). |
| `tools/sdc_sync.py::process_one_from_sdc` | New `download_url` parameter. For the P7482 claim, augments qualifiers with `P2699 = download_url` before `check()` dispatch — covers the new-upload path. |
| `tools/sdc_sync.py::_amend_p7482_url_qualifiers` (new) | Called between `_post_new_claims` and `_reconcile_existing_claims`. Finds the existing DPLA-authored P7482 (P973-matched), POSTs `wbsetqualifier` for any missing P2699 / P6108 via the existing `postqual` helper. Invalidates the entity cache first to see post-`_post_new_claims` state. Idempotent. |
| `tools/sdc_sync.py::_DPLA_EXTRA_QUALIFIER_PROPS["P7482"]` | Adds P2699 + P6108. `_is_safe_to_amend_in_place` now treats them as DPLA-owned. |

## Code-review fixes applied pre-push

1. **Negative-index bug** in the ord_str→file_list lookup (`"0"` → `file_list[-1]`). Replaced with explicit range check.
2. **Cache invalidation** before `_amend_p7482_url_qualifiers`'s `get_entity` so it reads post-`_post_new_claims` state.
3. **IIIF manifest URL validation** — strip + http(s) startswith — rejects `null` / whitespace / non-URL values that would otherwise land as P6108.

Documented limitations (out of scope): exact-string P973 match misses on URL drift (worth normalization later); `postqual` failures are silent best-effort (next sync retries).

## Tests

9 new tests, 444 total locally on Python 3.13. Covers:
- P6108 emission gates: with / without iiifManifest, 6 junk-value rejections, 3 valid-URL round-trips
- P2699 is per-ordinal only (never in sdc.json)
- Legacy backfill: existing P7482 missing P2699/P6108 → wbsetqualifier
- Idempotency: already-present qualifiers → no calls
- New upload (no existing P7482) → helper no-op (the main add path handles it)
- Foreign statement: `_is_safe_to_amend_in_place` blocks the amend
- `_DPLA_EXTRA_QUALIFIER_PROPS["P7482"]` contains both new + existing qualifiers

## Test plan

- [ ] CI green
- [ ] After merge, run `/wikimedia-upload <dpla-id>` for a non-IIIF item (e.g. Hoover) — verify P7482 grows a P2699 qualifier matching the file's download URL, no duplicate P7482
- [ ] Same for an IIIF-sourced item — verify P7482 grows BOTH P2699 and P6108
- [ ] Second run on the same item is a no-op (zero qualifier amends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Stamp P2699 and P6108 qualifiers on P7482 DPLA claims

This PR ensures every DPLA upload to Commons carries a P2699 (download URL) qualifier on its P7482 (described at) statement; IIIF-sourced uploads additionally carry a P6108 (IIIF manifest URL) qualifier. Existing DPLA uploads that already have a DPLA-authored P7482 but lack P2699/P6108 are backfilled once on the first qualifying sync; subsequent syncs are no-ops (idempotent).

## Changes

ingest_wikimedia/sdc.py
- `_build_source_claim(iiif_manifest_url=None)` — accepts optional `iiif_manifest_url` and emits a P6108 qualifier when provided.
- `build_claims_for_doc()` — extracts `doc["iiifManifest"]`, trims it, validates it starts with http:// or https://, and passes it into `_build_source_claim()` (invalid/junky values rejected).

tools/sdc_sync.py
- `process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url=None)` — accepts optional `download_url`; when creating a new P7482, materializes P2699 before check()/post.
- New helper `_amend_p7482_url_qualifiers(...)` — invalidates the entity cache, finds the DPLA-authored P7482 (matched by P973), verifies it is safe to amend in place, and POSTs any missing P2699 and/or P6108 qualifiers via postqual/wbsetqualifier. Idempotent and called between posting new claims and reconciling existing ones; cache invalidated before amend and again after successful amendments.
- `_DPLA_EXTRA_QUALIFIER_PROPS["P7482"]` updated to include P2699 and P6108 so amendments are treated as DPLA-owned-safe.
- `_run_partner_mode()` — attempts to load per-item file-list.txt from S3 to map ordinals → per-file download URLs; robust bounds and explicit 1-based ordinal parsing (fixes previous negative-index bug). Missing/malformed file-list or out-of-range ordinals result in `download_url=None` (graceful/no-op).

tests
- 9 new tests added (covering emission, IIIF validation, backfill behavior, idempotency, and safety checks). (Locally: 444 total tests.)

Other fixes and hardening
- Fixed negative-index ordinal parsing bug.
- Added cache invalidation before reading entity state for amendments.
- IIIF manifest URL validation/stripping to reject junk values like "null" or whitespace.
- Hardened qualifier-value extraction to avoid brittle list-comprehension KeyError patterns.

## Backward compatibility & behavior
- Existing DPLA-authored P7482 statements missing P2699/P6108 will be backfilled once during the first qualifying sync; subsequent syncs are no-ops.
- The reconciler treats P2699/P6108 as DPLA-owned qualifiers for P7482; the amend-in-place gate avoids touching statements with any user-authored qualifiers/references.

## Infrastructure, deployment, and security notes (explicit)
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No changes to shared infra (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No public API response shape changes or new/removed endpoints.
- No manual pipeline trigger or ECS redeploy required for code to take effect; behavior takes effect when the next sdc-sync (partner-mode or normal SDC sync) runs.
- Security: IIIF manifest inputs are validated (must be http/https after trimming). Qualifier additions use existing wbsetqualifier/postqual flows; no new credential handling introduced.

## Tests & verification
- Unit tests added for IIIF handling, P6108 emission, `_amend_p7482_url_qualifiers` behavior (add/no-op/skip/foreign-shaped statements), and regression checks for the extra-qualifier props.
- Manual verification: run a partner-mode sync or re-run sdc-sync for sample items to observe P2699/P6108 backfill on existing DPLA-authored P7482 claims and confirm no writes when qualifiers already present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->