### PR TITLE
sdc: chunk long mainsnak values (P1545) + per-ordinal P304 page numbers

### DIFF
--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -50,6 +50,7 @@ import json
 import logging
 import os
 import re
+import unicodedata
 import xml.etree.ElementTree as ET
 from collections.abc import Iterable
 from typing import Any
@@ -150,11 +151,41 @@ PD_MARK_URI_CANONICAL = "http://creativecommons.org/publicdomain/mark/1.0"
 
 RECONCI_ENDPOINT = "https://wikidata.reconci.link/en/api"
 RECONCI_BATCH_SIZE = 10
-TEXT_VALUE_LIMIT = 1499  # matches sdc-sync's longstanding truncation cap
-# Maximum length for a raw P217 (inventory number) value before we skip it
-# entirely. sdc-sync's original guard was `len(local_id) >= 1501`, so anything
-# strictly longer than 1500 is dropped.
-LOCAL_ID_MAX_LENGTH = 1500
+TEXT_VALUE_LIMIT = 1499  # matches sdc-sync's longstanding truncation cap;
+# retained for snak values inside qualifiers (P2093 in P170, P1932 in P571),
+# which can't be chunked at the qualifier level. Mainsnak values are chunked
+# instead via _chunk_value below.
+
+# Wikibase's hard cap for `string` and `monolingualtext` mainsnak values on
+# Wikidata-class wikis (Commons inherits via the MediaInfo extension).
+# Reference: https://www.wikidata.org/wiki/Help:Data_type — both datatypes
+# listed at 1500. Mainsnak values exceeding this get split into multiple
+# claims, each carrying a P1545 (series ordinal) qualifier so the Lua
+# template on Commons can reassemble them on read.
+WIKIBASE_STRING_LIMIT = 1500
+
+# P1545 (series ordinal) is added by _chunk_and_emit_claims as a qualifier
+# on every chunked-claim and is therefore a DPLA-authored qualifier wherever
+# chunking is enabled. tools/sdc_sync.py's _DPLA_EXTRA_QUALIFIER_PROPS must
+# include P1545 under each chunked property so _is_safe_to_amend_in_place
+# treats it as part of the DPLA-owned envelope.
+CHUNKABLE_PROPS = frozenset(
+    {
+        "P760",  # DPLA ID (typically short, normalized but rarely chunks)
+        "P217",  # local identifier
+        "P4272",  # subject string
+        "P1225",  # NARA NAID
+        "P1476",  # title (monolingualtext)
+        "P10358",  # description (monolingualtext)
+    }
+)
+
+# Character class for ASCII / Latin-1 control characters. Mirrors Wikibase's
+# server-side `preg_replace('/\\p{Cc}+/u', ' ', $value)` normalization for
+# string and monolingualtext datatypes (lib/includes/StringNormalizer.php).
+# We apply the same transform locally so chunk boundary char counts match
+# what Wikibase will actually store after the wbeditentity round-trip.
+_CONTROL_CHAR_RUN = re.compile(r"[\x00-\x1F\x7F-\x9F]+")
 
 # DPLA subject → Wikidata Q-ID lookup table; sourced from dpla/ingestion3
 # alongside institutions_v2.json. Fetched fresh per run so upstream changes
