### PR TITLE
sdc-sync: stamp type:statement on every wbeditentity fragment (fix #284)

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -2791,7 +2791,17 @@ def test_submit_per_item_edit_bundles_all_fragments_into_one_post():
         "type": "statement",
         "rank": "normal",
     }
-    ref_update = {"id": "M999$existing", "references": [{"snaks": {}}]}
+    # Reference- and qualifier-update fragments carry ``type: "statement"``
+    # — wbeditentity rejects the bundle without it. The dispatcher
+    # backstops this by stamping the field on any fragment that's
+    # missing it, so callers may pass fragments with or without it
+    # interchangeably; the assertion below checks both fragments end up
+    # with it in the POSTed payload regardless of which side set it.
+    ref_update = {
+        "id": "M999$existing",
+        "type": "statement",
+        "references": [{"snaks": {}}],
+    }
     qual_update = {"id": "M999$amend", "qualifiers": {"P459": []}}
     removal = {"id": "M999$gone", "remove": ""}
 
@@ -2818,7 +2828,12 @@ def test_submit_per_item_edit_bundles_all_fragments_into_one_post():
     assert action == "wbeditentity"
     assert mediaid == "M999"
     payload = json.loads(kw["data"])
-    assert payload["claims"] == [new_claim, ref_update, qual_update, removal]
+    # ``qual_update`` was passed in without ``type``; the dispatcher
+    # should have stamped it on. Assert against the dispatcher-stamped
+    # shape so this test enforces the invariant rather than enshrining
+    # the broken pre-fix one.
+    expected_qual_update = {**qual_update, "type": "statement"}
+    assert payload["claims"] == [new_claim, ref_update, expected_qual_update, removal]
 
 
 def test_p813_refresh_skips_when_no_other_edits():
