### PR TITLE
retry: classify SDC sync failures as retryable when transient

### DIFF
--- a/docs/maintenance-tools.md
+++ b/docs/maintenance-tools.md
@@ -149,7 +149,7 @@ Distinct from `retirer`: nuke hard-deletes everything (sidecars, media, metadata
 
 Source: `tools/get_ids_retry.py`. Invoked by `scripts/wikimedia_retry.py` (which is triggered by `/wikimedia-upload retry`).
 
-Parses recent upload + download logs and classifies failures into two retry types:
+Parses recent upload + download + SDC logs and classifies failures into three retry types:
 
 ### `upload-retry`
 
@@ -171,11 +171,26 @@ Matches `Failed downloading <url>` patterns, excluding the empty-URL IIIF-parser
 
 For these, the S3 bytes are absent — re-run the downloader with `--max-age-days 1` to force a re-fetch of any partial / stale state.
 
+### `sdc-retry`
+
+Matches `-- Ordinal N (Mxxx) for <DPLA-ID>: SDC sync failed; skipping ordinal.` markers in `*-sdc.log`, then classifies the trailing traceback against `SDC_TRANSIENT_ERRORS`:
+
+- `MaxlagTimeoutError`, `maxlag`, `readonly`, `ratelimited` — Wikibase replica lag, read-only mode, rate limiting
+- `ServerError` — HTTP 5xx from MediaWiki / Wikibase
+- `ReadTimeoutError`, `ReadTimeout`, `ConnectTimeoutError`, `EndpointConnectionError`, `ChunkedEncodingError`, `ProtocolError`, `ConnectionError` — botocore / requests / urllib3 transients
+- `internal_api_error_DBQueryError`, `internal_api_error_DBConnectionError` — MediaWiki API DB blips
+- `editconflict`, `failed-save` — race / save retry storm
+- `SlowDown`, `RequestTimeout`, `ServiceUnavailable`, `InternalError` — S3 transients during sidecar reads
+
+Structural failures (`invalid-claim`, `permissiondenied`, `no-such-entity`, code bugs like `KeyError` / `AttributeError`) are deliberately excluded — re-running won't help, so they're left to surface in the next regular sync where an operator will catch them and fix the underlying issue.
+
+For SDC retries, just re-run `sdc-sync --partner <slug> --ids-file <csv>`. The SDC sync is idempotent so the IDs that were already done re-run as no-ops; only the ones that hit transient failures actually write.
+
 ### Output
 
 One CSV per partner per type to `--output-dir` (default `<INGEST_WIKIMEDIA_DIR>/retry/`). Logs are processed oldest-first per partner so a later clean run can supersede an earlier failure for the same item.
 
-The retry script merges upload-retry + download-retry CSVs per hub into one combined `<slug>-retry-<days>d-combined.csv` and runs the uploader once on the combined list, so an operator sees one "Retry Complete" summary per hub instead of one-per-type.
+The retry script merges upload-retry + download-retry CSVs per hub into one combined `<slug>-retry-<days>d-combined.csv` and runs the uploader once on the combined list, so an operator sees one "Retry Complete" summary per hub instead of one-per-type. If an SDC-retry CSV also exists for the same hub, `sdc-sync` runs as a final step after the uploader so it sees the freshly-refreshed `upload-result.json` sidecars. An SDC-only retry (no upload / download failures) skips the uploader and downloader entirely.
 
 ---
 

--- a/docs/slack-guide.md
+++ b/docs/slack-guide.md
@@ -150,7 +150,7 @@ The downloader is invoked with `--notify-complete` so a #tech-alerts summary fir
 
 ## 8. Retry recent failures
 
-`/wikimedia-upload retry <days> [<hub>]` scans the last N days of upload + download logs across all partners (or one, if specified), classifies retryable failures, and launches new uploader / downloader runs to clean them up.
+`/wikimedia-upload retry <days> [<hub>]` scans the last N days of upload + download + SDC logs across all partners (or one, if specified), classifies retryable failures, and launches new uploader / downloader / sdc-sync runs to clean them up.
 
 ```text
 /wikimedia-upload retry 7              # all partners, last 7 days
@@ -159,8 +159,11 @@ The downloader is invoked with `--notify-complete` so a #tech-alerts summary fir
 
 Retryable failure types (see [maintenance-tools.md](maintenance-tools.md#get-ids-retry) for the full list):
 
-- Upload-side: `lockmanager-fail-conflict`, `stashfailed: Could not acquire lock`, `backend-fail-internal`, hash drift, redirect collisions.
-- Download-side: `Failed downloading <url>` (excluding the empty-URL IIIF bug pattern).
+- **Upload-side:** `lockmanager-fail-conflict`, `stashfailed: Could not acquire lock`, `backend-fail-internal`, hash drift, redirect collisions.
+- **Download-side:** `Failed downloading <url>` (excluding the empty-URL IIIF bug pattern).
+- **SDC-side:** Wikibase API transients (`MaxlagTimeoutError`, replica lag, rate limiting, 5xx, network blips, `editconflict`, `readonly`). Structural failures (`invalid-claim`, `permissiondenied`, `no-such-entity`, code bugs) are deliberately excluded — re-running wouldn't help.
+
+When a hub has both upload and SDC failures, the retry pipeline runs upload first, then SDC — so `sdc-sync` sees the freshly-refreshed `upload-result.json` from the upload step. SDC-only retries (e.g. a one-off maxlag spike during an otherwise clean SDC pass) skip the uploader and downloader entirely.
 
 The retry response is ephemeral (only you see the immediate Slack reply); the actual retry session posts to #tech-alerts normally once it starts.
 

--- a/scripts/wikimedia_retry.py
+++ b/scripts/wikimedia_retry.py
@@ -182,6 +182,9 @@ def main() -> None:
         elif filename.endswith("-upload-retry.csv"):
             csv_partner_dir = filename[: -len("-upload-retry.csv")]
             retry_type = "upload"
+        elif filename.endswith("-sdc-retry.csv"):
+            csv_partner_dir = filename[: -len("-sdc-retry.csv")]
+            retry_type = "sdc"
         else:
             logging.warning("Unexpected CSV filename: %s", filename)
             continue
@@ -337,6 +340,16 @@ def main() -> None:
             cat_args = " ".join(shlex.quote(c) for c in upload_inputs)
             steps.append(f"awk '!seen[$0]++' {cat_args} > {shlex.quote(combined_csv)}")
             steps.append(f"uploader {shlex.quote(combined_csv)} {slug}")
+        # SDC retries: a separate phase that follows download+upload because
+        # sdc-sync's partner mode reads per-item upload-result.json from S3
+        # to find which ordinals exist on Commons. Re-running download or
+        # upload (above) refreshes that sidecar, so the sdc-sync step sees
+        # current state. When only an sdc-retry CSV exists for the hub
+        # (typical case: transient maxlag during the original sync), this
+        # is the only step in the block.
+        sdc_csv = type_csvs.get("sdc")
+        if sdc_csv:
+            steps.append(f"sdc-sync --partner {slug} --ids-file {shlex.quote(sdc_csv)}")
         target_steps = " && ".join(steps)
         target_blocks.append(
             f"{label_export}; {{ {target_steps}; }}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,82 @@
+"""Test-suite-wide safety net for Slack-side leakage.
+
+Several scripts in this repo post to the DPLA bot's Slack channel when
+they encounter operational failures (``_slack_fail``'s fallback
+``post_message`` call in ``wikimedia_launch.py``) or when their no-op
+path runs (``post_message`` from the "No retryable failures found" path
+in ``wikimedia_retry.py``). When ``DPLA_SLACK_BOT_TOKEN`` is set in the
+environment (typical of EC2 where ``.bashrc`` exports it), an unmocked
+test that exercises these code paths posts a real message to
+``#tech-alerts``.
+
+Most tests do mock ``post_message`` locally, but missing a single mock
+on a single new test silently leaks. This autouse fixture removes the
+class of bug by:
+
+  1. Stripping every Slack token / webhook env var before each test, so
+     code paths gated on ``if os.environ.get('DPLA_SLACK_BOT_TOKEN')``
+     short-circuit cleanly.
+  2. Patching every ``post_message`` import site to a no-op so even
+     code that doesn't gate on the env var (or that captured the token
+     at import time) can't reach Slack.
+
+A test that genuinely needs ``post_message`` to be exercised — e.g. an
+assertion on the message text — can still install its own ``patch.object``
+and assert against it, since the test's local patch is the inner-most
+context manager and wins over this autouse stub.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+_SLACK_ENV_VARS = (
+    "DPLA_SLACK_BOT_TOKEN",
+    "DPLA_SLACK_WEBHOOK",
+    "DPLA_SLACK_INGESTS_BOT_TOKEN",
+)
+
+# Every module that imports ``post_message`` directly. Each import site
+# gets its own module-level binding, so patching just
+# ``ingest_wikimedia.slack.post_message`` doesn't reach the call sites
+# in ``scripts/*`` that did ``from ingest_wikimedia.slack import
+# post_message`` at module load. Mirror the list of importers
+# discovered via ``grep -rn "from ingest_wikimedia.slack import"``.
+_POST_MESSAGE_IMPORT_SITES = (
+    "ingest_wikimedia.slack.post_message",
+    "scripts.wikimedia_launch.post_message",
+    "scripts.wikimedia_retry.post_message",
+    "scripts.wikimedia_kill.post_message",
+    "scripts.wikimedia_upload_status.post_message",
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_slack_in_tests(monkeypatch: pytest.MonkeyPatch):
+    """Autouse fixture preventing any test from posting to Slack.
+
+    Runs before every test; teardown automatic via monkeypatch / patch.
+    """
+    for var in _SLACK_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    patches = []
+    for target in _POST_MESSAGE_IMPORT_SITES:
+        try:
+            p = patch(target)
+            p.start()
+            patches.append(p)
+        except (AttributeError, ModuleNotFoundError):
+            # Module exists in the import graph but doesn't bind
+            # post_message at module level (or doesn't exist at all in
+            # this test run). Skip — the env-var strip above is the
+            # primary defense; this patch list is belt-and-suspenders.
+            continue
+
+    yield
+
+    for p in patches:
+        p.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,4 +87,7 @@ def _no_slack_in_tests(monkeypatch: pytest.MonkeyPatch):
         try:
             p.stop()
         except Exception:
+            # Best-effort: the patch may have already been stopped (e.g.
+            # by a test that manually managed its lifetime).  Swallow so
+            # subsequent ``p.stop()`` calls in this loop still run.
             pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,5 +78,13 @@ def _no_slack_in_tests(monkeypatch: pytest.MonkeyPatch):
 
     yield
 
+    # Best-effort cleanup: if one patch's stop() raises (rare but possible
+    # when a test has already manually stopped it), keep going so the
+    # remaining patches still get torn down.  A stranded patch would leak
+    # into subsequent tests and surface as confusing test-order
+    # dependencies.
     for p in patches:
-        p.stop()
+        try:
+            p.stop()
+        except Exception:
+            pass

--- a/tests/test_get_ids_retry.py
+++ b/tests/test_get_ids_retry.py
@@ -1,0 +1,181 @@
+"""Tests for the SDC log scanner in tools.get_ids_retry.
+
+The upload and download scanners are exercised indirectly by integration
+tests on the retry pipeline; this file focuses on parse_sdc_log because
+its classification rules are dense (every transient pattern is one
+substring match) and the scanner is the only point where structural
+errors are deliberately excluded from the retry CSV.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tools.get_ids_retry import parse_sdc_log
+
+MAXLAG_BLOCK = """\
+[INFO] 09:11:50:  -- Ordinal 113: M192146077 (something)
+[ERROR] 09:16:50:  -- Ordinal 113 (M192146077) for {id}: SDC sync failed; skipping ordinal.
+Traceback (most recent call last):
+  File "/x/sdc_sync.py", line 3307, in _run_partner_mode
+    process_one_from_sdc(...)
+  File "/x/sdc_sync.py", line 3011, in process_one_from_sdc
+    get_entity(mediaid)
+  File "/x/sdc_sync.py", line 496, in get_entity
+    raw = site.simple_request(action="wbgetentities", ids=mediaid).submit()
+pywikibot.exceptions.MaxlagTimeoutError: Maximum retries attempted due to maxlag without success.
+[INFO] 09:21:51:  -- Ordinal 114: M192146082 (something)
+"""
+
+READONLY_BLOCK = """\
+[ERROR] 09:30:00:  -- Ordinal 22 (M9999) for {id}: SDC sync failed; skipping ordinal.
+Traceback (most recent call last):
+  ...
+pywikibot.exceptions.APIError: readonly: The wiki is currently in read-only mode.
+[INFO] 09:30:05:  -- Ordinal 23: M99999 (something)
+"""
+
+EDITCONFLICT_BLOCK = """\
+[ERROR] 09:40:00:  -- Ordinal 5 (M5555) for {id}: SDC sync failed; skipping ordinal.
+Traceback (most recent call last):
+  ...
+pywikibot.exceptions.EditConflictError: editconflict: An edit conflict occurred.
+[INFO] 09:40:05:  -- Ordinal 6: M5556 (something)
+"""
+
+CONNRESET_BLOCK = """\
+[ERROR] 09:50:00:  -- Ordinal 2 (M2222) for {id}: SDC sync failed; skipping ordinal.
+Traceback (most recent call last):
+  ...
+  File ".../urllib3/connection.py", line 100, in _new_conn
+    raise NewConnectionError(...)
+requests.exceptions.ConnectionError: HTTPSConnectionPool(host='commons.wikimedia.org', port=443): Max retries exceeded
+[INFO] 09:50:05:  -- Ordinal 3: M2223 (something)
+"""
+
+INVALID_CLAIM_BLOCK = """\
+[ERROR] 10:00:00:  -- Ordinal 8 (M8888) for {id}: SDC sync failed; skipping ordinal.
+Traceback (most recent call last):
+  ...
+  File "/x/sdc_sync.py", line 1914, in _submit_sdc_write
+    raise RuntimeError(...) from e
+RuntimeError: wbeditentity failed for M8888 (deadbeef...): invalid-claim - Type is missing
+[INFO] 10:00:05:  -- Ordinal 9: M8889 (something)
+"""
+
+PERMISSION_BLOCK = """\
+[ERROR] 10:10:00:  -- Ordinal 11 (M1111) for {id}: SDC sync failed; skipping ordinal.
+Traceback (most recent call last):
+  ...
+pywikibot.exceptions.APIError: permissiondenied: You don't have permission to edit this page.
+[INFO] 10:10:05:  -- Ordinal 12: M1112 (something)
+"""
+
+KEYERROR_BLOCK = """\
+[ERROR] 10:20:00:  -- Ordinal 14 (M1414) for {id}: SDC sync failed; skipping ordinal.
+Traceback (most recent call last):
+  ...
+  File "/x/sdc_sync.py", line 555, in process_one_from_sdc
+    foo = claim['nonexistent']
+KeyError: 'nonexistent'
+[INFO] 10:20:05:  -- Ordinal 15: M1415 (something)
+"""
+
+
+def _write_log(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "20260101-000000-nara+example-sdc.log"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+@pytest.mark.parametrize(
+    "block,name",
+    [
+        (MAXLAG_BLOCK, "maxlag"),
+        (READONLY_BLOCK, "readonly"),
+        (EDITCONFLICT_BLOCK, "editconflict"),
+        (CONNRESET_BLOCK, "connection-reset"),
+    ],
+)
+def test_transient_errors_are_retryable(tmp_path, block, name):
+    """Every pattern in SDC_TRANSIENT_ERRORS classifies the ID as retryable."""
+    dpla_id = "a" * 32
+    log = _write_log(tmp_path, block.format(id=dpla_id))
+    assert parse_sdc_log(log) == {dpla_id}, f"{name} should be retryable"
+
+
+@pytest.mark.parametrize(
+    "block,name",
+    [
+        (INVALID_CLAIM_BLOCK, "invalid-claim"),
+        (PERMISSION_BLOCK, "permissiondenied"),
+        (KEYERROR_BLOCK, "KeyError-code-bug"),
+    ],
+)
+def test_structural_errors_excluded(tmp_path, block, name):
+    """Structural / permanent failures must NOT land in the retry set."""
+    dpla_id = "b" * 32
+    log = _write_log(tmp_path, block.format(id=dpla_id))
+    assert parse_sdc_log(log) == set(), f"{name} should be excluded"
+
+
+def test_mixed_log_collects_only_retryable(tmp_path):
+    """Single log file with multiple per-ordinal errors of varying types:
+    only the transient ones end up in the result."""
+    log_body = (
+        MAXLAG_BLOCK.format(id="1" * 32)
+        + INVALID_CLAIM_BLOCK.format(id="2" * 32)
+        + CONNRESET_BLOCK.format(id="3" * 32)
+        + PERMISSION_BLOCK.format(id="2" * 32)  # same id as the invalid-claim
+        + EDITCONFLICT_BLOCK.format(id="4" * 32)
+    )
+    log = _write_log(tmp_path, log_body)
+    # Note: "2" * 32 has BOTH a structural and a permission error in this
+    # synthetic log. Neither matches SDC_TRANSIENT_RE, so the ID stays out.
+    assert parse_sdc_log(log) == {"1" * 32, "3" * 32, "4" * 32}
+
+
+def test_same_id_multiple_ordinals_dedups(tmp_path):
+    """An item with N transient-failed ordinals appears once in the result."""
+    dpla_id = "c" * 32
+    log_body = MAXLAG_BLOCK.format(id=dpla_id) + CONNRESET_BLOCK.format(id=dpla_id)
+    log = _write_log(tmp_path, log_body)
+    assert parse_sdc_log(log) == {dpla_id}
+
+
+def test_empty_log_returns_empty_set(tmp_path):
+    log = _write_log(tmp_path, "")
+    assert parse_sdc_log(log) == set()
+
+
+def test_log_with_no_errors_returns_empty_set(tmp_path):
+    log = _write_log(
+        tmp_path,
+        "[INFO] 09:00:00: Partner mode: nara — 100 items from ...csv\n"
+        "[INFO] 09:00:01:  -- Ordinal 1: M1 (something)\n"
+        "[INFO] 09:00:02:  -- Touched 'File:foo.jpg' (category refresh).\n",
+    )
+    assert parse_sdc_log(log) == set()
+
+
+def test_traceback_terminates_at_next_error_marker(tmp_path):
+    """Back-to-back per-ordinal errors with no [INFO] between them: each
+    error's traceback ends when the next [ERROR] marker is reached, so
+    the classifier doesn't blur the two error contexts together.
+    """
+    id_a = "a" * 32
+    id_b = "b" * 32
+    # First error is structural (KeyError), second is transient (maxlag).
+    # If the parser blurred them, both IDs would appear in the result
+    # because the maxlag string would taint the first block. Correct
+    # behavior: only the maxlag-id is retryable.
+    log_body = (
+        KEYERROR_BLOCK.format(id=id_a).rstrip().rsplit("\n", 1)[0] + "\n"
+        f"[ERROR] 10:25:00:  -- Ordinal 14 (M1414) for {id_b}: SDC sync failed; skipping ordinal.\n"
+        "pywikibot.exceptions.MaxlagTimeoutError: Maximum retries attempted.\n"
+        "[INFO] 10:25:05:  -- Ordinal 15: M1415 (foo)\n"
+    )
+    log = _write_log(tmp_path, log_body)
+    result = parse_sdc_log(log)
+    assert id_b in result
+    assert id_a not in result

--- a/tests/test_wikimedia_retry.py
+++ b/tests/test_wikimedia_retry.py
@@ -498,3 +498,49 @@ def test_retry_clears_stale_csvs_even_when_no_partner_given():
     assert "rm -f" in scan_cmd
     assert "*-retry.csv" in scan_cmd
     assert scan_cmd.find("rm -f") < scan_cmd.find("get-ids-retry")
+
+
+def test_retry_sdc_only_csv_runs_sdc_sync_step():
+    """When only an sdc-retry CSV exists for a hub, the pipeline runs
+    sdc-sync (partner mode against that CSV) and does NOT invoke the
+    downloader or uploader — S3 assets and Commons pages are already
+    correct; only SDC needs to be re-attempted."""
+    commands = _run_main_with_csvs(
+        ["wikimedia_retry.py", "--days", "7", "--partner", "nara"],
+        ["/home/ec2-user/ingest-wikimedia/retry/nara-sdc-retry.csv"],
+    )
+    pipeline_cmd = _find_pipeline_script(commands)
+
+    assert "downloader" not in pipeline_cmd, (
+        f"sdc-only retry must not invoke downloader; got: {pipeline_cmd!r}"
+    )
+    assert "uploader" not in pipeline_cmd, (
+        f"sdc-only retry must not invoke uploader; got: {pipeline_cmd!r}"
+    )
+    assert (
+        "sdc-sync --partner nara --ids-file /home/ec2-user/ingest-wikimedia/retry/nara-sdc-retry.csv"
+        in pipeline_cmd
+    )
+
+
+def test_retry_sdc_runs_after_upload_when_both_csvs_present():
+    """Upload + SDC retries on the same hub: the sdc-sync step runs
+    AFTER the uploader because the uploader refreshes upload-result.json
+    on S3, which sdc-sync reads to find SDC-eligible ordinals."""
+    commands = _run_main_with_csvs(
+        ["wikimedia_retry.py", "--days", "7", "--partner", "nara"],
+        [
+            "/home/ec2-user/ingest-wikimedia/retry/nara-upload-retry.csv",
+            "/home/ec2-user/ingest-wikimedia/retry/nara-sdc-retry.csv",
+        ],
+    )
+    pipeline_cmd = _find_pipeline_script(commands)
+
+    upload_pos = pipeline_cmd.find("uploader ")
+    sdc_pos = pipeline_cmd.find("sdc-sync ")
+    assert upload_pos != -1, f"uploader step missing: {pipeline_cmd!r}"
+    assert sdc_pos != -1, f"sdc-sync step missing: {pipeline_cmd!r}"
+    assert upload_pos < sdc_pos, (
+        f"sdc-sync must follow uploader (uploader writes upload-result.json "
+        f"that sdc-sync reads); got positions upload={upload_pos} sdc={sdc_pos}"
+    )

--- a/tools/get_ids_retry.py
+++ b/tools/get_ids_retry.py
@@ -1,8 +1,8 @@
 """
-Extract DPLA IDs from recent upload/download logs for items that failed due to
-transient or now-resolvable issues and should be retried.
+Extract DPLA IDs from recent upload/download/sdc logs for items that failed due
+to transient or now-resolvable issues and should be retried.
 
-Two failure types are identified:
+Three failure types are identified:
 
   upload   — Wikimedia-side transient errors (lock contention, backend storage
               failures) and title/hash-drift errors that the uploader can now
@@ -11,6 +11,12 @@ Two failure types are identified:
 
   download — Media-server HTTP failures after all retries are exhausted.  Both
               the downloader and uploader need to run.
+
+  sdc      — Wikibase API transient failures during SDC sync (maxlag, replica
+              lag, rate limiting, 5xx, network blips).  Filtered to exceptions
+              a bare retry is likely to succeed against — structural errors
+              (invalid-claim, no-such-entity, permission denied) are NOT
+              classified as retryable because re-running won't help.
 
 Output: one CSV per partner per failure type, written to --output-dir.
 A summary table is printed to stdout.
@@ -60,6 +66,64 @@ DOWNLOAD_FAILED_RE = re.compile(r"Failed: ([0-9a-f]{32})")
 # The double space indicates an empty URL — produced by the IIIF parsing bug fixed in PR #180.
 EMPTY_URL_FAILURE = "Failed downloading  to"
 
+# The per-ordinal failure marker logged from sdc_sync._run_partner_mode's
+# exception boundary.  The traceback follows on subsequent lines until the
+# next [INFO] / [ERROR] marker.
+SDC_ORDINAL_ERROR_RE = re.compile(
+    r"-- Ordinal \d+ \(M\d+\) for ([0-9a-f]{32}): SDC sync failed; skipping ordinal\."
+)
+
+# Substring patterns that indicate the failure is transient and a bare retry
+# (re-running sdc-sync against the same staged sdc.json) is likely to succeed.
+# Anything not matching one of these patterns is treated as STRUCTURAL —
+# either a code bug, malformed SDC fragment, or Commons-side permanent state
+# (deleted entity, permission denial) — and excluded from the retry CSV
+# because re-running would just reproduce the same failure.
+#
+# Match strings are taken verbatim from observed traceback / API-error text:
+#
+#   * MaxlagTimeoutError                 — replica lag exhausted pywikibot retry budget
+#   * ServerError                        — HTTP 5xx from MediaWiki / Wikibase
+#   * ReadTimeoutError / ReadTimeout     — botocore / requests
+#   * ConnectTimeoutError                — botocore
+#   * EndpointConnectionError            — botocore
+#   * ChunkedEncodingError               — requests partial-response
+#   * ProtocolError                      — urllib3 connection drops
+#   * ConnectionError                    — requests / urllib3
+#   * internal_api_error_DBQueryError    — MediaWiki API replica/DB blip
+#   * internal_api_error_DBConnectionError
+#   * editconflict                       — concurrent writer race on the entity
+#   * failed-save                        — Wikibase save retry storm
+#   * readonly                           — MediaWiki database in read-only mode
+#   * ratelimited                        — API rate limit reached
+#   * maxlag                             — explicit maxlag rejection (lowercase form)
+#   * SlowDown / RequestTimeout /        — S3 transient sidecar reads
+#     ServiceUnavailable / InternalError
+SDC_TRANSIENT_ERRORS = (
+    "MaxlagTimeoutError",
+    "ServerError",
+    "ReadTimeoutError",
+    "ReadTimeout",
+    "ConnectTimeoutError",
+    "EndpointConnectionError",
+    "ChunkedEncodingError",
+    "ProtocolError",
+    "ConnectionError",
+    "internal_api_error_DBQueryError",
+    "internal_api_error_DBConnectionError",
+    "editconflict",
+    "failed-save",
+    "readonly",
+    "ratelimited",
+    "maxlag",
+    "SlowDown",
+    "RequestTimeout",
+    "ServiceUnavailable",
+    "InternalError",
+)
+
+SDC_TRANSIENT_RE = re.compile("|".join(re.escape(e) for e in SDC_TRANSIENT_ERRORS))
+
 
 def parse_upload_log(path: Path) -> tuple[set[str], set[str]]:
     """Return (transient_failure_ids, successfully_uploaded_ids) from an upload log.
@@ -102,8 +166,71 @@ def parse_download_log(path: Path) -> set[str]:
     return failed
 
 
-def collect_partner_ids(partner: str, cutoff: datetime) -> tuple[set[str], set[str]]:
-    """Scan logs for *partner* and return (upload_failures, download_failures).
+def parse_sdc_log(path: Path) -> set[str]:
+    """Return DPLA IDs whose per-ordinal SDC sync failed with a transient error.
+
+    The per-ordinal exception boundary in ``sdc_sync._run_partner_mode`` logs
+    a single marker line followed by a Python traceback.  We collect the
+    traceback text up to the next ``[INFO]`` / ``[ERROR]`` line and classify:
+
+      retryable  — traceback matches ``SDC_TRANSIENT_RE``.  The DPLA ID is
+                   added to the result set.
+      structural — anything else.  Either a code bug, malformed SDC, or
+                   permanent Commons-side state (deleted entity, permission
+                   denial).  Re-running won't help; excluded from the CSV.
+
+    A single DPLA item can have many ordinals; if ANY ordinal hit a
+    retryable error, the whole item ID is included (sdc-sync's partner
+    mode reads each item's sidecars and only writes diffs against
+    Commons-side state, so re-syncing the whole item is safe and cheap —
+    the already-clean ordinals produce zero writes).
+    """
+    retryable: set[str] = set()
+    current_id: str | None = None
+    current_traceback: list[str] = []
+
+    def _flush() -> None:
+        # Close the current traceback block: if it matched a transient
+        # pattern, register the ID for retry.  Reset state regardless.
+        nonlocal current_id, current_traceback
+        if current_id and current_traceback:
+            blob = "".join(current_traceback)
+            if SDC_TRANSIENT_RE.search(blob):
+                retryable.add(current_id)
+        current_id = None
+        current_traceback = []
+
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            m = SDC_ORDINAL_ERROR_RE.search(line)
+            if m:
+                # New error block: flush any prior, start fresh.
+                _flush()
+                current_id = m.group(1)
+                continue
+            if current_id is None:
+                continue
+            # Inside an error block: collect traceback lines until the
+            # next [INFO] / [ERROR] marker.  Anything starting with
+            # "[INFO] " or "[ERROR] " ends the block.
+            if line.startswith("[INFO] ") or line.startswith("[ERROR] "):
+                _flush()
+                # If this terminating line is itself a new ordinal error,
+                # re-classify it as the start of the next block.
+                m2 = SDC_ORDINAL_ERROR_RE.search(line)
+                if m2:
+                    current_id = m2.group(1)
+                continue
+            current_traceback.append(line)
+        # End-of-file: flush whatever is pending.
+        _flush()
+    return retryable
+
+
+def collect_partner_ids(
+    partner: str, cutoff: datetime
+) -> tuple[set[str], set[str], set[str]]:
+    """Scan logs for *partner* and return ``(upload, download, sdc)`` retry sets.
 
     Upload logs are processed oldest-first so each run's outcome can supersede
     the previous one.  For each run an ID is classified as:
@@ -116,11 +243,19 @@ def collect_partner_ids(partner: str, cutoff: datetime) -> tuple[set[str], set[s
     An ID that fails in an early run but uploads cleanly in a later run ends up
     as "done" and is excluded.  An ID with partial success in a single run
     (some files fail, some succeed) stays "retry".
+
+    SDC logs are processed similarly: each per-ordinal error is classified as
+    transient (matches ``SDC_TRANSIENT_RE``) or structural.  Only transient
+    failures land in the retry set.  Items that succeed in a later run aren't
+    excluded — the per-item SDC sync is idempotent, so re-running them is a
+    no-op that produces zero writes; the simpler "any transient error in the
+    window" rule is cheaper than tracking per-run outcomes.
     """
     log_dir = BASE_DIR / partner / "logs"
     # id → "retry" | "done"; later log files (by mtime) overwrite earlier ones.
     outcomes: dict[str, str] = {}
     download_failures: set[str] = set()
+    sdc_failures: set[str] = set()
 
     for log_file in sorted(
         log_dir.glob("*-upload.log"), key=lambda f: f.stat().st_mtime
@@ -138,12 +273,24 @@ def collect_partner_ids(partner: str, cutoff: datetime) -> tuple[set[str], set[s
             continue
         download_failures.update(parse_download_log(log_file))
 
+    for log_file in sorted(log_dir.glob("*-sdc.log")):
+        if datetime.fromtimestamp(log_file.stat().st_mtime, tz=timezone.utc) < cutoff:
+            continue
+        sdc_failures.update(parse_sdc_log(log_file))
+
     upload_failures = {dpla_id for dpla_id, o in outcomes.items() if o == "retry"}
     fully_uploaded = {dpla_id for dpla_id, o in outcomes.items() if o == "done"}
     download_failures -= fully_uploaded
-    # Avoid scheduling the same ID for both retry types.
+    # Avoid scheduling the same ID for both upload-side retry types.  An ID
+    # that needs an upload retry will also re-run sdc-sync downstream when the
+    # uploader catches up, so don't double-list it in the sdc-retry CSV
+    # either — that would force the sdc-sync step to run twice on the same
+    # ID.  Same rule for download: the combined retry pipeline already
+    # chains uploader after downloader and sdc-sync after uploader.
     upload_failures -= download_failures
-    return upload_failures, download_failures
+    sdc_failures -= upload_failures
+    sdc_failures -= download_failures
+    return upload_failures, download_failures, sdc_failures
 
 
 def write_ids(path: Path, ids: set[str]) -> None:
@@ -181,6 +328,7 @@ def main(days: int, partner: str | None, output_dir: str) -> None:
     Writes one CSV per partner per failure type to OUTPUT_DIR:
       <partner>-upload-retry.csv   — run uploader only
       <partner>-download-retry.csv — run downloader then uploader
+      <partner>-sdc-retry.csv      — run sdc-sync only (transient SDC failures)
     """
     cutoff = datetime.now(tz=timezone.utc) - timedelta(days=days)
     out = Path(output_dir)
@@ -196,8 +344,12 @@ def main(days: int, partner: str | None, output_dir: str) -> None:
             logging.warning("No logs directory for partner '%s', skipping.", p)
             continue
 
-        upload_ids, download_ids = collect_partner_ids(p, cutoff)
-        for suffix, ids in (("upload", upload_ids), ("download", download_ids)):
+        upload_ids, download_ids, sdc_ids = collect_partner_ids(p, cutoff)
+        for suffix, ids in (
+            ("upload", upload_ids),
+            ("download", download_ids),
+            ("sdc", sdc_ids),
+        ):
             if ids:
                 csv_path = out / f"{p}-{suffix}-retry.csv"
                 write_ids(csv_path, ids)


### PR DESCRIPTION
## Summary

`/wikimedia-upload retry` previously only scanned upload + download logs. SDC-phase failures (the per-ordinal exception boundary in `sdc_sync._run_partner_mode`) were invisible to retry, so a hub that hit a Wikibase maxlag spike (like the recent NARA Eisenhower run that lost 2 ordinals on `885d80e9b033924c5b2e93e20ebfde8d`) needed a manual `/wikimedia-upload sdc <target>` to clean up.

This PR extends the retry classifier to also scan `*-sdc.log` and dispatch a new \`<partner>-sdc-retry.csv\` through \`sdc-sync\`.

## Design

- **New SDC scanner** in \`tools/get_ids_retry.py\`. Walks each \`*-sdc.log\`, finds \`-- Ordinal N (Mxxx) for <DPLA-ID>: SDC sync failed; skipping ordinal.\` markers, captures the trailing traceback up to the next \`[INFO]\`/\`[ERROR]\` marker, and classifies:
  - **Retryable** — traceback matches \`SDC_TRANSIENT_ERRORS\` (maxlag, readonly, ratelimited, server-side 5xx, network blips, editconflict, S3 sidecar transients).
  - **Structural** — anything else. Excluded from the retry CSV because re-running won't help.
- **Dispatcher update** in \`scripts/wikimedia_retry.py\`. The \`-sdc-retry.csv\` filename is recognised and the per-hub block appends \`sdc-sync --partner <slug> --ids-file <csv>\` as a final step after the uploader. SDC-only retries skip the uploader and downloader entirely.

The structural-exclusion list is deliberate: \`invalid-claim\`, \`permissiondenied\`, \`no-such-entity\`, and Python code bugs (\`KeyError\`, \`AttributeError\`) all surface a real issue — either bad SDC, missing permissions, missing entity, or a regression in our code. Auto-retrying these would mask the problem and rack up wasted API calls.

## Test plan

- [x] 12 new unit tests in \`tests/test_get_ids_retry.py\` against fixture log blocks: each transient pattern (maxlag, readonly, editconflict, ConnectionError) classifies as retryable, each structural category (invalid-claim, permissiondenied, KeyError code-bug) excluded, plus mixed / dedup / empty / boundary cases.
- [x] 2 new integration tests in \`tests/test_wikimedia_retry.py\` asserting the \`sdc-sync\` step is included, runs after the uploader when both CSVs exist, and runs alone when only the sdc-retry CSV exists.
- [x] Full test suite: 507 pass (was 505).
- [ ] Manual end-to-end on EC2 after merge against a fresh \`/wikimedia-upload retry 7 nara\` (expect the 2 Eisenhower ordinals from this morning to show up in the sdc-retry CSV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR extends retry tooling to detect and classify SDC-phase per-ordinal failures (from *-sdc.log) and to surface retryable SDC sync IDs to the retry pipeline.

What changed
- tools/get_ids_retry.py
  - Adds parse_sdc_log(path: Path) -> set[str], regexes/constants (SDC_ORDINAL_ERROR_RE, SDC_TRANSIENT_ERRORS, SDC_TRANSIENT_RE).
  - collect_partner_ids(...) now returns (upload_failures, download_failures, sdc_failures) and deduplicates IDs across retry types.
  - Writes <partner>-sdc-retry.csv alongside existing CSVs.
  - SDC failures are classified as:
    - Retryable — matches transient patterns (maxlag, readonly, rate-limited, server 5xx, network blips, editconflict, S3 sidecar transients).
    - Structural — other errors (invalid-claim, permissiondenied, no-such-entity, KeyError/AttributeError, etc.) — excluded from retry CSV.
- scripts/wikimedia_retry.py
  - Recognizes *-sdc-retry.csv and maps them to retry_type="sdc".
  - Dispatches sdc-sync --partner <slug> --ids-file <csv>.
  - When both normal and sdc-retry CSVs exist, sdc-sync is appended after the uploader; when only sdc-retry CSV exists, sdc-sync runs alone (downloader/uploader skipped).
- tests
  - Added tests/test_get_ids_retry.py (12 unit tests) covering transient vs structural classification, mixed/dedup/empty/boundary cases and traceback boundary behavior.
  - Added two integration tests in tests/test_wikimedia_retry.py asserting sdc-sync dispatch behavior.
  - Updated tests/conftest.py fixture teardown to avoid stranded patches.
  - Test count increased (full suite: 507 passing; was 505).
- docs
  - Updated docs/maintenance-tools.md and docs/slack-guide.md to document SDC scanning, retry categories (now three), sdc-retry CSV behavior and ordering relative to uploader/downloader.

Behavioral notes and impact
- No changes to public APIs, exported function signatures beyond the internal collect_partner_ids return type change noted above.
- No environment variables or AWS Secrets Manager keys are added/removed/renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM) are made in this PR.
- No direct security-sensitive changes (no new credential handling or external API endpoints).
- Manual end-to-end verification: the author notes a manual end-to-end run on EC2 remains to be executed after merge. This is a manual verification step only — the change does not require a pipeline trigger or ECS redeployment to take effect.

Test and reviewer guidance
- Reviewers should focus on the SDC parsing regexes/transient pattern list and deduplication logic to ensure no IDs are erroneously included/excluded.
- Pay attention to the new tests covering boundary cases and the updated autouse fixture in tests/conftest.py.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->