### PR TITLE
sdc-sync: clear _entity_cache at file boundary (memory leak fix)

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -2925,7 +2925,6 @@ def test_qualifier_values_returns_empty_when_no_qualifiers():
     assert sdc_sync._first_qualifier_value(stmt, "P999") is None
 
 
-
 # ---------------------------------------------------------------------------
 # Entity-cache leak fix.
 #
@@ -3012,5 +3011,76 @@ def test_entity_cache_does_not_grow_across_many_files(monkeypatch):
     assert max(sizes) <= 1, (
         f"_entity_cache grew across files (max size {max(sizes)}); "
         f"cache locality must be per-file"
+    )
+    sdc_sync._entity_cache.clear()
+
+
+def _patch_process_one_dependencies(monkeypatch, sdc_sync, current_mediaid, tmp_path):
+    """Stub the legacy ``process_one`` entry point's network/IO so its
+    file-boundary clear can be tested in isolation. ``parsed`` returning
+    a falsy value causes the function to return after writing
+    ``Missing ids.txt`` — chdir into ``tmp_path`` so that write happens
+    in a throwaway directory rather than polluting the working tree."""
+    fake_request = MagicMock()
+    fake_request.submit.return_value = {
+        "entities": {
+            current_mediaid: {
+                "pageid": int(current_mediaid.lstrip("M")),
+                "statements": {},
+            }
+        }
+    }
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value = fake_request
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+    monkeypatch.setattr(sdc_sync, "parsed", lambda *a, **kw: None)
+    monkeypatch.chdir(tmp_path)
+
+
+def test_process_one_clears_entity_cache_at_file_boundary(monkeypatch, tmp_path):
+    """Symmetric regression guard for the legacy ``process_one`` entry
+    point. Both file-boundary entry points (``process_one`` and
+    ``process_one_from_sdc``) must flush the module-level cache; locking
+    down only the partner-mode entry would silently leave the legacy
+    path leaking on ``--file`` / ``--cat`` / ``--list`` reruns."""
+    from tools import sdc_sync
+
+    sdc_sync._entity_cache.update(
+        {
+            "M111": {"pageid": 111, "statements": {}},
+            "M222": {"pageid": 222, "statements": {}},
+            "M333": {"pageid": 333, "statements": {}},
+        }
+    )
+    assert len(sdc_sync._entity_cache) == 3
+
+    _patch_process_one_dependencies(monkeypatch, sdc_sync, "M999", tmp_path)
+
+    sdc_sync.process_one("M999", "abcdef")
+
+    for prior in ("M111", "M222", "M333"):
+        assert prior not in sdc_sync._entity_cache, (
+            f"prior file {prior} leaked across the legacy-path file boundary"
+        )
+    sdc_sync._entity_cache.clear()
+
+
+def test_process_one_cache_does_not_grow_across_many_files(monkeypatch, tmp_path):
+    """Direct memory-leak regression for the legacy path. Parallel to
+    ``test_entity_cache_does_not_grow_across_many_files`` but exercising
+    ``process_one`` rather than ``process_one_from_sdc``."""
+    from tools import sdc_sync
+
+    sdc_sync._entity_cache.clear()
+    sizes = []
+    for i in range(100):
+        mediaid = f"M{1000 + i}"
+        _patch_process_one_dependencies(monkeypatch, sdc_sync, mediaid, tmp_path)
+        sdc_sync.process_one(mediaid, f"dpla{i:06d}")
+        sizes.append(len(sdc_sync._entity_cache))
+
+    assert max(sizes) <= 1, (
+        f"_entity_cache grew across files via legacy path (max size "
+        f"{max(sizes)}); cache locality must be per-file"
     )
     sdc_sync._entity_cache.clear()

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -2923,3 +2923,94 @@ def test_qualifier_values_returns_empty_when_no_qualifiers():
     assert sdc_sync._qualifier_values(stmt, "P304") == ["2"]
     assert sdc_sync._first_qualifier_value(stmt, "P304") == "2"
     assert sdc_sync._first_qualifier_value(stmt, "P999") is None