@@ -590,8 +621,216 @@ def parse_dpla_doc(
 
 
 def _truncate(value: str) -> str:
-    """Match sdc-sync's longstanding `[:1499].rstrip()` normalization."""
+    """Match sdc-sync's longstanding `[:1499].rstrip()` normalization.
+
+    Used only for snak values inside qualifiers (e.g. P2093 in a P170
+    creator statement). Mainsnak string/monolingualtext values go through
+    :func:`_normalize_string_value` + :func:`_chunk_value` instead so long
+    values are preserved across multiple claims rather than truncated.
+    """
     return value[:TEXT_VALUE_LIMIT].rstrip() if value else ""
+
+
+def _normalize_string_value(text: str, *, is_monolingualtext: bool = False) -> str:
+    """Apply Wikibase's server-side string normalization locally.
+
+    Mirrors `lib/includes/StringNormalizer.php` (Wikibase) so our in-memory
+    value matches the bytes Wikibase will store after wbeditentity. Without
+    this, the next sync would see drift on values containing newlines,
+    leading/trailing whitespace, or invisible format characters (BOM,
+    bidi marks) and trigger spurious re-writes; for chunked values, the
+    drift compounds across every chunk.
+
+    The transforms, applied in the order Wikibase applies them:
+
+      1. ``trimBadChars`` — strip a fixed set of invisible/non-character
+         codepoints that Wikibase rejects: BOM (``U+FEFF``), bidi marks
+         (``U+200E``/``U+200F``), and non-characters (``U+FFFE``/
+         ``U+FFFF``). Source CSV/JSON occasionally carries these when
+         partner metadata is round-tripped through pasted-text fields.
+      2. Collapse every run of ASCII / Latin-1 control characters
+         (``\\x00`` – ``\\x1F``, ``\\x7F`` – ``\\x9F`` — includes ``\\n``,
+         ``\\r``, ``\\t``) to a single ASCII space.
+      3. Strip leading and trailing whitespace. Python's ``str.strip()``
+         covers chars where ``isspace()`` is true, which matches
+         Wikibase's ``\\p{Z}`` strip closely enough for DPLA's
+         source-metadata corpus.
+      4. For monolingualtext datatypes only: NFC-normalize via
+         :func:`unicodedata.normalize`. Wikibase wires `cleanupToNFC` for
+         the monolingualtext parser path.
+
+    Wikibase does NOT collapse internal regular spaces; neither does this
+    helper. ``<``, ``>``, ``&`` are stored verbatim — no HTML escaping at
+    the snak layer.
+    """
+    if not text:
+        return ""
+    text = text.translate(_BAD_CHARS_TABLE)
+    text = _CONTROL_CHAR_RUN.sub(" ", text)
+    text = text.strip()
+    if is_monolingualtext:
+        text = unicodedata.normalize("NFC", text)
+    return text
+
+
+# Codepoints Wikibase rejects via its trimBadChars equivalent. BOM (U+FEFF)
+# and bidi marks (U+200E/U+200F) appear mid-string when partner metadata
+# comes through pasted-text fields; non-characters (U+FFFE/U+FFFF) are
+# always invalid Unicode regardless. Without stripping these locally, a
+# value with an embedded BOM would round-trip through Wikibase shorter
+# than what we emit, and the next sync would see a mismatch and re-write.
+_BAD_CHARS_TABLE = dict.fromkeys((0xFEFF, 0x200E, 0x200F, 0xFFFE, 0xFFFF))
+
+
+def _chunk_value(text: str, limit: int = WIKIBASE_STRING_LIMIT) -> list[str]:
+    """Split ``text`` into chunks no longer than ``limit`` characters each.
+
+    Boundary search picks a position N (1 ≤ N ≤ ``limit``) where both
+    ``text[N-1]`` and ``text[N]`` are non-whitespace. This guarantees neither
+    side of the split has leading or trailing whitespace that Wikibase
+    would strip on save, so concat-after-store reassembles bit-for-bit
+    identical to the original.
+
+    Pathological case: a whitespace run longer than ``limit`` characters
+    that straddles the chunk window leaves no valid non-whitespace boundary
+    within reach. We fall back to splitting at exactly ``limit`` and emit a
+    warning — interior whitespace at that boundary will collapse on
+    round-trip, but content outside the whitespace run survives intact.
+    DPLA source metadata never contains runs this long in practice.
+
+    Callers must apply :func:`_normalize_string_value` before chunking so
+    input matches Wikibase's stored form.
+    """
+    if len(text) <= limit:
+        return [text]
+    chunks: list[str] = []
+    remaining = text
+    while len(remaining) > limit:
+        boundary = limit
+        while boundary > 0 and (
+            remaining[boundary - 1].isspace() or remaining[boundary].isspace()
+        ):
+            boundary -= 1
+        if boundary == 0:
+            logger.warning(
+                "Chunk boundary fell inside a whitespace run longer than %d "
+                "characters; interior whitespace at this boundary will "
+                "collapse on Wikibase round-trip",
+                limit,
+            )
+            boundary = limit
+        chunks.append(remaining[:boundary])
+        remaining = remaining[boundary:]
+    if remaining:
+        chunks.append(remaining)
+    return chunks
+
+
+def _next_series_letter(
+    letters: dict[tuple[str, str], str], prop: str, language: str
+) -> str:
+    """Return the next series letter for a chunked value on (prop, language).
+
+    First long value seen for a (prop, lang) gets ``"A"``; second ``"B"``;
+    twenty-seventh ``"AA"``; then ``"AB"``, ``"AC"``... — Excel-style
+    column-letter sequence so the series never silently advances past
+    ``"Z"`` into non-alpha codepoints (``chr(ord('Z') + 1) == '['``,
+    which Commons-side reassembly would mis-group). 26+ long values on
+    one (prop, lang) is unlikely in practice, but the failure mode is
+    silent data corruption — well worth the eight extra lines to make
+    it impossible.
+
+    The letter is paired with the chunk ordinal to form the P1545
+    qualifier value (e.g. ``"A1"``, ``"A2"``, ``"AA1"``). The Lua
+    template on Commons groups chunks by series letter and sorts by
+    ordinal to reassemble each long value independently.
+
+    Mutates ``letters`` in place — callers thread the same dict through
+    one ``build_claims_for_doc`` invocation to maintain per-doc state.
+    """
+    current = letters.get((prop, language))
+    new_letter = "A" if current is None else _advance_series_letter(current)
+    letters[(prop, language)] = new_letter
+    return new_letter
+
+
+def _advance_series_letter(letter: str) -> str:
+    """Advance an Excel-style column-letter sequence by one: ``A → B``,
+    ``Z → AA``, ``AZ → BA``, ``ZZ → AAA``.
+
+    Pure function. Used only by :func:`_next_series_letter` to safely
+    increment past ``Z`` rather than falling off the end of the ASCII
+    uppercase range.
+    """
+    chars = list(letter)
+    i = len(chars) - 1
+    while i >= 0:
+        if chars[i] == "Z":
+            chars[i] = "A"
+            i -= 1
+        else:
+            chars[i] = chr(ord(chars[i]) + 1)
+            return "".join(chars)
+    # All Z's — extend the sequence by one position ("ZZ" → "AAA").
+    return "A" + "".join(chars)
+
+
+def _chunk_and_emit_claims(
+    prop: str,
+    text: str,
+    value_type: str,
+    dpla_id: str,
+    retrieval_date: datetime.date,
+    chunk_series_letters: dict[tuple[str, str], str],
+    *,
+    language: str = "",
+) -> list[dict]:
+    """Normalize ``text``, chunk if it exceeds ``WIKIBASE_STRING_LIMIT``,
+    and return one claim per chunk.
+
+    Single-chunk values (≤ limit after normalization) emit one claim with
+    no P1545 qualifier — bytewise identical to the pre-chunking output
+    apart from the normalization pass.
+
+    Multi-chunk values emit one claim per chunk, each carrying a P1545
+    qualifier with value ``f"{letter}{ordinal}"`` (e.g. ``"A1"``, ``"A2"``).
+    The series letter advances per (prop, language) so a second long
+    value on the same property + language gets the next letter, keeping
+    the chunk groups separable for reassembly.
+
+    ``value_type`` is ``"string"`` or ``"monolingualtext"``. For
+    monolingualtext, ``language`` is required and is also used as part of
+    the series-letter key so two long English titles get A/B series
+    while a long French title gets its own A series.
+
+    Mutates ``chunk_series_letters`` in place when a long value consumes
+    a fresh series letter — callers thread the same dict through one
+    ``build_claims_for_doc`` invocation.
+    """
+    is_monolingualtext = value_type == "monolingualtext"
+    normalized = _normalize_string_value(text, is_monolingualtext=is_monolingualtext)
+    if not normalized:
+        return []
+    chunks = _chunk_value(normalized)
+    if len(chunks) == 1:
+        value: Any = (
+            {"text": normalized, "language": language}
+            if is_monolingualtext
+            else normalized
+        )
+        return [formattedclaim(prop, value, value_type, dpla_id, retrieval_date)]
+    letter = _next_series_letter(chunk_series_letters, prop, language)
+    out: list[dict] = []
+    for ordinal, chunk in enumerate(chunks, start=1):
+        chunk_value: Any = (
+            {"text": chunk, "language": language} if is_monolingualtext else chunk
+        )
+        claim = formattedclaim(prop, chunk_value, value_type, dpla_id, retrieval_date)
+        claim["qualifiers"]["P1545"] = [
+            _qualifier_string_snak("P1545", f"{letter}{ordinal}")
+        ]
+        out.append(claim)
+    return out
 
 
 def _build_rights_claims(
@@ -735,11 +974,25 @@ def _build_local_id_claim(
     institution: str,
     dpla_id: str,
     retrieval_date: datetime.date,
-) -> dict:
-    """Build a P217 (inventory number) claim with P195 (collection) qualifier."""
-    claim = formattedclaim("P217", local_id, "string", dpla_id, retrieval_date)
-    claim["qualifiers"]["P195"] = [_qualifier_item_snak("P195", institution)]
-    return claim
+    chunk_series_letters: dict[tuple[str, str], str],
+) -> list[dict]:
+    """Build a P217 (inventory number) claim with P195 (collection) qualifier.
+
+    Returns one claim per chunk when ``local_id`` exceeds the Wikibase
+    string limit; the P195 collection qualifier is replicated on every
+    chunk claim since each chunk is its own statement.
+    """
+    claims = _chunk_and_emit_claims(
+        "P217",
+        local_id,
+        "string",
+        dpla_id,
+        retrieval_date,
+        chunk_series_letters,
+    )
+    for claim in claims:
+        claim["qualifiers"]["P195"] = [_qualifier_item_snak("P195", institution)]
+    return claims
 
 
 def _build_creator_claim(
@@ -978,16 +1231,22 @@ def _build_monolingual_claim(
     text: str,
     dpla_id: str,
     retrieval_date: datetime.date,
-) -> dict | None:
-    normalized = _truncate(text)
-    if not normalized:
-        return None
-    return formattedclaim(
+    chunk_series_letters: dict[tuple[str, str], str],
+) -> list[dict]:
+    """Build the monolingualtext claim(s) for a long-form text field.
+
+    Returns multiple claims with P1545 series-ordinal qualifiers when the
+    text exceeds the Wikibase string limit; the Lua template on Commons
+    reassembles by series + ordinal.
+    """
+    return _chunk_and_emit_claims(
         prop,
-        {"text": normalized, "language": "en"},
+        text,
         "monolingualtext",
         dpla_id,
         retrieval_date,
+        chunk_series_letters,
+        language="en",
     )
 
 
@@ -1035,17 +1294,29 @@ def build_claims_for_doc(
 
     claims: list[dict] = []
 
+    # Track series-letter assignments for long-value chunking. Keyed by
+    # (prop, language); first long value seen for a key gets letter "A",
+    # second "B", and so on. The chunk emitters mutate this dict as they
+    # consume letters.
+    chunk_series_letters: dict[tuple[str, str], str] = {}
+
     # Rights cluster (P275/P6426/P6216).
     claims.extend(_build_rights_claims(rs, rights, dpla_id, retrieval_date))
 
     # P760 — DPLA ID.
-    claims.append(formattedclaim("P760", dpla_id, "string", dpla_id, retrieval_date))
+    claims.extend(
+        _chunk_and_emit_claims(
+            "P760", dpla_id, "string", dpla_id, retrieval_date, chunk_series_letters
+        )
+    )
 
-    # P1476 — title (one statement per title).
+    # P1476 — title (one statement per title; chunked if needed).
     for title in titles:
-        c = _build_monolingual_claim("P1476", title, dpla_id, retrieval_date)
-        if c is not None:
-            claims.append(c)
+        claims.extend(
+            _build_monolingual_claim(
+                "P1476", title, dpla_id, retrieval_date, chunk_series_letters
+            )
+        )
 
     # P195 — collection (one statement; Smithsonian uses hub-as-institution).
     if institution:
@@ -1075,8 +1346,15 @@ def build_claims_for_doc(
     # P4272 (subject string) and P921 (subject entity).
     for name, subjqid in subjects:
         if name:
-            claims.append(
-                formattedclaim("P4272", name, "string", dpla_id, retrieval_date)
+            claims.extend(
+                _chunk_and_emit_claims(
+                    "P4272",
+                    name,
+                    "string",
+                    dpla_id,
+                    retrieval_date,
+                    chunk_series_letters,
+                )
             )
         if subjqid:
             claims.append(
@@ -1089,11 +1367,13 @@ def build_claims_for_doc(
                 )
             )
 
-    # P10358 — description.
+    # P10358 — description (chunked if needed).
     for desc in descs:
-        c = _build_monolingual_claim("P10358", desc, dpla_id, retrieval_date)
-        if c is not None:
-            claims.append(c)
+        claims.extend(
+            _build_monolingual_claim(
+                "P10358", desc, dpla_id, retrieval_date, chunk_series_letters
+            )
+        )
 
     # P9126 — maintained by chain.
     claims.extend(_build_contributed_claims(hub, institution, dpla_id, retrieval_date))
@@ -1121,18 +1401,30 @@ def build_claims_for_doc(
     )
 
     # P217 — local identifier (non-NARA; per-value, with P195 qualifier).
+    # Values exceeding the Wikibase string limit are chunked rather than
+    # dropped, preserving the source identifier across multiple P217
+    # statements (each carrying P195 + a P1545 series-ordinal qualifier).
     for local_id in local_ids:
-        if not local_id or len(local_id) > LOCAL_ID_MAX_LENGTH:
+        if not local_id:
             continue
-        claims.append(
-            _build_local_id_claim(local_id, institution, dpla_id, retrieval_date)
+        claims.extend(
+            _build_local_id_claim(
+                local_id, institution, dpla_id, retrieval_date, chunk_series_letters
+            )
         )
 
     # NARA-only fields.
     for naid in naids:
         if naid:
-            claims.append(
-                formattedclaim("P1225", naid, "string", dpla_id, retrieval_date)
+            claims.extend(
+                _chunk_and_emit_claims(
+                    "P1225",
+                    naid,
+                    "string",
+                    dpla_id,
+                    retrieval_date,
+                    chunk_series_letters,
+                )
             )
     if access:
         claims.append(

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -572,3 +572,324 @@ def test_build_source_claim_never_stamps_p2699():
         iiif_manifest_url="https://example.org/iiif/abc/manifest.json",
     )
     assert "P2699" not in claim["qualifiers"]
+
+
+# --------------------------------------------------------------------------
+# Long-value chunking — _normalize_string_value, _chunk_value,
+# _next_series_letter, _chunk_and_emit_claims.
+#
+# Wikibase normalizes string and monolingualtext values on save
+# (lib/includes/StringNormalizer.php): control char runs become a single
+# space, leading/trailing Unicode whitespace is stripped, monolingualtext
+# is NFC-normalized. We pre-apply the same transforms locally so chunk
+# boundary char counts match what Wikibase will store and chunk-by-chunk
+# matching stays stable across syncs.
+# --------------------------------------------------------------------------
+
+
+def test_normalize_string_value_strips_leading_trailing_whitespace():
+    from ingest_wikimedia.sdc import _normalize_string_value
+
+    assert _normalize_string_value("  hello  ") == "hello"
+    assert _normalize_string_value("\thello\t") == "hello"
+    assert _normalize_string_value(" hello ") == "hello"
+
+
+def test_normalize_string_value_collapses_control_char_runs_to_single_space():
+    """Wikibase's preg_replace('/\\p{Cc}+/u', ' ', ...) — any run of
+    control chars becomes a single ASCII space. Internal regular
+    spaces are NOT collapsed."""
+    from ingest_wikimedia.sdc import _normalize_string_value
+
+    assert _normalize_string_value("Line one.\nLine two.") == "Line one. Line two."
+    assert _normalize_string_value("a\n\n\nb") == "a b"
+    assert _normalize_string_value("a\t\r\n\tb") == "a b"
+    assert _normalize_string_value("a    b") == "a    b"
+
+
+def test_normalize_string_value_empty_input():
+    from ingest_wikimedia.sdc import _normalize_string_value
+
+    assert _normalize_string_value("") == ""
+    assert _normalize_string_value("   ") == ""
+    assert _normalize_string_value("\n\t\r") == ""
+
+
+def test_normalize_string_value_idempotent():
+    """Applying normalization twice yields the same result as once."""
+    from ingest_wikimedia.sdc import _normalize_string_value
+
+    samples = ["  hello  ", "a\nb", "café", "Line\n\nbreak", "\thello\t"]
+    for s in samples:
+        once = _normalize_string_value(s)
+        twice = _normalize_string_value(once)
+        assert once == twice, f"non-idempotent on {s!r}: {once!r} → {twice!r}"
+
+
+def test_normalize_string_value_nfc_for_monolingualtext():
+    """cleanupToNFC is wired only for monolingualtext on Wikibase."""
+    from ingest_wikimedia.sdc import _normalize_string_value
+
+    decomposed = "é"  # e + COMBINING ACUTE ACCENT (NFD)
+    precomposed = "é"  # NFC
+    assert _normalize_string_value(decomposed, is_monolingualtext=True) == precomposed
+    assert _normalize_string_value(decomposed, is_monolingualtext=False) == decomposed
+
+
+def test_chunk_value_under_limit_returns_single_chunk():
+    from ingest_wikimedia.sdc import _chunk_value
+
+    assert _chunk_value("short") == ["short"]
+    text = "x" * 1500
+    assert _chunk_value(text) == [text]
+
+
+def test_chunk_value_over_limit_splits_at_non_whitespace_boundary():
+    """Boundary search walks backward to find a position where both
+    adjacent characters are non-whitespace, so Wikibase's
+    leading/trailing-whitespace strip can't eat bytes at the boundary."""
+    from ingest_wikimedia.sdc import _chunk_value
+
+    text = "abcdefghij klmnopqrst"
+    chunks = _chunk_value(text, limit=12)
+    assert len(chunks) == 2
+    assert not chunks[0].endswith(" ")
+    assert not chunks[1].startswith(" ")
+    assert "".join(chunks) == text
+
+
+def test_chunk_value_pathological_whitespace_run_falls_back_to_exact_limit(caplog):
+    """A whitespace run longer than the chunk window leaves no valid
+    non-whitespace boundary in reach. Chunk at exactly limit + warn."""
+    import logging
+
+    from ingest_wikimedia.sdc import _chunk_value
+
+    text = "a" + (" " * 20) + "b"
+    with caplog.at_level(logging.WARNING, logger="ingest_wikimedia.sdc"):
+        chunks = _chunk_value(text, limit=10)
+    assert len(chunks) >= 2
+    assert any("whitespace run" in rec.message for rec in caplog.records)
+    assert "".join(chunks) == text
+
+
+def test_chunk_value_multiple_chunks():
+    from ingest_wikimedia.sdc import _chunk_value
+
+    text = "x" * 3500
+    chunks = _chunk_value(text, limit=1000)
+    assert len(chunks) == 4
+    assert sum(len(c) for c in chunks) == 3500
+    for chunk in chunks:
+        assert len(chunk) <= 1000
+
+
+def test_next_series_letter_advances_per_key():
+    from ingest_wikimedia.sdc import _next_series_letter
+
+    letters = {}
+    assert _next_series_letter(letters, "P1476", "en") == "A"
+    assert _next_series_letter(letters, "P1476", "en") == "B"
+    assert _next_series_letter(letters, "P10358", "en") == "A"
+    assert _next_series_letter(letters, "P1476", "en") == "C"
+    assert _next_series_letter(letters, "P1476", "fr") == "A"
+
+
+def test_chunk_and_emit_claims_short_value_emits_one_claim_no_p1545():
+    """Single-chunk values keep the pre-chunking shape — no P1545."""
+    import datetime as _dt
+
+    from ingest_wikimedia.sdc import _chunk_and_emit_claims
+
+    letters = {}
+    claims = _chunk_and_emit_claims(
+        "P1476",
+        "Short title",
+        "monolingualtext",
+        "abc",
+        _dt.date(2026, 1, 1),
+        letters,
+        language="en",
+    )
+    assert len(claims) == 1
+    assert "P1545" not in claims[0]["qualifiers"]
+    assert letters == {}
+
+
+def test_chunk_and_emit_claims_long_value_emits_multiple_with_p1545():
+    """Long values split into multiple claims, each with P1545="A1",
+    "A2", etc. Series letter advances for the next long value on the
+    same (prop, language)."""
+    import datetime as _dt
+
+    from ingest_wikimedia.sdc import _chunk_and_emit_claims
+
+    letters = {}
+    long_text = "x" * 1500 + " " + "y" * 800
+    claims = _chunk_and_emit_claims(
+        "P10358",
+        long_text,
+        "monolingualtext",
+        "abc",
+        _dt.date(2026, 1, 1),
+        letters,
+        language="en",
+    )
+    assert len(claims) == 2
+    assert claims[0]["qualifiers"]["P1545"][0]["datavalue"]["value"] == "A1"
+    assert claims[1]["qualifiers"]["P1545"][0]["datavalue"]["value"] == "A2"
+    assert letters == {("P10358", "en"): "A"}
+
+    second_long = "z" * 1500 + " " + "w" * 800
+    more = _chunk_and_emit_claims(
+        "P10358",
+        second_long,
+        "monolingualtext",
+        "abc",
+        _dt.date(2026, 1, 1),
+        letters,
+        language="en",
+    )
+    assert [c["qualifiers"]["P1545"][0]["datavalue"]["value"] for c in more] == [
+        "B1",
+        "B2",
+    ]
+
+
+def test_chunk_and_emit_claims_empty_after_normalization_emits_nothing():
+    import datetime as _dt
+
+    from ingest_wikimedia.sdc import _chunk_and_emit_claims
+
+    assert (
+        _chunk_and_emit_claims(
+            "P1476",
+            "   ",
+            "monolingualtext",
+            "abc",
+            _dt.date(2026, 1, 1),
+            {},
+            language="en",
+        )
+        == []
+    )
+    assert (
+        _chunk_and_emit_claims("P217", "", "string", "abc", _dt.date(2026, 1, 1), {})
+        == []
+    )
+
+
+def test_chunk_and_emit_claims_per_language_series_independent():
+    """A long English description and a long French description on the
+    same property each start a fresh A series — series-letter key is
+    (prop, language)."""
+    import datetime as _dt
+
+    from ingest_wikimedia.sdc import _chunk_and_emit_claims
+
+    letters = {}
+    en = _chunk_and_emit_claims(
+        "P10358",
+        "x" * 2500,
+        "monolingualtext",
+        "abc",
+        _dt.date(2026, 1, 1),
+        letters,
+        language="en",
+    )
+    fr = _chunk_and_emit_claims(
+        "P10358",
+        "y" * 2500,
+        "monolingualtext",
+        "abc",
+        _dt.date(2026, 1, 1),
+        letters,
+        language="fr",
+    )
+    assert en[0]["qualifiers"]["P1545"][0]["datavalue"]["value"].startswith("A")
+    assert fr[0]["qualifiers"]["P1545"][0]["datavalue"]["value"].startswith("A")
+
+
+def test_chunk_and_emit_claims_normalizes_before_chunking():
+    """Embedded newlines collapse to single spaces (per Wikibase's
+    server-side normalization) BEFORE the chunk boundary search runs.
+    Without this, our chunk char counts would diverge from Wikibase's
+    stored byte length and matching would drift on every sync."""
+    import datetime as _dt
+
+    from ingest_wikimedia.sdc import _chunk_and_emit_claims
+
+    # 1500 'x' + newline + 1500 'y' → after normalization it's
+    # 1500 'x' + single space + 1500 'y' = 3001 chars, chunked.
+    text = "x" * 1500 + "\n" + "y" * 1500
+    claims = _chunk_and_emit_claims(
+        "P10358",
+        text,
+        "monolingualtext",
+        "abc",
+        _dt.date(2026, 1, 1),
+        {},
+        language="en",
+    )
+    # Concatenated values reassemble to the normalized form, not the raw.
+    rebuilt = "".join(c["mainsnak"]["datavalue"]["value"]["text"] for c in claims)
+    assert rebuilt == "x" * 1500 + " " + "y" * 1500
+
+
+def test_normalize_string_value_strips_bom_and_bidi_marks():
+    """Wikibase's trimBadChars equivalent strips BOM (U+FEFF), bidi marks
+    (U+200E/U+200F), and non-characters (U+FFFE/U+FFFF) — invisible
+    codepoints that DPLA source CSV/JSON occasionally carries from
+    pasted-text round-trips. Without local stripping, the next sync
+    would see drift on every such value (Wikibase stores N-1 bytes,
+    we emit N) and re-write every chunk indefinitely."""
+    from ingest_wikimedia.sdc import _normalize_string_value
+
+    # BOM at start, mid, and end — all stripped.
+    assert _normalize_string_value("﻿Hello") == "Hello"
+    assert _normalize_string_value("Hello﻿") == "Hello"
+    assert _normalize_string_value("He﻿llo") == "Hello"
+    # LRM (U+200E) and RLM (U+200F) — both stripped.
+    assert _normalize_string_value("Hello‎") == "Hello"
+    assert _normalize_string_value("a‏b") == "ab"
+    # Non-characters U+FFFE / U+FFFF — both stripped.
+    assert _normalize_string_value("Hello￾") == "Hello"
+    assert _normalize_string_value("a￿b") == "ab"
+
+
+def test_advance_series_letter_basic_increment():
+    from ingest_wikimedia.sdc import _advance_series_letter
+
+    assert _advance_series_letter("A") == "B"
+    assert _advance_series_letter("B") == "C"
+    assert _advance_series_letter("Y") == "Z"
+
+
+def test_advance_series_letter_carry_past_z():
+    """The bug this guards against: ``chr(ord('Z') + 1) == '['`` —
+    silently advancing into non-alpha codepoints would corrupt Lua-side
+    reassembly. Excel-style carry to AA is the documented behavior."""
+    from ingest_wikimedia.sdc import _advance_series_letter
+
+    assert _advance_series_letter("Z") == "AA"
+    assert _advance_series_letter("AA") == "AB"
+    assert _advance_series_letter("AZ") == "BA"
+    assert _advance_series_letter("BZ") == "CA"
+    assert _advance_series_letter("ZZ") == "AAA"
+    assert _advance_series_letter("AAZ") == "ABA"
+
+
+def test_next_series_letter_advances_past_z_without_corruption():
+    """A doc with 27+ long values on one (prop, lang) advances past Z
+    safely. Verify the first 28 letters in sequence."""
+    from ingest_wikimedia.sdc import _next_series_letter
+
+    letters = {}
+    seen = [_next_series_letter(letters, "P10358", "en") for _ in range(28)]
+    # First 26 letters A through Z.
+    assert seen[:26] == [chr(ord("A") + i) for i in range(26)]
+    # 27th is AA (not "[").
+    assert seen[26] == "AA"
+    assert seen[27] == "AB"
+    # The persisted state matches the last value returned.
+    assert letters[("P10358", "en")] == "AB"

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1882,6 +1882,52 @@ def test_build_expected_from_parsed_includes_both_shapes_for_p571(monkeypatch):
     assert len(canonical_keys) == 2
 
 
+def test_build_expected_from_parsed_emits_tuple_keys_for_chunkable_props(monkeypatch):
+    """Regression guard against CodeRabbit's PR #282 finding: the legacy
+    ``dpla_claims()`` path's expected map MUST key chunkable-property
+    values as ``(value, p1545)`` tuples so the reconciler's tuple-keyed
+    Commons-side extraction sees a match. Without this, a legacy
+    ``--file`` / ``--cat`` / ``--list`` rerun would treat every
+    DPLA-authored P760/P217/P4272/P1225/P1476/P10358 statement as
+    unexpected and queue it for removal."""
+    from ingest_wikimedia.sdc import CHUNKABLE_PROPS
+    from tools import sdc_sync
+
+    monkeypatch.setattr(sdc_sync, "rights", {}, raising=False)
+
+    expected = sdc_sync._build_expected_from_parsed(
+        dpla_id="abcdef",
+        url="http://example.com/x",
+        descs=["a description"],
+        dates=[],
+        titles=["A title"],
+        hub="Q1",
+        local_ids=["local-1", "local-2"],
+        institution="Q2",
+        rs="",
+        creators=[],
+        subjects=[("subj-1", ""), ("subj-2", "Q5")],
+        naids=["naid-1"],
+        access="",
+        level="",
+    )
+    # Each chunkable-prop entry is a list of (value, None) tuples — the
+    # legacy path never produces chunked claims (it predates chunking),
+    # so p1545 is always None on this side.
+    assert expected["P760"] == [("abcdef", None)]
+    assert expected["P217"] == [("local-1", None), ("local-2", None)]
+    assert expected["P1476"] == [("A title", None)]
+    assert expected["P10358"] == [("a description", None)]
+    assert expected["P4272"] == [("subj-1", None), ("subj-2", None)]
+    assert expected["P1225"] == [("naid-1", None)]
+    # Sanity: every CHUNKABLE_PROPS entry is the tuple shape.
+    for prop in CHUNKABLE_PROPS:
+        for v in expected.get(prop, []):
+            assert isinstance(v, tuple) and len(v) == 2, (
+                f"{prop} entry {v!r} must be a (value, p1545) tuple"
+            )
+
+
 # ---------------------------------------------------------------------------
 # P2699 / P6108 qualifiers on P7482 (PR description in
 # tools/sdc_sync.py::_amend_p7482_url_qualifiers).
@@ -2305,6 +2351,130 @@ def test_amend_p760_page_qualifier_skips_when_no_dpla_authored_p760():
             "M999", "abcdef", {"claims": []}, page_number=1
         )
 
+    assert postqual_calls == []
+
+
+def test_amend_p760_page_qualifier_removes_stale_value_when_page_changes():
+    """Renumber scenario: existing DPLA-authored P760 has P304="3"
+    (from a prior sync), but the recomputed page_number is now 2 (a
+    sibling ordinal got deleted, shifting this file's position). The
+    helper must remove the stale "3" qualifier via wbremovequalifiers
+    BEFORE adding the new "2"; otherwise the statement accumulates
+    conflicting page numbers indefinitely since the reconciler matches
+    P760 only by mainsnak value."""
+    from tools import sdc_sync
+
+    existing_p760 = {
+        "id": "M999$p760id",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abcdef"},
+        },
+        "qualifiers": {
+            "P459": _dpla_p459(),
+            "P304": [
+                {
+                    "snaktype": "value",
+                    "property": "P304",
+                    "datavalue": {"type": "string", "value": "3"},
+                    "hash": "stale-snak-hash-3",
+                }
+            ],
+        },
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P760": [existing_p760]}}
+
+    submit_calls = []
+    postqual_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync,
+            "_submit_sdc_write",
+            side_effect=lambda action, *a, **kw: submit_calls.append((action, a, kw)),
+        ),
+        patch.object(
+            sdc_sync, "postqual", side_effect=lambda *a: postqual_calls.append(a)
+        ),
+    ):
+        sdc_sync._amend_p760_page_qualifier(
+            "M999", "abcdef", {"claims": []}, page_number=2
+        )
+
+    # wbremovequalifiers was called for the stale snak hash.
+    assert len(submit_calls) == 1
+    action, _args, kw = submit_calls[0]
+    assert action == "wbremovequalifiers"
+    assert kw["claim"] == "M999$p760id"
+    assert kw["qualifiers"] == "stale-snak-hash-3"
+
+    # postqual added the new value.
+    assert len(postqual_calls) == 1
+    claimid, prop, value_json = postqual_calls[0]
+    assert claimid == "M999$p760id"
+    assert prop == "P304"
+    assert json.loads(value_json) == "2"
+
+
+def test_amend_p760_page_qualifier_removes_stale_when_expected_also_present():
+    """Mixed case: existing P304 has both the expected value AND a stale
+    one (e.g. a prior renumber wasn't cleaned up). Helper must remove
+    only the stale snak and NOT re-add the expected value."""
+    from tools import sdc_sync
+
+    existing_p760 = {
+        "id": "M999$p760id",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abcdef"},
+        },
+        "qualifiers": {
+            "P459": _dpla_p459(),
+            "P304": [
+                {
+                    "snaktype": "value",
+                    "property": "P304",
+                    "datavalue": {"type": "string", "value": "2"},
+                    "hash": "hash-2",
+                },
+                {
+                    "snaktype": "value",
+                    "property": "P304",
+                    "datavalue": {"type": "string", "value": "3"},
+                    "hash": "stale-hash-3",
+                },
+            ],
+        },
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P760": [existing_p760]}}
+
+    submit_calls = []
+    postqual_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync,
+            "_submit_sdc_write",
+            side_effect=lambda action, *a, **kw: submit_calls.append((action, a, kw)),
+        ),
+        patch.object(
+            sdc_sync, "postqual", side_effect=lambda *a: postqual_calls.append(a)
+        ),
+    ):
+        sdc_sync._amend_p760_page_qualifier(
+            "M999", "abcdef", {"claims": []}, page_number=2
+        )
+
+    # Only the stale snak got removed; the expected value was already
+    # present, so no postqual.
+    assert len(submit_calls) == 1
+    assert submit_calls[0][2]["qualifiers"] == "stale-hash-3"
     assert postqual_calls == []
 
 

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -2109,3 +2109,516 @@ def test_dpla_extra_qualifier_props_p7482_includes_new_url_quals():
     # against an accidental overwrite.
     assert "P973" in allowed
     assert "P137" in allowed
+
+
+# --------------------------------------------------------------------------
+# #40 — P304 (page-number) per-ordinal qualifier on P760 (DPLA ID).
+#
+# Multipage items have multiple Commons files. Files of the same extension
+# get numbered within their format series (3 JPGs → 1/2/3, 2 PDFs → 1/2).
+# A file that's the only one of its extension on the item gets no P304.
+# --------------------------------------------------------------------------
+
+
+def test_file_extension_lowercases_and_handles_dotless_titles():
+    from tools import sdc_sync
+
+    assert sdc_sync._file_extension("File:Foo - 1.jpg") == "jpg"
+    assert sdc_sync._file_extension("File:Foo.PDF") == "pdf"
+    assert sdc_sync._file_extension("File:Foo - 1 - bar.JPG") == "jpg"
+    assert sdc_sync._file_extension("noext") == ""
+    assert sdc_sync._file_extension("") == ""
+    assert sdc_sync._file_extension(None) == ""
+
+
+def test_compute_page_numbers_single_ordinal_returns_empty():
+    """One file → no P304 (not multipage)."""
+    from tools import sdc_sync
+
+    ordinals = [("1", {"title": "File:Solo.jpg"})]
+    assert sdc_sync._compute_page_numbers(ordinals) == {}
+
+
+def test_compute_page_numbers_multiple_jpgs_single_pdf_numbers_only_jpgs():
+    """3 JPGs + 1 PDF: only the JPGs get P304 (the PDF is alone in its
+    extension series). User-confirmed: 'we are only numbering within
+    each ordinal series — JPGs and PDFs are numbered separately'."""
+    from tools import sdc_sync
+
+    ordinals = [
+        ("1", {"title": "File:A.jpg"}),
+        ("2", {"title": "File:B.pdf"}),
+        ("3", {"title": "File:C.jpg"}),
+        ("4", {"title": "File:D.jpg"}),
+    ]
+    result = sdc_sync._compute_page_numbers(ordinals)
+    # JPGs (ordinals 1, 3, 4) get 1, 2, 3 in the order encountered.
+    assert result == {"1": 1, "3": 2, "4": 3}
+    # The single PDF gets no entry.
+    assert "2" not in result
+
+
+def test_compute_page_numbers_multiple_extensions_each_numbered_separately():
+    """3 JPGs + 2 PDFs: JPGs get 1/2/3, PDFs get 1/2."""
+    from tools import sdc_sync
+
+    ordinals = [
+        ("1", {"title": "File:A.jpg"}),
+        ("2", {"title": "File:B.pdf"}),
+        ("3", {"title": "File:C.jpg"}),
+        ("4", {"title": "File:D.pdf"}),
+        ("5", {"title": "File:E.jpg"}),
+    ]
+    result = sdc_sync._compute_page_numbers(ordinals)
+    assert result == {"1": 1, "3": 2, "5": 3, "2": 1, "4": 2}
+
+
+def test_compute_page_numbers_mixed_singletons_returns_empty():
+    """1 JPG + 1 PDF: neither file is part of a multipage series within
+    its own format. No P304 anywhere."""
+    from tools import sdc_sync
+
+    ordinals = [
+        ("1", {"title": "File:A.jpg"}),
+        ("2", {"title": "File:B.pdf"}),
+    ]
+    assert sdc_sync._compute_page_numbers(ordinals) == {}
+
+
+def test_amend_p760_page_qualifier_noop_when_page_number_is_none():
+    """``page_number=None`` (single-file extension group) means no P304;
+    helper must not POST anything."""
+    from tools import sdc_sync
+
+    postqual_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity") as mock_get,
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync, "postqual", side_effect=lambda *a: postqual_calls.append(a)
+        ),
+    ):
+        sdc_sync._amend_p760_page_qualifier(
+            "M999", "abcdef", {"claims": []}, page_number=None
+        )
+        mock_get.assert_not_called()
+    assert postqual_calls == []
+
+
+def test_amend_p760_page_qualifier_stamps_missing_p304_via_postqual():
+    """Existing DPLA-authored P760 with no P304 → postqual gets called
+    with the page-number value."""
+    from tools import sdc_sync
+
+    existing_p760 = {
+        "id": "M999$p760id",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abcdef"},
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P760": [existing_p760]}}
+
+    postqual_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync, "postqual", side_effect=lambda *a: postqual_calls.append(a)
+        ),
+    ):
+        sdc_sync._amend_p760_page_qualifier(
+            "M999", "abcdef", {"claims": []}, page_number=2
+        )
+
+    assert len(postqual_calls) == 1
+    claimid, prop, value_json = postqual_calls[0]
+    assert claimid == "M999$p760id"
+    assert prop == "P304"
+    assert json.loads(value_json) == "2"
+
+
+def test_amend_p760_page_qualifier_idempotent_when_p304_already_matches():
+    """Existing DPLA-authored P760 already has the correct P304 value →
+    no POST. Re-running the same sync must be a no-op."""
+    from tools import sdc_sync
+
+    existing_p760 = {
+        "id": "M999$p760id",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abcdef"},
+        },
+        "qualifiers": {
+            "P459": _dpla_p459(),
+            "P304": _qual_string("P304", "2"),
+        },
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P760": [existing_p760]}}
+
+    postqual_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync, "postqual", side_effect=lambda *a: postqual_calls.append(a)
+        ),
+    ):
+        sdc_sync._amend_p760_page_qualifier(
+            "M999", "abcdef", {"claims": []}, page_number=2
+        )
+
+    assert postqual_calls == []
+
+
+def test_amend_p760_page_qualifier_skips_when_no_dpla_authored_p760():
+    """Only foreign / unsafe P760 statements on Commons → nothing to
+    amend; helper exits quietly."""
+    from tools import sdc_sync
+
+    foreign_p760 = {
+        "id": "M999$foreign",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abcdef"},
+        },
+        "qualifiers": {"P1001": _qual_string("P1001", "user-added")},
+        "references": [_foreign_reference()],
+    }
+    entity = {"pageid": 999, "statements": {"P760": [foreign_p760]}}
+
+    postqual_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync, "postqual", side_effect=lambda *a: postqual_calls.append(a)
+        ),
+    ):
+        sdc_sync._amend_p760_page_qualifier(
+            "M999", "abcdef", {"claims": []}, page_number=1
+        )
+
+    assert postqual_calls == []
+
+
+def test_dpla_extra_qualifier_props_p760_includes_p304_and_p1545():
+    """``_DPLA_EXTRA_QUALIFIER_PROPS["P760"]`` must include P304 (per-
+    ordinal page number) and P1545 (chunk series ordinal) so
+    ``_is_safe_to_amend_in_place`` counts them as DPLA-owned."""
+    from tools import sdc_sync
+
+    allowed = sdc_sync._DPLA_EXTRA_QUALIFIER_PROPS["P760"]
+    assert "P304" in allowed
+    assert "P1545" in allowed
+
+
+# --------------------------------------------------------------------------
+# #39 — chunked-claim idempotency: _extract_p1545_value, check(),
+# _extract_comparable_value tuple shape.
+# --------------------------------------------------------------------------
+
+
+def test_extract_p1545_value_returns_none_when_absent():
+    from tools import sdc_sync
+
+    stmt = {"qualifiers": {"P459": _dpla_p459()}}
+    assert sdc_sync._extract_p1545_value(stmt) is None
+    # Also handles missing qualifiers key.
+    assert sdc_sync._extract_p1545_value({}) is None
+
+
+def test_extract_p1545_value_returns_string_when_present():
+    from tools import sdc_sync
+
+    stmt = {"qualifiers": {"P1545": _qual_string("P1545", "A2")}}
+    assert sdc_sync._extract_p1545_value(stmt) == "A2"
+
+
+def test_extract_p1545_value_skips_malformed_snaks():
+    """A P1545 qualifier missing 'datavalue' or whose snaktype isn't
+    'value' shouldn't crash — return None and move on."""
+    from tools import sdc_sync
+
+    stmt = {
+        "qualifiers": {
+            "P1545": [
+                {"snaktype": "novalue", "property": "P1545"},
+                # Then a well-formed one — still returns the well-formed value.
+                {
+                    "snaktype": "value",
+                    "property": "P1545",
+                    "datavalue": {"type": "string", "value": "B1"},
+                },
+            ]
+        }
+    }
+    assert sdc_sync._extract_p1545_value(stmt) == "B1"
+
+
+def test_extract_comparable_value_returns_tuple_for_string():
+    """String/monolingualtext comparable values are (value, p1545)
+    tuples so chunk-by-chunk matching can distinguish chunks of the
+    same logical value."""
+    from tools import sdc_sync
+
+    unchunked = {
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abcdef"},
+        }
+    }
+    assert sdc_sync._extract_comparable_value(unchunked) == ("abcdef", None)
+
+    chunked = {
+        "mainsnak": {
+            "property": "P217",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "chunk-1-text"},
+        },
+        "qualifiers": {"P1545": _qual_string("P1545", "A1")},
+    }
+    assert sdc_sync._extract_comparable_value(chunked) == ("chunk-1-text", "A1")
+
+
+def test_extract_comparable_value_returns_tuple_for_monolingualtext():
+    from tools import sdc_sync
+
+    claim = {
+        "mainsnak": {
+            "property": "P1476",
+            "snaktype": "value",
+            "datavalue": {
+                "type": "monolingualtext",
+                "value": {"text": "Hello", "language": "en"},
+            },
+        },
+        "qualifiers": {"P1545": _qual_string("P1545", "A2")},
+    }
+    assert sdc_sync._extract_comparable_value(claim) == ("Hello", "A2")
+
+
+def test_check_chunked_claim_matches_only_same_p1545():
+    """sdc.json claim with P1545="A1" must NOT match an existing Commons
+    statement with P1545="A2" — different chunks of the same logical
+    value are independent."""
+    from tools import sdc_sync
+
+    chunked_a1 = {
+        "id": "M999$chunkA1",
+        "mainsnak": {
+            "property": "P1476",
+            "snaktype": "value",
+            "datavalue": {
+                "type": "monolingualtext",
+                "value": {"text": "shared chunk text", "language": "en"},
+            },
+        },
+        "qualifiers": {"P459": _dpla_p459(), "P1545": _qual_string("P1545", "A1")},
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P1476": [chunked_a1]}}
+
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        # Looking for A1 — should find the existing A1 (no add).
+        result_a1 = sdc_sync.check(
+            "M999", ("monolingualtext", ("shared chunk text", "A1")), "P1476"
+        )
+        # Looking for A2 — same text but different chunk; should add new.
+        result_a2 = sdc_sync.check(
+            "M999", ("monolingualtext", ("shared chunk text", "A2")), "P1476"
+        )
+
+    assert result_a1[0] is False  # don't duplicate the matching A1
+    assert result_a2[0] is True  # A2 is a distinct chunk — add it
+
+
+def test_check_chunked_claim_does_not_match_unchunked_legacy_statement():
+    """A pre-chunking Commons statement (no P1545) is NOT the same logical
+    claim as a new chunked statement, even with matching text. The
+    reconciler will remove the legacy one; check() must let the new one
+    through."""
+    from tools import sdc_sync
+
+    legacy_stmt = {
+        "id": "M999$legacy",
+        "mainsnak": {
+            "property": "P1476",
+            "snaktype": "value",
+            "datavalue": {
+                "type": "monolingualtext",
+                "value": {"text": "value", "language": "en"},
+            },
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P1476": [legacy_stmt]}}
+
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        result = sdc_sync.check("M999", ("monolingualtext", ("value", "A1")), "P1476")
+
+    # The chunked sdc.json claim must be added — it's not equivalent to
+    # the pre-chunking statement.
+    assert result[0] is True
+
+
+def test_check_legacy_string_qid_still_accepted():
+    """Backwards compat: legacy callers (dpla_claims path) still pass
+    plain-string qids without P1545. check() must accept that shape
+    and treat it as p1545=None."""
+    from tools import sdc_sync
+
+    legacy_stmt = {
+        "id": "M999$legacy",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abc"},
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P760": [legacy_stmt]}}
+
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        # qid[1] is a raw string (not tuple) — legacy shape.
+        result = sdc_sync.check("M999", ("string", "abc"), "P760")
+
+    # Existing matches with no P1545, qid implicitly p1545=None → no
+    # duplicate add.
+    assert result[0] is False
+
+
+def test_dpla_extra_qualifier_props_chunkable_have_p1545():
+    """Every chunkable property must include P1545 in its allowed
+    qualifier set; otherwise ``_is_safe_to_amend_in_place`` would treat
+    DPLA's own chunked claims as foreign. The dict is populated from
+    ``CHUNKABLE_PROPS`` so adding a new chunkable property in sdc.py
+    automatically widens this allowed-qualifier set."""
+    from ingest_wikimedia.sdc import CHUNKABLE_PROPS
+    from tools import sdc_sync
+
+    for prop in CHUNKABLE_PROPS:
+        allowed = sdc_sync._DPLA_EXTRA_QUALIFIER_PROPS[prop]
+        assert "P1545" in allowed, f"{prop} allowed set missing P1545: {allowed}"
+
+
+def test_chunked_claim_roundtrip_extract_comparable_value_preserves_chunk_identity():
+    """End-to-end: build a long monolingualtext value via
+    ``build_claims_for_doc``, then extract comparable tuples for each
+    resulting chunk claim via ``_extract_comparable_value``. The
+    tuples must be distinct per chunk (text or P1545 differs), and
+    the P1545 series ordinal must follow A1/A2/A3 in order. Without
+    this end-to-end coverage, the sdc.py and sdc_sync.py halves could
+    drift on the chunk-key contract."""
+    import datetime as _dt
+
+    from ingest_wikimedia.sdc import build_claims_for_doc
+    from tools import sdc_sync
+
+    long_desc = "a" * 1500 + " " + "b" * 1500 + " " + "c" * 800
+    doc = {
+        "id": "abc1234567890",
+        "provider": {"name": "Digital Commonwealth"},
+        "dataProvider": {"name": "Boston Public Library"},
+        "sourceResource": {
+            "title": ["A title"],
+            "description": [long_desc],
+        },
+        "isShownAt": "https://example.org/item/abc",
+        "rights": "http://rightsstatements.org/vocab/InC/1.0/",
+    }
+    hubs = {
+        "Digital Commonwealth": {
+            "Wikidata": "Q1",
+            "institutions": {"Boston Public Library": {"Wikidata": "Q2"}},
+        }
+    }
+    out = build_claims_for_doc(
+        doc, "abc1234567890", hubs, {}, {}, {}, _dt.date(2026, 6, 1)
+    )
+    assert out is not None, "doc should be parseable; check fixture shape"
+    desc_claims = [c for c in out["claims"] if c["mainsnak"]["property"] == "P10358"]
+    assert len(desc_claims) == 3, (
+        f"expected 3 chunks for {len(long_desc)}-char description, "
+        f"got {len(desc_claims)}"
+    )
+    comparable_tuples = [sdc_sync._extract_comparable_value(c) for c in desc_claims]
+    # All distinct.
+    assert len(set(comparable_tuples)) == 3
+    # P1545 ordinals follow A1/A2/A3.
+    assert [t[1] for t in comparable_tuples] == ["A1", "A2", "A3"]
+
+
+def test_amend_p760_page_qualifier_does_not_re_invalidate_when_p304_matches():
+    """When the existing P760 already has the expected P304, the helper
+    must skip both postqual AND the terminal invalidate_entity — at
+    millions of items, the spared cache drop is real. Mirrors the
+    conditional-invalidate pattern in ``_amend_p7482_url_qualifiers``."""
+    from tools import sdc_sync
+
+    existing_p760 = {
+        "id": "M999$p760id",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abcdef"},
+        },
+        "qualifiers": {
+            "P459": _dpla_p459(),
+            "P304": _qual_string("P304", "2"),
+        },
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P760": [existing_p760]}}
+
+    invalidate_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(
+            sdc_sync,
+            "invalidate_entity",
+            side_effect=lambda *a: invalidate_calls.append(a),
+        ),
+        patch.object(sdc_sync, "postqual"),
+    ):
+        sdc_sync._amend_p760_page_qualifier(
+            "M999", "abcdef", {"claims": []}, page_number=2
+        )
+
+    # Idempotent path: no invalidate, no postqual. (The pre-PR version
+    # always invalidated at the end; the cleanup keeps it conditional.)
+    assert invalidate_calls == []
+
+
+def test_qualifier_values_returns_empty_when_no_qualifiers():
+    """Module-level helper safety — passes the smoke-test cases that
+    callers used to inline in each amend helper."""
+    from tools import sdc_sync
+
+    assert sdc_sync._qualifier_values({}, "P304") == []
+    assert sdc_sync._qualifier_values({"qualifiers": {}}, "P304") == []
+    # Skip malformed snaks rather than crash.
+    stmt = {
+        "qualifiers": {
+            "P304": [
+                {"snaktype": "novalue", "property": "P304"},
+                {
+                    "snaktype": "value",
+                    "property": "P304",
+                    "datavalue": {"type": "string", "value": "2"},
+                },
+            ]
+        }
+    }
+    assert sdc_sync._qualifier_values(stmt, "P304") == ["2"]
+    assert sdc_sync._first_qualifier_value(stmt, "P304") == "2"
+    assert sdc_sync._first_qualifier_value(stmt, "P999") is None

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1882,50 +1882,97 @@ def test_build_expected_from_parsed_includes_both_shapes_for_p571(monkeypatch):
     assert len(canonical_keys) == 2
 
 
-def test_build_expected_from_parsed_emits_tuple_keys_for_chunkable_props(monkeypatch):
-    """Regression guard against CodeRabbit's PR #282 finding: the legacy
-    ``dpla_claims()`` path's expected map MUST key chunkable-property
-    values as ``(value, p1545)`` tuples so the reconciler's tuple-keyed
-    Commons-side extraction sees a match. Without this, a legacy
-    ``--file`` / ``--cat`` / ``--list`` rerun would treat every
-    DPLA-authored P760/P217/P4272/P1225/P1476/P10358 statement as
-    unexpected and queue it for removal."""
-    from ingest_wikimedia.sdc import CHUNKABLE_PROPS
+def test_reconciler_protected_props_skips_removal_for_chunkable_claims():
+    """The legacy ``dpla_claims()`` path passes
+    ``protected_props=CHUNKABLE_PROPS`` to ``_reconcile_existing_claims``
+    so partner-mode-written chunked claims (P1545="A1", "A2", ...) on
+    a Commons file aren't queued for removal during a legacy
+    ``--file`` / ``--cat`` / ``--list`` rerun. The legacy expected-
+    builder doesn't model chunk shape; without protection the
+    reconciler would see chunked Commons claims as unexpected and
+    delete them.
+    """
     from tools import sdc_sync
 
-    monkeypatch.setattr(sdc_sync, "rights", {}, raising=False)
+    # A chunked P10358 statement on Commons — DPLA-authored, P1545="A1".
+    chunked_a1 = {
+        "id": "M999$chunkA1",
+        "mainsnak": {
+            "property": "P10358",
+            "snaktype": "value",
+            "datavalue": {
+                "type": "monolingualtext",
+                "value": {"text": "chunk one text", "language": "en"},
+            },
+        },
+        "qualifiers": {"P459": _dpla_p459(), "P1545": _qual_string("P1545", "A1")},
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P10358": [chunked_a1]}}
 
-    expected = sdc_sync._build_expected_from_parsed(
-        dpla_id="abcdef",
-        url="http://example.com/x",
-        descs=["a description"],
-        dates=[],
-        titles=["A title"],
-        hub="Q1",
-        local_ids=["local-1", "local-2"],
-        institution="Q2",
-        rs="",
-        creators=[],
-        subjects=[("subj-1", ""), ("subj-2", "Q5")],
-        naids=["naid-1"],
-        access="",
-        level="",
-    )
-    # Each chunkable-prop entry is a list of (value, None) tuples — the
-    # legacy path never produces chunked claims (it predates chunking),
-    # so p1545 is always None on this side.
-    assert expected["P760"] == [("abcdef", None)]
-    assert expected["P217"] == [("local-1", None), ("local-2", None)]
-    assert expected["P1476"] == [("A title", None)]
-    assert expected["P10358"] == [("a description", None)]
-    assert expected["P4272"] == [("subj-1", None), ("subj-2", None)]
-    assert expected["P1225"] == [("naid-1", None)]
-    # Sanity: every CHUNKABLE_PROPS entry is the tuple shape.
-    for prop in CHUNKABLE_PROPS:
-        for v in expected.get(prop, []):
-            assert isinstance(v, tuple) and len(v) == 2, (
-                f"{prop} entry {v!r} must be a (value, p1545) tuple"
-            )
+    # Legacy expected models the unchunked full text — won't match the
+    # ("chunk one text", "A1") tuple the reconciler extracts.
+    expected = {"P10358": ["the full unchunked description text"]}
+
+    submit_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync,
+            "_submit_sdc_write",
+            side_effect=lambda action, *a, **kw: submit_calls.append((action, a, kw)),
+        ),
+    ):
+        sdc_sync._reconcile_existing_claims(
+            "M999",
+            "abcdef",
+            expected,
+            protected_props=frozenset({"P10358"}),
+        )
+
+    # Nothing got queued for removal because P10358 is protected.
+    assert submit_calls == []
+
+
+def test_reconciler_without_protection_would_remove_unrecognized_chunked_claim():
+    """Sanity check that the previous test would fail without
+    protection — the protection mechanism is doing real work, not just
+    a no-op covering for some other guard."""
+    from tools import sdc_sync
+
+    chunked_a1 = {
+        "id": "M999$chunkA1",
+        "mainsnak": {
+            "property": "P10358",
+            "snaktype": "value",
+            "datavalue": {
+                "type": "monolingualtext",
+                "value": {"text": "chunk one text", "language": "en"},
+            },
+        },
+        "qualifiers": {"P459": _dpla_p459(), "P1545": _qual_string("P1545", "A1")},
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P10358": [chunked_a1]}}
+    expected = {"P10358": ["the full unchunked description text"]}
+
+    submit_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync,
+            "_submit_sdc_write",
+            side_effect=lambda action, *a, **kw: submit_calls.append((action, a, kw)),
+        ),
+    ):
+        # No protected_props — the chunked statement gets queued for removal
+        # because ("chunk one text", "A1") isn't in expected["P10358"].
+        sdc_sync._reconcile_existing_claims("M999", "abcdef", expected)
+
+    assert len(submit_calls) == 1
+    assert submit_calls[0][0] == "wbremoveclaims"
 
 
 # ---------------------------------------------------------------------------
@@ -2231,15 +2278,40 @@ def test_compute_page_numbers_mixed_singletons_returns_empty():
     assert sdc_sync._compute_page_numbers(ordinals) == {}
 
 
-def test_amend_p760_page_qualifier_noop_when_page_number_is_none():
-    """``page_number=None`` (single-file extension group) means no P304;
-    helper must not POST anything."""
+def test_amend_p760_page_qualifier_noop_when_page_number_is_none_and_no_existing_p304():
+    """``page_number=None`` (singleton in extension group) + no
+    existing P304 → no writes. Note the helper STILL reads the entity
+    to confirm there's no stale P304 to clean up; this is intentional
+    (the cleanup pass is the whole reason None doesn't early-return)."""
     from tools import sdc_sync
 
+    no_p304_stmt = {
+        "id": "M999$p760id",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abcdef"},
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P760": [no_p304_stmt]}}
+
     postqual_calls = []
+    submit_calls = []
+    invalidate_calls = []
     with (
-        patch.object(sdc_sync, "get_entity") as mock_get,
-        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(
+            sdc_sync,
+            "invalidate_entity",
+            side_effect=lambda *a: invalidate_calls.append(a),
+        ),
+        patch.object(
+            sdc_sync,
+            "_submit_sdc_write",
+            side_effect=lambda action, *a, **kw: submit_calls.append((action, a, kw)),
+        ),
         patch.object(
             sdc_sync, "postqual", side_effect=lambda *a: postqual_calls.append(a)
         ),
@@ -2247,7 +2319,66 @@ def test_amend_p760_page_qualifier_noop_when_page_number_is_none():
         sdc_sync._amend_p760_page_qualifier(
             "M999", "abcdef", {"claims": []}, page_number=None
         )
-        mock_get.assert_not_called()
+    assert postqual_calls == []
+    assert submit_calls == []
+    # No writes happened → no terminal invalidate.
+    assert invalidate_calls == []
+
+
+def test_amend_p760_page_qualifier_removes_stale_p304_when_page_number_is_none():
+    """Critical CodeRabbit-flagged case: file that USED to be in a
+    multi-file extension group (had P304="2") is now a singleton
+    (e.g. siblings were deleted). page_number is None in the new
+    computation, but the existing P304 must be removed — otherwise
+    the file keeps incorrect page metadata indefinitely, since the
+    reconciler doesn't diff P304."""
+    from tools import sdc_sync
+
+    existing_p760 = {
+        "id": "M999$p760id",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abcdef"},
+        },
+        "qualifiers": {
+            "P459": _dpla_p459(),
+            "P304": [
+                {
+                    "snaktype": "value",
+                    "property": "P304",
+                    "datavalue": {"type": "string", "value": "2"},
+                    "hash": "obsolete-hash",
+                }
+            ],
+        },
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P760": [existing_p760]}}
+
+    submit_calls = []
+    postqual_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync,
+            "_submit_sdc_write",
+            side_effect=lambda action, *a, **kw: submit_calls.append((action, a, kw)),
+        ),
+        patch.object(
+            sdc_sync, "postqual", side_effect=lambda *a: postqual_calls.append(a)
+        ),
+    ):
+        sdc_sync._amend_p760_page_qualifier(
+            "M999", "abcdef", {"claims": []}, page_number=None
+        )
+
+    # wbremovequalifiers fired for the stale snak; no postqual.
+    assert len(submit_calls) == 1
+    action, _args, kw = submit_calls[0]
+    assert action == "wbremovequalifiers"
+    assert kw["qualifiers"] == "obsolete-hash"
     assert postqual_calls == []
 
 

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1598,13 +1598,55 @@ def _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_number):
         return
 
     expected_value = str(page_number)
