### PR TITLE
sdc-sync: include mainsnak on partial-update wbeditentity fragments (fix #285 followup)

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -3168,25 +3168,27 @@ def test_flush_emits_type_statement_on_every_non_removal_fragment():
     assert len(submit_calls) == 1, "dispatcher should POST exactly once"
     payload = json.loads(submit_calls[0][1]["data"])
     sent_claims = payload["claims"]
-    # Sanity: we should be sending one of each fragment kind so this
-    # test is actually exercising all three code paths.
-    kinds = {
-        "removal": [c for c in sent_claims if c.get("remove") == ""],
-        "qualifier": [
-            c for c in sent_claims if "qualifiers" in c and c.get("remove") != ""
-        ],
-        "reference": [
-            c for c in sent_claims if "references" in c and c.get("remove") != ""
-        ],
-    }
-    assert kinds["removal"], "removal fragment should be present"
-    assert kinds["qualifier"], "qualifier-update fragment should be present"
-    assert kinds["reference"], "P813 refresh fragment should be present"
+    by_id = {c.get("id"): c for c in sent_claims}
+    # Sanity: every code path should be exercised by this fixture so
+    # the assertions below actually cover all three fragment kinds.
+    assert "M999$gone" in by_id, "removal fragment should be present"
+    assert "M999$amend" in by_id, "qualifier-update fragment should be present"
+    assert "M999$stale" in by_id, "P813 refresh fragment should be present"
     for claim in sent_claims:
         if claim.get("remove") == "":
-            continue  # removal entries don't take a type
+            continue  # removal entries are exempt from the type/mainsnak rule
         assert claim.get("type") == "statement", (
             f"non-removal fragment missing type:statement — wbeditentity "
+            f"would reject the bundle: {claim!r}"
+        )
+        # wbeditentity treats every non-removal claim as a
+        # wholesale-replace; partial fragments ``{id, qualifiers}`` /
+        # ``{id, references}`` get rejected with
+        # ``invalid-claim: Attribute "mainsnak" is missing`` and the
+        # atomic bundle (every OTHER edit in this file's per-file
+        # batch) is dropped with it.
+        assert "mainsnak" in claim, (
+            f"non-removal fragment missing mainsnak — wbeditentity "
             f"would reject the bundle: {claim!r}"
         )
     sdc_sync._reset_per_file_accumulators()

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -3129,6 +3129,7 @@ def test_flush_emits_type_statement_on_every_non_removal_fragment():
     }
     amend_target = {
         "id": "M999$amend",
+        "rank": "preferred",
         "mainsnak": {
             "property": "P7482",
             "snaktype": "value",
@@ -3138,6 +3139,7 @@ def test_flush_emits_type_statement_on_every_non_removal_fragment():
             },
         },
         "qualifiers": {"P459": _dpla_p459()},
+        "references": [_dpla_reference("abcdef")],
     }
     entity = {
         "pageid": 999,
@@ -3191,4 +3193,19 @@ def test_flush_emits_type_statement_on_every_non_removal_fragment():
             f"non-removal fragment missing mainsnak — wbeditentity "
             f"would reject the bundle: {claim!r}"
         )
+    # Sibling-field preservation: wbeditentity wholesale-replaces every
+    # field provided, so a fragment that drops the sibling field (e.g.
+    # qualifier-update without ``references``) would silently erase
+    # those references on the live statement. Catch both the rejection
+    # path AND the silent-data-loss side by asserting each fragment
+    # kind preserves the fields it isn't supposed to modify.
+    assert by_id["M999$amend"]["references"] == amend_target["references"], (
+        "qualifier-update fragment must preserve existing references"
+    )
+    assert by_id["M999$amend"]["rank"] == "preferred", (
+        "qualifier-update fragment must preserve existing rank"
+    )
+    assert by_id["M999$stale"]["qualifiers"] == stale_claim["qualifiers"], (
+        "P813 refresh fragment must preserve existing qualifiers"
+    )
     sdc_sync._reset_per_file_accumulators()

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2065,12 +2065,24 @@ def _build_qualifier_update_fragments(mediaid):
             existing_qualifiers, removes_by_id.get(claimid, set())
         )
         merged = _merge_qualifier_snaks(kept, adds_by_id.get(claimid, []))