+
+
+
+# ---------------------------------------------------------------------------
+# Entity-cache leak fix.
+#
+# Pre-fix, ``_entity_cache`` accumulated one cached MediaInfo entity per file
+# processed across a session's lifetime — only ``invalidate_entity(mediaid)``
+# (per-write, single-key pop) ever evicted entries. A 25-hour NARA run
+# reached ~2.6 GB RSS as the cache grew to ~200k entities. Both
+# ``process_one`` and ``process_one_from_sdc`` now ``_entity_cache.clear()``
+# at the file-boundary entry so cache locality stays per-file but doesn't
+# leak across files.
+# ---------------------------------------------------------------------------
+
+
+def _patch_process_one_from_sdc_dependencies(monkeypatch, sdc_sync, current_mediaid):
+    """Stub every network/IO surface ``process_one_from_sdc`` touches so the
+    test can drive it without contacting Commons."""
+    fake_request = MagicMock()
+    fake_request.submit.return_value = {
+        "entities": {
+            current_mediaid: {
+                "pageid": int(current_mediaid.lstrip("M")),
+                "statements": {},
+            }
+        }
+    }
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value = fake_request
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+    monkeypatch.setattr(sdc_sync, "_post_new_refs", lambda *a, **kw: None)
+    monkeypatch.setattr(sdc_sync, "_post_new_claims", lambda *a, **kw: None)
+    monkeypatch.setattr(sdc_sync, "_amend_p7482_url_qualifiers", lambda *a, **kw: None)
+    monkeypatch.setattr(sdc_sync, "_amend_p760_page_qualifier", lambda *a, **kw: None)
+    monkeypatch.setattr(sdc_sync, "_reconcile_existing_claims", lambda *a, **kw: None)
+
+
+def test_process_one_from_sdc_clears_entity_cache_at_file_boundary(monkeypatch):
+    """Regression guard for the cache-leak fix. The module-level
+    ``_entity_cache`` must be flushed at every file-boundary entry so a
+    long-running session's RSS stays flat regardless of file count."""
+    from tools import sdc_sync
+
+    sdc_sync._entity_cache.update(
+        {
+            "M111": {"pageid": 111, "statements": {}},
+            "M222": {"pageid": 222, "statements": {}},
+            "M333": {"pageid": 333, "statements": {}},
+            "M444": {"pageid": 444, "statements": {}},
+            "M555": {"pageid": 555, "statements": {}},
+        }
+    )
+    assert len(sdc_sync._entity_cache) == 5
+
+    _patch_process_one_from_sdc_dependencies(monkeypatch, sdc_sync, "M999")
+
+    sdc_sync.process_one_from_sdc("M999", "abcdef", {"claims": []})
+
+    # Prior files' entities are gone. The current mediaid may or may not
+    # be in the cache afterward (post-write cleanup invalidates it), but
+    # in no case do prior files persist.
+    for prior in ("M111", "M222", "M333", "M444", "M555"):
+        assert prior not in sdc_sync._entity_cache, (
+            f"prior file {prior} leaked across the file boundary"
+        )
+    # Defensive cleanup so this test doesn't leak state into the next.
+    sdc_sync._entity_cache.clear()
+
+
+def test_entity_cache_does_not_grow_across_many_files(monkeypatch):
+    """Direct memory-leak regression. Run the file-boundary entry point
+    against many synthetic files in sequence; cache size must stay
+    bounded (≤ 1 entry per call), never accumulating."""
+    from tools import sdc_sync
+
+    sdc_sync._entity_cache.clear()
+    sizes = []
+    for i in range(100):
+        mediaid = f"M{1000 + i}"
+        _patch_process_one_from_sdc_dependencies(monkeypatch, sdc_sync, mediaid)
+        sdc_sync.process_one_from_sdc(mediaid, f"dpla{i:06d}", {"claims": []})
+        sizes.append(len(sdc_sync._entity_cache))
+
+    # Pre-fix, sizes would be [1, 2, 3, ..., 100] (linear growth).
+    # Post-fix, every entry must be ≤ 1.
+    assert max(sizes) <= 1, (
+        f"_entity_cache grew across files (max size {max(sizes)}); "
+        f"cache locality must be per-file"
+    )
+    sdc_sync._entity_cache.clear()

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -391,11 +391,15 @@ _PYWIKIBOT_RETRY_WAIT = 5
 _PYWIKIBOT_RETRY_MAX = 60
 
 