-    if expected_value in _qualifier_values(target_stmt, "P304"):
-        # Already matches; skip the postqual and the cache invalidation.
-        # Matches the conditional-invalidate pattern in
-        # ``_amend_p7482_url_qualifiers``.
+    # Walk existing P304 qualifiers and bucket them: present-with-expected-
+    # value (idempotent — nothing to do) vs. present-with-different-value
+    # (stale, must be removed before adding the new one). Without removing
+    # stale values, a renumber between syncs — e.g. a sibling ordinal was
+    # deleted by a Commons curator, shifting this file from page 3 to
+    # page 2 — would leave the prior P304="3" alongside the new P304="2"
+    # indefinitely; the statement-level reconciler can't clean it up
+    # because it matches P760 statements only by mainsnak value, not by
+    # their qualifier set.
+    # TODO: ``_amend_p7482_url_qualifiers`` has the same latent issue
+    # for P2699 and P6108. Trigger is rarer there (partner catalog URLs
+    # almost never change for already-uploaded files), but the cleanup
+    # should be unified — likely as a shared ``_replace_dpla_qualifier``
+    # helper once we have a second use case (this one).
+    expected_already_present = False
+    stale_snak_hashes = []
+    for q in target_stmt.get("qualifiers", {}).get("P304", []) or []:
+        if q.get("snaktype") != "value":
+            continue
+        dv = q.get("datavalue")
+        if not (isinstance(dv, dict) and "value" in dv):
+            continue
+        if dv["value"] == expected_value:
+            expected_already_present = True
+        elif q.get("hash"):
+            stale_snak_hashes.append(q["hash"])
+
+    if expected_already_present and not stale_snak_hashes:
+        # Idempotent — exact match, no writes. Matches the conditional-
+        # invalidate pattern in ``_amend_p7482_url_qualifiers``.
         return
 