@@ -3081,4 +3096,97 @@ def test_p813_refresh_preserves_user_added_references():
     assert refs[0] == user_ref
     today_iso = "+" + _dt.date.today().isoformat() + "T00:00:00Z"
     assert refs[1]["snaks"]["P813"][0]["datavalue"]["value"]["time"] == today_iso
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_flush_emits_type_statement_on_every_non_removal_fragment():
+    """Regression: wbeditentity rejects the entire bundle with
+    ``invalid-claim: Type is missing`` unless every non-removal claim
+    entry carries ``type: "statement"``. The dispatcher's atomicity then
+    drops every other edit too — so a missing ``type`` on one fragment
+    silently blocks unrelated P2699 backfills, new-claim adds, and
+    removals on the same file.
+
+    Exercise the realistic mix: one queued qualifier-amend (drives a
+    qualifier-update fragment), one queued removal (drives a removal
+    fragment), and a DPLA-authored claim with a stale P813 reference
+    (drives a P813 refresh fragment). Assert every non-removal claim
+    in the POSTed payload carries ``type: "statement"``.
+    """
+    import json
+
+    from tools import sdc_sync
+
+    stale_claim = {
+        "id": "M999$stale",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"value": "abcdef", "type": "string"},
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [_stale_p813_ref("abcdef")],
+    }
+    amend_target = {
+        "id": "M999$amend",
+        "mainsnak": {
+            "property": "P7482",
+            "snaktype": "value",
+            "datavalue": {
+                "type": "wikibase-entityid",
+                "value": {"entity-type": "item", "id": "Q74228490"},
+            },
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+    }
+    entity = {
+        "pageid": 999,
+        "statements": {
+            "P760": [stale_claim],
+            "P7482": [amend_target],
+        },
+    }
+
+    sdc_sync._reset_per_file_accumulators()
+    sdc_sync.qualifier_amends.append(
+        ("M999$amend", "P2699", sdc_sync._url_snak("P2699", "https://example.com/foo"))
+    )
+    sdc_sync.removals.append("M999$gone")
+
+    submit_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync,
+            "_submit_sdc_write",
+            side_effect=lambda *a, **kw: submit_calls.append((a, kw)),
+        ),
+    ):
+        sdc_sync._flush_per_file_edits("M999", "abcdef")
+
+    assert len(submit_calls) == 1, "dispatcher should POST exactly once"
+    payload = json.loads(submit_calls[0][1]["data"])
+    sent_claims = payload["claims"]
+    # Sanity: we should be sending one of each fragment kind so this
+    # test is actually exercising all three code paths.
+    kinds = {
+        "removal": [c for c in sent_claims if c.get("remove") == ""],
+        "qualifier": [
+            c for c in sent_claims if "qualifiers" in c and c.get("remove") != ""
+        ],
+        "reference": [
+            c for c in sent_claims if "references" in c and c.get("remove") != ""
+        ],
+    }
+    assert kinds["removal"], "removal fragment should be present"
+    assert kinds["qualifier"], "qualifier-update fragment should be present"
+    assert kinds["reference"], "P813 refresh fragment should be present"
+    for claim in sent_claims:
+        if claim.get("remove") == "":
+            continue  # removal entries don't take a type
+        assert claim.get("type") == "statement", (
+            f"non-removal fragment missing type:statement — wbeditentity "
+            f"would reject the bundle: {claim!r}"
+        )
     sdc_sync._reset_per_file_accumulators()

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1955,6 +1955,13 @@ def _submit_per_item_edit(
     * ``removals`` — claim dicts shaped ``{"id": ..., "remove": ""}``.
       Wikibase deletes the named statement.
 
+    Wikibase requires ``"type": "statement"`` on every non-removal claim
+    entry; the dispatcher stamps it on any fragment that's missing it
+    before POSTing, so callers may omit the field. (The two in-tree
+    builders set it explicitly for local readability, but the guard
+    here protects future builders and ad-hoc callers from re-introducing
+    the bundle-wide ``invalid-claim: Type is missing`` rejection.)
+
     Atomicity: the entire bundle lands as a single revision on the
     file's MediaInfo entity, or none of it does. There is no partial-
     update window where new claims have been written but removals
@@ -1978,6 +1985,23 @@ def _submit_per_item_edit(
     )
     if not all_fragments:
         return
+
+    # Defense-in-depth: stamp ``type: "statement"`` on every non-removal
+    # fragment that's missing it. Wikibase rejects the entire bundle
+    # with ``invalid-claim: Type is missing`` if any non-removal entry
+    # lacks this field, and atomicity means one malformed fragment
+    # silently drops every other edit on the file. The two known
+    # builders (``_build_qualifier_update_fragments`` /
+    # ``_build_p813_refresh_fragments``) set it themselves, but adding
+    # the guard here makes any future builder that forgets — or any
+    # external caller passing hand-built fragments — fail closed
+    # instead of nuking the whole edit. Removals (``{"id": ...,
+    # "remove": ""}``) are exempt: Wikibase accepts them without
+    # ``type``, and adding it has no effect.
+    for fragment in all_fragments:
+        if fragment.get("remove") == "":
+            continue
+        fragment.setdefault("type", "statement")
 
     _submit_sdc_write(
         "wbeditentity",
@@ -2041,7 +2065,12 @@ def _build_qualifier_update_fragments(mediaid):
             existing_qualifiers, removes_by_id.get(claimid, set())
         )
         merged = _merge_qualifier_snaks(kept, adds_by_id.get(claimid, []))
-        fragments.append({"id": claimid, "qualifiers": merged})
+        # ``type: "statement"`` is required by wbeditentity on every
+        # non-removal claim entry — omitting it makes Wikibase reject
+        # the whole bundle with ``invalid-claim: Type is missing``,
+        # which (because the dispatcher is atomic) drops every other
+        # edit in the file's per-file batch too.
+        fragments.append({"id": claimid, "type": "statement", "qualifiers": merged})
     return fragments
 
 
@@ -2102,7 +2131,9 @@ def _build_p813_refresh_fragments(mediaid, dpla_id, already_touched_ids):
                 new_refs.append(refreshed)
                 changed = True
             if changed:
-                fragments.append({"id": stmt_id, "references": new_refs})
+                fragments.append(
+                    {"id": stmt_id, "type": "statement", "references": new_refs}
+                )
     return fragments
 
 


### PR DESCRIPTION
## Summary

- PR #284's consolidated dispatcher built qualifier-update and P813-refresh fragments missing `\"type\": \"statement\"`, so wbeditentity rejected the entire bundle with `invalid-claim: Type is missing` for any file needing an incremental edit (P2699/P6108/P304 backfill, P813 refresh). Atomicity meant new-claim adds on the same files were dropped silently too — the failure surfaced only as `SDC_ORDINALS_SKIPPED_ERROR`.
- Add `\"type\": \"statement\"` in the two builders, document the invariant, and add a dispatcher-side backstop that stamps `type` on any non-removal fragment that's missing it so future builders fail closed instead of nuking the bundle.

## Test plan

- [x] `uv run pytest tests/test_sdc_sync.py` — 97 passing (1 new, 1 existing updated)
- [x] Confirmed new regression test fails on parent ref (origin/main) and passes after the fix
- [ ] EC2 smoke-test on the same NARA DPLA ID (`06b558045c5fd4cc5dc697248272159a`) that surfaced the bug — expect a single wbeditentity per file landing the missing P2699 qualifier + P813 refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bug fix: stamp `"type": "statement"` on wbeditentity fragments

Fixes a bug introduced in PR `#284` where the SDC sync dispatcher produced wbeditentity fragments for qualifier updates and P813 reference refreshes missing the required `"type": "statement"` field. Wikibase rejected entire bundles containing these malformed fragments with `invalid-claim: Type is missing`. Because the dispatcher submits edits atomically per file, a single malformed fragment silently dropped all other edits in that batch—including new-claim additions and removals—resulting in `SDC_ORDINALS_SKIPPED_ERROR` on the operator side.

### Changes

**`tools/sdc_sync.py`:**
- Updated `_build_qualifier_update_fragments` and `_build_p813_refresh_fragments` to explicitly include `"type": "statement"` when creating fragments with `{id, qualifiers}` and `{id, references}` shapes
- Added a dispatcher-side defense-in-depth backstop in `_submit_per_item_edit` that stamps `"type": "statement"` onto any non-removal fragment missing it (removals remain exempt, as wbeditentity accepts `{"id": ..., "remove": ""}` without the field)
- Updated `_submit_per_item_edit`'s docstring to document this invariant and the backstop behavior

**`tests/test_sdc_sync.py`:**
- Updated `test_submit_per_item_edit_bundles_all_fragments_into_one_post` to assert that `reference_updates` and `qualifier_updates` fragments include `type: "statement"` in the dispatcher's output (including a variant with expected `qual_update` shape)
- Added new regression test `test_flush_emits_type_statement_on_every_non_removal_fragment` that exercises a realistic mixed workload (qualifier amend fragment, removal fragment, and stale-P813 refresh fragment) and asserts every non-removal claim in the POSTed payload includes `"type": "statement"` to prevent wbeditentity rejection

### Test coverage

97 tests passing (1 new test, 1 updated test). The new regression test fails on the parent ref and passes after the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->