-# Per-file cache for wbgetentities, populated at the start of process_one()
-# and consulted by check() for all subsequent add_* calls. Avoids ~25 redundant
-# round-trips per file. Invalidate when claims change to keep the read-after-write
-# semantics correct (process_one batches writes at the end, so a single fetch is
-# safe for the duration of one file).
+# Per-file cache for wbgetentities. Populated at the start of process_one()
+# / process_one_from_sdc() and consulted by check() and the various amend_*
+# helpers for all subsequent reads of the same mediaid. Avoids ~25 redundant
+# round-trips per file. ``invalidate_entity(mediaid)`` is called after writes
+# to the same file so the next read sees post-write state. The cache is
+# cleared in full at every file-boundary entry point (``_entity_cache.clear()``
+# at the top of process_one / process_one_from_sdc) so a long-running session
+# doesn't accumulate one entity per file processed indefinitely — that
+# unbounded growth caused multi-GB RSS on long NARA runs.
 _entity_cache = {}
 
 
@@ -2552,11 +2556,15 @@ def process_one(mediaid, dpla_id):
     """Fetch DPLA metadata and sync SDC claims for a single Commons file."""
     global claims, refclaims
 
-    # Drop any stale cache from a prior file so check() always reads fresh state
-    # for this mediaid.
-    invalidate_entity(mediaid)
-    # Pre-warm the per-file entity cache so the ~25 add_*/check() calls below
-    # share a single wbgetentities round-trip.
+    # Drop every prior file's cached entity at the file boundary. The cache
+    # locality the per-file check() / reconciler / amend_* calls rely on is
+    # scoped to ONE file's processing; without this clear, the module-level
+    # ``_entity_cache`` accumulates an entity per file processed and leaks
+    # memory monotonically across a long-running session (a 25-hour NARA
+    # run reached ~2.6 GB RSS before this clear was added). Pre-warm the
+    # cache so the ~25 add_* / check() calls below share one wbgetentities
+    # round-trip.
+    _entity_cache.clear()
     get_entity(mediaid)
 
     # parsed() returns None on lookup failure (was: returned False and the