-    postqual(target_stmt["id"], "P304", json.dumps(expected_value))
+    if stale_snak_hashes:
+        _submit_sdc_write(
+            "wbremovequalifiers",
+            mediaid,
+            dpla_id,
+            claim=target_stmt["id"],
+            qualifiers="|".join(stale_snak_hashes),
+            summary=(
+                f"Removing stale P304 page-number qualifier(s) before"
+                f" applying recomputed value for [[dpla:{dpla_id}|{dpla_id}]]."
+                f" [[COM:DPLA/MOD|Leave feedback]]!"
+            ),
+        )
+
+    if not expected_already_present:
+        postqual(target_stmt["id"], "P304", json.dumps(expected_value))
+
     invalidate_entity(mediaid)
 
 
@@ -2002,18 +2044,26 @@ def _build_expected_from_parsed(
             base = f"{base}|circa"
         p571_expected.append(base)
 
+    # Chunkable-prop values are keyed as (value, p1545) tuples in
+    # _reconcile_existing_claims (it extracts the same tuple shape from
+    # Commons-side statements). The legacy partner-API path never
+    # produces chunked claims — it predates chunking and runs on the
+    # parsed-doc tuple, not sdc.json — so p1545 is always None here.
+    # Without these tuples, the reconciler's `value not in expected[prop]`
+    # would see Commons-side ("text", None) versus expected ["text"] and
+    # queue every DPLA-authored string/monolingualtext claim for removal.
     expected = {
-        "P217": local_ids,
-        "P760": [dpla_id],
-        "P1476": titles,
+        "P217": [(v, None) for v in local_ids],
+        "P760": [(dpla_id, None)],
+        "P1476": [(v, None) for v in titles],
         "P195": ["Q518155" if hub == "Q518155" else institution],
         "P170": creators,
         "P9126": ["Q2944483", hub, institution],
         "P7482": [url],
-        "P4272": subjects,
+        "P4272": [(v, None) for v in subjects],
         "P571": p571_expected,
-        "P10358": descs,
-        "P1225": naids,
+        "P10358": [(v, None) for v in descs],
+        "P1225": [(v, None) for v in naids],
         "P6224": [level],
         "P7228": [access],
         "P921": parsesubjectentities,

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1568,12 +1568,24 @@ def _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_number):
     Matching is by mainsnak value (the DPLA ID itself). One P760 per
     MediaInfo entity carries that DPLA ID, so the match is unambiguous.
 
-    A no-op when ``page_number`` is ``None`` (the ordinal isn't part of a
-    multi-file extension group), when no DPLA-authored P760 exists yet,
-    or when P304 already matches the expected value.
+    A no-op when no DPLA-authored P760 exists yet or when the existing
+    P304 already matches the expected value. When ``page_number`` is
+    ``None`` (the ordinal is no longer part of a multi-file extension
+    group), still walks the existing P304 qualifiers and removes any
+    stale entries — the reconciler doesn't diff P304, so without this
+    cleanup pass a file would keep incorrect page metadata after its
+    sibling ordinals were deleted.
     """
-    if page_number is None:
-        return
+    # ``page_number=None`` means "no P304 is expected for this file" —
+    # typically a file that was once part of a multi-file extension
+    # group (with a P304 stamped) but is now a singleton in its group
+    # (e.g. siblings were deleted by a Commons curator). We must still
+    # walk the existing qualifiers and remove any stale P304; otherwise
+    # the file keeps incorrect page metadata indefinitely. Early-
+    # returning here would mean the reconciler never catches it
+    # (the statement-level reconciler diffs P760 by mainsnak value
+    # only, never by qualifier set).
+    expected_value = None if page_number is None else str(page_number)
 
     # No leading invalidate_entity: ``_amend_p7482_url_qualifiers`` runs
     # immediately before this helper in process_one_from_sdc and either
@@ -1597,16 +1609,15 @@ def _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_number):
     if target_stmt is None:
         return
 
-    expected_value = str(page_number)
-    # Walk existing P304 qualifiers and bucket them: present-with-expected-
-    # value (idempotent — nothing to do) vs. present-with-different-value
-    # (stale, must be removed before adding the new one). Without removing
-    # stale values, a renumber between syncs — e.g. a sibling ordinal was
-    # deleted by a Commons curator, shifting this file from page 3 to
-    # page 2 — would leave the prior P304="3" alongside the new P304="2"
-    # indefinitely; the statement-level reconciler can't clean it up
-    # because it matches P760 statements only by mainsnak value, not by
-    # their qualifier set.
+    # Walk existing P304 qualifiers and bucket them: matches-expected
+    # (idempotent — nothing to do) vs. stale (must be removed). Three
+    # scenarios reach here:
+    #   * expected_value is None: any existing P304 is stale (file is
+    #     no longer in a multi-file extension group).
+    #   * expected_value matches one existing value: any OTHER existing
+    #     P304 is stale (renumber between syncs left a duplicate).
+    #   * expected_value doesn't match any existing value: every existing
+    #     P304 is stale, and the new value still needs to be added.
     # TODO: ``_amend_p7482_url_qualifiers`` has the same latent issue
     # for P2699 and P6108. Trigger is rarer there (partner catalog URLs
     # almost never change for already-uploaded files), but the cleanup
@@ -1620,13 +1631,14 @@ def _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_number):
         dv = q.get("datavalue")
         if not (isinstance(dv, dict) and "value" in dv):
             continue
-        if dv["value"] == expected_value:
+        if expected_value is not None and dv["value"] == expected_value:
             expected_already_present = True
         elif q.get("hash"):
             stale_snak_hashes.append(q["hash"])
 
-    if expected_already_present and not stale_snak_hashes:
-        # Idempotent — exact match, no writes. Matches the conditional-
+    if not stale_snak_hashes and (expected_value is None or expected_already_present):
+        # No work: either nothing exists and nothing's expected, or the
+        # exact match is already there. Matches the conditional-
         # invalidate pattern in ``_amend_p7482_url_qualifiers``.
         return
 
@@ -1638,13 +1650,13 @@ def _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_number):
             claim=target_stmt["id"],
             qualifiers="|".join(stale_snak_hashes),
             summary=(
-                f"Removing stale P304 page-number qualifier(s) before"
-                f" applying recomputed value for [[dpla:{dpla_id}|{dpla_id}]]."
+                f"Removing stale P304 page-number qualifier(s) for"
+                f" [[dpla:{dpla_id}|{dpla_id}]]."
                 f" [[COM:DPLA/MOD|Leave feedback]]!"
             ),
         )
 
-    if not expected_already_present:
+    if expected_value is not None and not expected_already_present:
         postqual(target_stmt["id"], "P304", json.dumps(expected_value))
 
     invalidate_entity(mediaid)
@@ -1953,7 +1965,15 @@ def dpla_claims(
         access,
         level,
     )
-    _reconcile_existing_claims(mediaid, dpla_id, expected)
+    # Protect chunkable properties from the legacy reconciler: their
+    # expected values may exist on Commons as a multi-claim chunked
+    # series (P1545="A1", "A2", ...) that the legacy expected-builder
+    # doesn't model. Without this, a `--file`/`--cat`/`--list` rerun
+    # against a partner-mode-migrated file would queue every chunked
+    # statement for removal. See _reconcile_existing_claims docstring.
+    _reconcile_existing_claims(
+        mediaid, dpla_id, expected, protected_props=CHUNKABLE_PROPS
+    )
 
 
 def _build_expected_from_parsed(
@@ -2044,26 +2064,28 @@ def _build_expected_from_parsed(
             base = f"{base}|circa"
         p571_expected.append(base)
 
-    # Chunkable-prop values are keyed as (value, p1545) tuples in
-    # _reconcile_existing_claims (it extracts the same tuple shape from
-    # Commons-side statements). The legacy partner-API path never
-    # produces chunked claims — it predates chunking and runs on the
-    # parsed-doc tuple, not sdc.json — so p1545 is always None here.
-    # Without these tuples, the reconciler's `value not in expected[prop]`
-    # would see Commons-side ("text", None) versus expected ["text"] and
-    # queue every DPLA-authored string/monolingualtext claim for removal.
+    # Chunkable-prop values (P760, P217, P1476, P4272, P10358, P1225)
+    # are intentionally still plain strings here even though
+    # _reconcile_existing_claims extracts them from Commons as
+    # (value, p1545) tuples — the legacy path passes
+    # ``protected_props=CHUNKABLE_PROPS`` to skip reconciliation for
+    # these properties entirely. The legacy expected-builder doesn't
+    # know about chunk shape and partial-matching (value, None) versus
+    # (chunk_text, "A1") would still wrongly queue partner-mode chunked
+    # statements for removal. Skipping reconciliation is safer than
+    # half-matching; full parity is a follow-up to this PR.
     expected = {
-        "P217": [(v, None) for v in local_ids],
-        "P760": [(dpla_id, None)],
-        "P1476": [(v, None) for v in titles],
+        "P217": local_ids,
+        "P760": [dpla_id],
+        "P1476": titles,
         "P195": ["Q518155" if hub == "Q518155" else institution],
         "P170": creators,
         "P9126": ["Q2944483", hub, institution],
         "P7482": [url],
-        "P4272": [(v, None) for v in subjects],
+        "P4272": subjects,
         "P571": p571_expected,
-        "P10358": [(v, None) for v in descs],
-        "P1225": [(v, None) for v in naids],
+        "P10358": descs,
+        "P1225": naids,
         "P6224": [level],
         "P7228": [access],
         "P921": parsesubjectentities,
@@ -2085,13 +2107,31 @@ def _build_expected_from_parsed(
     return expected
 
 
-def _reconcile_existing_claims(mediaid, dpla_id, expected):
+def _reconcile_existing_claims(mediaid, dpla_id, expected, protected_props=frozenset()):
     """Walk DPLA-referenced claims on Commons, queue removals for any whose
     comparable value isn't in `expected`. POSTs wbremoveclaims if needed.
 
     Shared by `dpla_claims` (legacy partner-API path) and
     `process_one_from_sdc` (PR 4 partner-mode path). Same removal logic;
     just different sources for `expected`.
+
+    ``protected_props`` is a set of property IDs whose existing
+    DPLA-authored claims are NOT subject to reconciliation — they're
+    left in place regardless of whether they appear in ``expected``.
+    The legacy partner-API path uses this for ``CHUNKABLE_PROPS``
+    (string/monolingualtext properties whose values may have been
+    chunked into multi-statement series with P1545 ordinals by
+    partner mode). Without protection, a legacy ``--file``/``--cat``/
+    ``--list`` rerun would treat partner-mode chunked claims as
+    unexpected — the legacy ``expected`` is keyed on un-chunked
+    ``(value, None)`` tuples while Commons-side chunked statements
+    extract as ``(chunk_text, "A1")``, ``(chunk_text, "A2")``... — and
+    queue them all for removal. For long P217 values, ``process_one``
+    additionally skips re-adding them, so the identifier would
+    disappear entirely. Protecting the chunkable-prop set in legacy
+    reconciliation keeps maintenance-mode reruns safe until full
+    chunking parity is added to the legacy builders (out of scope
+    here).
     """
     # Use pywikibot's wbgetentities (via get_entity) rather than a direct
     # requests.get to Special:EntityData: Wikimedia rejects the default
@@ -2225,6 +2265,12 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
                                 removals.append(stmt["id"])
     for claim in dpla_claim_list:
         for prop in claim:
+            if prop in protected_props:
+                # Caller has declared this property off-limits for
+                # removal — typically chunkable properties on the
+                # legacy path where the legacy expected-builder
+                # doesn't know about chunk shape. Skip the diff.
+                continue
             if prop not in expected:
                 removals.append(claim[prop]["id"])
             elif claim[prop]["value"] not in expected[prop]:

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -15,7 +15,11 @@ import tomllib
 import urllib.parse
 from pywikibot import pagegenerators
 from ingest_wikimedia.logs import setup_logging
-from ingest_wikimedia.sdc import parse_dpla_date, parse_nara_access_level
+from ingest_wikimedia.sdc import (
+    CHUNKABLE_PROPS,
+    parse_dpla_date,
+    parse_nara_access_level,
+)
 from ingest_wikimedia.slack import notify_phase_start, notify_sdc_complete
 from ingest_wikimedia.tracker import Result, Tracker
 from ingest_wikimedia.wikimedia import extract_dpla_id_from_commons_title
@@ -457,13 +461,27 @@ def invalidate_entity(mediaid):
 #                                  P6108 (IIIF manifest URL — per-item;
 #                                  emitted by build_claims_for_doc when
 #                                  the source carries iiifManifest)
+# Every chunked claim (one whose mainsnak value was split across multiple
+# statements by sdc.py) carries a P1545 (series ordinal) qualifier so the
+# Lua template on Commons can reassemble the chunks. P1545 is therefore a
+# DPLA-authored qualifier on every chunkable property and must be in the
+# safe-to-amend allowed set. ``CHUNKABLE_PROPS`` is the single source of
+# truth (imported from ingest_wikimedia.sdc); the dict below is built from
+# it so adding a new chunkable property in sdc.py automatically widens the
+# allowed-qualifier set here.
 _DPLA_EXTRA_QUALIFIER_PROPS = {
     "P170": {"P2093"},
     "P571": {"P1932", "P1480"},
     "P9126": {"P3831"},
     "P217": {"P195"},
     "P7482": {"P973", "P137", "P2699", "P6108"},
+    # P304 is the per-ordinal page-number qualifier on P760, materialized at
+    # write time from upload-result.json by sdc-sync (multipage items only,
+    # grouped per file extension).
+    "P760": {"P304"},
 }
+for _chunkable_prop in CHUNKABLE_PROPS:
+    _DPLA_EXTRA_QUALIFIER_PROPS.setdefault(_chunkable_prop, set()).add("P1545")
 
 
 def _allowed_qualifier_props(prop):
@@ -523,6 +541,51 @@ def _is_safe_to_amend_in_place(statement, prop):
         if not _is_dpla_reference(reference):
             return False
     return True
+
+
+def _qualifier_values(statement, prop):
+    """Return the list of value-typed qualifier values for ``prop`` on
+    ``statement``, skipping any snak that isn't well-formed (snaktype
+    other than ``"value"``, missing or non-dict ``datavalue``, missing
+    ``"value"`` key).
+
+    Module-level helper so check(), _amend_p7482_url_qualifiers,
+    _amend_p760_page_qualifier, and _extract_p1545_value all read
+    qualifiers through one safe extraction path. Returning a list keeps
+    callers flexible: ``[0]`` for first-match, ``in expected`` for
+    presence, ``== [target]`` for exact-match.
+    """
+    out = []
+    for q in (statement.get("qualifiers") or {}).get(prop, []) or []:
+        if q.get("snaktype") != "value":
+            continue
+        dv = q.get("datavalue")
+        if isinstance(dv, dict) and "value" in dv:
+            out.append(dv["value"])
+    return out
+
+
+def _first_qualifier_value(statement, prop):
+    """Return the first well-formed value-typed qualifier value for
+    ``prop`` on ``statement``, or ``None`` when no such qualifier
+    exists."""
+    values = _qualifier_values(statement, prop)
+    return values[0] if values else None
+
+
+def _extract_p1545_value(statement):
+    """Return the first P1545 (series ordinal) qualifier value on
+    ``statement``, or ``None`` when no P1545 qualifier is present.
+
+    P1545 marks chunked claims emitted by
+    :func:`ingest_wikimedia.sdc._chunk_and_emit_claims`. Chunked-claim
+    matching is chunk-by-chunk: a sdc.json claim with P1545="A1" only
+    matches an existing Commons claim with the same mainsnak value AND
+    the same P1545="A1" — distinct chunks (A1 vs A2) and chunked-vs-
+    unchunked variants of the same text are kept separate so the Lua
+    template can reassemble each series independently.
+    """
+    return _first_qualifier_value(statement, "P1545")
 
 
 def check(mediaid, qid, prop):
@@ -593,67 +656,93 @@ def check(mediaid, qid, prop):
 
         return True, ref
     if qid[0] == "string":
+        # qid[1] is (value, p1545) from _extract_comparable_value on the new
+        # sdc.json path. Legacy callers (dpla_claims) still pass the raw
+        # string — accept that shape too by wrapping to the tuple form with
+        # p1545=None, which correctly preserves their pre-chunking behavior
+        # (those code paths never produce chunked claims).
+        target_value, target_p1545 = (
+            qid[1] if isinstance(qid[1], tuple) else (qid[1], None)
+        )
         for statement in statements:
             if (
-                statement["mainsnak"]["datavalue"]["value"] == qid[1]
+                statement["mainsnak"]["datavalue"]["value"] == target_value
+                and _extract_p1545_value(statement) == target_p1545
                 and not statement.get("references")
                 and _is_safe_to_amend_in_place(statement, prop)
             ):
                 ref = statement["id"]
                 break
-        for statement in statements:
-            if statement["mainsnak"]["datavalue"]["value"] == qid[
-                1
-            ] and not statement.get("qualifiers"):
-                return add_det(mediaid, statement["id"]), ref
+        # The bare-add-det branch (stamp P459 onto an existing qualifier-less
+        # statement) is meaningful only for unchunked values — a chunked
+        # sdc.json claim shouldn't graft itself onto a pre-existing bare
+        # statement, since they represent different chunks of different
+        # series. Restrict the branch to target_p1545 is None.
+        if target_p1545 is None:
+            for statement in statements:
+                if statement["mainsnak"]["datavalue"][
+                    "value"
+                ] == target_value and not statement.get("qualifiers"):
+                    return add_det(mediaid, statement["id"]), ref
 
         if any(
-            statement["mainsnak"]["datavalue"]["value"] == qid[1]
+            statement["mainsnak"]["datavalue"]["value"] == target_value
+            and _extract_p1545_value(statement) == target_p1545
             and _is_safe_to_amend_in_place(statement, prop)
             for statement in statements
         ):
             print(
-                f" -- There already exists a DPLA-authored statement with a {prop} > {qid[1]} claim for {mediaid}."
+                f" -- There already exists a DPLA-authored statement with a {prop} > {target_value} claim for {mediaid}."
             )
             return False, ref
 
         if any(
-            statement["mainsnak"]["datavalue"]["value"] == qid[1]
+            statement["mainsnak"]["datavalue"]["value"] == target_value
+            and _extract_p1545_value(statement) == target_p1545
             for statement in statements
         ):
             print(
-                f" -- A foreign {prop} > {qid[1]} statement exists for {mediaid}; adding the DPLA-authored statement alongside."
+                f" -- A foreign {prop} > {target_value} statement exists for {mediaid}; adding the DPLA-authored statement alongside."
             )
             return True, ""
 
         return True, ref
     if qid[0] == "monolingualtext":
+        # qid[1] is (text, p1545); legacy callers still pass raw text — same
+        # backwards-compat shim as the string branch above.
+        target_value, target_p1545 = (
+            qid[1] if isinstance(qid[1], tuple) else (qid[1], None)
+        )
         for statement in statements:
             if (
-                statement["mainsnak"]["datavalue"]["value"]["text"] == qid[1]
+                statement["mainsnak"]["datavalue"]["value"]["text"] == target_value
+                and _extract_p1545_value(statement) == target_p1545
                 and not statement.get("references")
                 and _is_safe_to_amend_in_place(statement, prop)
             ):
                 ref = statement["id"]
                 break
-        for statement in statements:
-            if statement["mainsnak"]["datavalue"]["value"]["text"] == qid[
-                1
-            ] and not statement.get("qualifiers"):
-                return add_det(mediaid, statement["id"]), ref
+        if target_p1545 is None:
+            for statement in statements:
+                if statement["mainsnak"]["datavalue"]["value"][
+                    "text"
+                ] == target_value and not statement.get("qualifiers"):
+                    return add_det(mediaid, statement["id"]), ref
 
         if any(
-            statement["mainsnak"]["datavalue"]["value"]["text"] == qid[1]
+            statement["mainsnak"]["datavalue"]["value"]["text"] == target_value
+            and _extract_p1545_value(statement) == target_p1545
             and _is_safe_to_amend_in_place(statement, prop)
             for statement in statements
         ):
             print(
-                f" -- There already exists a DPLA-authored statement with a {prop} > {qid[1]} claim for {mediaid}."
+                f" -- There already exists a DPLA-authored statement with a {prop} > {target_value} claim for {mediaid}."
             )
             return False, ref
 
         if any(
-            statement["mainsnak"]["datavalue"]["value"]["text"] == qid[1]
+            statement["mainsnak"]["datavalue"]["value"]["text"] == target_value
+            and _extract_p1545_value(statement) == target_p1545
             for statement in statements
         ):
             print(
@@ -1365,16 +1454,8 @@ def _amend_p7482_url_qualifiers(mediaid, dpla_id, sdc_payload, download_url):
     if sdc_p7482 is None:
         return
 
-    def _first_qual_value(claim, prop):
-        for q in claim.get("qualifiers", {}).get(prop, []) or []:
-            if q.get("snaktype") == "value":
-                dv = q.get("datavalue") or {}
-                if "value" in dv:
-                    return dv["value"]
-        return None
-
-    expected_p973 = _first_qual_value(sdc_p7482, "P973")
-    expected_p6108 = _first_qual_value(sdc_p7482, "P6108")
+    expected_p973 = _first_qualifier_value(sdc_p7482, "P973")
+    expected_p6108 = _first_qualifier_value(sdc_p7482, "P6108")
 
     # _post_new_refs / _post_new_claims (called just before this helper)
     # don't invalidate the entity cache after writing — same shape as
@@ -1391,7 +1472,7 @@ def _amend_p7482_url_qualifiers(mediaid, dpla_id, sdc_payload, download_url):
     for stmt in existing_p7482:
         if not _is_safe_to_amend_in_place(stmt, "P7482"):
             continue
-        if _first_qual_value(stmt, "P973") == expected_p973:
+        if _first_qualifier_value(stmt, "P973") == expected_p973:
             target_stmt = stmt
             break
     if target_stmt is None:
@@ -1401,19 +1482,8 @@ def _amend_p7482_url_qualifiers(mediaid, dpla_id, sdc_payload, download_url):
         return
 
     claimid = target_stmt["id"]
-
-    def _qual_values(stmt, prop):
-        out = []
-        for q in stmt.get("qualifiers", {}).get(prop, []) or []:
-            if q.get("snaktype") != "value":
-                continue
-            dv = q.get("datavalue")
-            if isinstance(dv, dict) and "value" in dv:
-                out.append(dv["value"])
-        return out
-
-    existing_p2699_values = _qual_values(target_stmt, "P2699")
-    existing_p6108_values = _qual_values(target_stmt, "P6108")
+    existing_p2699_values = _qualifier_values(target_stmt, "P2699")
+    existing_p6108_values = _qualifier_values(target_stmt, "P6108")
 
     amended = False
     if download_url and download_url not in existing_p2699_values:
@@ -1429,6 +1499,113 @@ def _amend_p7482_url_qualifiers(mediaid, dpla_id, sdc_payload, download_url):
         # immediately below the caller) reads the freshly-amended state
         # — same invariant ``add_det`` maintains for P459.
         invalidate_entity(mediaid)
+
+
+def _file_extension(title):
+    """Return the lowercased extension of a Commons file title, or ``""``
+    when no extension is present.
+
+    Uploader-produced titles look like ``File:Some Image - 1.jpg``; we want
+    ``"jpg"`` so ordinals can be grouped per-format for P304 numbering.
+    """
+    # Check the separator (not the third element): rpartition returns the
+    # entire string as the third element when "." is absent, which would
+    # otherwise misclassify a dotless title as having an extension equal
+    # to the title itself.
+    _, sep, ext = (title or "").rpartition(".")
+    return ext.lower() if sep else ""
+
+
+def _compute_page_numbers(ordinal_items):
+    """Compute per-ordinal P304 (page-number) values for a multipage item,
+    grouped per file extension.
+
+    ``ordinal_items`` is the ``[(ord_str, data), ...]`` list of eligible
+    ordinals for the item, sorted by ordinal. Returns a mapping
+    ``ord_str → page_number`` populated only for ordinals belonging to a
+    multi-file extension group. Ordinals in single-file groups are
+    omitted — that file isn't part of a multipage series within its own
+    format.
+
+    Example: an item with 3 JPGs and 2 PDFs returns
+    ``{jpg_ord_1: 1, jpg_ord_2: 2, jpg_ord_3: 3, pdf_ord_1: 1, pdf_ord_2: 2}``.
+    An item with one JPG and one PDF returns ``{}`` — neither file is part
+    of a multipage series within its own format.
+
+    Page numbers reset per extension group so an item's JPGs are numbered
+    1, 2, 3 independently of its PDFs (per the user-confirmed rule:
+    "we are only numbering within each ordinal series — JPGs and PDFs are
+    numbered separately").
+
+    Assumes ``ordinal_items`` is already sorted by integer ordinal — the
+    caller in ``_run_partner_mode`` sorts before calling — so iteration
+    order produces the expected per-extension sequence (the first JPG by
+    ordinal gets P304=1, the second gets P304=2, etc.).
+    """
+    ext_groups = {}
+    for ord_str, data in ordinal_items:
+        ext = _file_extension(data.get("title") or "")
+        ext_groups.setdefault(ext, []).append(ord_str)
+    page_numbers = {}
+    for ord_strs in ext_groups.values():
+        if len(ord_strs) <= 1:
+            continue
+        for idx, ord_str in enumerate(ord_strs, start=1):
+            page_numbers[ord_str] = idx
+    return page_numbers
+
+
+def _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_number):
+    """Stamp a missing ``P304`` (page-number) qualifier onto an existing
+    DPLA-authored ``P760`` (DPLA ID) statement on Commons.
+
+    Mirror of :func:`_amend_p7482_url_qualifiers` for P304. Every file
+    uploaded before this code shipped has a P760 with only its DPLA
+    publisher reference and P459 qualifier; without this pass, the
+    normal ``check()`` path finds the existing P760, returns False
+    ("don't add a duplicate"), and P304 never lands.
+
+    Matching is by mainsnak value (the DPLA ID itself). One P760 per
+    MediaInfo entity carries that DPLA ID, so the match is unambiguous.
+
+    A no-op when ``page_number`` is ``None`` (the ordinal isn't part of a
+    multi-file extension group), when no DPLA-authored P760 exists yet,
+    or when P304 already matches the expected value.
+    """
+    if page_number is None:
+        return
+
+    # No leading invalidate_entity: ``_amend_p7482_url_qualifiers`` runs
+    # immediately before this helper in process_one_from_sdc and either
+    # left the cache valid (it didn't write) or invalidated it (it did),
+    # so get_entity here returns fresh state in both cases. Saves a
+    # wbgetentities round-trip per ordinal at scale.
+    entity = get_entity(mediaid)
+    existing_p760 = (entity.get("statements") or {}).get("P760") or []
+
+    target_stmt = None
+    for stmt in existing_p760:
+        if not _is_safe_to_amend_in_place(stmt, "P760"):
+            continue
+        try:
+            mainsnak_value = stmt["mainsnak"]["datavalue"]["value"]
+        except (KeyError, TypeError):
+            continue
+        if mainsnak_value == dpla_id:
+            target_stmt = stmt
+            break
+    if target_stmt is None:
+        return
+
+    expected_value = str(page_number)
+    if expected_value in _qualifier_values(target_stmt, "P304"):
+        # Already matches; skip the postqual and the cache invalidation.
+        # Matches the conditional-invalidate pattern in
+        # ``_amend_p7482_url_qualifiers``.
+        return
+
+    postqual(target_stmt["id"], "P304", json.dumps(expected_value))
+    invalidate_entity(mediaid)
 
 
 def add_ref(claimid, claim):
@@ -1572,9 +1749,12 @@ def _extract_comparable_value(claim):
         v = datavalue["value"]
         return v.get("id") or f"Q{v['numeric-id']}"
     if dtype == "string":
-        return datavalue["value"]
+        # Tuple shape so chunk-by-chunk matching can distinguish chunks of
+        # the same logical value (A1 vs A2) and chunked-vs-unchunked
+        # variants of the same text. ``p1545`` is None for unchunked claims.
+        return (datavalue["value"], _extract_p1545_value(claim))
     if dtype == "monolingualtext":
-        return datavalue["value"]["text"]
+        return (datavalue["value"]["text"], _extract_p1545_value(claim))
     if dtype == "time":
         try:
             return _time_claim_comparable(claim)
@@ -1916,13 +2096,21 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
                                     }
                                 )
                             elif dtype == "string":
+                                # Tuple key — mirrors _extract_comparable_value
+                                # so the reconciler diffs the chunk identity
+                                # (text + P1545) rather than just the text.
+                                # Without this, a chunked statement on Commons
+                                # whose chunk text appears in expected[prop]
+                                # but at a different P1545 ordinal would
+                                # incorrectly survive reconciliation.
                                 dpla_claim_list.append(
                                     {
                                         stmt["mainsnak"]["property"]: {
                                             "id": stmt["id"],
-                                            "value": stmt["mainsnak"]["datavalue"][
-                                                "value"
-                                            ],
+                                            "value": (
+                                                stmt["mainsnak"]["datavalue"]["value"],
+                                                _extract_p1545_value(stmt),
+                                            ),
                                         }
                                     }
                                 )
@@ -1931,9 +2119,12 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected):
                                     {
                                         stmt["mainsnak"]["property"]: {
                                             "id": stmt["id"],
-                                            "value": stmt["mainsnak"]["datavalue"][
-                                                "value"
-                                            ]["text"],
+                                            "value": (
+                                                stmt["mainsnak"]["datavalue"]["value"][
+                                                    "text"
+                                                ],
+                                                _extract_p1545_value(stmt),
+                                            ),
                                         }
                                     }
                                 )
@@ -2364,7 +2555,9 @@ def process_one(mediaid, dpla_id):
         return
 
 
-def process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url=None):
+def process_one_from_sdc(
+    mediaid, dpla_id, sdc_payload, download_url=None, page_number=None
+):
     """Sync SDC for a single Commons file against a precomputed claim list.
 
     Reads the claim envelope produced by `build_claims_for_doc` and staged
@@ -2388,6 +2581,15 @@ def process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url=None):
     than baked into the per-item sdc.json. For existing P7482
     statements on Commons that lack P2699, ``_amend_p7482_url_qualifiers``
     POSTs the missing qualifier via wbsetqualifier (idempotent).
