### PR TITLE
docs: add comprehensive technical + operator pipeline documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,27 @@
 
 # ingest-wikimedia
 
-Uploads public-domain media from DPLA partner collections to [Wikimedia Commons](https://commons.wikimedia.org/). Each pipeline run fetches item IDs from DPLA's Elasticsearch index, stages media files to S3, then uploads them to Commons with structured metadata.
+Uploads public-domain media from DPLA partner collections to [Wikimedia Commons](https://commons.wikimedia.org/) and synchronises structured data (SDC) statements on every uploaded file's MediaInfo entity.
+
+A run is triggered from Slack (e.g. `/wikimedia-upload bpl`), dispatched through AWS Lambda → GitHub Actions → AWS SSM into a long-running tmux session on a pinned EC2 instance, where it executes four sequential phases: enumerate IDs from DPLA's Elasticsearch index, download media to S3, upload to Commons, then post SDC. Each phase is idempotent and re-running is safe.
+
+## Documentation
+
+### Operators
+
+- **[docs/slack-guide.md](docs/slack-guide.md)** — Copy-paste Slack examples for every run type (hub-level, institution-level, Wikidata QID, single DPLA ID, refresh-only, SDC-only, retry, kill, status). Non-technical.
+- **[docs/operations.md](docs/operations.md)** — Full operations reference: hub registry, eligibility rules, session naming, monitoring, troubleshooting playbook.
+
+### Architecture and internals
+
+- **[docs/architecture.md](docs/architecture.md)** — End-to-end system architecture: Slack → Lambda → GitHub Actions → SSM → EC2; concurrency keys; target resolution; failure semantics.
+- **[docs/pipeline-phases.md](docs/pipeline-phases.md)** — Deep dive on each of the four phases (`get-ids-es`, `downloader`, `uploader`, `sdc-sync`), the Elasticsearch-vs-API switch, NARA's special enumeration, and the `--single-id`/`--sdc-only`/`--refresh-only` modes.
+- **[docs/sidecars.md](docs/sidecars.md)** — The S3 sidecar files (`dpla-map.json`, `sdc.json`, `upload-result.json`, `file-list.txt`, `iiif.json`) that connect the phases. Schemas, writers, readers, lifecycle.
+- **[docs/sdc-sync.md](docs/sdc-sync.md)** — SDC sync phase in depth: the atomic single-`wbeditentity` dispatcher, every property the bot writes, idempotency via `check()`, the P1545 chunked-claim convention, the P813 refresh, and the Wikibase API gotchas (type/mainsnak required on partial-update fragments).
+- **[docs/special-cases.md](docs/special-cases.md)** — Duplicate detection (SHA1-based and title-based), the four hash-drift cases the uploader resolves, file renames, CommonsDelinker integration, redirect handling, orphan tagging.
+- **[docs/templates.md](docs/templates.md)** — How `{{Artwork}}` is currently emitted at upload, how `{{DPLA metadata}}` + `Module:DPLA` read SDC after upload, and the planned transition to `{{DPLA metadata}}` as the primary template.
+- **[docs/metrics.md](docs/metrics.md)** — The scheduled CIM-pageviews workflow that publishes monthly pageview data to Commons `Data:` pages, plus the GitHub Pages site that consumes them.
+- **[docs/maintenance-tools.md](docs/maintenance-tools.md)** — `verify-item`, `retirer`, `nuke`, `remimer`, `sign`, `get-incomplete-items`, `get-ids-retry`, `fix-unknown-categories`.
 
 ## Development setup
 
@@ -15,56 +35,28 @@ source .venv/bin/activate
 
 Pre-commit hooks use [ruff](https://docs.astral.sh/ruff/) for linting and formatting, and [ggshield](https://www.gitguardian.com/ggshield) for secret scanning. Install with `pre-commit install`.
 
-## Running the pipeline
-
-The pipeline has four sequential phases, each invoked as a CLI command:
-
-```bash
-# 1. Generate IDs and stage metadata (writes <partner>.csv + per-item sdc.json sidecars)
-get-ids-es <partner>
-get-ids-es <partner> --institution "Institution Name"   # institution-level run
-
-# 2. Download media to S3
-downloader <partner>.csv <partner>
-
-# 3. Upload from S3 to Wikimedia Commons
-uploader <partner>.csv <partner>
-
-# 4. Reconcile SDC (MediaInfo statements) on Commons against the staged sdc.json
-sdc-sync --partner <partner> --ids-file <partner>.csv
-```
-
-All four must run from the partner's working directory on EC2 (e.g. `/home/ec2-user/ingest-wikimedia/bpl/`), where `config.toml` is resolved from CWD.
-
-**In practice, pipelines are launched via Slack or GitHub Actions** — see [docs/operations.md](docs/operations.md) for the full operations guide.
-
 ## Project structure
 
 | Path | Purpose |
 |------|---------|
-| `ingest_wikimedia/` | Shared library (partner registry, S3, Slack, SSM, Wikimedia API) |
-| `tools/` | CLI entry points (`get-ids-es`, `downloader`, `uploader`, `sdc-sync`) |
-| `scripts/` | GitHub Actions step scripts (`wikimedia_launch.py`, `wikimedia_kill.py`, `wikimedia_upload_status.py`) |
-| `lambda/wikimedia-slack-dispatch/` | Lambda handler for Slack slash commands |
-| `.github/workflows/` | Workflow definitions for launch, kill, and status checks |
+| `ingest_wikimedia/` | Shared library: partner registry, ES client, S3, Slack, SSM, Wikimedia API, SDC builders |
+| `tools/` | CLI entry points (`get-ids-es`, `downloader`, `uploader`, `sdc-sync`, plus maintenance utilities) |
+| `scripts/` | GitHub-Actions step scripts (`wikimedia_launch.py`, `wikimedia_kill.py`, `wikimedia_retry.py`, `wikimedia_upload_status.py`) |
+| `lambda/wikimedia-slack-dispatch/` | AWS Lambda handler for `/wikimedia-*` Slack slash commands |
+| `.github/workflows/` | Workflow definitions for launch, kill, retry, status, CIM pageviews, plus CI (pytest, ruff, codeql) |
+| `metrics/` | Source for the GitHub-Pages site plus the scheduled `CIMviews.py` bot |
+| `tests/` | Pytest suite (one `test_<module>.py` per source module) |
+| `dpla-id-banlist.txt` | DPLA IDs to skip in eligibility checks |
+| `rights.json` | Rights-URI → Wikidata QID mapping consumed by SDC builders |
 
-## Options
+## CLI reference
 
 ```text
-get-ids-es <partner> [--institution NAME] [--dry-run]
-downloader <partner>.csv <partner> [--dry-run] [--verbose]
-uploader   <partner>.csv <partner> [--dry-run] [--verbose]
+get-ids-es <partner> [--institution NAME ...] [--collection NAME] [--single-id ID]
+downloader <ids.csv> <partner> [--max-age-days N] [--notify-complete] [--overwrite] [--dry-run] [--verbose]
+uploader   <ids.csv> <partner> [--dry-run] [--verbose]
 sdc-sync   --partner <partner> [--ids-file PATH]
+sdc-sync   --file "File:Title.jpg" [--file ...] | --cat <Category> | --lists <dir>
 ```
 
-Pass `--help` to any command for full option details.
-
-## Operations
-
-See **[docs/operations.md](docs/operations.md)** for:
-- Slack slash command reference
-- Target formats (hub slugs, institution-level runs, Wikidata QIDs)
-- Partner hub registry
-- Upload eligibility system
-- EC2 infrastructure details
-- Monitoring and troubleshooting
+Pass `--help` to any command for full option details. In practice nothing here is invoked by hand — runs are launched via Slack and orchestrated by `scripts/wikimedia_launch.py`. See [docs/architecture.md](docs/architecture.md) for the dispatch chain.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Pre-commit hooks use [ruff](https://docs.astral.sh/ruff/) for linting and format
 |------|---------|
 | `ingest_wikimedia/` | Shared library: partner registry, ES client, S3, Slack, SSM, Wikimedia API, SDC builders |
 | `tools/` | CLI entry points (`get-ids-es`, `downloader`, `uploader`, `sdc-sync`, plus maintenance utilities) |
-| `scripts/` | GitHub-Actions step scripts (`wikimedia_launch.py`, `wikimedia_kill.py`, `wikimedia_retry.py`, `wikimedia_upload_status.py`) |
+| `scripts/` | GitHub Actions step scripts (`wikimedia_launch.py`, `wikimedia_kill.py`, `wikimedia_retry.py`, `wikimedia_upload_status.py`) |
 | `lambda/wikimedia-slack-dispatch/` | AWS Lambda handler for `/wikimedia-*` Slack slash commands |
 | `.github/workflows/` | Workflow definitions for launch, kill, retry, status, CIM pageviews, plus CI (pytest, ruff, codeql) |
 | `metrics/` | Source for the GitHub-Pages site plus the scheduled `CIMviews.py` bot |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,182 @@
+# Pipeline Architecture
+
+This document describes how an upload run flows from a Slack slash command through the dispatch chain into a long-running pipeline on EC2, and how the components fit together. For operator-level instructions (how to *use* the pipeline), see [slack-guide.md](slack-guide.md) and [operations.md](operations.md).
+
+## Table of contents
+
+1. [End-to-end picture](#end-to-end-picture)
+2. [Why Elasticsearch instead of api.dp.la](#why-elasticsearch-instead-of-apidpla)
+3. [The dispatch chain](#the-dispatch-chain)
+4. [Target resolution](#target-resolution)
+5. [Session naming and concurrency](#session-naming-and-concurrency)
+6. [Failure semantics](#failure-semantics)
+7. [Component map](#component-map)
+
+---
+
+## End-to-end picture
+
+```text
+Slack user
+    │ /wikimedia-upload bpl pa
+    ▼
+AWS Lambda  (wikimedia-slack-dispatch)
+    │  HMAC-validates Slack signature
+    │  Pre-validates hub slugs / QID format
+    │  Computes SHA-256 concurrency key
+    │  Returns ack to Slack (<3 s)
+    ▼
+GitHub Actions  (wikimedia-launch.yml)
+    │  scripts/wikimedia_launch.py runs:
+    │    • resolves QIDs / DPLA IDs via institutions_v2.json + ES
+    │    • re-checks eligibility, conflicts, EC2 memory
+    │    • base64-encodes the pipeline shell script
+    │    • copies updated source code onto EC2
+    ▼
+AWS SSM  →  EC2  (i-033eff6c8c168f999, "wiki downloads")
+    │  tmux session: wikimedia-bpl+pa
+    │  Per target, sequentially:
+    │    1. get-ids-es <partner> > <partner>.csv
+    │    2. downloader <partner>.csv <partner>
+    │    3. uploader   <partner>.csv <partner>
+    │    4. sdc-sync   --partner <partner> --ids-file <partner>.csv
+    ▼
+S3 (s3://dpla-wikimedia/)        Wikimedia Commons
+    sidecars + media bytes       file pages + MediaInfo SDC
+```
+
+Phase completion notifications and pipeline failures post to **#tech-alerts** via the Tech Reports bot (`DPLA_SLACK_BOT_TOKEN`). User-level errors (unknown hub, invalid target, etc.) come back to the slash-command caller as ephemeral Slack messages.
+
+## Why Elasticsearch instead of api.dp.la
+
+Before March 2026, `tools/get_ids_api.py` enumerated DPLA IDs by paginating the public DPLA API at `api.dp.la`. That tool is now a one-line shim; the cutover (commit `15375ab`) combined two changes:
+
+1. **`tools/get_ids_es.py`** queries DPLA's internal Elasticsearch alias `dpla_alias` at `search-prod1.internal.dp.la:9200` directly. Pagination uses `search_after` with `sort = ["id", "_doc"]` and `size = 500`. Every page is validated for `timed_out=true` or partial-shard failures so a 200 OK with `_shards.failed > 0` cannot silently terminate a long-running paginator. A `SIGALRM`-based 120 s hard timeout catches stalled mid-response reads that `requests.timeout=30` doesn't.
+2. **Sidecar staging.** As `get-ids-es` enumerates, it writes the full ES `_source` for each item to S3 as `dpla-map.json`, and pre-computes the file's Wikibase claim envelope into `sdc.json`. The downloader and uploader read these sidecars instead of re-fetching per-item metadata from `api.dp.la`, which removed thousands of round-trips per partner from the hot path.
+
+The result: `get-ids-es` is now both the ID enumerator *and* the metadata pre-stager. The downloader, uploader, and SDC-sync phases no longer talk to `api.dp.la` at all in partner-mode runs. (See [pipeline-phases.md](pipeline-phases.md) and [sidecars.md](sidecars.md) for the details.)
+
+## The dispatch chain
+
+### Step 1 — Lambda (`lambda/wikimedia-slack-dispatch/handler.py`)
+
+The Slack app sends every `/wikimedia-*` slash command to a Lambda Function URL. The handler:
+
+1. **Verifies the request.** Parses `x-slack-request-timestamp` (rejecting anything > 300 s old to defeat replay), builds the canonical signing string `v0:<ts>:<body>`, HMAC-SHA-256s it with `SLACK_SIGNING_SECRET`, and compares against `x-slack-signature` using `hmac.compare_digest`.
+2. **Decodes the body.** Slack sends `application/x-www-form-urlencoded`; API-Gateway base64-encodes it. `command`, `text`, and `response_url` are extracted.
+3. **Routes by subcommand.** Each subcommand (`upload`, `kill`, `retry`, `sdc`, `refresh`, status) builds the right inputs and posts to `https://api.github.com/repos/dpla/ingest-wikimedia/actions/workflows/<workflow>.yml/dispatches`. The dispatch call has a 2 s timeout — well inside Slack's 3 s ack window.
+4. **Pre-validates inputs.** For `/wikimedia-upload`, hub slugs are looked up in the local `PARTNER_HUBS` registry and rejected with an ephemeral Slack error if unknown. QIDs are format-validated against `^Q\d+$` but resolved later (inside the workflow) because the Lambda would have to fetch `institutions_v2.json` to do it here, blowing the 3 s budget.
+5. **Computes a concurrency key.** A 16-char SHA-256 hex prefix of the joined target string is passed as `concurrency_key` to the workflow so its concurrency group name stays under GitHub's 400-char limit while still folding equivalent inputs together.
+
+Environment variables: `SLACK_SIGNING_SECRET`, `GH_TOKEN` (fine-grained PAT with `actions:write` on `dpla/ingest-wikimedia`), `GH_REPO` (default `dpla/ingest-wikimedia`).
+
+### Step 2 — GitHub Actions workflow
+
+Four `workflow_dispatch`-only workflows handle the slash-command traffic:
+
+| Workflow | Triggered by | Concurrency group |
+|---|---|---|
+| `wikimedia-launch.yml` | `/wikimedia-upload`, `/wikimedia-upload sdc`, `/wikimedia-upload refresh` | `wikimedia-launch-${concurrency_key \|\| run_id}` |
+| `wikimedia-kill.yml` | `/wikimedia-upload kill` | none — fire-and-forget |
+| `wikimedia-retry.yml` | `/wikimedia-upload retry` | `wikimedia-retry-${partner \|\| 'all'}` |
+| `wikimedia-upload-status.yml` | `/wikimedia-status` + cron `0 */6 * * *` | fixed `wikimedia-upload-status` |
+
+Each workflow installs Python + `boto3`/`requests`, then invokes a single Python script from `scripts/`. The scripts hold all the orchestration logic — the YAML is intentionally thin.
+
+### Step 3 — `scripts/wikimedia_launch.py`
+
+This is the bulk of the dispatch logic. In order, it:
+
+1. **Parses the `--partner` input** via `shlex.split` and classifies each token as hub slug, `hub|institution` pair, `hub|institution|collection` triple, Wikidata QID, or DPLA ID (32-hex).
+2. **Resolves targets.** QIDs are looked up against `institutions_v2.json` (live-fetched from `github.com/dpla/ingestion3/.../wiki/institutions_v2.json`, module-cached so warm Lambda calls don't refetch). DPLA IDs are batched into one SSM call to `resolve-dpla-ids` on EC2, which does an ES `terms` query and applies the full eligibility filter.
+3. **Checks EC2 memory.** Aborts when available RAM is below 30 %. Each session uses ~300–500 MB on a 7.6 GB instance, so 30 % free leaves room for 4–5 concurrent sessions.
+4. **Detects session conflicts.** Hub-level, institution-level, and collection-level targets define conflict rules so that, e.g., a hub run blocks any institution-level run inside that hub. `force=true` (GH-Actions-manual-only — the Lambda never sets it) kills offending sessions instead of aborting.
+5. **Updates EC2 source code.** Clones `dpla/ingest-wikimedia` at `GITHUB_SHA` into `/tmp` and `cp -r`s `ingest_wikimedia/`, `tools/`, `pyproject.toml`, `uv.lock` onto the EC2 install, then runs `uv sync`. The EC2 install is an editable install, so updated source files take effect immediately.
+6. **Builds the pipeline shell script.** Each target becomes a `cd <base> && get-ids-es ... && downloader ... && uploader ... && sdc-sync ... || { notify_pipeline_fail; }` block; the blocks are joined with `; ` so one target's failure doesn't abort the batch (only the `&&` chain inside one target).
+7. **Launches the tmux session via SSM.** The script is base64-encoded, written to `/tmp/wm-pipeline-<sha1>.sh` on EC2, then started under `tmux new-session -d -s <session_name> -c <cwd> 'bash <script>'`. Base64 avoids SSM's command-length cap (~25 KB) and shell-metacharacter escaping issues — large batches of 20+ targets hit the cap before this change.
+8. **Posts a launch confirmation** to #tech-alerts.
+
+### Step 4 — EC2 execution
+
+The tmux session runs detached. For each target block, `bash` exports `WIKIMEDIA_SESSION_LABEL`, `WIKIMEDIA_PARTNER_DIR`, `WIKIMEDIA_TARGET_IS_LAST`, and (for single-item targets) `WIKIMEDIA_SINGLE_ITEM`. These env vars are read by the Slack-notification helpers inside the Python phase tools so completion / failure messages identify the right target.
+
+Phase output is logged to `<partner_dir>/logs/<timestamp>-<label>-<phase>.log` (download / upload / sdc). The status workflow's progress derivation tails these logs.
+
+## Target resolution
+
+`/wikimedia-upload` accepts five target forms, mixed freely on the same command:
+
+| Form | Example | Resolves to |
+|---|---|---|
+| Hub slug | `bpl` | One full-hub target |
+| Hub alias | `ma`, `mass` (= `bpl`) | One full-hub target, slug normalised |
+| `hub\|institution` | `"indiana\|Indiana State Library"` | One institution-level target |
+| `hub\|institution\|collection` | `"indiana\|Indiana State Library\|Cushman Photographs"` | One collection-level target |
+| Wikidata QID | `Q72380652` | One or more targets, looked up in `institutions_v2.json` |
+| DPLA item ID | `06b558045c5fd4cc5dc697248272159a` | One single-item target (32-hex) |
+
+**Wikidata QID resolution.** `partners.resolve_wikidata_id(qid)` walks every hub in `institutions_v2.json` and returns every match — a QID at hub level becomes a full-hub target; a QID at institution level becomes an institution-level target; a QID matching multiple institutions inside the same hub becomes one combined target with all matching institution names ORed in the ES filter. If a QID matches *both* a hub and one of its own institutions (e.g. an institution that runs its own hub), the hub-level scope wins and the per-institution matches are discarded as strictly narrower.
+
+**DPLA ID resolution.** DPLA IDs are batched into a single SSM call to `tools/resolve_dpla_ids.py`, which does one ES `terms` query and applies the eligibility filter (banlist, `rightsCategory == "Unlimited Re-Use"`, has-media, hub resolves, institution upload-eligible). Eligible IDs become single-item targets and get re-staged through `get-ids-es --single-id <id>` so their `dpla-map.json` and `sdc.json` reflect the latest mapping code before the downstream phases run.
+
+**Collection-level QIDs are not supported.** The QID resolver only walks hub and institution Wikidata fields. To target a collection, use the explicit `hub|institution|collection` triple syntax.
+
+## Session naming and concurrency
+
+The tmux session name is `wikimedia-<label1>+<label2>+...` where each `<label>` is:
+
+- Hub-level → `<canonical-slug>`
+- Institution-level → `<hub>+<institution-slug>`
+- Collection-level → `<hub>+<institution-slug>+<collection-slug>`
+- Single-item DPLA ID → `<hub>+<first8hex>`
+- Multi-institution QID resolving to N institutions → `<hub>+<first-slug>-and-N-more`
+
+Slugification (`partners.slugify_session_label_component`) lowercases, replaces spaces with `-`, and strips everything outside `[a-z0-9-]`. Both the launch script and `wikimedia_kill.py` import this same function so the kill matcher and launch labeler stay in sync.
+
+Session conflict rules:
+
+- **Hub-level requests** conflict with any active session whose label is the canonical slug or starts with `<canonical>+`.
+- **Institution-level requests** conflict with hub-level for the same hub, with an exact-label match, or with collection-level sessions under the same institution.
+- **Collection-level requests** conflict with hub-level for the same hub, with the institution-level parent, or with an exact-triple match.
+- **Single-item DPLA IDs** conflict only with a hub-wide session for the same hub or an exact-duplicate single-item label.
+
+GitHub Actions concurrency keys layer over the SSM-level conflict detection. The Lambda passes `concurrency_key = sha256(shlex.join(targets))[:16]`; two identical dispatches collapse to the same group and queue. Different targets get different keys and run in parallel inside the workflow (the EC2-side conflict check is what serialises them if needed).
+
+## Failure semantics
+
+Inside a target block, steps are chained with `&&` — any step failing aborts that target's remaining steps and triggers the `||` failure handler. The handler runs `notify_pipeline_fail()` from `ingest_wikimedia.slack`, which reads `WIKIMEDIA_LAST_EXIT` and posts a #tech-alerts message including:
+
+- The exit-code hint table: 137 → SIGKILL (likely OOM), 143 → SIGTERM, 139 → SIGSEGV, 134 → SIGABRT, 130 → SIGINT, anything else > 128 reported as `signal {rc-128}`.
+- The latest log path (located by `_find_latest_log` globbing `<partner_dir>/logs/*-<label>-*.log` and picking the most-recent mtime).
+- A four-marker count from `_summarize_log` (uploads / skips / downloads / failures).
+- The last 8 lines of the log in a fenced code block.
+
+Between target blocks the separator is `;` (not `&&`), so a failed target does *not* abort the batch — `notify_pipeline_fail` posts, then the next target's `&&` chain begins fresh. `WIKIMEDIA_TARGET_IS_LAST=1` controls the suffix wording (`no further targets in batch` vs `skipping to next target`).
+
+The downloader and uploader also handle per-item failures internally; they only let the phase fail if something catastrophic happens (e.g. ES timeout, AWS credentials missing). Most "this item didn't work" outcomes are caught and counted in `Result.FAILED` without aborting the phase.
+
+## Component map
+
+| Component | Path | Responsibility |
+|---|---|---|
+| Slack-dispatch Lambda | `lambda/wikimedia-slack-dispatch/handler.py` | Validate Slack signature, route subcommands, fire `workflow_dispatch` |
+| Launch script | `scripts/wikimedia_launch.py` | Target resolution, EC2 health checks, conflict detection, tmux launch |
+| Kill script | `scripts/wikimedia_kill.py` | List + kill matching `wikimedia-*` tmux sessions |
+| Retry script | `scripts/wikimedia_retry.py` | Parse logs for retryable failures, build per-hub retry CSVs |
+| Status script | `scripts/wikimedia_upload_status.py` | Read latest logs, derive phase + progress, post status |
+| ID enumeration | `tools/get_ids_es.py` (general) / `tools/get_ids_nara.py` (NARA) | Query ES, stage `dpla-map.json` + `sdc.json` |
+| Single-item resolver | `tools/resolve_dpla_ids.py` | One ES batch query + eligibility check + stage |
+| Download | `tools/downloader.py` | Iterate IDs, download media (mediaMaster / IIIF), stage to S3, write `file-list.txt` + `iiif.json` |
+| Upload | `tools/uploader.py` | Iterate IDs, upload from S3 to Commons, resolve hash drift, write `upload-result.json` |
+| SDC sync | `tools/sdc_sync.py` | Read sidecars, post atomic per-file `wbeditentity` to Commons MediaInfo |
+| Partner registry | `ingest_wikimedia/partners.py` | Hub slugs, aliases, eligibility lookup, slugification, parsing |
+| ES client | `ingest_wikimedia/es.py` | Validated `post_es`, hard timeout, partial-response guards |
+| S3 client | `ingest_wikimedia/s3.py` | `dpla-wikimedia` bucket, sidecar paths, get/put helpers |
+| SSM client | `ingest_wikimedia/ssm.py` | `ssm_run`, `stage_and_launch_tmux` |
+| Slack helpers | `ingest_wikimedia/slack.py` | All `notify_*` functions, `notify_pipeline_fail`, log summariser |
+| Tracker | `ingest_wikimedia/tracker.py` | Per-phase counter set, used in completion messages |
+| SDC builders | `ingest_wikimedia/sdc.py` | `build_claims_for_doc`, P1545 chunking, rights mapping, NARA XML parsing |
+| Wikimedia helpers | `ingest_wikimedia/wikimedia.py` | Title generation, hash-drift handling, CommonsDelinker post |
+| Banlist | `ingest_wikimedia/banlist.py` + `dpla-id-banlist.txt` | Per-DPLA-ID skip list |
+
+The shared library (`ingest_wikimedia/`) is deliberately layered so `partners.py` is stdlib-only — the Lambda only needs that one module and `urllib`, no AWS SDK, no requests, no pywikibot. That keeps the Lambda cold-start fast.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,7 +91,7 @@ This is the bulk of the dispatch logic. In order, it:
 2. **Resolves targets.** QIDs are looked up against `institutions_v2.json` (live-fetched from `github.com/dpla/ingestion3/.../wiki/institutions_v2.json`, module-cached so warm Lambda calls don't refetch). DPLA IDs are batched into one SSM call to `resolve-dpla-ids` on EC2, which does an ES `terms` query and applies the full eligibility filter.
 3. **Checks EC2 memory.** Aborts when available RAM is below 30 %. Each session uses ~300–500 MB on a 7.6 GB instance, so 30 % free leaves room for 4–5 concurrent sessions.
 4. **Detects session conflicts.** Hub-level, institution-level, and collection-level targets define conflict rules so that, e.g., a hub run blocks any institution-level run inside that hub. `force=true` (GH-Actions-manual-only — the Lambda never sets it) kills offending sessions instead of aborting.
-5. **Updates EC2 source code.** Clones `dpla/ingest-wikimedia` at `GITHUB_SHA` into `/tmp` and `cp -r`s `ingest_wikimedia/`, `tools/`, `pyproject.toml`, `uv.lock` onto the EC2 install, then runs `uv sync`. The EC2 install is an editable install, so updated source files take effect immediately.
+5. **Updates EC2 source code.** Clones `dpla/ingest-wikimedia` at `GITHUB_SHA` into `/tmp` and runs `cp -r` over `ingest_wikimedia/`, `tools/`, `pyproject.toml`, `uv.lock` onto the EC2 install, then runs `uv sync`. The EC2 install is an editable install, so updated source files take effect immediately.
 6. **Builds the pipeline shell script.** Each target becomes a `cd <base> && get-ids-es ... && downloader ... && uploader ... && sdc-sync ... || { notify_pipeline_fail; }` block; the blocks are joined with `; ` so one target's failure doesn't abort the batch (only the `&&` chain inside one target).
 7. **Launches the tmux session via SSM.** The script is base64-encoded, written to `/tmp/wm-pipeline-<sha1>.sh` on EC2, then started under `tmux new-session -d -s <session_name> -c <cwd> 'bash <script>'`. Base64 avoids SSM's command-length cap (~25 KB) and shell-metacharacter escaping issues — large batches of 20+ targets hit the cap before this change.
 8. **Posts a launch confirmation** to #tech-alerts.
@@ -100,7 +100,7 @@ This is the bulk of the dispatch logic. In order, it:
 
 The tmux session runs detached. For each target block, `bash` exports `WIKIMEDIA_SESSION_LABEL`, `WIKIMEDIA_PARTNER_DIR`, `WIKIMEDIA_TARGET_IS_LAST`, and (for single-item targets) `WIKIMEDIA_SINGLE_ITEM`. These env vars are read by the Slack-notification helpers inside the Python phase tools so completion / failure messages identify the right target.
 
-Phase output is logged to `<partner_dir>/logs/<timestamp>-<label>-<phase>.log` (download / upload / sdc). The status workflow's progress derivation tails these logs.
+Phase output is logged to `<partner_dir>/logs/<timestamp>-<label>-<phase>.log` (download / upload / sdc). The status workflow tails these logs to derive progress.
 
 ## Target resolution
 

--- a/docs/maintenance-tools.md
+++ b/docs/maintenance-tools.md
@@ -68,7 +68,7 @@ For eligible items: stages the ES document to S3 as `dpla-map.json` with `_stage
 
 Output (one line per ID, parsed by `wikimedia_launch.py`):
 
-```
+```text
 <id> HUB=<slug>            # eligible
 <id> NOT_FOUND
 <id> INELIGIBLE:<reason>
@@ -107,7 +107,7 @@ Walks `s3://dpla-wikimedia/<partner>/images/` looking for objects whose stored c
 
 Used when the original downloader couldn't determine MIME (typically because the source server returned `application/octet-stream`). Once libmagic identifies the actual type, the uploader can pick a sensible file extension.
 
-The companion `MetadataDirective="REPLACE"` rule applies — `Metadata=dict(s3_object.metadata)` is explicitly passed to preserve the `CHECKSUM` field across the copy. See the lesson at `~/.claude/lessons.md` under "AWS S3 `copy_object` with `MetadataDirective="REPLACE"`".
+The companion `MetadataDirective="REPLACE"` rule applies — `Metadata=dict(s3_object.metadata)` is explicitly passed to preserve the `CHECKSUM` field across the copy. `MetadataDirective="REPLACE"` silently drops every metadata field not provided in the request, so any time you re-stamp an S3 object's content-type (or any other system metadata), you have to pass the existing user metadata back through explicitly or you'll lose the SHA1 and break duplicate detection.
 
 ---
 

--- a/docs/maintenance-tools.md
+++ b/docs/maintenance-tools.md
@@ -1,0 +1,204 @@
+# Maintenance Tools
+
+These tools sit alongside the four pipeline phases but are not part of the Slack-launched pipeline chain. They are invoked manually by operators (usually via SSM on EC2) for specific maintenance jobs.
+
+| Tool | Purpose |
+|---|---|
+| [`verify-item`](#verify-item) | End-to-end verification of one DPLA item against S3 + Commons |
+| [`get-incomplete-items`](#get-incomplete-items) | Detect items whose download phase didn't complete |
+| [`resolve-dpla-ids`](#resolve-dpla-ids) | Single-item eligibility check + staging for Slack-driven launches |
+| [`sign`](#sign) | Backfill SHA1 metadata on legacy S3 objects |
+| [`remimer`](#remimer) | Re-detect and fix wrong content-types on S3 objects |
+| [`retirer`](#retirer) | "Retire" ineligible items by zeroing their S3 bytes |
+| [`nuke`](#nuke) | Hard-delete S3 contents for a list of DPLA IDs |
+| [`get-ids-retry`](#get-ids-retry) | Parse logs to build per-hub retry CSVs |
+| [`fix-unknown-categories`](#fix-unknown-categories) | Backfill maintenance categories after partner registry changes |
+
+---
+
+## `verify-item`
+
+Source: `tools/verify_item.py`.
+
+End-to-end consistency checker for one DPLA item. Given `<dpla_id> <partner>`:
+
+1. Reads each ordinal in the item's `file-list.txt` from S3.
+2. For each S3 object: reads `sha1`, size, and content-type from user metadata.
+3. Calls `compute_ordinal_exts_and_page_labels` (the same helper the uploader uses, so titles align exactly) to predict the Commons file title for each ordinal.
+4. Batches `action=query&prop=imageinfo|info&iiprop=sha1` requests against the Commons API (50 titles per batch).
+5. Classifies each ordinal as `CORRECT`, `MISMATCH`, `REDIRECT`, `MISSING`, or `SKIPPED`.
+6. Writes the full per-ordinal report to `/tmp/verify_<dpla_id>.json` for triage.
+
+Exit code 0 only when every uploadable ordinal is `CORRECT`. Used as a deploy-verification probe — runs after a fixed sdc-sync or uploader bug to confirm a known-good item is unaffected.
+
+---
+
+## `get-incomplete-items`
+
+Source: `tools/get_incomplete_items.py`.
+
+Walks `s3://dpla-wikimedia/<partner>/images/` looking for items whose downloader phase didn't complete:
+
+1. For each `file-list.txt`, count the URL lines.
+2. Count the media-file objects in the same folder (excluding `file-list.txt`, `dpla-map.json`, `iiif.json`).
+3. If the two counts differ, print the DPLA ID.
+
+Output is one DPLA ID per line on stdout. Pipe it back into the downloader for a targeted re-download:
+
+```bash
+get-incomplete-items <partner> > <partner>-incomplete.csv
+downloader <partner>-incomplete.csv <partner>
+```
+
+---
+
+## `resolve-dpla-ids`
+
+Source: `tools/resolve_dpla_ids.py`.
+
+Used by `wikimedia_launch.py` for single-item Slack launches (`/wikimedia-upload <dpla-id>`). Takes one or more DPLA IDs on the CLI; does ONE batched ES `terms` query; then per-ID applies the eligibility filter:
+
+- Banlist check against `dpla-id-banlist.txt`.
+- `rightsCategory == "Unlimited Re-Use"`.
+- Has-media (`mediaMaster` / `iiifManifest` / CONTENTdm IIIF URL).
+- Hub resolves to a known slug.
+- Institution is upload-eligible per `institutions_v2.json`.
+
+For eligible items: stages the ES document to S3 as `dpla-map.json` with `_staged_by_get_ids_es: true`.
+
+Output (one line per ID, parsed by `wikimedia_launch.py`):
+
+```
+<id> HUB=<slug>            # eligible
+<id> NOT_FOUND
+<id> INELIGIBLE:<reason>
+<id> ERROR:<msg>
+```
+
+Operators can also call `resolve-dpla-ids` by hand to check eligibility without launching anything.
+
+---
+
+## `sign`
+
+Source: `tools/sign.py`.
+
+Walks `s3://dpla-wikimedia/<partner>/images/` looking for objects with no `CHECKSUM` (SHA1) in user metadata. For each:
+
+1. Downloads the object.
+2. Computes SHA1 + libmagic-detected content-type.
+3. Updates the S3 object in place via `copy_from(MetadataDirective="REPLACE", ContentType=..., Metadata=...)`.
+
+Idempotent — skips objects whose `CHECKSUM` is already set.
+
+Used to backfill SHA1 metadata on items uploaded to S3 before the SHA1-on-write convention was established. The pipeline today writes SHA1 on every download (`downloader.py::upload_file_to_s3`), so `sign` is only needed for legacy backlog.
+
+---
+
+## `remimer`
+
+Source: `tools/remimer.py`.
+
+Walks `s3://dpla-wikimedia/<partner>/images/` looking for objects whose stored content-type is `binary/octet-stream` or `application/octet-stream`. For each:
+
+1. Downloads to a temp file.
+2. Re-detects MIME via `local_fs.get_content_type()` (libmagic).
+3. Writes the detected content-type back to S3 via `copy_object(MetadataDirective="REPLACE", ContentType=detected, CopySource=...)`.
+
+Used when the original downloader couldn't determine MIME (typically because the source server returned `application/octet-stream`). Once libmagic identifies the actual type, the uploader can pick a sensible file extension.
+
+The companion `MetadataDirective="REPLACE"` rule applies — `Metadata=dict(s3_object.metadata)` is explicitly passed to preserve the `CHECKSUM` field across the copy. See the lesson at `~/.claude/lessons.md` under "AWS S3 `copy_object` with `MetadataDirective="REPLACE"`".
+
+---
+
+## `retirer`
+
+Source: `tools/retirer.py`.
+
+"Retires" S3 objects by replacing their body with empty bytes while preserving user metadata. Does NOT delete anything on Commons. The S3 bytes are zeroed (so the bucket stops paying for them) but the metadata footprint stays (so a future audit can tell "this WAS a file at this title with this SHA1").
+
+A file is retired when ANY of these is true:
+
+- The DPLA item is no longer wiki-eligible (banlist, rights change, institution flag toggled).
+- The S3 object has no `CHECKSUM` user-metadata.
+- The content-type is missing or unrecognised.
+- `mimetypes.guess_extension(mime)` returns nothing usable.
+- BOTH a file with this SHA1 exists on Commons AND a Commons page exists at the expected title (i.e. successful upload — we don't need the S3 master anymore).
+
+Entry: `python -m tools.retirer <partner> [--dry-run]`. Always run with `--dry-run` first to confirm the candidate list.
+
+---
+
+## `nuke`
+
+Source: `tools/nuke.py`.
+
+42 lines. Takes an IDs file and a partner; for each DPLA ID runs:
+
+```bash
+aws s3 rm s3://dpla-wikimedia/<partner>/images/<a>/<b>/<c>/<d>/<dpla_id>/ --recursive
+```
+
+(Path built via `S3Client.get_item_s3_path`.) Used for hard purges — typically after a partner is removed from `institutions_v2.json` entirely, or a contractual takedown. `--dry-run` appends `--dryrun` to the underlying `aws s3 rm` call so the deletion is previewed without taking effect.
+
+Distinct from `retirer`: nuke hard-deletes everything (sidecars, media, metadata); retirer only zeroes the body and only on ineligibility / completion criteria.
+
+---
+
+## `get-ids-retry`
+
+Source: `tools/get_ids_retry.py`. Invoked by `scripts/wikimedia_retry.py` (which is triggered by `/wikimedia-upload retry`).
+
+Parses recent upload + download logs and classifies failures into two retry types:
+
+### `upload-retry`
+
+Matches against `UPLOAD_TRANSIENT_ERRORS`:
+
+- `lockmanager-fail-conflict`
+- `stashfailed: Could not acquire lock`
+- `uploadstash-exception`
+- `backend-fail-internal`
+- `File linked to another page`
+- `ArticleExistsConflictError`
+- `fileexists-shared-forbidden`
+
+For these, S3 is already complete — just re-run the uploader.
+
+### `download-retry`
+
+Matches `Failed downloading <url>` patterns, excluding the empty-URL IIIF-parser bug fixed in PR #180.
+
+For these, the S3 bytes are absent — re-run the downloader with `--max-age-days 1` to force a re-fetch of any partial / stale state.
+
+### Output
+
+One CSV per partner per type to `--output-dir` (default `<INGEST_WIKIMEDIA_DIR>/retry/`). Logs are processed oldest-first per partner so a later clean run can supersede an earlier failure for the same item.
+
+The retry script merges upload-retry + download-retry CSVs per hub into one combined `<slug>-retry-<days>d-combined.csv` and runs the uploader once on the combined list, so an operator sees one "Retry Complete" summary per hub instead of one-per-type.
+
+---
+
+## `fix-unknown-categories`
+
+Source: `tools/fix_unknown_categories.py`.
+
+Walks Commons looking for files in `Category:Media contributed by the Digital Public Library of America with unknown partner` or `... with unknown institution` — files where the Lua module couldn't resolve a hub or institution category from SDC. For each, attempts to re-resolve against current `institutions_v2.json` mappings and writes the corrected categories back via wikitext edit.
+
+Used after a major `institutions_v2.json` change (new hub added, institution moved between hubs, partner names normalised) to clean up the maintenance categories that accumulated under the old mappings.
+
+---
+
+## Where these tools run
+
+All maintenance tools are typically invoked on EC2 via SSM, from the partner's working directory:
+
+```bash
+# Example: dry-run retire for bpl
+aws ssm send-command \
+  --instance-ids i-033eff6c8c168f999 \
+  --document-name AWS-RunShellScript \
+  --parameters 'commands=["sudo -u ec2-user bash -lc \"cd /home/ec2-user/ingest-wikimedia/bpl && uv run python -m tools.retirer bpl --dry-run\""]'
+```
+
+No Slack slash command exists for any of these — they're considered "operator-level" maintenance, and the operational friction of going through SSM is intentional.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,125 @@
+# Metrics
+
+A separate, scheduled workflow tracks monthly pageview metrics for DPLA-uploaded files on Wikimedia Commons. This is independent of the ingest pipeline — it does not upload, does not move files, and does not call any of the four pipeline phases.
+
+## Overview
+
+```text
+[scheduled cron / manual trigger]
+        │
+        ▼
+┌─────────────────────────────────┐
+│  GitHub Actions                 │
+│  .github/workflows/cim-...yml   │
+└────────────────┬────────────────┘
+                 │
+                 ▼
+        ┌────────────────┐
+        │  CIMviews.py   │ (pywikibot bot, user "DPLA bot")
+        └────────┬───────┘
+                 │
+        ┌────────┴────────┐
+        ▼                 ▼
+ Wikimedia REST     Commons "Data:" pages
+ (pageview API)     Data:Views/<category>.tab
+                    Data:Views/<category>.chart
+                              │
+                              ▼
+                  GitHub-Pages site (metrics/)
+                  reads Data: pages client-side,
+                  renders Google Charts
+```
+
+## The bot: `metrics/cim-pageviews/CIMviews.py`
+
+A pywikibot script with two modes selected via `--mode`:
+
+### `--mode data` (default)
+
+For every Commons category that transcludes `{{views from category}}`:
+
+1. Walks `Category:Category with page views table` to enumerate target categories (removing the maintenance subcategory `Category:Category page views need to be updated`).
+2. Calls the Wikimedia Commons-Impact-Metrics REST endpoint:
+   ```
+   https://wikimedia.org/api/rest_v1/metrics/commons-analytics/pageviews-per-category-monthly/<category>/deep/all-wikis/00000101/99991231
+   ```
+   This returns monthly pageview counts for every wiki that ever displayed a file in the category.
+3. Writes two pages on Commons per category:
+   - **`Data:Views/<category>.tab`** — a `jsondata` page with a declared schema (two columns: timestamp + pageviews) and one row per month.
+   - **`Data:Views/<category>.chart`** — a chart definition referencing the `.tab` page.
+4. Calls `category.touch()` on the source category so dependent templates re-render with the new data.
+
+### `--mode categories`
+
+Walks `Category:Category requested for Commons Impact Metrics`. For categories now in the Wikimedia "category allow list" (fetched live from the Airflow DAGs repo at `gitlab.wikimedia.org`), removes the request as fulfilled. For categories not yet in the allow list, adds the request via the standard `{{Commons Impact Metrics request}}` template — unless a request is already pending.
+
+In effect: `data` mode publishes the numbers; `categories` mode manages the queue of categories that *should* have numbers published.
+
+## The workflow: `.github/workflows/cim-pageviews.yml`
+
+Triggers:
+
+```yaml
+on:
+  schedule:
+    - cron: "0 8 * * *"        # daily 08:00 UTC → categories mode
+    - cron: "0 8 1,7 * *"      # 1st and 7th of every month → data mode
+  workflow_dispatch:
+    inputs:
+      mode: { default: data, type: choice, options: [data, categories] }
+```
+
+Two jobs (`categories`, `data`), each gated by the matching trigger:
+
+- **`categories`** runs on the daily 08:00 cron (and on manual dispatch with `mode=categories`). 60-minute timeout.
+- **`data`** runs on the monthly 1st/7th cron (and on manual dispatch with `mode=data`). 120-minute timeout.
+
+Both jobs do the same setup:
+
+1. Checkout the repo.
+2. Install Python via `actions/setup-python`.
+3. Install `uv`; run `uv sync --no-dev`.
+4. Build `metrics/cim-pageviews/user-password.py` at runtime via a HEREDOC, embedding `BotPassword('PARTNER_UPLOADS', '<secret>')` where `<secret>` is `secrets.PYWIKIBOT_PASSWORD`. (The committed `user-config.py` references this file but doesn't contain the secret.)
+5. Run `python metrics/cim-pageviews/CIMviews.py --mode <mode>` with `PYWIKIBOT_DIR=metrics/cim-pageviews`.
+
+Permissions: `contents: read`. The bot's edits to Commons happen via pywikibot's own auth flow, not GitHub's permissions.
+
+## The site: `metrics/`
+
+`metrics/index.html` is the landing page of a small Jekyll site published via GitHub Pages on this repo. Layout: `jekyll-theme-cayman`, with `_includes/head-custom.html` wiring favicon links from `assets/favicons/`.
+
+The page does no server-side work; everything is client-side JS in `metrics/metrics.js`:
+
+1. Loads Google Charts via `https://www.gstatic.com/charts/loader.js`.
+2. Fetches the Wikimedia category-allow-list TSV from GitLab (`https://gitlab.wikimedia.org/api/v4/projects/repos%2Fdata-engineering%2Fairflow-dags/repository/files/main%2Fdags%2Fcommons%2Fcommons_category_allow_list.tsv/raw?ref=main`).
+3. Populates a `<datalist>` autocomplete from that TSV.
+4. URL modes:
+   - `?show=all` — every category in the allow list with pageview data.
+   - `?show=dpla` — only categories under the DPLA umbrella (walks Commons' category hierarchy from `Category:Media contributed by the Digital Public Library of America` → hubs → contributing institutions).
+   - `?show=<category>` — a single named category.
+   - `?hub=<name>` — every contributing institution within one DPLA hub.
+5. For each rendered category, fetches the `Data:Views/<category>.tab` JSON page from Commons via the standard MediaWiki API and renders a Google Chart from the monthly series.
+
+A pre-paint inline script (`metrics/index.html` line 11) sets a `.filter-view` class on `<html>` when the URL has a `show` or `hub` parameter — this lets CSS hide the input form without a flash-of-unstyled-content.
+
+There is no server-side state. The bot publishes `Data:` pages on Commons; the GitHub Pages site fetches them client-side. The two systems are decoupled — a change to either doesn't break the other as long as the `Data:Views/<category>.tab` JSON schema stays stable.
+
+## Why this is separate from the ingest pipeline
+
+The metrics system is operationally and architecturally distinct:
+
+- **Different trigger.** Cron / manual dispatch, never Slack.
+- **Different EC2 footprint.** None. CIMviews runs entirely inside the GitHub Actions runner; no SSM, no tmux.
+- **Different secrets.** Uses `PYWIKIBOT_PASSWORD` (the DPLA bot's pywikibot bot-password), not the ingest pipeline's AWS / Slack tokens.
+- **Different cadence.** Daily (categories) and monthly (data), versus on-demand for the ingest pipeline.
+- **Different output channel.** Commons `Data:` pages, not S3.
+- **Decoupled audience.** Operators don't need to be aware of the metrics system to run the ingest pipeline; metrics consumers (Commons editors looking at pageview data) don't need to know about ingest.
+
+The only connection is the bot identity (`User:DPLA bot`), and `dpla-id-banlist.txt` / `rights.json` are not consulted by the metrics workflow.
+
+## Operations
+
+- **Adding a category** — edit `Category:Category requested for Commons Impact Metrics` on Commons with the `{{Commons Impact Metrics request}}` template. The daily `categories` job will surface it and the next monthly `data` job will publish numbers for it.
+- **Removing a category** — remove `{{views from category}}` from its category page; the next `data` job will stop touching it. The Commons `Data:Views/<category>.tab` and `.chart` pages can be deleted manually if desired.
+- **Manual catch-up after a data outage** — trigger the workflow manually with `mode=data` (admin-only via GitHub Actions UI). The 120-minute timeout is sized for the full category set.
+- **Bot password rotation** — rotate `PYWIKIBOT_PASSWORD` in the repo's secret store. No code change needed.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -40,7 +40,8 @@ For every Commons category that transcludes `{{views from category}}`:
 
 1. Walks `Category:Category with page views table` to enumerate target categories (removing the maintenance subcategory `Category:Category page views need to be updated`).
 2. Calls the Wikimedia Commons-Impact-Metrics REST endpoint:
-   ```
+
+   ```text
    https://wikimedia.org/api/rest_v1/metrics/commons-analytics/pageviews-per-category-monthly/<category>/deep/all-wikis/00000101/99991231
    ```
    This returns monthly pageview counts for every wiki that ever displayed a file in the category.
@@ -51,7 +52,7 @@ For every Commons category that transcludes `{{views from category}}`:
 
 ### `--mode categories`
 
-Walks `Category:Category requested for Commons Impact Metrics`. For categories now in the Wikimedia "category allow list" (fetched live from the Airflow DAGs repo at `gitlab.wikimedia.org`), removes the request as fulfilled. For categories not yet in the allow list, adds the request via the standard `{{Commons Impact Metrics request}}` template — unless a request is already pending.
+For categories tracked by `{{views from category}}` but NOT yet in the Wikimedia "category allow list" (fetched live from the Airflow DAGs repo at `gitlab.wikimedia.org`), the bot appends `[[Category:Category requested for Commons Impact Metrics]]` directly to the category page's wikitext via `category.save(...)`. Categories that ARE on the allow list get the same tracking category *removed* via `category.change_category(cimcat, None, ...)` — so `Category:Category requested for Commons Impact Metrics` becomes a self-cleaning queue of pending requests. The bot skips a category whose wikitext already carries the request tag, so re-runs don't duplicate.
 
 In effect: `data` mode publishes the numbers; `categories` mode manages the queue of categories that *should* have numbers published.
 
@@ -77,10 +78,10 @@ Two jobs (`categories`, `data`), each gated by the matching trigger:
 Both jobs do the same setup:
 
 1. Checkout the repo.
-2. Install Python via `actions/setup-python`.
-3. Install `uv`; run `uv sync --no-dev`.
+2. Install `uv` via `astral-sh/setup-uv`.
+3. Run `uv python install` to provision the Python interpreter `uv` will use, then `uv sync --no-dev` to install dependencies.
 4. Build `metrics/cim-pageviews/user-password.py` at runtime via a HEREDOC, embedding `BotPassword('PARTNER_UPLOADS', '<secret>')` where `<secret>` is `secrets.PYWIKIBOT_PASSWORD`. (The committed `user-config.py` references this file but doesn't contain the secret.)
-5. Run `python metrics/cim-pageviews/CIMviews.py --mode <mode>` with `PYWIKIBOT_DIR=metrics/cim-pageviews`.
+5. Run the bot under `uv run`: `uv run python metrics/cim-pageviews/CIMviews.py` (data job, default mode) or `uv run python metrics/cim-pageviews/CIMviews.py --mode categories` (categories job), with `PYWIKIBOT_DIR=metrics/cim-pageviews` exported.
 
 Permissions: `contents: read`. The bot's edits to Commons happen via pywikibot's own auth flow, not GitHub's permissions.
 
@@ -98,11 +99,11 @@ The page does no server-side work; everything is client-side JS in `metrics/metr
    - `?show=dpla` — only categories under the DPLA umbrella (walks Commons' category hierarchy from `Category:Media contributed by the Digital Public Library of America` → hubs → contributing institutions).
    - `?show=<category>` — a single named category.
    - `?hub=<name>` — every contributing institution within one DPLA hub.
-5. For each rendered category, fetches the `Data:Views/<category>.tab` JSON page from Commons via the standard MediaWiki API and renders a Google Chart from the monthly series.
+5. For each rendered category, calls the same Wikimedia Commons-Impact-Metrics REST endpoint the bot writes from (`wikimedia.org/api/rest_v1/metrics/commons-analytics/pageviews-per-category-monthly/<category>/deep/all-wikis/00000101/99991231`) and renders a Google Chart from the monthly series in the response.
 
 A pre-paint inline script (`metrics/index.html` line 11) sets a `.filter-view` class on `<html>` when the URL has a `show` or `hub` parameter — this lets CSS hide the input form without a flash-of-unstyled-content.
 
-There is no server-side state. The bot publishes `Data:` pages on Commons; the GitHub Pages site fetches them client-side. The two systems are decoupled — a change to either doesn't break the other as long as the `Data:Views/<category>.tab` JSON schema stays stable.
+The frontend and the bot read the same REST API, but they're decoupled: the bot writes Commons `Data:Views/<category>.tab` / `.chart` pages so other on-wiki templates and tools can consume the monthly series without hitting the REST endpoint themselves, while this site goes direct to the REST endpoint for freshness. A change to either side doesn't break the other as long as the REST response schema is stable.
 
 ## Why this is separate from the ingest pipeline
 

--- a/docs/pipeline-phases.md
+++ b/docs/pipeline-phases.md
@@ -1,0 +1,192 @@
+# Pipeline Phases
+
+Four sequential phases per target. All four are idempotent — re-running picks up where it left off. All four operate per-partner, reading and writing under `s3://dpla-wikimedia/<partner>/images/<sharded-prefix>/<dpla-id>/` (see [sidecars.md](sidecars.md) for the path layout and file inventory).
+
+```
+get-ids-es  →  downloader  →  uploader  →  sdc-sync
+   ▼              ▼            ▼              ▼
+dpla-map.json   media bytes   Commons         MediaInfo
+sdc.json        file-list.txt upload-         statements
+                iiif.json     result.json
+```
+
+## 1. `get-ids-es` — ID enumeration & metadata staging
+
+Source: `tools/get_ids_es.py`.
+
+**Inputs.** A partner slug (required), plus optional `--institution NAME` (repeatable), `--collection NAME` (requires exactly one `--institution`), or `--single-id <id>` (mutually exclusive with the other two).
+
+**What it does.**
+
+1. Resolves the hub display name via `PARTNER_HUBS[partner]`.
+2. Loads upload-eligible institution names from `institutions_v2.json` (live-fetched from `dpla/ingestion3`). An institution is eligible iff both its hub and itself have non-empty Wikidata QIDs and at least one of them has `upload: true`. Per-name keys, not per-QID, so two name variants pointing at the same QID can carry independent flags.
+3. Paginates the `dpla_alias` Elasticsearch index with `search_after` (size 500, sort `["id", "_doc"]`), applying:
+   - `provider.name.not_analyzed == <hub-name>`
+   - `rightsCategory == "Unlimited Re-Use"`
+   - `dataProvider.name.not_analyzed in <eligible-names>` (skipped under `--single-id`)
+   - asset gate: `mediaMaster` exists OR `iiifManifest` exists OR `isShownAt` matches a CONTENTdm IIIF-derivable wildcard
+   - banlist check against `dpla-id-banlist.txt`
+4. For CONTENTdm items with no `mediaMaster` and no `iiifManifest`, derives the IIIF manifest URL from `isShownAt` and patches it into the document as `iiifManifest`.
+5. Stamps `_staged_by_get_ids_es: true` on every document so the downloader can refuse to operate on legacy unstaged metadata.
+6. Stages each document to S3 as `dpla-map.json` via a `ThreadPoolExecutor` (max 10 workers, bounded semaphore of 40 in-flight tasks to bound memory).
+7. Echoes the DPLA ID to stdout — this stream **is** the IDs CSV the downloader consumes (the caller redirects it).
+8. **Phase 3 — `sdc.json` pre-compute.** After enumeration, re-reads each item's `dpla-map.json` from S3 (not from in-memory state, to keep peak RAM at O(unique-subjects) rather than O(hub-size)), runs `build_claims_for_doc()` from `ingest_wikimedia/sdc.py`, and stages the resulting `{"claims": [...]}` envelope to S3 as `sdc.json`. Items whose provider/dataProvider don't resolve into `institutions_v2` are skipped at this step silently — their `dpla-map.json` is still written so the downloader/uploader can proceed; only the SDC phase will be a no-op.
+
+**Reliability features.**
+
+- `SIGALRM`-based 120 s hard wall-clock timeout on every ES request (`requests.timeout=30` cannot catch stalled mid-response reads).
+- `check_es_response()` rejects any response with `timed_out=true` or `_shards.failed > 0` so a 200-OK partial response cannot silently terminate a `search_after` paginator.
+- Bounded-semaphore-protected S3 writes so the worker pool's task queue doesn't OOM on a 100 K-item hub.
+
+**Flags.** No `--dry-run` or `--max-records`. To bound a run, redirect stdout to a temporary CSV and `head` it. Pre-flight Slack notification fires from `notify_phase_start("get-ids-es")`.
+
+### NARA's special enumerator (`tools/get_ids_nara.py`)
+
+The general `get-ids-es` enumeration would never complete on NARA's 18M+-item hub under hub-wide pagination. `tools/get_ids_nara.py` replaces it for NARA with five priority strategies executed sequentially (smallest first, with cross-strategy dedup):
+
+1. **Format** — `terms` on `sourceResource.format` for every bucket below 12,000 items, batched 6 per query.
+2. **mediaMaster extension** — `regexp` on `mediaMaster` matching `.+\.(mp3|mpg|png|gif|wav)`.
+3. **Identifier** — `regexp` on `sourceResource.identifier` matching `[0-9]{1,6}` (≤ 6-digit numerics).
+4. **Collection** — currently disabled; will re-enable once the first three phases complete. Excludes high-volume top-level collections by prefix and substring.
+5. **Language** — `terms` on `sourceResource.language.name` excluding English, batched 10 per query.
+
+After enumeration, NARA runs the same Phase 2 (Wikidata reconciliation of `exactMatch` subjects) and Phase 3 (`sdc.json` staging) as the general enumerator.
+
+NARA cannot be launched from Slack — it's a hand-managed batch process.
+
+### Single-item mode
+
+`get-ids-es <partner> --single-id <id>` does one ES `term` query (size 2 to make the defensive "expected exactly one hit" check reachable), bypasses hub-eligibility filtering (the caller is presumed to have eligibility-checked via `resolve-dpla-ids`), and stages the single document's sidecars. Used by `/wikimedia-upload <dpla-id>` flows to re-stage sidecars with current mapping code before downstream phases run.
+
+## 2. `downloader` — media → S3
+
+Source: `tools/downloader.py`.
+
+**Inputs.** `<ids.csv> <partner>` plus optional `--max-age-days N` (default 365), `--notify-complete`, `--overwrite`, `--dry-run`, `--verbose`, `--sleep`.
+
+**What it does.**
+
+1. Reads the IDs CSV.
+2. For each item: reads `dpla-map.json` from S3. **Refuses** to operate if the document lacks `_staged_by_get_ids_es: true` — legacy unstaged metadata is no longer supported. Operator must re-run `get-ids-es`.
+3. Chooses between `mediaMaster` (direct list of media URLs) and `iiifManifest` (fetch + parse). For IIIF: fetches the manifest, walks v2 or v3 to produce per-canvas image-API URLs (full-size, not tiles), stages the manifest to `iiif.json`, and writes the URL list to `file-list.txt`.
+4. For each media URL (1-indexed ordinal): downloads to a temp file, then uploads to `s3://dpla-wikimedia/<partner>/images/<a>/<b>/<c>/<d>/<dpla_id>/<ordinal>_<dpla_id>`. The S3 object's user-metadata is stamped with the SHA1 in the `CHECKSUM` field.
+
+**Idempotency and refresh.**
+
+- `s3_file_exists()` treats any S3 object with `content_length == 0` as **absent** so corrupted stubs get re-attempted automatically.
+- `--max-age-days N` re-downloads keys with `last_modified` older than N days, used for refresh sweeps.
+- `--overwrite` forces unconditional re-download.
+- Default behaviour: skip a file if it already exists in S3 with non-zero length.
+
+**Defence-in-depth against silent corruption.**
+
+- `download_file_to_temp_path()` tracks `bytes_written` and raises if the HTTP response yielded 0 bytes — defends against the case where `requests` returns 200 OK with an empty body, which would otherwise plant a 0-byte stub.
+- `upload_file_to_s3()` refuses to upload any 0-byte local file.
+- When re-uploading the same key with metadata changes (e.g. content-type fix), it uses `s3.copy_object(MetadataDirective="REPLACE", Metadata=dict(s3_object.metadata))` — the explicit `Metadata=` is load-bearing because `REPLACE` silently drops every metadata field not provided. An earlier version lost the `CHECKSUM` metadata via this exact bug; a lesson note captures it.
+
+**Error handling.**
+
+| Failure | Behaviour |
+|---|---|
+| 404 / 5xx during download | Per-ordinal `Result.FAILED`; per-item processing continues |
+| NARA `https/` malformed-scheme URLs | Repaired in place (add the missing colon) |
+| Disallowed MIME / octet-stream / download-only | `Result.SKIPPED`; per-item continues |
+| IAM credential blip | `CredentialRetrievalError` retry loop (up to 3 attempts) |
+| 0-byte response | Raise + per-item continue |
+
+**Output.** A per-item summary line `Item <dpla_id>: N ordinals (skipped=..., fetched=..., refreshed=..., rejected=..., failed=...)`, plus a phase-end `COUNTS:` block of `tracker.py` counters.
+
+`--notify-complete` is set by the `refresh_only` run mode so the refresh-style sweeps post their own `Wikimedia Download Refresh Complete:` Slack summary at the end. During a normal `get-ids-es → downloader → uploader → sdc-sync` chain, the downloader is silent — the uploader's completion message subsumes it.
+
+## 3. `uploader` — S3 → Wikimedia Commons
+
+Source: `tools/uploader.py`. The most complex phase.
+
+**Inputs.** `<ids.csv> <partner>` plus optional `--dry-run`, `--verbose`.
+
+**What it does (per item).**
+
+1. Reads `dpla-map.json` and `file-list.txt` from S3.
+2. Computes per-ordinal Commons file titles via `get_page_title()` and `compute_ordinal_exts_and_page_labels()` — see [special-cases.md](special-cases.md#title-generation) for the sanitization rules.
+3. For each ordinal: downloads the S3 object to a temp file, computes (or reads from S3 metadata) its SHA1, and decides how to upload it. The decision tree handles hash drift, redirects, and cross-item collisions — see [special-cases.md](special-cases.md#duplicate-detection-decision-tree) for the four cases.
+4. Composes Wikimedia file-page wikitext via `get_wiki_text()` — currently an `{{Artwork}}` block with `| source = {{DPLA|...}}` and `| Institution = {{Institution|wikidata=...}}` parameters. See [templates.md](templates.md).
+5. Uploads via pywikibot's `site.upload()`. Catches `fileexists-shared-forbidden`, `filetype-badmime`, `filetype-banned`, `duplicate`, `no-change`, `backend-fail-internal` and other Wikimedia errors per the `IGNORE_WIKIMEDIA_WARNINGS` list (which suppresses cosmetic warnings but lets actual conflicts surface).
+6. After the per-ordinal loop, runs a **post-item orphan check**: probes `(page N+1)`, `(page N+2)`, etc. and tags any orphan from a previous run as `{{Duplicate|...}}` if its SHA1 matches a kept ordinal.
+7. Writes `upload-result.json` to S3 with one entry per ordinal (status / title / pageid / error). This sidecar is the SDC phase's source of truth for which Commons pages exist.
+
+**Per-ordinal statuses written to `upload-result.json`.** `UPLOADED`, `SKIPPED`, `NOT_PRESENT`, `INELIGIBLE`, `FAILED`. Only `UPLOADED` and `SKIPPED` are SDC-eligible.
+
+**Critical correctness detail: pageid refresh.** `wiki_file_page.pageid` returns the cached `0` from the pre-upload existence check rather than the just-assigned ID. `process_file` constructs a fresh `FilePage` and forces `.exists()` to refresh `pageid` before persisting (`uploader.py:625-649`). On any failure, `pageid` is set to `None` (not `0`) so `sdc_sync.py`'s `if not pageid` guard cleanly skips malformed entries.
+
+**Output.** Phase-end `COUNTS:` block plus per-item summary lines. A "Retry Complete" Slack message variant fires when the session label starts with `retry-` — the helper folds in download-phase failures so operators see one combined count instead of two confusing messages.
+
+## 4. `sdc-sync` — SDC sync
+
+Source: `tools/sdc_sync.py`. See [sdc-sync.md](sdc-sync.md) for the full SDC deep dive. This section covers the phase's role in the pipeline.
+
+**Inputs.** Partner mode: `--partner <partner> [--ids-file PATH]`. Legacy mode: `--file "File:Title.jpg"` (repeatable) or `--cat <Category>` or `--lists <dir>` (Slack runs never use the legacy mode).
+
+**What it does (partner mode).**
+
+1. Reads the IDs CSV.
+2. For each item: reads `sdc.json`, `upload-result.json`, and `file-list.txt` from S3. Items missing any of these sidecars are skipped (counter `SDC_ITEMS_SKIPPED_NO_SIDECAR`).
+3. Filters to ordinals whose `upload-result.json` status is `UPLOADED` or `SKIPPED`. Computes per-ordinal P304 page numbers via `_compute_page_numbers()` for multi-file extension groups (e.g. items with both jpg and pdf get separate page-number sequences per extension).
+4. For each eligible ordinal: looks up its `download_url` from `file-list.txt` by 1-based index, derives `mediaid = M<pageid>` from `upload-result.json`, then calls `process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url, page_number)`.
+5. Inside `process_one_from_sdc`: walks the staged `sdc.json` claims, runs the `check()` matcher against current Commons-side state, accumulates new claims / qualifier amends / reference updates / removals into per-file lists, then **flushes everything as one `wbeditentity` revision** via `_flush_per_file_edits()`. The previous design (multiple separate `wbsetclaim` / `wbsetqualifier` / `wbremoveclaims` POSTs per file) could leak orphaned stale statements if an intermediate call failed; the consolidated dispatcher is all-or-nothing per file.
+
+**Per-ordinal qualifiers materialised at write time** (not baked into `sdc.json`, because they vary per ordinal):
+
+- P304 (page number) qualifier on P760, only when the ordinal is part of a multi-file extension group.
+- P2699 (URL) qualifier on P7482, with the per-ordinal direct download URL from `file-list.txt`.
+
+**Counters tracked.** `SDC_ITEMS_SYNCED`, `SDC_CLAIMS_ADDED`, `SDC_REFS_ADDED`, `SDC_REMOVALS`, `SDC_ITEMS_SKIPPED_NO_SIDECAR`, `SDC_ITEMS_SKIPPED_MAPPING`, `SDC_ORDINALS_SKIPPED_ERROR`, `SDC_ORDINALS_SKIPPED_MISSING_ENTITY`, `SDC_ITEMS_SKIPPED_ERROR`. The error / mapping / missing-entity split is deliberate — operators need to distinguish bad-data items from bad-network items from upload-never-happened items.
+
+---
+
+## Alternate run modes
+
+`wikimedia-launch.yml` accepts two boolean inputs that swap the default 4-phase chain for a shorter variant. They are mutually exclusive — pick at most one.
+
+### `refresh_only=true`
+
+Chain: `get-ids-es → downloader` only. No uploader, no SDC. The downloader is invoked with `--notify-complete` (and `--max-age-days N` from the workflow input, default 365) so its own Slack summary fires at the end. For re-downloading aged master copies of media files without re-uploading.
+
+### `sdc_only=true`
+
+Chain: `get-ids-es → sdc-sync` only. No downloader, no uploader. The `get-ids-es` step re-stages each item's `sdc.json` from current ingestion3 data; `sdc-sync` then reconciles Commons against that. Used for backfilling or refreshing SDC after pipeline changes.
+
+**Caveat.** Single-item DPLA IDs and NARA hub-level targets do not re-stage `sdc.json` — the former uses `resolve-dpla-ids` (which stages `dpla-map.json` only), the latter uses `get-ids-nara`. For these, `sdc-sync` replays the existing sidecar. The launcher prints a warning to stderr when this combination is detected.
+
+---
+
+## The Tracker
+
+`ingest_wikimedia/tracker.py` is a tiny dict-backed counter, keyed by `Result` enum values. Its `__str__` produces a `COUNTS:` block emitting only keys with `value > 0` so the per-phase output stays clean.
+
+```python
+COUNTS:
+UPLOADED: 1244
+SKIPPED: 312
+FAILED: 3
+BYTES: 4831234567
+```
+
+End-of-phase emission in each phase's `main()`:
+
+```python
+logging.info("\n" + str(tracker))
+notify_*_complete(tracker, partner_label, elapsed, dry_run)
+```
+
+The SDC phase resets the tracker at the start of `_run_partner_mode` so per-partner counts don't accumulate across invocations in the same process.
+
+## Phase-start notifications
+
+`notify_phase_start()` fires from inside each phase's `main()` (the `get-ids-es`, `get-ids-nara`, `downloader`, `uploader`, `sdc-sync` entry points). Suppressed when `WIKIMEDIA_SINGLE_ITEM=1` so single-item runs don't spam channel with per-phase chatter.
+
+| Phase | Emoji | Message |
+|---|---|---|
+| `get-ids-es` | 🔍 | `wikimedia-<label>: starting get-ids-es` |
+| `downloader` | ⬇ | `wikimedia-<label>: starting downloader` |
+| `uploader` | ⬆ | `wikimedia-<label>: starting uploader` |
+| `sdc-sync` | 🔗 | `wikimedia-<label>: starting sdc-sync` |

--- a/docs/pipeline-phases.md
+++ b/docs/pipeline-phases.md
@@ -2,7 +2,7 @@
 
 Four sequential phases per target. All four are idempotent — re-running picks up where it left off. All four operate per-partner, reading and writing under `s3://dpla-wikimedia/<partner>/images/<sharded-prefix>/<dpla-id>/` (see [sidecars.md](sidecars.md) for the path layout and file inventory).
 
-```
+```text
 get-ids-es  →  downloader  →  uploader  →  sdc-sync
    ▼              ▼            ▼              ▼
 dpla-map.json   media bytes   Commons         MediaInfo

--- a/docs/sdc-sync.md
+++ b/docs/sdc-sync.md
@@ -186,6 +186,6 @@ The two fragment builders (`_build_qualifier_update_fragments`, `_build_p813_ref
 
 The hash-preserving merge is what keeps a P2699 backfill from re-stamping every existing P973/P137/P459 qualifier as "changed" — the existing snaks come back with their pre-existing hashes, Wikibase recognises them, and the diff shows only the new P2699 snak.
 
-### Lessons file
+### Regression test
 
-The lesson stored at `~/.claude/lessons.md` under "wbeditentity claim entries must carry `type: "statement"`" captures the broader pattern: any hand-built dict appended to `wbeditentity`'s `data.claims` list that isn't a removal must carry `type: "statement"` AND `mainsnak`. Tests that mock `_submit_sdc_write` don't catch this — the fragment shape must be asserted directly against the payload. The regression test `test_flush_emits_type_statement_on_every_non_removal_fragment` does exactly that for every fragment kind.
+The shape contract — every hand-built dict in `wbeditentity`'s `data.claims` list that isn't a removal must carry `type: "statement"` AND `mainsnak` — is asserted by the regression test `test_flush_emits_type_statement_on_every_non_removal_fragment`. Tests that mock `_submit_sdc_write` don't catch this class of bug because they never inspect the actual payload shape; the regression test exercises a realistic mix of fragment kinds (new claim, qualifier amend, P813 refresh, removal) and asserts both fields are present on every non-removal entry of the bundle. New fragment builders should be added to the same scenario so the contract stays enforced.

--- a/docs/sdc-sync.md
+++ b/docs/sdc-sync.md
@@ -1,0 +1,191 @@
+# SDC Sync
+
+The `sdc-sync` phase reconciles each DPLA-uploaded Commons file's MediaInfo structured data against the per-item `sdc.json` envelope staged by `get-ids-es`. It is the only phase that talks to Commons' Wikibase API directly.
+
+This document covers the *internals* — every property the bot writes, the atomic dispatcher design, idempotency, chunked claims, and known Wikibase API gotchas. For the phase's role in the pipeline, see [pipeline-phases.md](pipeline-phases.md#4-sdc-sync--sdc-sync).
+
+## Table of contents
+
+1. [Entry points](#entry-points)
+2. [The atomic dispatcher](#the-atomic-dispatcher)
+3. [What the bot writes (per property)](#what-the-bot-writes-per-property)
+4. [The canonical reference triple](#the-canonical-reference-triple)
+5. [Idempotency: `check()`](#idempotency-check)
+6. [Chunked claims](#chunked-claims)
+7. [The P813 refresh](#the-p813-refresh)
+8. [Wikibase API gotchas](#wikibase-api-gotchas)
+
+---
+
+## Entry points
+
+```python
+# Partner mode (Slack-launched runs)
+sdc-sync --partner <partner> [--ids-file <path>]
+
+# Legacy modes (operator runs, not used in pipeline)
+sdc-sync --file "File:Title.jpg" [--file "File:Other.jpg" ...]
+sdc-sync --cat <Commons-category> [--recurse] [--limit N]
+sdc-sync --lists <directory-of-txt-files>
+```
+
+**Partner mode** drives off the S3 sidecars only (no `api.dp.la` calls). It iterates the IDs CSV, reads `sdc.json` + `upload-result.json` + `file-list.txt` per item, picks `UPLOADED` / `SKIPPED` ordinals from `upload-result.json`, and calls `process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url, page_number)` per ordinal.
+
+**Legacy mode** builds claims at runtime via `parsed()`, fetching the source document either from S3 (`--from-s3 <partner>`) or from `api.dp.la` directly (one retry on network failure). Calls `process_one(mediaid, dpla_id)`. `--file` is repeatable (pass once per title); `--lists` reads every `.txt` file in a directory as a list of titles. Slack-launched runs never go through this path; it remains supported for one-off operator runs.
+
+Both paths converge on the per-file accumulators + atomic `wbeditentity` dispatcher.
+
+## The atomic dispatcher
+
+`_submit_per_item_edit(mediaid, dpla_id, summary, new_claims=, reference_updates=, qualifier_updates=, removals=)` is the single chokepoint for every SDC write. It accepts four fragment kinds and bundles them into one `wbeditentity` revision:
+
+| Fragment kind | Shape | When emitted |
+|---|---|---|
+| `new_claims` | Full claim dict, no `id` | A property that doesn't yet exist on the file |
+| `reference_updates` | `{id, type, mainsnak, qualifiers, rank, references}` | The P813 refresh (see below) |
+| `qualifier_updates` | `{id, type, mainsnak, qualifiers, rank, references}` | Amending qualifiers on an existing DPLA-authored claim |
+| `removals` | `{id, remove: ""}` | The reconciler decided a stale DPLA claim must go |
+
+**Why "atomic" matters.** The previous design issued five-to-seven separate API calls per file (one `wbeditentity` for new claims, one for references, `wbsetqualifier` per qualifier amend, `wbremovequalifiers` for stale qualifier cleanup, `wbremoveclaims` for reconciler removals). A failure between calls could leak orphaned stale statements onto Commons. The consolidated dispatcher is all-or-nothing per file — the bundle lands as one revision or none of it does.
+
+**Defence-in-depth.** Every non-removal fragment gets `type: "statement"` and `mainsnak` injected if missing — Wikibase rejects the entire bundle with `invalid-claim: Type is missing` or `invalid-claim: Attribute "mainsnak" is missing` otherwise, and atomic semantics mean one malformed fragment drops every other edit on the file. Two PRs (#285, #286) fixed sub-cases where partial-update fragments missed these fields.
+
+**Per-file accumulators** (module-level globals in `tools/sdc_sync.py`):
+
+- `claims["claims"]` — new claims to add.
+- `refclaims["claims"]` — reference attachments to existing claims (used by `check()` when it finds a matching DPLA-authored statement that lacks the reference).
+- `qualifier_amends` — list of `(claimid, prop, snak)` triples for qualifier adds.
+- `qualifier_removals` — list of `(claimid, snak_hash)` for stale qualifier removals.
+- `removals` — list of statement IDs to delete.
+
+`_reset_per_file_accumulators()` clears all five at the start of each `process_one*` call so cross-file state can't leak.
+
+## What the bot writes (per property)
+
+All properties below are defined in `build_claims_for_doc()` (`ingest_wikimedia/sdc.py`) for new uploads and reconciled by `tools/sdc_sync.py` on re-runs.
+
+| Property | Snaktype | Source | Notes |
+|---|---|---|---|
+| **P760** (DPLA ID) | string | `dpla-map.json` `id` | Per-ordinal `P304` qualifier added at sync time for multi-file extension groups |
+| **P1476** (title) | monolingualtext | `sourceResource.title` | Chunked across statements with `P1545` ordinal when value exceeds 1500 chars |
+| **P195** (collection) | wikibase-entityid | institution Q-ID (Smithsonian: hub Q-ID = institution) | |
+| **P170** (creator) | somevalue + `P2093` stated-as | `sourceResource.creator` | Always somevalue + stated-as text qualifier; never a direct entity link |
+| **P571** (inception/date) | time + `P1932` stated-as, or somevalue + `P1932` stated-as | `sourceResource.date` | `parse_dpla_date` extracts a value-typed time when parseable; `P1932` (stated as) qualifier always carries the verbatim source string on both branches. When `parse_dpla_date` flags the value as approximate, a `P1480 = Q5727902` (circa) qualifier is added |
+| **P10358** (description) | monolingualtext | `sourceResource.description` | Chunked across statements |
+| **P9126** (maintained by) | wikibase-entityid (×3 statements) | DPLA Q2944483 + hub Q-ID + institution Q-ID | Each carries an explicit `P3831` (object role) qualifier: publisher / aggregator / contributing institution |
+| **P7482** (described at source catalog) | wikibase-entityid | `isShownAt` URL | `P973` qualifier with the URL; `P6108` qualifier with IIIF manifest URL when valid; per-ordinal `P2699` qualifier added at sync time |
+| **P217** (local identifier) | string + `P195` qualifier | `sourceResource.identifier` | Chunked if needed |
+| **P275** (copyright license) | wikibase-entityid | `rights` URI → Q via `rights.json` | Rights cluster: one of `P275`, `P6216`, or `P6426` |
+| **P6216** (copyright status) | wikibase-entityid | `rights` URI → Q | Rights cluster |
+| **P6426** (rights status as a creator) | wikibase-entityid | `rights` URI → Q | Rights cluster |
+| **P4272** (subject string) | string | `sourceResource.subject[].name` | Always emitted, even when entity reconciliation succeeds |
+| **P921** (main subject) | wikibase-entityid | `sourceResource.subject[].exactMatch` → Wikidata Q-ID | Only when Wikidata reconciliation succeeded in get-ids-es Phase 2 |
+
+**NARA-only** (parsed from the originalRecord XML by `parse_nara_access_level` via stdlib ElementTree since PR #278):
+
+| Property | Snaktype | Meaning |
+|---|---|---|
+| **P1225** (NARA NAID) | string | NARA Authority ID |
+| **P7228** (access level) | wikibase-entityid | Q-ID for the access level |
+| **P6224** (level of description) | wikibase-entityid | Q-ID for the level |
+
+**Per-ordinal qualifiers materialised at write time** (in `process_one_from_sdc`, not baked into `sdc.json`):
+
+- **`P304`** (page number) qualifier on `P760`. Only added when the ordinal belongs to a multi-file extension group within the item (so an item with 3 JPGs and 2 PDFs gets `P304=1,2,3` on the JPG slots and `P304=1,2` on the PDF slots; a 1-JPG-1-PDF item gets no P304).
+- **`P2699`** (URL = download URL) qualifier on `P7482`. The per-ordinal direct download URL from `file-list.txt`, indexed 1-based with an explicit range guard (Python's negative-index would silently corrupt against an off-by-one).
+
+**Legacy-state backfills** (run inside `process_one_from_sdc` against files uploaded before these qualifiers existed):
+
+- `_amend_p7482_url_qualifiers` — looks up the DPLA-authored P7482 statement on Commons, checks for missing `P2699` / `P6108` qualifiers, and queues a qualifier-update fragment if they're absent.
+- `_amend_p760_page_qualifier` — same shape for `P304` on `P760`.
+
+## The canonical reference triple
+
+Every DPLA-authored statement carries the same reference triple:
+
+```json
+{
+  "snaks": {
+    "P854": [<DPLA item URL = https://dp.la/item/<dpla_id>>],
+    "P123": [<Q2944483 = Digital Public Library of America>],
+    "P813": [<retrieval date, precision day>]
+  }
+}
+```
+
+`_is_dpla_reference()` checks for `P123 = Q2944483` to identify "this is OUR reference" later. User-added references on the same claim (which carry different / no P123) are preserved verbatim.
+
+Every DPLA-authored statement also carries a `P459 = Q61848113` (determination method = heuristic) qualifier, so the SDC phase can re-identify "this is OUR claim" on subsequent runs without trusting the reference (which a user could conceivably alter).
+
+## Idempotency: `check()`
+
+`check(mediaid, qid, prop)` is the per-property duplicate-detection gate. Returns `(should_add: bool, ref_claim_id_to_amend: str)`. The four outcomes per property `kind` (`item`, `string`, `monolingualtext`, `somevalue`, `time`, `source`):
+
+1. **Matching no-reference DPLA-shaped statement** found → capture its ID as `ref` (caller will stamp the DPLA reference via `add_ref` and bundle into the dispatcher).
+2. **Matching statement exists without qualifiers** → call `add_det` to stamp the `P459` qualifier; return `False` for add.
+3. **Matching DPLA-shaped statement with qualifiers AND references** → already our write; return `(False, ref)`. No edits queued.
+4. **Matching foreign statement** → return `(True, "")` so the dispatcher adds the DPLA-authored claim alongside without disturbing the foreign one.
+
+`_is_safe_to_amend_in_place()` gates the amend-in-place decision (#1, #2 above): only amends when *every* qualifier and *every* reference on the existing statement is DPLA-authored. That guarantees the wholesale-replace round-trip of `wbeditentity` cannot erase user-added data.
+
+**String and monolingualtext branches** recognise chunked claims by comparing `(value, p1545)` tuples — see below. The bare-add-det branch is restricted to unchunked values (`target_p1545 is None`) because grafting onto an unchunked pre-existing statement would conflate different chunks of the new value.
+
+**Time comparison** uses `_time_claim_comparable` and the canonical `time|precision[|circa]` comparable string from `_extract_comparable_value` — so a `2026-06-01` precision-day claim matches an existing `2026-06-01` precision-day claim regardless of which property they're on.
+
+## Chunked claims
+
+Wikibase enforces a 1500-character cap on `string` and `monolingualtext` values. DPLA descriptions and titles often exceed this. The bot splits long values into per-chunk statements, each carrying a `P1545` (series ordinal) qualifier to preserve ordering.
+
+**The convention:**
+
+- First chunk of the first long value for `(prop, language)`: `P1545 = "A1"`. Second chunk: `"A2"`. Etc.
+- First chunk of the second long value: `"B1"`. `"B2"`. Etc.
+- A non-chunked value (≤ 1500 chars) gets no `P1545` qualifier.
+- Letters wrap `Z` → `AA` → `AB` → … (`_advance_series_letter` handles the rollover; an early version had `Z` → `[` which slipped through tests because no DPLA value had > 26 distinct long-value series in a single language; PR #282 caught it during property-mapping review).
+
+`_chunk_and_emit_claims()` (`sdc.py`) is the chunker. `_normalize_string_value` collapses whitespace before chunking. `_truncate` enforces the 1499-char limit on each chunk (the off-by-one to 1499 avoids edge cases with multi-byte UTF-8 truncation).
+
+**At render time on Commons**, `Module:DPLA` reassembles the chunks by walking the `(prop, P1545)` pairs in order and concatenating their values. See [templates.md](templates.md).
+
+**On re-sync**, `check()` uses `_extract_comparable_value` to compare `(value, p1545)` tuples — so the chunked-statement set is treated atomically. A re-run only writes when the chunks differ from what's on Commons.
+
+## The P813 refresh
+
+When the dispatcher is making *any* other edit on a file, it also refreshes `P813` (retrieved on) on every DPLA-authored claim whose existing P813 isn't already today's date. The idea: when the bot has re-verified a file's metadata against DPLA, every DPLA assertion on the file is effectively "as-of today" — useful provenance for downstream consumers, free inside an edit being made anyway.
+
+`_build_p813_refresh_fragments()`:
+
+1. Computes today's P813 snak via `_build_p813_snak(datetime.date.today())`.
+2. Walks every statement on the file's MediaInfo entity.
+3. Skips statements that are *already* being touched by another fragment (`already_touched_ids` from the dispatcher).
+4. Skips statements with no references.
+5. Per-statement, walks the existing references list: keeps user-added references verbatim, keeps DPLA references whose P813 is already today verbatim, and replaces DPLA references with stale P813.
+6. Emits a `reference_updates` fragment per modified statement — full statement shape (`mainsnak`/`qualifiers`/`rank`/new `references`) because Wikibase's partial-update semantics require it.
+
+**Conditional.** `_build_p813_refresh_fragments` is only invoked when the per-file dispatcher already has other edits to make (`has_any_other_edit`). Files where nothing else changed do *not* generate spurious revisions just to bump P813.
+
+**Cosmetic note on diffs.** When `P813` changes, Wikibase's diff renderer shows the entire reference (URL, publisher, retrieved date) twice — once removed, once added — because reference identity is content-hash, not a stable ID. The data is correct; the diff is just noisy. Switching to `wbsetreference` for in-place reference updates is theoretically possible but would break the atomic-bundle property (separate API calls per refreshed reference) without changing the visual diff in any documented way.
+
+## Wikibase API gotchas
+
+Three rules that caused real production incidents:
+
+### Non-removal fragments must carry `type: "statement"`
+
+Without it, Wikibase rejects the entire bundle with `invalid-claim: Type is missing`. Because the dispatcher is atomic, ONE malformed fragment drops every other edit. The dispatcher backstops this by stamping `type: "statement"` on every non-removal fragment that's missing it.
+
+### Non-removal fragments must carry `mainsnak`
+
+`wbeditentity` treats every non-removal claim entry as a wholesale-replace operation, so the fragment must carry the full statement context (`mainsnak`, `rank`, `qualifiers`, `references`) — not just the field being amended. Partial fragments shaped `{id, type, qualifiers}` or `{id, type, references}` are rejected with `invalid-claim: Attribute "mainsnak" is missing`, and atomicity drops every other edit with them.
+
+The two fragment builders (`_build_qualifier_update_fragments`, `_build_p813_refresh_fragments`) copy `mainsnak` / `rank` / the sibling field from the cached statement so the diff is minimal but the fragment is complete. Deep-copies guard against subsequent helpers mutating shared cache state.
+
+### Qualifier wholesale-replace semantics
+
+`wbeditentity` replaces the entire qualifier set when a `qualifiers` field is included. The dispatcher merges new qualifier snaks with existing qualifier set (preserving snak hashes so Wikibase recognises unchanged snaks and doesn't dirty them in the diff). `_merge_qualifier_snaks` and `_exclude_qualifier_snaks` are the two transform helpers.
+
+The hash-preserving merge is what keeps a P2699 backfill from re-stamping every existing P973/P137/P459 qualifier as "changed" — the existing snaks come back with their pre-existing hashes, Wikibase recognises them, and the diff shows only the new P2699 snak.
+
+### Lessons file
+
+The lesson stored at `~/.claude/lessons.md` under "wbeditentity claim entries must carry `type: "statement"`" captures the broader pattern: any hand-built dict appended to `wbeditentity`'s `data.claims` list that isn't a removal must carry `type: "statement"` AND `mainsnak`. Tests that mock `_submit_sdc_write` don't catch this — the fragment shape must be asserted directly against the payload. The regression test `test_flush_emits_type_statement_on_every_non_removal_fragment` does exactly that for every fragment kind.

--- a/docs/sidecars.md
+++ b/docs/sidecars.md
@@ -2,7 +2,7 @@
 
 The four pipeline phases communicate via JSON / text sidecar files in S3, plus the media bytes themselves. Every sidecar for a DPLA item lives under one prefix:
 
-```
+```text
 s3://dpla-wikimedia/<partner>/images/<a>/<b>/<c>/<d>/<dpla-id>/
 ```
 

--- a/docs/sidecars.md
+++ b/docs/sidecars.md
@@ -1,0 +1,256 @@
+# S3 Sidecars
+
+The four pipeline phases communicate via JSON / text sidecar files in S3, plus the media bytes themselves. Every sidecar for a DPLA item lives under one prefix:
+
+```
+s3://dpla-wikimedia/<partner>/images/<a>/<b>/<c>/<d>/<dpla-id>/
+```
+
+where `<a><b><c><d>` are the first four lowercase hex characters of the DPLA ID. This sharding keeps any one S3 list-objects call to ≤ 4 K items in practice.
+
+Path construction lives in `ingest_wikimedia/s3.py`:
+
+```python
+S3_BUCKET = "dpla-wikimedia"
+
+def get_item_s3_path(dpla_id, filename, partner):
+    return (
+        f"{partner}/images/{dpla_id[0]}/{dpla_id[1]}/"
+        f"{dpla_id[2]}/{dpla_id[3]}/{dpla_id}/{filename}"
+    )
+```
+
+Three special slug-to-directory mappings: `si` (Smithsonian) maps to `smithsonian/` for the local EC2 working directory but the S3 prefix is still `si/`.
+
+## Inventory
+
+| File | Writer | Readers | Content type |
+|---|---|---|---|
+| `dpla-map.json` | `get-ids-es` (and `get-ids-nara`, `resolve-dpla-ids`) | `downloader`, `uploader`, `get-ids-es` Phase 3, `sdc-sync` legacy mode | `application/json` |
+| `sdc.json` | `get-ids-es` Phase 3 (and `get-ids-nara` Phase 3) | `sdc-sync` partner mode | `application/json` |
+| `iiif.json` | `downloader` | (cache; no programmatic reader currently) | `application/json` |
+| `file-list.txt` | `downloader` | `uploader`, `sdc-sync` | `text/plain` |
+| `upload-result.json` | `uploader` | `sdc-sync` partner mode | `application/json` |
+| `<N>_<dpla-id>` | `downloader` | `uploader` (1-indexed media bytes) | (sniffed MIME) |
+
+---
+
+## `dpla-map.json`
+
+The full Elasticsearch `_source` document for the DPLA item, with two pipeline-added markers.
+
+**Writers.**
+
+- `tools/get_ids_es.py` — staged during Phase 1 enumeration.
+- `tools/get_ids_nara.py` — same shape, NARA-only enumerator.
+- `tools/resolve_dpla_ids.py` — for single-item launches.
+
+**Readers.**
+
+- `tools/downloader.py` — refuses to operate if the marker `_staged_by_get_ids_es` is absent.
+- `tools/uploader.py` — reads `dataProvider`, `provider`, `sourceResource.title`, `sourceResource.identifier`, etc. to compose file titles + wikitext.
+- `tools/get_ids_es.py` Phase 3 — re-reads each item's `dpla-map.json` to build `sdc.json`, rather than buffering all source docs in memory (keeps peak RAM at O(unique-subjects) rather than O(hub-size)).
+- `tools/sdc_sync.py` legacy mode (`--from-s3 <partner>` path) — for runs not driven by `--partner`.
+
+**Top-level keys** (DPLA's ES schema):
+
+```text
+id                            DPLA item ID (32-hex)
+provider                      {name, exactMatch, ...}        — hub
+dataProvider                  {name, exactMatch, ...}        — institution
+rightsCategory                "Unlimited Re-Use" for eligible items
+rights                        URI to license / rights statement
+isShownAt                     URL to source-institution catalog page
+sourceResource                {title, subject, date, identifier, description, format, language, collection}
+mediaMaster                   [URL, ...] (when provider exposes direct media)
+iiifManifest                  URL (when provider exposes IIIF; auto-derived for CONTENTdm)
+_staged_by_get_ids_es         true                            — pipeline marker
+ingestType / ingestDate / @context etc.                       — DPLA boilerplate
+```
+
+The `_staged_by_get_ids_es` marker is what the downloader uses to fence off legacy unstaged metadata.
+
+**Lifecycle.** Rewritten on every `get-ids-es` / `get-ids-nara` run. The metadata is treated as ephemeral — there's no archival snapshot.
+
+---
+
+## `sdc.json`
+
+The pre-computed Wikibase claim envelope for the item, ready to feed `wbeditentity`.
+
+**Writer.** `get-ids-es` / `get-ids-nara` Phase 3 (via `staging.stage_sdc_to_s3` → `S3Client.write_item_file`).
+
+**Reader.** `tools/sdc_sync.py::_run_partner_mode`.
+
+**Shape:**
+
+```json
+{
+  "claims": [
+    {
+      "mainsnak": {
+        "property": "P760",
+        "snaktype": "value",
+        "datavalue": {"value": "06b558045c5fd4cc5dc697248272159a", "type": "string"}
+      },
+      "type": "statement",
+      "rank": "normal",
+      "qualifiers": {
+        "P459": [<determination-method snak>]
+      },
+      "references": [
+        {
+          "snaks": {
+            "P854": [<DPLA item URL>],
+            "P123": [<DPLA Q2944483>],
+            "P813": [<retrieval date>]
+          }
+        }
+      ]
+    },
+    ...
+  ]
+}
+```
+
+Every DPLA-authored statement carries the same canonical envelope:
+
+- **Qualifier `P459 = Q61848113`** (determination method = heuristic) on every claim, so the SDC phase can re-identify "this is our claim" later.
+- **Reference triple** on every claim: `P854` (DPLA item URL) + `P123` (publisher = Q2944483, DPLA) + `P813` (retrieval date).
+
+**Properties written** (depends on what the source document carries — see [sdc-sync.md](sdc-sync.md) for the full mapping):
+
+P760 (DPLA ID), P1476 (title), P195 (collection), P170 (creator), P571 (date), P10358 (description), P9126 (maintained by), P7482 (described at source), P217 (local identifier), P275/P6216/P6426 (rights cluster), P4272 + P921 (subjects), plus NARA-only P1225 / P7228 / P6224.
+
+**Per-ordinal qualifiers NOT in `sdc.json`:**
+
+- **P304** (page number) — per-ordinal, materialised at SDC sync time in `process_one_from_sdc`. Only added when the ordinal belongs to a multi-file extension group within the item.
+- **P2699** (URL = download URL) — per-ordinal, materialised at SDC sync time from `file-list.txt`. Different ordinals of the same item have different download URLs, so this can't live in the per-item `sdc.json`.
+
+**Chunked claims for long values.** Strings or monolingual-text values exceeding Wikibase's per-string limit (1500) are split across multiple statements, each carrying a `P1545` (series ordinal) qualifier — `A1`, `A2`, ..., then `B1`, `B2`, ... for the second long value. The Lua module `Module:DPLA` on Commons reassembles them at render time. See [sdc-sync.md](sdc-sync.md#chunked-claims) for the full convention.
+
+**Lifecycle.** Rewritten on every `get-ids-es` / `get-ids-nara` run. The SDC phase reads whichever sidecar is present, so sdc.json drift between runs is the failure mode `--single-id` was added to address (it re-stages sdc.json before running sdc-sync).
+
+---
+
+## `iiif.json`
+
+The raw IIIF manifest JSON, cached so subsequent runs don't refetch.
+
+**Writer.** `tools/downloader.py` — written only for IIIF-sourced items.
+
+**Reader.** None currently — this is an operator/debug cache. The downloader walks the manifest in memory and writes the resulting URL list to `file-list.txt`.
+
+**Lifecycle.** Written by every downloader run that resolves an IIIF item.
+
+---
+
+## `file-list.txt`
+
+The ordered list of media URLs for the item, one URL per line.
+
+**Writer.** `tools/downloader.py`, after resolving either `mediaMaster` or the IIIF manifest. URL ordering matches the ordinal numbering used by the upload step (1-indexed).
+
+**Readers.**
+
+- `tools/uploader.py` — iteration count, per-ordinal URL.
+- `tools/sdc_sync.py::_run_partner_mode` — per-ordinal URL used as the value for the `P2699` (URL) qualifier on `P7482` (described at source).
+
+**Lifecycle.** Rewritten by every downloader run. The uploader treats the cached version as authoritative subject to `--max-age-days` (when refreshed, both the cached IIIF manifest and the regenerated URL list are updated together).
+
+---
+
+## `upload-result.json`
+
+Per-item upload verdict — the SDC phase's source of truth for which Commons pages exist for each ordinal.
+
+**Writer.** `tools/uploader.py::Uploader._persist_upload_result` at every non-exception exit through `process_item`. Critically NOT written on the catch-all exception path — so a transient failure doesn't blow away a previously accurate verdict.
+
+**Reader.** `tools/sdc_sync.py::_run_partner_mode`. Skips ordinals whose status is anything other than `UPLOADED` or `SKIPPED`.
+
+**Shape:**
+
+```json
+{
+  "run_at": "2026-06-08T13:24:55+00:00",
+  "ordinals": {
+    "1": {"status": "UPLOADED",    "title": "...", "pageid": 123456},
+    "2": {"status": "SKIPPED",     "title": "...", "pageid": 234567},
+    "3": {"status": "NOT_PRESENT"},
+    "4": {"status": "INELIGIBLE"},
+    "5": {"status": "FAILED",      "error": "..."}
+  }
+}
+```
+
+**Status meanings:**
+
+| Status | Meaning |
+|---|---|
+| `UPLOADED` | New file landed on Commons in this run |
+| `SKIPPED` | File already on Commons (SHA1 match at the correct title) |
+| `NOT_PRESENT` | No corresponding S3 object for this ordinal (downloader didn't write it) |
+| `INELIGIBLE` | Pre-flight rejected (bad MIME, banned filetype, etc.) |
+| `FAILED` | Catastrophic failure; see `error` field |
+
+**Critical correctness detail.** `pageid` is `None` on failure (not `0`) so `sdc_sync.py`'s `if not pageid:` guard cleanly skips malformed entries — `M0` is not a valid Commons mediaid and would propagate downstream as a confusing pywikibot APIError.
+
+**Lifecycle.** Overwritten on every uploader run. Dry-runs are no-ops for sidecar writes. The catch-all-exception exit path deliberately does *not* write the sidecar, so a transient infrastructure failure during a re-run doesn't erase a prior accurate verdict.
+
+---
+
+## `<ordinal>_<dpla-id>` (media bytes)
+
+The actual media file, one S3 object per ordinal. 1-indexed.
+
+**Writer.** `tools/downloader.py::Downloader.upload_file_to_s3`.
+
+**Reader.** `tools/uploader.py::process_item` — downloads to a temp file, hashes, then uploads to Commons.
+
+**User-metadata stamped at write:**
+
+- `CHECKSUM` — SHA1 hex digest of the file. Used by:
+  - `uploader.py` — duplicate detection (cross-S3 + against Commons via `allimages?sha1=`).
+  - `uploader.py::collect_duplicate_source_sha1s` — to detect legitimate intra-item duplicates that shouldn't be treated as drift.
+  - `retirer.py` — eligibility for retirement (file must have a valid SHA1).
+- Content-Type — libmagic-sniffed MIME.
+
+**Lifecycle.** Written once per ordinal. Re-downloaded only when `--max-age-days` triggers or `--overwrite` is set. Can be "retired" (body replaced with empty bytes, metadata preserved) via `tools/retirer.py` — see [maintenance-tools.md](maintenance-tools.md).
+
+---
+
+## Helper APIs
+
+`ingest_wikimedia/s3.py` provides these accessors:
+
+```python
+class S3Client:
+    def write_item_metadata(self, partner, dpla_id, body_bytes)        # dpla-map.json
+    def write_item_file(self, partner, dpla_id, filename, body, ctype) # arbitrary sidecar
+    def write_file_list(self, partner, dpla_id, urls)                  # file-list.txt
+    def write_iiif_manifest(self, partner, dpla_id, body_bytes)        # iiif.json
+    def get_item_metadata(self, partner, dpla_id) -> str | None        # dpla-map.json
+    def get_sdc_json(self, partner, dpla_id) -> str | None             # sdc.json
+    def get_upload_result(self, partner, dpla_id) -> str | None        # upload-result.json
+    def get_file_list(self, partner, dpla_id) -> list[str]             # file-list.txt
+    def get_item_file(self, partner, dpla_id, file_name) -> str | None # arbitrary sidecar
+    def get_metadata_files_for_partner(self, partner) -> Iterator      # walks all dpla-map.json under a partner
+```
+
+`get_metadata_files_for_partner()` is used by maintenance tools (`retirer`, `nuke`, `sign`, `remimer`) to iterate every item under a partner without holding the full ID list in memory. It yields `(dpla_id, body_bytes)` pairs lazily.
+
+---
+
+## Sidecar handshakes across phases
+
+The phases hand off via these sidecars:
+
+| Handoff | Producer side | Consumer side |
+|---|---|---|
+| Enumeration → Download | `dpla-map.json` (`_staged_by_get_ids_es: true`) | downloader refuses to operate without the marker |
+| Download → Upload | media bytes + `file-list.txt` + `dpla-map.json` | uploader iterates `file-list.txt`, reads media bytes, reads metadata |
+| Upload → SDC | `upload-result.json` | sdc-sync skips ordinals whose status isn't `UPLOADED`/`SKIPPED` |
+| Enumeration → SDC (separate pass) | `sdc.json` | sdc-sync diffs against Commons-side state |
+| Download → SDC (separate pass) | `file-list.txt` | sdc-sync uses per-ordinal URL for `P2699` qualifier |
+
+This decoupling is what lets `sdc-sync` re-run independently of the other phases (the `sdc_only` mode), and lets `refresh-only` re-download without disturbing already-uploaded files.

--- a/docs/slack-guide.md
+++ b/docs/slack-guide.md
@@ -1,0 +1,262 @@
+# Slack Guide
+
+Non-technical reference for triggering Wikimedia upload runs from Slack. Every command in this guide is something you type into a Slack channel; nothing here requires shell access or a GitHub login. For the full operations reference, see [operations.md](operations.md).
+
+## Quick reference
+
+| What you want to do | Slack command |
+|---|---|
+| Upload an entire DPLA hub | `/wikimedia-upload <hub-slug>` |
+| Upload a single institution within a hub | `/wikimedia-upload "<hub>\|<institution>"` |
+| Upload one specific DPLA item | `/wikimedia-upload <dpla-id>` |
+| Upload by Wikidata identifier (hub or institution) | `/wikimedia-upload <QID>` |
+| Re-sync SDC only (no re-upload) | `/wikimedia-upload sdc <target>` |
+| Refresh aged media in S3 (no upload, no SDC) | `/wikimedia-upload refresh <target> [<target> ...] <days>` |
+| Retry recent failures | `/wikimedia-upload retry <days> [<hub>]` |
+| Stop a running upload | `/wikimedia-upload kill <label>` |
+| See what's running | `/wikimedia-status` |
+
+All commands respond in #tech-alerts (and an immediate ephemeral ack to you).
+
+---
+
+## 1. Full-hub uploads
+
+A hub slug runs every upload-eligible institution in that hub.
+
+```text
+/wikimedia-upload bpl
+/wikimedia-upload indiana
+/wikimedia-upload p2p
+```
+
+Multiple hubs in one command run sequentially in a single tmux session:
+
+```text
+/wikimedia-upload bpl pa indiana
+```
+
+If `bpl` fails partway through, `pa` still starts after `bpl`'s failure notification fires; only the failed target's remaining steps are skipped.
+
+Common slug aliases (full list in [operations.md](operations.md#partner-hub-registry)):
+
+| Type | Aliases |
+|---|---|
+| Massachusetts (Digital Commonwealth) | `bpl`, `ma`, `mass` |
+| Indiana Memory | `indiana`, `in` |
+| Ohio Digital Network | `ohio`, `oh`, `odn` |
+| Minnesota Digital Library | `minnesota`, `mn` |
+| Digital Library of Georgia | `georgia`, `ga`, `dlg` |
+| Sunshine State Digital Network | `florida`, `fl`, `ssdn` |
+| Illinois Digital Heritage Hub | `il`, `idhh` |
+| Plains to Peaks Collective | `p2p`, `ppc` |
+| Northwest Digital Heritage | `northwest-heritage`, `nwdh` |
+| Smithsonian Institution | `si`, `smithsonian` |
+
+NARA cannot be launched via this command — it uses a separate process.
+
+## 2. Institution-level uploads
+
+Use `hub|institution` syntax to upload only items from one institution. Quote the whole argument so Slack treats it as one token. The institution name must match `institutions_v2.json` exactly:
+
+```text
+/wikimedia-upload "indiana|Indiana State Library"
+/wikimedia-upload "pa|Free Library of Philadelphia"
+/wikimedia-upload "p2p|Denver Public Library"
+```
+
+Mix institution-level and hub-level targets freely:
+
+```text
+/wikimedia-upload bpl "indiana|Indiana State Library" pa
+```
+
+Each runs as its own block in the same session.
+
+## 3. Collection-level uploads
+
+Use `hub|institution|collection` to scope down to a single named collection within an institution:
+
+```text
+/wikimedia-upload "indiana|Indiana State Library|Cushman Photographs"
+```
+
+The collection name must match exactly what appears in `sourceResource.collection.title` for items in DPLA's index. If you're not sure of the exact string, run an institution-level upload instead — extra items are skipped at item level by eligibility, so over-scoping is cheap.
+
+## 4. Wikidata QID
+
+If you know a hub's or institution's Wikidata QID, pass it instead of a slug. The launcher resolves QIDs against `institutions_v2.json`:
+
+```text
+/wikimedia-upload Q72380652     # full hub or single institution
+/wikimedia-upload Q14688462
+```
+
+Behaviour:
+
+- QID matches a **hub** Wikidata field → equivalent to the hub slug.
+- QID matches an **institution** Wikidata field → equivalent to `hub|Institution Name`.
+- QID matches multiple institutions inside one hub → all of them are ORed together as a single target.
+- QID matches both a hub and one of its own institutions → the hub wins (broader scope).
+
+Collection-level QIDs are *not* supported as bare arguments — use the explicit `hub|institution|collection` syntax for collections.
+
+## 5. Single-item DPLA ID
+
+If you only need one specific item, pass its 32-character DPLA ID (hex):
+
+```text
+/wikimedia-upload 06b558045c5fd4cc5dc697248272159a
+/wikimedia-upload c6505b825ae42e53f5aee419973bb24a 4c3f5ad9bfac4097b95c9f8deb8e1a21
+```
+
+Single-item runs:
+
+- Re-stage their `dpla-map.json` and `sdc.json` from current code before downloading.
+- Skip the per-phase "starting download" / "starting upload" Slack messages (single-item runs are usually quick; per-phase chatter would be noise).
+- Get a session label like `wikimedia-nara+06b55804` (hub + first 8 hex of the ID) so multiple single-item runs can be distinguished.
+
+## 6. SDC-only re-sync
+
+`/wikimedia-upload sdc <target>` runs `get-ids-es → sdc-sync` only — no downloader, no uploader. Useful when:
+
+- You changed something in the SDC pipeline (date parser, chunking rule, new property) and want to roll it out to already-uploaded files.
+- The bot wrote stale SDC under an old data model and you want to re-reconcile against current ingestion3 mappings.
+
+```text
+/wikimedia-upload sdc bpl
+/wikimedia-upload sdc "indiana|Indiana State Library"
+/wikimedia-upload sdc Q72380652
+/wikimedia-upload sdc 06b558045c5fd4cc5dc697248272159a
+```
+
+`get-ids-es` re-stages `sdc.json` from current mapping code, and `sdc-sync` posts only the diff against existing Commons-side state. SDC sync is fully idempotent — a re-sync against an already-correct file produces zero writes.
+
+**Caveat for single-item and NARA targets:** these targets don't re-stage `sdc.json` (NARA uses a separate enumerator and single-item targets use `resolve-dpla-ids`). For these, `sdc-sync` replays whatever sidecar was written by the last regular run. Useful for re-running fixed sdc-sync logic; not useful for picking up upstream mapping changes.
+
+## 7. Refresh-only (re-download)
+
+`/wikimedia-upload refresh <target> [<target> ...] <days>` re-downloads aged media files in S3 without re-uploading. Used to refresh master copies for partners whose source URLs may have rotated. One or more targets, with the `<days>` threshold as the trailing positional.
+
+```text
+/wikimedia-upload refresh bpl 365
+/wikimedia-upload refresh "indiana|Indiana State Library" 180
+/wikimedia-upload refresh bpl pa indiana 90
+```
+
+The trailing number is a `--max-age-days` threshold — only S3 keys older than N days are re-downloaded. `<days>` is required (no default at the Slack layer to prevent accidental full refreshes).
+
+The downloader is invoked with `--notify-complete` so a #tech-alerts summary fires when it finishes (`Wikimedia Download Refresh Complete:`).
+
+## 8. Retry recent failures
+
+`/wikimedia-upload retry <days> [<hub>]` scans the last N days of upload + download logs across all partners (or one, if specified), classifies retryable failures, and launches new uploader / downloader runs to clean them up.
+
+```text
+/wikimedia-upload retry 7              # all partners, last 7 days
+/wikimedia-upload retry 14 bpl         # bpl only, last 14 days
+```
+
+Retryable failure types (see [maintenance-tools.md](maintenance-tools.md#get-ids-retry) for the full list):
+
+- Upload-side: `lockmanager-fail-conflict`, `stashfailed: Could not acquire lock`, `backend-fail-internal`, hash drift, redirect collisions.
+- Download-side: `Failed downloading <url>` (excluding the empty-URL IIIF bug pattern).
+
+The retry response is ephemeral (only you see the immediate Slack reply); the actual retry session posts to #tech-alerts normally once it starts.
+
+## 9. Kill a running session
+
+```text
+/wikimedia-upload kill bpl
+/wikimedia-upload kill indiana-state-library
+/wikimedia-upload kill bpl pa
+/wikimedia-upload kill Q72380652
+```
+
+`kill` matches against any `+`-delimited component of an active session name. So all of these match a session named `wikimedia-indiana+indiana-state-library`:
+
+- `/wikimedia-upload kill indiana`
+- `/wikimedia-upload kill indiana-state-library`
+- The hub's or institution's Wikidata QID (resolved to the matching label components)
+
+If your kill argument matches zero active sessions, the response says so but no error is raised. If it matches multiple (e.g. `/wikimedia-upload kill bpl` against a session with three institutions inside the bpl hub), all of them in the same session are killed together — sessions are not split.
+
+## 10. Check status
+
+```text
+/wikimedia-status
+```
+
+Posts to #tech-alerts with each active session and its current phase + progress:
+
+```text
+🟢 Active Wikimedia upload sessions
+• wikimedia-bpl — Uploading (3,214 / 11,503, ~28%)
+• wikimedia-indiana+indiana-state-library — SDC syncing (812 / 4,002, ~20%)
+```
+
+The status workflow runs automatically every 6 hours and posts only when something is active. The Slack-triggered version always posts (so an empty result confirms "nothing's running" rather than looking like the command silently failed).
+
+---
+
+## Common scenarios
+
+### "I added a new institution to `institutions_v2.json`. How do I upload it?"
+
+Once ingestion3's `main` branch has merged your change, the launcher will pick it up on the next invocation (it fetches `institutions_v2.json` fresh from GitHub each cold start). Then:
+
+```text
+/wikimedia-upload "<hub>|<Your New Institution Name>"
+```
+
+### "I just merged a fix to the SDC sync code and need to redo every file."
+
+A full SDC-only sweep, per hub:
+
+```text
+/wikimedia-upload sdc bpl
+/wikimedia-upload sdc indiana
+# ...etc.
+```
+
+The SDC sync is idempotent, so any item that doesn't need changes produces no writes. Files that *do* need changes get exactly the changes you fixed.
+
+### "A run failed overnight — how do I see what happened?"
+
+The #tech-alerts message includes the latest log path on EC2 and the last 8 lines tail of that log. For more detail:
+
+```text
+/wikimedia-status   # confirms whether the session is still running or fully dead
+```
+
+Then triage the log directly on EC2 (see [operations.md](operations.md#troubleshooting)).
+
+### "Two operators issued the same `/wikimedia-upload bpl` at the same time."
+
+The first one launches; the second one is dropped with a "session already running" ephemeral error (the GitHub Actions concurrency-key collapses identical dispatches as well, but the EC2-side conflict detection is the authoritative gate). To force-kill the existing session and start over, an operator can re-trigger `wikimedia-launch.yml` manually from the GitHub Actions tab with `force: true` — that's the only place that switch is exposed.
+
+### "I want to refresh all of bpl's source media but not re-upload."
+
+```text
+/wikimedia-upload refresh bpl 30
+```
+
+Re-downloads any S3 key older than 30 days. No uploads, no SDC sync. The completion message in #tech-alerts will read `Wikimedia Download Refresh Complete:` with the refreshed / skipped / failed counts.
+
+---
+
+## What posts to #tech-alerts (and what you see ephemerally)
+
+| Event | Where it posts |
+|---|---|
+| You hit `/wikimedia-upload`, command accepted | Ephemeral ack to you |
+| Unknown hub / invalid target / no such institution | Ephemeral error to you |
+| Launch confirmation | #tech-alerts |
+| Each phase begins (download/upload/SDC) | #tech-alerts (suppressed for single-item runs) |
+| Phase completes successfully | #tech-alerts (full counts and runtime) |
+| Pipeline step fails | #tech-alerts (exit-code hint + log tail) |
+| Kill confirmation | #tech-alerts |
+| `/wikimedia-status` results | #tech-alerts |
+| Scheduled status report (every 6 h, only when sessions active) | #tech-alerts |
+| `/wikimedia-upload retry` immediate response | Ephemeral to you |
+| `/wikimedia-upload refresh` download-complete summary | #tech-alerts |

--- a/docs/slack-guide.md
+++ b/docs/slack-guide.md
@@ -16,7 +16,7 @@ Non-technical reference for triggering Wikimedia upload runs from Slack. Every c
 | Stop a running upload | `/wikimedia-upload kill <label>` |
 | See what's running | `/wikimedia-status` |
 
-All commands respond in #tech-alerts (and an immediate ephemeral ack to you).
+Slack-side outcomes (unknown hub, invalid syntax, ineligible institution) come back as ephemeral replies visible only to you. Once the workflow has accepted the command, ongoing progress and completion messages post to #tech-alerts — see [What posts to #tech-alerts](#what-posts-to-tech-alerts-and-what-you-see-ephemerally) at the bottom of this guide for the full split.
 
 ---
 

--- a/docs/special-cases.md
+++ b/docs/special-cases.md
@@ -14,7 +14,7 @@ The uploader carries the bulk of the pipeline's "what if Commons-side state does
 
 `get_page_title()` in `ingest_wikimedia/wikimedia.py` is the single source of truth for Commons file titles. The final form is:
 
-```
+```text
 <sanitized-source-title> - DPLA - <dpla-id>[ (page N)]<extension>
 ```
 
@@ -35,7 +35,7 @@ Applied in order to the first 181 chars of the source title:
 | `� → '` | Unicode replacement char → right single quote |
 | `replace_invisible()` | Strip zero-width / bidi characters that Commons rejects |
 
-There is no separate "title blacklist" file the uploader reads; the rules are encoded as the substitution table above. Each was added in response to a specific incident; the lesson at `~/.claude/lessons.md` under "Title-blacklist character substitutions: guard on the actual rule, not on any single character" captures the most-recent revision (the `&...=` together-only rule replacing an unconditional always-replace-`&` from an earlier version).
+There is no separate "title blacklist" file the uploader reads; the rules are encoded as the substitution table above. Each was added in response to a specific incident: the colon and slash substitutions trace back to NARA imports in May 2026 where the prior code silently orphaned items whose source titles contained mid-title `:` or `/`; the `&...=` together-only rule replaced an earlier unconditional `&`-replacer that was too aggressive (Commons' actual blacklist only matches when both characters appear together, typical of unencoded query-string titles). The pattern in all cases: match the *actual* MediaWiki rejection rule (which usually involves multiple characters together), not any single character in isolation, so the substitution doesn't damage benign titles.
 
 ## Duplicate-detection decision tree
 

--- a/docs/special-cases.md
+++ b/docs/special-cases.md
@@ -1,0 +1,190 @@
+# Special Cases: Duplicate Detection, File Renames, CommonsDelinker
+
+The uploader carries the bulk of the pipeline's "what if Commons-side state doesn't match what I'm about to upload?" logic. This document covers:
+
+1. [Title generation](#title-generation)
+2. [Duplicate-detection decision tree](#duplicate-detection-decision-tree)
+3. [Hash drift: the four cases](#hash-drift-the-four-cases)
+4. [Redirect handling](#redirect-handling)
+5. [CommonsDelinker integration](#commonsdelinker-integration)
+6. [Orphan tagging](#orphan-tagging)
+7. [Wikimedia error codes](#wikimedia-error-codes)
+
+## Title generation
+
+`get_page_title()` in `ingest_wikimedia/wikimedia.py` is the single source of truth for Commons file titles. The final form is:
+
+```
+<sanitized-source-title> - DPLA - <dpla-id>[ (page N)]<extension>
+```
+
+The `(page N)` suffix is added by `compute_ordinal_exts_and_page_labels()` only when the same extension appears on more than one ordinal of the item. Single-extension multipage items get `(page 1)`, `(page 2)`, etc.; an item with one JPG and one PDF gets no page suffix on either (separate "series" per extension).
+
+### Sanitisation rules
+
+Applied in order to the first 181 chars of the source title:
+
+| Rule | Why |
+|---|---|
+| `& → +` and `= → -` (when both present) | Commons' title blacklist rule fires only when both characters are present together — typical of unencoded query-string titles |
+| `: → -` | MediaWiki strips mid-title colons from File-namespace titles (5 NARA items orphaned in May 2026 by an earlier version that left them alone) |
+| `/ → -` | MediaWiki rejects subpage-parsed names on `UploadBase::isValidName` (4,114 NARA items hit `imageinvalidfilename` during Case-3 moves before this was added; dates like `1/5/1966` were the culprit) |
+| `\ → -`, `< → -`, `> → -` | Outside `Title::legalChars()` |
+| `'' → "` | Titleblacklist double-apostrophe rule |
+| `[ → (`, `] → )`, `{ → (`, `} → )`, `# → -`, `\| → -` | Forbidden in MediaWiki page names; `\|` additionally breaks Commons' file-extension detection |
+| `� → '` | Unicode replacement char → right single quote |
+| `replace_invisible()` | Strip zero-width / bidi characters that Commons rejects |
+
+There is no separate "title blacklist" file the uploader reads; the rules are encoded as the substitution table above. Each was added in response to a specific incident; the lesson at `~/.claude/lessons.md` under "Title-blacklist character substitutions: guard on the actual rule, not on any single character" captures the most-recent revision (the `&...=` together-only rule replacing an unconditional always-replace-`&` from an earlier version).
+
+## Duplicate-detection decision tree
+
+The uploader detects "this content already exists on Commons" along two axes: SHA1 hash, and Commons file title. Three primitives in `ingest_wikimedia/wikimedia.py`:
+
+```python
+wiki_file_exists(site, sha1)                          # bool
+find_file_by_hash(site, sha1, preferred_title=None)   # FilePage or None
+collect_duplicate_source_sha1s(s3, dpla_id, partner)  # set of sha1s appearing > 1× in this item
+```
+
+`find_file_by_hash` calls Commons' `allimages?sha1=...` API; if any result lives at the `preferred_title`, returns it; otherwise returns the first result alphabetically. `collect_duplicate_source_sha1s` walks each S3 ordinal's user metadata and returns SHA1s that appear at two-or-more positions in the same DPLA item — used to short-circuit drift detection for legitimate intra-item duplicates.
+
+### The hot path (`process_file`)
+
+For each ordinal:
+
+```text
+sha1 = read from S3 user-metadata 'CHECKSUM'
+page_title = get_page_title(...)
+existing = find_file_by_hash(site, sha1, preferred_title=page_title)
+
+if existing is None:
+    upload to page_title             # net-new file
+elif existing.title == page_title:
+    SKIPPED                          # exact match, our content is already there
+elif is_dup_sha1_sibling_at_expected_title(...):
+    proceed with "upload_only"       # legitimate intra-item duplicate, not drift
+else:
+    drift_action = _resolve_hash_drift(...)  # see next section
+```
+
+## Hash drift: the four cases
+
+`_resolve_hash_drift()` is invoked when our SHA1 already exists on Commons but at a different title than we want. Four distinguishable cases:
+
+### Case 0 — Cross-item collision
+
+The existing title encodes a different DPLA ID (extracted via the regex `- DPLA - ([0-9a-f]{32})`), AND that other DPLA item is still valid in `api.dp.la`. Both files coexist; we upload to our intended title without touching the existing file.
+
+Return: `"upload_only"`.
+
+### Case 1 — Intended title is a redirect to the existing file
+
+The existing file lives at some other title, and our intended title is a redirect pointing at it. Treat as Case 3 — move the existing file to our intended title.
+
+### Case 2 — Intended title has real content with a different hash
+
+Conflict. The intended title is occupied by unrelated content; the existing file at the wrong title is ours. Three actions:
+
+1. Upload our SHA1 to the intended title with `force_ignore_warnings=True` (overwriting the unrelated content).
+2. Tag the old (wrong-title) file with `{{Duplicate|<correct-filename>|...}}` via `_tag_drift_duplicate` / `tag_as_duplicate` — using `prependtext` and the idempotent `_DUPLICATE_TAG_RE` regex so re-runs don't pile up tags.
+3. No CommonsDelinker request (we didn't move anything; we overwrote and tagged).
+
+Return: `"upload_and_tag"`.
+
+**Sibling-slot fallback.** If the wrong-title file is itself one of this item's other expected ordinal positions (a sibling slot about to be overwritten this run), the duplicate tag is suppressed and the function returns `"upload_only"` instead — the about-to-be-overwritten sibling shouldn't be tagged as a duplicate of a title we're still in the middle of writing.
+
+### Case 3 — Intended title is unoccupied
+
+The existing file is ours but at the wrong title; the intended title has nothing at it. Two actions:
+
+1. Move the existing file to the intended title via `existing_file.move(..., noredirect=False)` — leaving a redirect at the old title.
+2. Post a CommonsDelinker request to rewrite cross-wiki links pointing at the old title.
+
+Exception: if the old title is one of *this item's own* expected ordinal positions (a sibling slot about to be overwritten this same run), the move still happens but the delinker request is suppressed (`post_commonsdelinker=False`) — otherwise we'd ask the delinker to rewrite links pointing at a title we're about to clobber.
+
+Return: `"moved"`.
+
+### Short-circuit: intra-item duplicate-SHA1
+
+`is_dup_sha1_sibling_at_expected_title` checks whether the existing Commons file is one of THIS item's other expected ordinal positions. If so, the existing file is a legitimate sibling (same source media listed at multiple ordinals), not drift; we go straight to `"upload_only"` and proceed.
+
+## Redirect handling
+
+The other axis is: what if our intended title is itself a redirect? `process_file` checks `wiki_file_page.isRedirectPage()` early. Direct upload onto a redirect fails with `fileexists-shared-forbidden`. Two recovery strategies:
+
+### `_resolve_redirect_move`
+
+Used when the redirect's target carries the same DPLA ID at the same logical page (not a same-item different-page relic — `is_same_item_redirect_relic` filters this). Moves the redirect target to the intended title via `redirect_target.move(..., noredirect=False)` and posts a CommonsDelinker request.
+
+### `_resolve_redirect_overwrite`
+
+Used otherwise. Replaces the redirect text with fresh wikitext, optionally merging preserved license / category / `{{Image extracted|...}}` / assessment-class templates (`{{Picture of the day}}`, `{{Featured picture}}`, etc.) from the prior wikitext via `merge_preserved_wikitext`. The new `{{Artwork}}` block is always authoritative for the description; preserved blocks are appended.
+
+## CommonsDelinker integration
+
+`User:CommonsDelinker/commands/filemovers` on Commons is a community-operated bot's instruction queue. The pipeline appends `{{universal replace|<old>|<new>|reason=...}}` lines to it; CommonsDelinker reads the page out-of-band, rewrites every link to `[[File:<old>]]` on every Wikimedia wiki to point at `[[File:<new>]]`, and deletes the obsolete redirect.
+
+**One function, one API.** `post_commonsdelinker_request(site, old_filename, new_filename)` in `ingest_wikimedia/wikimedia.py` is the only call site. It uses MediaWiki's `appendtext` API parameter (not read-modify-write) for two reasons:
+
+1. The page is currently ~230 KB and growing. Loading it via `page.text` then re-saving the whole thing would burn ~500 KB per request — contributed to a recent OOM episode.
+2. `page.text` reads from a replica that can lag the primary by seconds; under burst load (a hub move-storm can post hundreds of requests in a minute) read-modify-write produced self-inflicted `editconflict` rejections. `appendtext` is server-side concatenation against the primary, no GET, atomic.
+
+**Reason string.** The default is `"[[COM:FR|File renamed]]: [[COM:FR#FR4|Criterion 4]] (harmonize the names of a set of images)"` — Commons' File Renaming policy criterion 4 (harmonising a set of related files). `build_title_drift_move_reason` iteratively shortens the reason string until it fits MediaWiki's 500-byte `CommentStore::COMMENT_CHARACTER_LIMIT` once username + filenames + the 36-byte fixed prefix overhead is accounted for.
+
+**Three call sites in `tools/uploader.py`:**
+
+| Call site | When | Notes |
+|---|---|---|
+| `_resolve_redirect_move` | After moving a redirect target to the intended title | Always posts a delinker request |
+| `_move_to_correct_title` (Case 3) | After moving a file from a wrong title to the intended title | Posts unless the old title is a sibling slot |
+| `_move_to_correct_title` (Case 1) | After moving a file when the intended title was a redirect to it | Same suppression rule |
+
+The Case-2 path does NOT post a delinker request — there, `_tag_drift_duplicate` flags the old file for human review instead.
+
+## Orphan tagging
+
+The post-item orphan check sweeps for stale files left behind by source-media truncations. If a previous run uploaded `Foo (page 5).jpg` but the source now lists only 4 pages, page 5 is an orphan on Commons.
+
+`_post_item_orphan_check()` probes `(page N+1)`, `(page N+2)`, etc. above the highest kept page label for each extension group. For each found orphan, it compares the orphan's `latest_file_info.sha1` against the per-extension `sha1 → kept_title` map built from this run's surviving ordinals. On match, `tag_as_duplicate` prepends `{{Duplicate|<kept-title>|...}}` to the orphan.
+
+**Counters:** `Result.ORPHANS_TAGGED` (matched the SHA1 of a kept ordinal and got the duplicate tag), `Result.ORPHANS_FLAGGED` (found but didn't match — left untouched for human review).
+
+`{{Duplicate}}` tagging is idempotent via the regex `_DUPLICATE_TAG_RE` that recognises `{{Duplicate}}` / `{{duplicate}}` with whitespace tolerance and a `(?:\||\}\})` lookahead so existing `{{DuplicateImageFinder|…}}` tags don't false-match.
+
+## Wikimedia error codes
+
+`ingest_wikimedia/wikimedia.py` exports the error-code constants:
+
+```python
+ERROR_FILEEXISTS    = "fileexists-shared-forbidden"
+ERROR_MIME          = "filetype-badmime"
+ERROR_BANNED        = "filetype-banned"
+ERROR_DUPLICATE     = "duplicate"
+ERROR_NOCHANGE      = "no-change"
+ERROR_BACKEND_FAIL  = "backend-fail-internal"
+```
+
+`IGNORE_WIKIMEDIA_WARNINGS` (passed to pywikibot's `ignore_warnings=` argument) suppresses cosmetic warnings:
+
+- `bad-prefix`, `duplicate-archive`, `duplicate-version`, `empty-file`, `exists`, `exists-normalized`, `was-deleted`, `large-file`, etc.
+
+But deliberately does NOT include `duplicate` or `no-change` — those still hard-fail because they indicate state we need to react to (different from a cosmetic "this filename is a bit weird" warning).
+
+### "File linked to another page"
+
+When `site.upload(...)` returns falsy (pywikibot returns `None` when the file exists under a different page title — typically a redirect not caught by the redirect-handling branch above), the uploader raises `RuntimeError("File linked to another page (possible ID drift)")`. The retry classifier (`tools/get_ids_retry.py`) catches this string and marks the item retryable.
+
+### Retryable failure patterns
+
+`tools/get_ids_retry.py` parses logs for these patterns (full list in `UPLOAD_TRANSIENT_ERRORS`):
+
+- `lockmanager-fail-conflict`
+- `stashfailed: Could not acquire lock`
+- `uploadstash-exception`
+- `backend-fail-internal`
+- `File linked to another page`
+- `ArticleExistsConflictError`
+- `fileexists-shared-forbidden`
+
+These all mean "transient or correctable" — re-running the upload usually succeeds. The retry CSV merges download-retry and upload-retry into one combined CSV per hub so a single uploader invocation handles both.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,141 @@
+# Templates and the Lua Module
+
+How the pipeline uses Commons templates to display item metadata — and how the planned transition from the legacy `{{Artwork}}`-based wikitext to the SDC-backed `{{DPLA metadata}}` will work.
+
+This document is the *pipeline's* view of the templates. For the user-facing template documentation (what editors see and how they augment it), see the [Template:DPLA metadata/doc](https://commons.wikimedia.org/wiki/Template:DPLA_metadata/doc) page on Commons.
+
+## Current state: `{{Artwork}}` at upload, `{{DPLA metadata}}` from SDC
+
+At upload time, the pipeline writes a fully-rendered `{{Artwork}}` block as the file page's wikitext. After SDC sync lands the same metadata as structured data, that metadata can *also* be rendered by `{{DPLA metadata}}` — but the pipeline does NOT include `{{DPLA metadata}}` in the wikitext it uploads. The two systems run side-by-side; `{{DPLA metadata}}` is currently maintained as a parallel rendering option and would replace `{{Artwork}}` only in a future PR (see [Planned transition](#planned-transition) below).
+
+### Upload-time wikitext (the `{{Artwork}}` path)
+
+`get_wiki_text(dpla_id, item_metadata, provider, data_provider)` in `ingest_wikimedia/wikimedia.py` composes the file-page wikitext. The current template literal:
+
+```wikitext
+== {{int:filedesc}} ==
+{{ Artwork
+   | Other fields 1 = {{ InFi | Creator | <creator> | id=fileinfotpl_aut }}
+   | title       = <title>
+   | description = <description>
+   | date        = <date_string>
+   | permission  = {{<permissions-template>}}
+   | source      = {{ DPLA
+                       | <data-provider>
+                       | hub      = <provider>
+                       | url      = <isShownAt>
+                       | dpla_id  = <dpla_id>
+                       | local_id = <local_id>
+                   }}
+   | Institution = {{ Institution | wikidata = <data-provider-qid> }}
+}}
+```
+
+Notable wiring:
+
+- The `| Other fields 1` row is included only when a creator is present.
+- `| source = {{DPLA|...}}` is the DPLA-specific glue: `Template:DPLA` on Commons renders DPLA's catalog link, hub attribution, and local identifier inside `{{Artwork}}`'s source slot. This `Template:DPLA` is distinct from `Module:DPLA` (the Lua module backing the new `{{DPLA metadata}}` template).
+- `| permission = {{<permissions-template>}}` resolves to one of `NKC`, `NoC-US`, `PD-US`, `cc-zero`, or a CC-by/by-sa code per `license_to_markup_code()` (mapping is in `ingest_wikimedia/wikimedia.py`).
+- `| Institution = {{Institution|wikidata=...}}` uses Commons' standard `{{Institution}}` template for the institution row.
+
+### Post-upload rendering: `{{DPLA metadata}}` + `Module:DPLA`
+
+`Template:DPLA metadata` on Commons is a thin wrapper:
+
+```wikitext
+{{#invoke:DPLA|render_metadata_table}}
+```
+
+`Module:DPLA` reads the file's MediaInfo entity directly and renders a two-box block:
+
+- **Blue box** — every field is sourced from a DPLA-determined SDC statement (recognised by the `P459 = Q61848113` qualifier). Updated automatically when the SDC sync re-writes; no editor intervention.
+- **Yellow box** — augmented from explicit template parameters (Artwork/Information-style names) plus any non-DPLA SDC statements on the same properties. The yellow box gives Commons editors a place to add corrections, translations, or supplementary metadata without conflicting with the bot's authoritative blue-box values.
+
+The module also writes three tracking categories per file with DPLA SDC: the DPLA umbrella category, the regional hub category (e.g. `Plains to Peaks Collective`), and the contributing institution category (e.g. `Denver Public Library`). When the hub partner is the institution itself (NARA, Smithsonian), the hub-role P9126 statement is omitted by the bot and the module falls back to the institution Q-ID for the hub category — preventing the "unknown partner" maintenance category for these special cases.
+
+The module supports chunked claims (P1545 series ordinals) and reassembles them at render time. See [sdc-sync.md](sdc-sync.md#chunked-claims).
+
+### Where `Module:DPLA` is referenced in this repo
+
+The module's existence is acknowledged in a handful of code comments inside the SDC builders:
+
+- `ingest_wikimedia/sdc.py` — chunked-claim convention notes ("so the Lua [module] can reassemble the chunks").
+- `tools/sdc_sync.py` — same chunking notes; "unchunked variants of the same text are kept separate so the Lua template..."
+
+The pipeline does NOT directly invoke the module, render it client-side, or test it. Module:DPLA lives on Commons and is maintained as a Wikimedia-side artefact; this repo's responsibility is to write SDC the module can render correctly. See the test file at `commons.wikimedia.org/wiki/File:Plate_49_of_King's_1933_aerial_coverage_of_Denver,_Colorado_-_DPLA_-_4c3f5ad9bfac4097b95c9f8deb8e1a21.jpg` for a live render.
+
+## Planned transition
+
+The roadmap is to ship `{{DPLA metadata}}` as the *primary* format the pipeline writes at upload time, replacing the `{{Artwork}}`-based wikitext block. Two reasons:
+
+1. **Single source of truth.** Today the metadata is duplicated — once as wikitext templated by the uploader, once as SDC reconciled by the sync phase. Switching the primary display to `{{DPLA metadata}}` means the SDC IS the metadata, full stop. The file-page wikitext becomes a one-line `{{DPLA metadata}}` invocation that picks everything up from SDC.
+2. **Live updates.** When `Module:DPLA` reads SDC, every file gets the current rendering of the current data — no need to re-edit thousands of wikitext blobs to push out a display change.
+
+### What would need to change in the uploader
+
+`get_wiki_text()` would need to be rewritten to emit (essentially) just `{{DPLA metadata}}` plus the licensing template — the rest comes from SDC. Concretely:
+
+```wikitext
+== {{int:filedesc}} ==
+{{DPLA metadata}}
+
+== {{int:license-header}} ==
+{{<permissions-template>}}
+```
+
+The licensing line stays separate because Commons' file curation conventions require the license template to be visible in the wikitext (not just SDC) for human review.
+
+### What would need to change in the phase order
+
+Today the upload phase writes wikitext *before* the SDC phase posts the SDC. If `{{DPLA metadata}}` is the primary format, the wikitext is empty of metadata until SDC arrives — files would temporarily look blank between upload and SDC sync. Two ways to handle this:
+
+1. **Reverse the phase order.** Make the uploader post a placeholder `{{DPLA metadata}}` block at upload, then have a new "SDC pre-stage" phase run *before* the upload commits, writing the SDC into a staging entity. This is doable but invasive — Commons' upload API doesn't allow SDC + file-page in one request, so the staging would still happen post-upload, just before publishing the wikitext.
+2. **Pre-populate template parameters.** Use the explicit-param path of `{{DPLA metadata}}` so the uploader writes `{{DPLA metadata|title=...|description=...|...}}` with the same values it would have put into `{{Artwork}}`. The Lua module already supports this (explicit params override SDC fallbacks). Then SDC sync lands the same values as structured data, and over time the params can be dropped from the wikitext as SDC becomes authoritative.
+
+Option 2 is the lower-risk path and is what's currently planned. The wikitext becomes a transition vehicle: explicit params today, gradual dropping of params as SDC coverage stabilises, eventually a bare `{{DPLA metadata}}`.
+
+### Workstreams the transition would touch
+
+- `ingest_wikimedia/wikimedia.py::get_wiki_text` — new template body.
+- Commons-side `Template:DPLA metadata/doc` — already updated to describe both the blue (SDC) and yellow (user/explicit-param) boxes.
+- `Commons:Digital Public Library of America/Modeling` — already updated to describe the SDC properties the module reads.
+- Operator runbook in [operations.md](operations.md) — note the change in the "what's on a fresh upload" wording.
+- A staged rollout — flip one hub at a time so a regression doesn't take down every partner.
+
+No code changes have landed for this transition yet; no TODO/FIXME comments in `tools/uploader.py` or `ingest_wikimedia/wikimedia.py` reference it.
+
+## How SDC and templates interact today
+
+A summary diagram:
+
+```
+            ┌──────────────────────────────────────────────┐
+            │  S3 sidecars (from get-ids-es Phase 3)       │
+            │    dpla-map.json      ──┐                    │
+            │    sdc.json           ──┘                    │
+            └────────┬─────────────────────────────────────┘
+                     │
+       ┌─────────────┴────────────┐
+       │                          │
+       ▼                          ▼
+ ┌─────────────────┐       ┌─────────────────────┐
+ │ uploader writes │       │ sdc-sync writes     │
+ │   {{Artwork}}   │       │   MediaInfo SDC     │
+ │   wikitext      │       │   (P760, P1476,     │
+ │   (file page)   │       │    P195, P9126, …)  │
+ └────────┬────────┘       └──────────┬──────────┘
+          │                           │
+          ▼                           ▼
+   File page wikitext           MediaInfo entity
+          │                           │
+          ▼                           ▼
+   ┌──────────────────────────────────────────────┐
+   │  Commons file page                           │
+   │                                              │
+   │  {{Artwork}} block (today's primary display) │
+   │  + (optionally) {{DPLA metadata}} block      │
+   │    rendered by Module:DPLA from SDC          │
+   └──────────────────────────────────────────────┘
+```
+
+In the planned future state, the left branch goes away — the uploader writes only `{{DPLA metadata}}`, and everything else comes from the SDC sync's writes via `Module:DPLA`.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -108,9 +108,9 @@ No code changes have landed for this transition yet; no TODO/FIXME comments in `
 
 A summary diagram:
 
-```
+```text
             ┌──────────────────────────────────────────────┐
-            │  S3 sidecars (from get-ids-es Phase 3)       │
+            │  S3 sidecars (from get-ids-es, Phase 1)      │
             │    dpla-map.json      ──┐                    │
             │    sdc.json           ──┘                    │
             └────────┬─────────────────────────────────────┘


### PR DESCRIPTION
## Summary

Adds eight new documentation files covering every recently-overhauled part of the pipeline, plus a non-technical Slack guide for operators. The repo had a thin README + one operations.md before; this PR fills in the architectural, phase-level, and special-case detail that was missing.

## What's added

| File | Audience | Covers |
|---|---|---|
| [`docs/slack-guide.md`](docs/slack-guide.md) | Operators | Copy-paste Slack examples for every run type |
| [`docs/architecture.md`](docs/architecture.md) | Engineers | End-to-end dispatch chain (Slack → Lambda → GH Actions → SSM → EC2), target resolution, session/concurrency rules, failure semantics |
| [`docs/pipeline-phases.md`](docs/pipeline-phases.md) | Engineers | Deep dive on `get-ids-es`, `downloader`, `uploader`, `sdc-sync`; NARA's enumerator; the `--single-id` / `--sdc-only` / `--refresh-only` modes |
| [`docs/sidecars.md`](docs/sidecars.md) | Engineers | Every S3 sidecar (`dpla-map.json`, `sdc.json`, `upload-result.json`, `file-list.txt`, `iiif.json`, media bytes) — schemas, writers, readers, handoffs |
| [`docs/sdc-sync.md`](docs/sdc-sync.md) | Engineers | Atomic single-wbeditentity dispatcher, every property the bot writes, idempotency via `check()`, P1545 chunked-claim convention, P813 refresh, Wikibase API gotchas |
| [`docs/special-cases.md`](docs/special-cases.md) | Engineers | Title sanitization, the four hash-drift cases, redirects, CommonsDelinker integration, orphan tagging, Wikimedia error codes |
| [`docs/templates.md`](docs/templates.md) | Engineers | Current `{{Artwork}}` upload-time wikitext + `Module:DPLA`/`{{DPLA metadata}}` SDC rendering + planned transition |
| [`docs/metrics.md`](docs/metrics.md) | Engineers | Scheduled `cim-pageviews.yml` workflow, `CIMviews.py` bot, GitHub-Pages metrics site |
| [`docs/maintenance-tools.md`](docs/maintenance-tools.md) | Engineers | `verify-item`, `retirer`, `nuke`, `remimer`, `sign`, `get-incomplete-items`, `get-ids-retry`, `resolve-dpla-ids`, `fix-unknown-categories` |

`README.md` updated to be a documentation index pointing at all of the above. `docs/operations.md` is unchanged (already comprehensive).

## Fact-checking pass

A separate fact-check agent spot-checked the most factually-dense claims against the actual code. Findings addressed in this PR:

- Corrected `sdc-sync` legacy-mode CLI flags (the actual argparse declarations are `--file` singular/repeatable and `--lists` plural — the inverse of what I'd originally written).
- Corrected the P571 row to note that `P1932` (stated-as) qualifier is always attached on both the parsed-time and the somevalue branches.
- Corrected the description of `_claim_has_circa_marker` to clarify it's a reconciler helper, not the writer-side trigger for `P1480 = Q5727902` (which comes from `parse_dpla_date`'s `approximate` flag).
- Corrected the `nuke` S3 path to include the `<partner>/images/<a>/<b>/<c>/<d>/` prefix.
- Added the Case 2 sibling-slot fallback to the hash-drift documentation.
- Corrected `/wikimedia-upload refresh` to show multi-target signature (the Lambda accepts multiple targets, not one).

## Test plan

- [x] All internal markdown links verified to point at existing files + anchors.
- [x] Fact-checker dispatched against the codebase; 7 findings addressed in commit; remainder of doc validated as accurate.
- [ ] Reviewer eyeballs to confirm tone + emphasis are right (some sections lean dense — feedback welcome on which to slim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds comprehensive operator and engineering documentation for the pipeline; it is documentation-only (no code/public-API changes, no migrations, no infra changes).

High-level summary
- Adds eight new docs and rewrites README to act as a documentation index:
  - docs/slack-guide.md — operator Slack command examples and operator scenarios.
  - docs/architecture.md — end-to-end dispatch chain (Slack → Lambda → GitHub Actions → SSM → EC2), target resolution, session/concurrency rules, failure semantics, and explanation of get-ids_es/Elasticsearch cutover.
  - docs/pipeline-phases.md — deep dive on the four sequential phases (get-ids-es, downloader, uploader, sdc-sync), inputs/outputs, idempotency, NARA special enumerator, and run modes (--single-id, --sdc-only, --refresh-only).
  - docs/sidecars.md — S3 sidecar layout, file schemas, writers/readers/lifecycles, and S3 path helper.
  - docs/sdc-sync.md — atomic wbeditentity dispatcher design, properties the bot writes, idempotency via check(), chunked-claim convention (P1545), P813 refresh, and Wikibase API gotchas.
  - docs/special-cases.md — title sanitization, duplicate/hash-drift resolution (Case 2 sibling-slot fallback added), redirects, CommonsDelinker integration, orphan tagging, Wikimedia error-code handling.
  - docs/templates.md — current upload-time wikitext ({{Artwork}}), Module:DPLA/{{DPLA metadata}} rendering, and planned transition to emit {{DPLA metadata}} at upload.
  - docs/metrics.md — CIM pageviews workflow (scheduled GitHub Actions + CIMviews.py), Data: pages written on Commons, and GitHub Pages metrics frontend.
  - docs/maintenance-tools.md — operator tooling docs (verify-item, retirer, nuke with corrected S3 path, remimer, sign, get-incomplete-items, get-ids-retry, resolve-dpla-ids, fix-unknown-categories).
- README rewritten to link to the new docs, summarize the dispatch chain and project structure, and update the CLI reference.

Notable factual / UX corrections included in this PR
- sdc-sync CLI flags clarified: --file is singular and repeatable; --lists is plural (directory-of-txt-files).
- Clarified P571 / P1932 behavior and _claim_has_circa_marker vs parse_dpla_date responsibilities.
- Corrected /wikimedia-upload refresh example to reflect multi-target Lambda signature.
- Seven fact-checker findings (separate agent) were addressed in-text.

Explicit checklist called out by reviewer instructions
- Manual pipeline trigger / redeploy required: No. This PR is documentation-only; no pipeline trigger, ECS redeploy, or runtime deployment is required to “take effect.”
- Adds/removes/renames environment variables or AWS Secrets Manager keys: No changes to env var names are introduced by the PR. The docs describe existing env vars the pipeline uses (examples: SLACK_SIGNING_SECRET, GH_TOKEN, GH_REPO) but do not add or rename them.
- Database migration: None.
- Shared infrastructure configuration changes (CodePipeline/CodeBuild/ECS/IAM): None. The docs describe current infra and workflows but do not modify shared infra definitions.
- Public-facing API response shape / new endpoints: None.
- Security implications: Documentation describes existing secrets and auth flows (Slack signing secret verification in Lambda, GitHub dispatch using a fine-grained GH token, SSM to EC2, and S3 access patterns). The PR itself does not introduce code changes that alter credentials handling or add new external inputs, but the docs call out where secrets are required and note external dependencies (internal ES host for get-ids-es, Wikimedia REST endpoints, GitLab-hosted allow list for metrics). Reviewers may wish to confirm operational guidance in the docs aligns with current secret rotation and least-privilege policies.

Test / verification notes (from PR summary)
- Internal markdown links were verified.
- A fact-checker run found 7 issues; all 7 were fixed in this PR.
- Commit history addresses prior CodeRabbit review comments (14 inline + 1 nit) and removed environment-specific references; several wording/formatting fixes applied across the docs.

Reviewer guidance / low-risk note
- This PR is documentation-only; review can focus on accuracy, tone, and any missing operational details (e.g., emergency rollback playbooks, exact AWS/Audit/SSM account names) rather than runtime behavior. If any operational changes are intended, they must be accompanied by code/infrastructure changes in a separate PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->