@@ -2689,12 +2697,15 @@ def process_one_from_sdc(
     """
     global claims, refclaims
 
-    # Drop any stale cache from a prior file so check() always reads fresh
-    # state for this mediaid. The cache survives across files within one
-    # process invocation, so explicit invalidation is necessary when we
-    # move to a new file. Pre-warm so the per-claim check() calls below
-    # share one wbgetentities round-trip.
-    invalidate_entity(mediaid)
+    # Drop every prior file's cached entity at the file boundary. The cache
+    # locality the per-claim check() / reconciler / amend_* calls below
+    # rely on is scoped to ONE file's processing; without this clear, the
+    # module-level ``_entity_cache`` accumulates an entity per file
+    # processed and leaks memory monotonically across a long-running
+    # session (a 25-hour NARA run reached ~2.6 GB RSS before this clear
+    # was added). Pre-warm so the per-claim calls share one
+    # wbgetentities round-trip.
+    _entity_cache.clear()
     get_entity(mediaid)
 
     claims = {"claims": []}


### PR DESCRIPTION
## Summary

Fix an unbounded memory leak in long-running \`sdc-sync\` sessions.

\`tools/sdc_sync.py\` defines a module-level \`_entity_cache\` dict used to memoize \`wbgetentities\` responses across the ~25 \`check()\` / reconciler / amend_* reads that happen while processing a single file. The cache is the right size at file scope (one entry, the current mediaid's MediaInfo entity), but **nothing was clearing it between files**:

- \`invalidate_entity(mediaid)\` only ever pops one specific key — used between writes to the same file for read-after-write semantics.
- The file-boundary entry points (\`process_one\` and \`process_one_from_sdc\`) called \`invalidate_entity(mediaid)\` for the *new* mediaid, which was a no-op (the new mediaid was never in the cache) and didn't touch prior files' entries.

Net effect: one cached entity (~10–15 KB as a Python dict) accumulated per file processed across the entire session lifetime.

## Observed in production

| Session | Started | RSS | Cause |
|---|---|---|---|
| sdc-sync NARA Clinton Library (PID 4600) | Jun 7 (~25h) | **2.6 GB** | ~200k cached entities |
| sdc-sync NARA NPRC Military Personnel (PID 139698) | Jun 7 (~22h) | **1.7 GB** | ~130k cached entities |
| sdc-sync Minnesota (just-started, today) | 20:07 / 20:30 | ~125 MB each | ~minutes of accumulation |
| downloader Minnesota (PID 3869249, 36h) | Jun 6 | 150 MB | Different code path; doesn't use this cache |

The two NARA sessions were terminated and reclaimed ~4 GB on the m7g.large instance. The cache size correlates with session age and file count, not partner or workload type.

## Fix

Replace \`invalidate_entity(mediaid)\` at the two file-boundary entry points with \`_entity_cache.clear()\`, then prime the cache with the current mediaid as before:

\`\`\`diff
 def process_one_from_sdc(...):
     global claims, refclaims
-    invalidate_entity(mediaid)
+    _entity_cache.clear()
     get_entity(mediaid)
\`\`\`

Cache locality stays per-file (the ~25 reads of the current entity still share one round-trip). The dict no longer grows across files.

## Test plan

- [x] Regression test asserting \`_entity_cache\` flushes prior entries at the file boundary
- [x] Direct memory-leak regression: process 100 synthetic files in sequence and assert cache size stays ≤1 at every step (pre-fix would grow 1→100)
- [x] All 492 existing tests pass
- [ ] Long-running session smoke test post-merge: restart the two killed NARA sessions and monitor RSS over 24 hours — should stay flat at ~150 MB

## Notes

This bug is independent of [#282](https://github.com/dpla/ingest-wikimedia/pull/282) and has existed since \`_entity_cache\` was added to \`sdc_sync.py\`. Surfaces under long-running sessions on partners with many ordinals per item — NARA hits it hardest because multipage records (military personnel files, presidential libraries) compound the per-file count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes an unbounded memory leak in long-running sdc-sync sessions by clearing the module-level _entity_cache dictionary at file boundaries.

## Problem

tools/sdc_sync.py used a module-level _entity_cache to memoize wbgetentities responses for the ~25 reads performed while processing a single file. The cache was intended to be file-scoped but was never cleared between files: invalidate_entity(mediaid) only popped a single key (for intra-file read-after-write semantics), and the file-boundary entry points (process_one and process_one_from_sdc) invoked invalidate_entity with the new mediaid (a no-op). This allowed one cached entity to accumulate per file processed and produced large RSS growth in production (examples: ~2.6 GB with ~200k cached entities; ~1.7 GB with ~130k).

## Solution

Replace invalidate_entity(mediaid) at the two file-boundary entry points with _entity_cache.clear(), then prime the cache with the current mediaid. This preserves per-file cache locality while preventing cache growth across files.

## Changes

- tools/sdc_sync.py (+27/-16)
  - Documented and implemented full _entity_cache clearing at file boundaries.
  - Replaced invalidate_entity(mediaid) with _entity_cache.clear() in process_one() and process_one_from_sdc(); pre-warm cache with current mediaid.

- tests/test_sdc_sync.py (+161/-0)
  - Added a helper to stub process_one_from_sdc dependencies and two regression tests:
    - test_process_one_from_sdc_clears_entity_cache_at_file_boundary()
    - test_entity_cache_does_not_grow_across_many_files()
  - Added symmetric legacy-path stubbing helper and two tests for process_one (legacy --file/--cat/--list path):
    - test_process_one_clears_entity_cache_at_file_boundary()
    - test_process_one_cache_does_not_grow_across_many_files()
  - Helper for legacy path (_patch_process_one_dependencies) stubs site and parsed() and uses monkeypatch.chdir(tmp_path) to avoid polluting the working tree.

## Testing

All existing tests pass; the change adds the new regression tests validating:
- _entity_cache is cleared at file boundary for both partner mode and legacy file-path entry points.
- Cache does not grow across many files (synthetic run, 100 iterations assert cache size ≤ 1).

A long-running smoke test after merge is planned.

## Special Considerations

- No manual pipeline trigger or ECS redeployment required.
- No environment variables, AWS Secrets Manager keys, database migrations, shared infrastructure config, public API surface, or credential-handling changes.
- No security-impacting changes identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->