+
+    ``page_number`` is the per-ordinal P304 (page-number) value computed
+    by :func:`_compute_page_numbers` from upload-result.json's per-file
+    extension grouping. Supplied only for files that are part of a
+    multi-file extension group on a multipage item; ``None`` for
+    single-file ordinals. When supplied, the P760 (DPLA ID) claim
+    receives a P304 qualifier with the page number; the legacy-state
+    backfill ``_amend_p760_page_qualifier`` handles existing P760
+    statements that lack it.
     """
     global claims, refclaims
 
@@ -2423,6 +2625,19 @@ def process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url=None):
                     "property": "P2699",
                     "datavalue": {"value": download_url, "type": "string"},
                     "datatype": "url",
+                }
+            ]
+
+        # Per-ordinal P304 (page-number) qualifier on the P760 (DPLA ID)
+        # claim — same per-ordinal rationale as P2699 above. Only stamped
+        # for files that are part of a multi-file extension group on a
+        # multipage item; ``page_number`` is ``None`` otherwise.
+        if prop == "P760" and page_number is not None:
+            claim.setdefault("qualifiers", {})["P304"] = [
+                {
+                    "snaktype": "value",
+                    "property": "P304",
+                    "datavalue": {"value": str(page_number), "type": "string"},
                 }
             ]
 
@@ -2462,6 +2677,11 @@ def process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url=None):
     # by design: a qualifier whose value already matches what sdc.json (+
     # per-ordinal download_url) says is silently skipped.
     _amend_p7482_url_qualifiers(mediaid, dpla_id, sdc_payload, download_url)
+
+    # Backfill the per-ordinal P304 (page-number) qualifier onto any
+    # pre-existing DPLA-authored P760 statement that lacks it. Same
+    # legacy-state rationale as ``_amend_p7482_url_qualifiers`` above.
+    _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_number)
 
     expected = _build_expected_from_sdc(sdc_payload)
     _reconcile_existing_claims(mediaid, dpla_id, expected)
@@ -2619,6 +2839,15 @@ def _run_partner_mode(partner, ids_file):
                 )
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
                 continue
+
+            # Compute per-ordinal P304 (page-number) values for any
+            # multi-file extension group. Single-file groups (one JPG,
+            # one PDF, etc.) are absent from the map — `page_numbers.get(
+            # ord_str)` returns None for them and process_one_from_sdc
+            # skips the qualifier. JPGs and PDFs are numbered as
+            # independent series per the user-confirmed rule.
+            page_numbers = _compute_page_numbers(ordinal_items)
+
             for ord_str, data in ordinal_items:
                 pageid = data.get("pageid")
                 # `if not pageid` rather than `is None` — a recorded
@@ -2679,7 +2908,11 @@ def _run_partner_mode(partner, ids_file):
                         download_url = None
                 try:
                     process_one_from_sdc(
-                        mediaid, dpla_id, sdc_payload, download_url=download_url
+                        mediaid,
+                        dpla_id,
+                        sdc_payload,
+                        download_url=download_url,
+                        page_number=page_numbers.get(ord_str),
                     )
                 except _MissingEntityError:
                     # Commons says the MediaInfo entity at this M-id doesn't


### PR DESCRIPTION
## Summary

Two combined SDC modeling changes (tasks #39 + #40):

- **Long-value chunking via P1545 series ordinals.** Mainsnak values for `string` and `monolingualtext` properties (P760, P217, P4272, P1225, P1476, P10358) that exceed the Wikibase 1500-char limit are now split into multiple statements, each carrying a P1545 series-ordinal qualifier so the Lua template on Commons can reassemble them on read. Series letter advances per `(prop, language)` — first long value → `A1/A2/A3`, second → `B1/B2`, past Z → `AA1/AB1` Excel-style.

- **Per-ordinal P304 page-number qualifiers on P760.** Multipage items now get a P304 qualifier per file. Files are grouped by extension; only multi-file groups within a single extension series are numbered (3 JPGs → 1/2/3, 2 PDFs → 1/2; an item with one JPG and one PDF gets no P304).

## Key design decisions

- **Pre-normalization mirrors Wikibase server-side normalization** (\`_normalize_string_value\` strips BOM/bidi marks/non-characters, collapses control-char runs to single space, strips leading/trailing whitespace, NFC for monolingualtext). Without this, the next sync would see drift on values containing newlines or trailing whitespace and re-write every chunk; for long values the drift compounds across every chunk.

- **Chunk boundaries land at non-whitespace transitions** so Wikibase's leading/trailing whitespace strip can't silently eat bytes at a chunk join. Pathological all-whitespace-run case falls back to exact-limit split with a warning.

- **Chunk-by-chunk idempotency.** \`_extract_comparable_value\` returns \`(value, p1545)\` tuples for string/monolingualtext so chunked claims with different P1545 are distinct, and chunked-vs-legacy-unchunked variants of the same text don't accidentally match. Legacy callers passing plain strings still work via a backwards-compat shim.

- **\`_amend_p760_page_qualifier\` mirrors \`_amend_p7482_url_qualifiers\`** (from #281): finds an existing DPLA-authored P760 by mainsnak value, stamps missing P304 via wbsetqualifier. Idempotent — no-op when the value already matches. Skips the redundant leading \`invalidate_entity\` (the prior helper already managed cache state) to save a wbgetentities round-trip per ordinal at scale.

- **\`CHUNKABLE_PROPS\` is single-sourced** in \`ingest_wikimedia/sdc.py\`; \`tools/sdc_sync.py\` imports it and builds the safe-to-amend allowed set programmatically, so adding a new chunkable property automatically widens the qualifier allowlist.

## Out of scope

- Lua / template updates to actually reassemble chunks on read (task #42).
- SDC edit consolidation into one \`wbeditentity\` per item (task #38).

## Test plan

- [x] 485 tests pass locally (+41 new across normalization steps, chunk boundary search, Z→AA series-letter overflow, BOM/bidi-mark stripping, P304 extension grouping, P304 legacy-state amend, chunked-claim idempotency)
- [x] End-to-end roundtrip test verifies sdc.py emit and sdc_sync.py compare stay in sync on the tuple key contract
- [ ] EC2 smoke test against a multi-page item with both JPG and PDF ordinals after merge
- [ ] Monitor first SDC sync for any unexpected re-write churn from the one-time wave of normalization fixes on legacy data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR implements two Wikibase/Commons SDC (Structured Data on Commons) modeling features and related sync/reconciliation changes.

### 1. Long-value chunking with P1545 series ordinals
- Mainsnak values for string and monolingualtext properties (P760, P217, P4272, P1225, P1476, P10358) that exceed Wikibase’s 1500-character limit are split into multiple statements. Each chunked statement receives a P1545 series-ordinal qualifier so Commons Lua/templates can reassemble them. Series letters advance per (property, language) in Excel-style (A1/A2/A3 → B1/B2 → … → AA1/AB1).
- Pre-chunk normalization mirrors Wikibase server-side normalization: strip BOM/bidi/non-characters, collapse control-character runs to a single space, trim leading/trailing whitespace, and apply NFC for monolingualtext.
- Chunk boundaries prefer non-whitespace transitions to avoid Wikibase trimming at joins; all-whitespace-run cases fall back to exact-limit splitting and emit a warning.
- Implementation details:
  - Deterministic normalization and whitespace-safe chunker added to ingest_wikimedia/sdc.py.
  - Series-letter tracker (chunk_series_letters) threaded through claim builders so chunk groups remain separable within a single build run.
  - _extract_comparable_value now returns (value, p1545) tuples so chunked claims are distinct from legacy unchunked ones; a backward-compatible shim preserves legacy callers.
  - CHUNKABLE_PROPS centralized in ingest_wikimedia/sdc.py and consumed by tools/sdc_sync.py for allowed-amend decisions.

### 2. Per-ordinal P304 (page-number) qualifiers on P760
- For multipage items, a P304 page-number qualifier is applied per file/ordinal. Files are grouped by extension; numbering is applied only to extension groups with >1 file (e.g., 3 JPGs → 1/2/3; mixed singletons across extensions are not numbered).
- _amend_p760_page_qualifier backfills missing P304 onto existing DPLA-authored P760 statements idempotently, removes stale P304 snak hashes when renumbering eliminates a multipage context, and avoids an extra invalidate_entity/wbgetentities round-trip.
- _DPLA_EXTRA_QUALIFIER_PROPS for P760 updated to include both P304 and P1545.

### Sync/Reconciliation and tooling changes
- tools/sdc_sync.py:
  - Computes per-extension ordinals and passes page_number into process_one_from_sdc. Function signature changed: process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url=None) → process_one_from_sdc(..., page_number=None).
  - Extracts P1545 with shared qualifier helpers and updates partner-mode reconciliation to represent Commons chunked string/monolingualtext claims as (value, p1545) tuples so mismatched ordinals do not incorrectly survive or get removed.
  - Adds protected_props support in _reconcile_existing_claims so legacy reconciliation skips removals for CHUNKABLE_PROPS (avoids removing chunked statements).

### Tests and fixes
- Tests added for normalization, chunking behavior and boundaries, series-letter sequencing (including carry past Z), comparable-tuple behavior, page-number grouping/backfill idempotency/stale qualifier cleanup, and end-to-end build_claims_for_doc chunk emission.
- Local test results updated: after fixes, 490 tests pass locally (net +2 new tests relative to prior baseline mentioned in PR notes).
- Recent fixes highlighted in commits:
  - Fixed stale P304 cleanup when expected page_number is None (previous early-return left stale P304s).
  - Restored legacy reconciler protection for chunkable props (avoid tuple-wrapping mismatch that could remove chunked statements).

### Operational impact / checklist
- Requires no manual pipeline trigger or ECS redeployment beyond normal code deployment (changes are self-contained Python code).
- No environment variables or AWS Secrets Manager keys added, removed, or renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM).
- No modifications to public-facing API shapes or endpoints.
- No security-relevant changes to secret/credential handling; changes are internal data-modeling and reconciliation logic. (Commons-side Lua/template reassembly is out of scope.)

### Not in scope / TODOs
- Lua/template reassembly on Commons is not included.
- Consolidating multi-chunk edits into a single wbeditentity is out of scope.
- End-to-end EC2/smoke tests and Commons-side template deployment remain pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->