### PR TITLE
docs+sdc: minor AI-review fixes (typo, link, debug log)

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -48,7 +48,7 @@ Notable wiring:
 
 `Module:DPLA` reads the file's MediaInfo entity directly and renders a two-box block:
 
-- **Blue box** — every field is sourced from a DPLA-determined SDC statement (recognised by the `P459 = Q61848113` qualifier). Updated automatically when the SDC sync re-writes; no editor intervention.
+- **Blue box** — every field is sourced from a DPLA-determined SDC statement (recognised by the `P459 = Q61848113` qualifier). Updated automatically when the SDC sync rewrites; no editor intervention.
 - **Yellow box** — augmented from explicit template parameters (Artwork/Information-style names) plus any non-DPLA SDC statements on the same properties. The yellow box gives Commons editors a place to add corrections, translations, or supplementary metadata without conflicting with the bot's authoritative blue-box values.
 
 The module also writes three tracking categories per file with DPLA SDC: the DPLA umbrella category, the regional hub category (e.g. `Plains to Peaks Collective`), and the contributing institution category (e.g. `Denver Public Library`). When the hub partner is the institution itself (NARA, Smithsonian), the hub-role P9126 statement is omitted by the bot and the module falls back to the institution Q-ID for the hub category — preventing the "unknown partner" maintenance category for these special cases.
@@ -62,7 +62,7 @@ The module's existence is acknowledged in a handful of code comments inside the 
 - `ingest_wikimedia/sdc.py` — chunked-claim convention notes ("so the Lua [module] can reassemble the chunks").
 - `tools/sdc_sync.py` — same chunking notes; "unchunked variants of the same text are kept separate so the Lua template..."
 
-The pipeline does NOT directly invoke the module, render it client-side, or test it. Module:DPLA lives on Commons and is maintained as a Wikimedia-side artefact; this repo's responsibility is to write SDC the module can render correctly. See the test file at `commons.wikimedia.org/wiki/File:Plate_49_of_King's_1933_aerial_coverage_of_Denver,_Colorado_-_DPLA_-_4c3f5ad9bfac4097b95c9f8deb8e1a21.jpg` for a live render.
+The pipeline does NOT directly invoke the module, render it client-side, or test it. Module:DPLA lives on Commons and is maintained as a Wikimedia-side artefact; this repo's responsibility is to write SDC the module can render correctly. See [this test file on Commons](https://commons.wikimedia.org/wiki/File:Plate_49_of_King%27s_1933_aerial_coverage_of_Denver,_Colorado_-_DPLA_-_4c3f5ad9bfac4097b95c9f8deb8e1a21.jpg) for a live render.
 
 ## Planned transition
 

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2499,8 +2499,15 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected, protected_props=froze
                                         }
                                     )
                                 except (KeyError, IndexError, TypeError):
-                                    # P7482 statement without a P973 qualifier — skip it
-                                    pass
+                                    # P7482 statement without a P973 qualifier — skip
+                                    # it from reconciliation, but log the statement ID
+                                    # so operators can spot malformed DPLA-authored
+                                    # claims rather than have them vanish silently.
+                                    logging.debug(
+                                        "P7482 statement %s missing P973 qualifier; "
+                                        "skipping reconciliation",
+                                        stmt.get("id"),
+                                    )
                             elif dtype == "wikibase-entityid":
                                 dpla_claim_list.append(
                                     {


### PR DESCRIPTION
## Summary

An AI code-quality pass surfaced 14 findings against current `main`. After review, only 3 looked worth applying; the rest were declined as comment-only nits, refactors that traded clarity for indirection, or factually wrong (e.g. one flagged `drift_action` as unused when it drives the entire upload dispatch).

The accepted fixes:

- **docs/templates.md** — `re-writes` → `rewrites` (consistency); convert a bare `commons.wikimedia.org/...` URL into a proper markdown link.
- **tools/sdc_sync.py** — when a P7482 statement is skipped from reconciliation because its P973 qualifier is missing/malformed, log the statement ID at `debug` level. Previously this was a silent `pass`, so malformed DPLA-authored claims could vanish from the reconciler with no operator-facing signal.

### Findings declined (for the record)

- BASE_DIR hardcoded fallback in `get_ids_retry.py` — script is intentionally EC2-targeted and the env-var override is already there.
- Two "add inline comment" requests in `get_ids_retry.py` — existing docstring already covers the rationale.
- Refactor multi-line nested dict access in `sdc_sync.py:2497` — the try/except already handles malformed shapes; extracting a helper would add noise.
- Seeding `random.randrange` in `sdc_sync.py:3477` for reproducibility — workflow state changes via `WORKING-` rename anyway; not a real issue.
- "Missing docstring" on `_fake_s3_client` — it already has one.
- Two "extract path-parsing helper" requests in test code — the one-liner `path.rsplit("/", 1)[-1].split("_", 1)[0]` mirrors the format defined 5 lines below; extracting saves nothing.
- Style nit on a `(_ for _ in ()).throw(...)` lambda — common idiom, not worth churn.
- "Unused `drift_action`" — actually drives the upload dispatch (used at uploader.py:376, 386); reviewer was wrong, and the cited file path didn't even match where the variable lives.

## Test plan

- [ ] CI green
- [ ] Spot-check the markdown link renders on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Minor AI-review fixes: documentation and debug logging

### Changes

**docs/templates.md**
- Fixed hyphenation: "re-writes" → "rewrites" for consistency with standard English convention
- Converted bare URL reference in "Blue box" description into a proper Markdown link labeled "this test file on Commons"

**tools/sdc_sync.py**
- Enhanced `_reconcile_existing_claims()` to log debug-level messages when a DPLA-authored P7482 statement is skipped due to missing or malformed P973 qualifier, including the statement ID. Enables operators to identify and diagnose malformed DPLA-authored claims in Wikidata.

### Notes

- No environment variables, AWS Secrets Manager keys, or shared infrastructure configuration affected
- No database migrations
- No public API changes
- No security implications
- No manual pipeline trigger or ECS redeployment required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->