-        # ``type: "statement"`` is required by wbeditentity on every
-        # non-removal claim entry — omitting it makes Wikibase reject
-        # the whole bundle with ``invalid-claim: Type is missing``,
-        # which (because the dispatcher is atomic) drops every other
-        # edit in the file's per-file batch too.
-        fragments.append({"id": claimid, "type": "statement", "qualifiers": merged})
+        # wbeditentity treats every non-removal claim entry as a
+        # wholesale-replace operation, so the fragment must carry the
+        # entire statement — ``mainsnak``, ``rank``, existing
+        # ``references`` — not just the field being amended. Omitting
+        # ``mainsnak`` fails the bundle with ``invalid-claim:
+        # Attribute "mainsnak" is missing``; omitting ``references``
+        # would silently erase them. Copy from the cached statement
+        # and overlay the new qualifier set; ``type`` is stamped by
+        # the dispatcher as a defense-in-depth.
+        fragment = {
+            "id": claimid,
+            "type": "statement",
+            "mainsnak": copy.deepcopy(stmt["mainsnak"]),
+            "rank": stmt.get("rank", "normal"),
+            "qualifiers": merged,
+            "references": copy.deepcopy(stmt.get("references") or []),
+        }
+        fragments.append(fragment)
     return fragments
 
 
@@ -2131,8 +2143,20 @@ def _build_p813_refresh_fragments(mediaid, dpla_id, already_touched_ids):
                 new_refs.append(refreshed)
                 changed = True
             if changed:
+                # Same wholesale-replace contract as
+                # _build_qualifier_update_fragments: include the
+                # statement's existing mainsnak / qualifiers / rank so
+                # wbeditentity preserves them and only diffs the
+                # references field.
                 fragments.append(
-                    {"id": stmt_id, "type": "statement", "references": new_refs}
+                    {
+                        "id": stmt_id,
+                        "type": "statement",
+                        "mainsnak": _copy.deepcopy(stmt["mainsnak"]),
+                        "rank": stmt.get("rank", "normal"),
+                        "qualifiers": _copy.deepcopy(stmt.get("qualifiers") or {}),
+                        "references": new_refs,
+                    }
                 )
     return fragments
 


### PR DESCRIPTION
## Summary

- PR #285 fixed `Type is missing` but only got us to the next Wikibase requirement: `invalid-claim: Attribute "mainsnak" is missing`. wbeditentity treats every non-removal claim entry as a wholesale-replace operation, so partial fragments `{id, type, qualifiers}` / `{id, type, references}` get rejected and the dispatcher's atomicity drops every other edit in the bundle with them.
- Both fragment builders now copy `mainsnak`, `rank`, and the unmodified sibling field (references for qualifier-updates; qualifiers for P813 refreshes) from the cached statement so wbeditentity sees a complete claim.
- Regression test extended to assert every non-removal fragment carries `mainsnak` as well as `type`. Switched the test's sanity partition from "filter by key presence" (broken now that both fragment kinds carry both keys) to "filter by claim id."

## Test plan

- [x] `uv run pytest tests/test_sdc_sync.py` — 97 passing
- [ ] EC2 smoke test on `06b558045c5fd4cc5dc697248272159a` after merge — expect one wbeditentity revision landing the P2699 backfill + P813 refresh, `SDC_ORDINALS_SKIPPED_ERROR: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Fixes a Wikibase rejection (`invalid-claim: Attribute "mainsnak" is missing`) introduced after PR `#285`. sdc-sync previously emitted incomplete claim fragments to wbeditentity (e.g., {id,type,qualifiers} or {id,type,references}); because wbeditentity treats non-removal claim entries as full-replaces, those partial fragments caused Wikibase to reject the edit bundle and drop other edits in the same batch.

## Changes

### tools/sdc_sync.py
- `_build_qualifier_update_fragments`: fragments now include `mainsnak`, `rank`, and the unmodified sibling field (`references`) copied from the cached Commons statement; merged qualifiers are overlaid. Uses `copy.deepcopy()` to avoid mutating cached data.
- `_build_p813_refresh_fragments`: fragments now include `mainsnak`, `rank`, and the unmodified sibling field (`qualifiers`) copied from the cached statement alongside the refreshed `references` (P813). Also uses `copy.deepcopy()`.

These changes ensure wbeditentity receives a complete statement payload for any non-removal claim entry, preventing the `mainsnak`-missing error.

### tests/test_sdc_sync.py
- Strengthened regression test `test_flush_emits_type_statement_on_every_non_removal_fragment`:
  - Now indexes emitted fragments by claim ID and asserts presence of removal, qualifier-update, and P813 refresh fragments.
  - Asserts every non-removal fragment includes `type: "statement"` and a `mainsnak`.
  - Verifies sibling-field preservation and `rank` preservation: qualifier-update fragment preserves existing `references` and `rank`; P813 refresh preserves existing `qualifiers`.
  - Replaced previous kind-based partitioning with claim-ID-based filtering.

## Deployment & Infrastructure
- No manual pipeline trigger or ECS redeployment required.
- No changes to environment variables, AWS Secrets Manager keys, database migrations, shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM), or public API shapes.
- No security implications introduced.

## Testing
- Local pytest: 97 passing tests reported by author; EC2 smoke test pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->