### PR TITLE
docs/templates: clarify planned 3-step DPLA-metadata lifecycle + adoption flow

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -68,36 +68,54 @@ The pipeline does NOT directly invoke the module, render it client-side, or test
 
 The roadmap is to ship `{{DPLA metadata}}` as the *primary* format the pipeline writes at upload time, replacing the `{{Artwork}}`-based wikitext block. Two reasons:
 
-1. **Single source of truth.** Today the metadata is duplicated — once as wikitext templated by the uploader, once as SDC reconciled by the sync phase. Switching the primary display to `{{DPLA metadata}}` means the SDC IS the metadata, full stop. The file-page wikitext becomes a one-line `{{DPLA metadata}}` invocation that picks everything up from SDC.
+1. **Single source of truth.** Today the metadata is duplicated — once as wikitext templated by the uploader, once as SDC reconciled by the sync phase. Switching the primary display to `{{DPLA metadata}}` means the SDC IS the metadata, full stop. The file-page wikitext becomes a bare `{{DPLA metadata}}` invocation that picks everything up from SDC.
 2. **Live updates.** When `Module:DPLA` reads SDC, every file gets the current rendering of the current data — no need to re-edit thousands of wikitext blobs to push out a display change.
 
-### What would need to change in the uploader
+### Per-file lifecycle (planned)
 
-`get_wiki_text()` would need to be rewritten to emit (essentially) just `{{DPLA metadata}}` plus the licensing template — the rest comes from SDC. Concretely:
+Three edits per file, in order:
+
+1. **Upload.** The uploader writes `{{DPLA metadata}}` with explicit wikitext parameters for every available field (title, description, creator, date, institution, subject, source). Wikitext params are necessary here because MediaWiki's [upload API](https://www.mediawiki.org/wiki/API:Upload) doesn't allow SDC statements to be attached in the same request, and Commons will not tolerate a file landing with no readable description even briefly. The Lua module already supports the explicit-param path (yellow box on a fresh upload, with no SDC populated yet).
+2. **SDC sync.** A subsequent edit posts the same metadata as MediaInfo statements via `wbeditentity`. After this edit, the wikitext params and the SDC contain the same values — the displayed page now has the SDC-driven blue box *and* the param-driven yellow box, both rendering identical content.
+3. **Cleanup edit.** A one-time follow-up edit strips the now-redundant wikitext params, leaving a bare `{{DPLA metadata}}` invocation. From this point on the file's display is entirely SDC-driven, and any future DPLA sync that updates the source data flows through to the rendered page automatically — no wikitext re-edit needed.
+
+Step 3 matters because explicit wikitext params *override* SDC on display (see [`Template:DPLA metadata/doc`](https://commons.wikimedia.org/wiki/Template:DPLA_metadata/doc) on Commons). Leaving stale params in place would mask any future SDC corrections.
+
+### Adoption of community-uploaded files
+
+The duplicate-detection logic already handles a related case: a file from a DPLA partner that some Commons editor has already uploaded directly (typically from the partner's online catalog or from Flickr). When the pipeline detects this overlap and adopts the file into DPLA's system — renaming it to the canonical `... - DPLA - <id>.<ext>` form — the planned workflow migrates whatever metadata the original uploader recorded in the existing wikitext into `{{DPLA metadata}}`'s yellow-box parameters. SDC sync then layers the DPLA-authoritative values on top: blue box shows DPLA, yellow box preserves the migrated editor data verbatim.
+
+The migration step is not yet implemented; today's duplicate-detection flow handles the rename and the `{{Duplicate}}` tagging of the original (see [special-cases.md](special-cases.md#hash-drift-the-four-cases)), but leaves the wikitext at the new title in its `{{Artwork}}` form.
+
+### Uploader code changes required
+
+`ingest_wikimedia/wikimedia.py::get_wiki_text` would need to be rewritten to emit `{{DPLA metadata}}` with explicit params instead of an `{{Artwork}}` block:
 
 ```wikitext
 == {{int:filedesc}} ==
-{{DPLA metadata}}
+{{DPLA metadata
+ |title       = ...
+ |description = ...
+ |author      = ...
+ |date        = ...
+ |institution = ...
+ |subject     = ...
+}}
 
 == {{int:license-header}} ==
 {{<permissions-template>}}
 ```
 
-The licensing line stays separate because Commons' file curation conventions require the license template to be visible in the wikitext (not just SDC) for human review.
+The licensing line stays separate because Commons' file-curation conventions require the license template to be visible in the wikitext (not just SDC) for human review.
 
-### What would need to change in the phase order
-
-Today the upload phase writes wikitext *before* the SDC phase posts the SDC. If `{{DPLA metadata}}` is the primary format, the wikitext is empty of metadata until SDC arrives — files would temporarily look blank between upload and SDC sync. Two ways to handle this:
-
-1. **Reverse the phase order.** Make the uploader post a placeholder `{{DPLA metadata}}` block at upload, then have a new "SDC pre-stage" phase run *before* the upload commits, writing the SDC into a staging entity. This is doable but invasive — Commons' upload API doesn't allow SDC + file-page in one request, so the staging would still happen post-upload, just before publishing the wikitext.
-2. **Pre-populate template parameters.** Use the explicit-param path of `{{DPLA metadata}}` so the uploader writes `{{DPLA metadata|title=...|description=...|...}}` with the same values it would have put into `{{Artwork}}`. The Lua module already supports this (explicit params override SDC fallbacks). Then SDC sync lands the same values as structured data, and over time the params can be dropped from the wikitext as SDC becomes authoritative.
-
-Option 2 is the lower-risk path and is what's currently planned. The wikitext becomes a transition vehicle: explicit params today, gradual dropping of params as SDC coverage stabilises, eventually a bare `{{DPLA metadata}}`.
+The cleanup edit (step 3 of the lifecycle) would be a new piece of code — likely a separate maintenance pass that runs at some interval after SDC sync, scans for files where SDC and wikitext params agree, and strips the params.
 
 ### Workstreams the transition would touch
 
-- `ingest_wikimedia/wikimedia.py::get_wiki_text` — new template body.
-- Commons-side `Template:DPLA metadata/doc` — already updated to describe both the blue (SDC) and yellow (user/explicit-param) boxes.
+- `ingest_wikimedia/wikimedia.py::get_wiki_text` — new template body with explicit params.
+- A new maintenance pass (e.g. `tools/strip_redundant_params.py`) for step 3.
+- The adoption-migration path in `tools/uploader.py::_resolve_hash_drift` — extend the rename branches to salvage the original editor's wikitext into yellow-box params.
+- Commons-side [`Template:DPLA metadata/doc`](https://commons.wikimedia.org/wiki/Template:DPLA_metadata/doc) — already documents the planned lifecycle.
 - `Commons:Digital Public Library of America/Modeling` — already updated to describe the SDC properties the module reads.
 - Operator runbook in [operations.md](operations.md) — note the change in the "what's on a fresh upload" wording.
 - A staged rollout — flip one hub at a time so a regression doesn't take down every partner.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -96,7 +96,7 @@ The migration step is not yet implemented; today's duplicate-detection flow hand
 {{DPLA metadata
  |title       = ...
  |description = ...
- |author      = ...
+ |creator     = ...
  |date        = ...
  |institution = ...
  |subject     = ...
@@ -106,6 +106,8 @@ The migration step is not yet implemented; today's duplicate-detection flow hand
 {{<permissions-template>}}
 ```
 
+The template also accepts `author` and `artist` as aliases for `creator` (for editor familiarity with `{{Information}}` and `{{Artwork}}` conventions); `creator` is preferred because of the [archival-records sense the SAA assigns to it](https://dictionary.archivists.org/entry/creator.html), which matches DPLA's source collections better than "Author."
+
 The licensing line stays separate because Commons' file-curation conventions require the license template to be visible in the wikitext (not just SDC) for human review.
 
 The cleanup edit (step 3 of the lifecycle) would be a new piece of code — likely a separate maintenance pass that runs at some interval after SDC sync, scans for files where SDC and wikitext params agree, and strips the params.
@@ -114,7 +116,7 @@ The cleanup edit (step 3 of the lifecycle) would be a new piece of code — like
 
 - `ingest_wikimedia/wikimedia.py::get_wiki_text` — new template body with explicit params.
 - A new maintenance pass (e.g. `tools/strip_redundant_params.py`) for step 3.
-- The adoption-migration path in `tools/uploader.py::_resolve_hash_drift` — extend the rename branches to salvage the original editor's wikitext into yellow-box params.
+- The adoption-migration path in `tools/uploader.py::Uploader._resolve_hash_drift` — extend the rename branches to salvage the original editor's wikitext into yellow-box params.
 - Commons-side [`Template:DPLA metadata/doc`](https://commons.wikimedia.org/wiki/Template:DPLA_metadata/doc) — already documents the planned lifecycle.
 - `Commons:Digital Public Library of America/Modeling` — already updated to describe the SDC properties the module reads.
 - Operator runbook in [operations.md](operations.md) — note the change in the "what's on a fresh upload" wording.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -4,17 +4,17 @@ How the pipeline uses Commons templates to display item metadata — and how the
 
 This document is the *pipeline's* view of the templates. For the user-facing template documentation (what editors see and how they augment it), see the [Template:DPLA metadata/doc](https://commons.wikimedia.org/wiki/Template:DPLA_metadata/doc) page on Commons.
 
-## Current state: `{{Artwork}}` at upload, `{{DPLA metadata}}` from SDC
+## Current state: `{{DPLA metadata}}` with explicit params at upload, then SDC
 
-At upload time, the pipeline writes a fully-rendered `{{Artwork}}` block as the file page's wikitext. After SDC sync lands the same metadata as structured data, that metadata can *also* be rendered by `{{DPLA metadata}}` — but the pipeline does NOT include `{{DPLA metadata}}` in the wikitext it uploads. The two systems run side-by-side; `{{DPLA metadata}}` is currently maintained as a parallel rendering option and would replace `{{Artwork}}` only in a future PR (see [Planned transition](#planned-transition) below).
+As of [PR #291](https://github.com/dpla/ingest-wikimedia/pull/291), the uploader writes a fully-rendered `{{DPLA metadata}}` block as the file page's wikitext at upload time. After SDC sync lands the same metadata as MediaInfo statements, the explicit params and the SDC carry the same values; the file page renders both side-by-side (yellow-box from params + blue-box from SDC) until the planned cleanup pass strips the now-redundant params (see [Planned transition](#planned-transition) below).
 
-### Upload-time wikitext (the `{{Artwork}}` path)
+### Upload-time wikitext
 
 `get_wiki_text(dpla_id, item_metadata, provider, data_provider)` in `ingest_wikimedia/wikimedia.py` composes the file-page wikitext. The current template literal:
 
 ```wikitext
 == {{int:filedesc}} ==
-{{ Artwork
+{{ DPLA metadata
    | Other fields 1 = {{ InFi | Creator | <creator> | id=fileinfotpl_aut }}
    | title       = <title>
    | description = <description>
@@ -33,10 +33,15 @@ At upload time, the pipeline writes a fully-rendered `{{Artwork}}` block as the 
 
 Notable wiring:
 
-- The `| Other fields 1` row is included only when a creator is present.
-- `| source = {{DPLA|...}}` is the DPLA-specific glue: `Template:DPLA` on Commons renders DPLA's catalog link, hub attribution, and local identifier inside `{{Artwork}}`'s source slot. This `Template:DPLA` is distinct from `Module:DPLA` (the Lua module backing the new `{{DPLA metadata}}` template).
+- The wrapper template is `{{DPLA metadata}}` (the DPLA-owned template backed by `Module:DPLA`), not `{{Artwork}}`. PR #291 swapped just the wrapper name; the inner parameter set is the same one the prior `{{Artwork}}`-based uploader had been emitting.
+- The `| Other fields 1` row is included only when a creator is present. It uses the same `{{InFi|Creator|…}}` idiom Artwork had, which the DPLA template renders compatibly. Once SDC sync lands the value as a creator statement, the cleanup pass would replace this row with a top-level `|creator=` param (yellow-box-compatible) before stripping it entirely.
+- `| source = {{DPLA|...}}` is the DPLA-specific source sub-template. `Template:DPLA` on Commons renders DPLA's catalog link, hub attribution, and local identifier inside the source slot. This `Template:DPLA` is distinct from `Module:DPLA` (the Lua module backing `{{DPLA metadata}}`); the sub-template stays for legacy pages even after the SDC sync lands the same data as `P7482` / `P760` / `P9126` claims.
 - `| permission = {{<permissions-template>}}` resolves to one of `NKC`, `NoC-US`, `PD-US`, `cc-zero`, or a CC-by/by-sa code per `license_to_markup_code()` (mapping is in `ingest_wikimedia/wikimedia.py`).
 - `| Institution = {{Institution|wikidata=...}}` uses Commons' standard `{{Institution}}` template for the institution row.
+
+### Files uploaded before PR #291
+
+Pages already on Commons keep their `{{Artwork}}` blocks until they're individually edited. There's no backfill pass yet; `Module:DPLA` happily renders an `{{Artwork}}`-wikitext file's SDC the same way it renders a `{{DPLA metadata}}`-wikitext file's, so the visible difference is only in the wikitext-tab view, not the rendered file description.
 
 ### Post-upload rendering: `{{DPLA metadata}}` + `Module:DPLA`
 
@@ -71,15 +76,15 @@ The roadmap is to ship `{{DPLA metadata}}` as the *primary* format the pipeline 
 1. **Single source of truth.** Today the metadata is duplicated — once as wikitext templated by the uploader, once as SDC reconciled by the sync phase. Switching the primary display to `{{DPLA metadata}}` means the SDC IS the metadata, full stop. The file-page wikitext becomes a bare `{{DPLA metadata}}` invocation that picks everything up from SDC.
 2. **Live updates.** When `Module:DPLA` reads SDC, every file gets the current rendering of the current data — no need to re-edit thousands of wikitext blobs to push out a display change.
 
-### Per-file lifecycle (planned)
+### Per-file lifecycle
 
 Three edits per file, in order:
 
-1. **Upload.** The uploader writes `{{DPLA metadata}}` with explicit wikitext parameters for every available field (title, description, creator, date, institution, subject, source). Wikitext params are necessary here because MediaWiki's [upload API](https://www.mediawiki.org/wiki/API:Upload) doesn't allow SDC statements to be attached in the same request, and Commons will not tolerate a file landing with no readable description even briefly. The Lua module already supports the explicit-param path (yellow box on a fresh upload, with no SDC populated yet).
-2. **SDC sync.** A subsequent edit posts the same metadata as MediaInfo statements via `wbeditentity`. After this edit, the wikitext params and the SDC contain the same values — the displayed page now has the SDC-driven blue box *and* the param-driven yellow box, both rendering identical content.
-3. **Cleanup edit.** A one-time follow-up edit strips the now-redundant wikitext params, leaving a bare `{{DPLA metadata}}` invocation. From this point on the file's display is entirely SDC-driven, and any future DPLA sync that updates the source data flows through to the rendered page automatically — no wikitext re-edit needed.
+1. **Upload — *done* (PR #291).** The uploader writes `{{DPLA metadata}}` with explicit wikitext parameters: `title`, `description`, `date`, `permission`, `source` (as a `{{DPLA|...}}` sub-template carrying catalog link, hub attribution, local identifier), `Institution`, plus a `{{InFi|Creator|…}}` row in `Other fields 1` when a creator is known. Wikitext params are necessary at this step because MediaWiki's [upload API](https://www.mediawiki.org/wiki/API:Upload) doesn't allow SDC statements to be attached in the same request, and Commons will not tolerate a file landing with no readable description even briefly. The Lua module renders these params in the yellow box on a fresh upload (with no SDC populated yet).
+2. **SDC sync — *done* (existing phase).** A subsequent edit posts the same metadata as MediaInfo statements via `wbeditentity`. After this edit, the wikitext params and the SDC contain the same values — the displayed page now has the SDC-driven blue box *and* the param-driven yellow box, both rendering identical content.
+3. **Cleanup edit — *planned*.** A one-time follow-up edit will strip the now-redundant wikitext params, leaving a bare `{{DPLA metadata}}` invocation plus the licensing template. From this point on the file's display is entirely SDC-driven, and any future DPLA sync that updates the source data flows through to the rendered page automatically — no wikitext re-edit needed.
 
-Step 3 matters because explicit wikitext params *override* SDC on display (see [`Template:DPLA metadata/doc`](https://commons.wikimedia.org/wiki/Template:DPLA_metadata/doc) on Commons). Leaving stale params in place would mask any future SDC corrections.
+Step 3 matters because explicit wikitext params *override* SDC on display (see [`Template:DPLA metadata/doc`](https://commons.wikimedia.org/wiki/Template:DPLA_metadata/doc) on Commons). Leaving stale params in place would mask any future SDC corrections. As of June 2026, files uploaded by PR #291 are in the intermediate "step 1 done, awaiting step 3" state.
 
 ### Adoption of community-uploaded files
 
@@ -87,34 +92,17 @@ The duplicate-detection logic already handles a related case: a file from a DPLA
 
 The migration step is not yet implemented; today's duplicate-detection flow handles the rename and the `{{Duplicate}}` tagging of the original (see [special-cases.md](special-cases.md#hash-drift-the-four-cases)), but leaves the wikitext at the new title in its `{{Artwork}}` form.
 
-### Uploader code changes required
+### Code changes — current and remaining
 
-`ingest_wikimedia/wikimedia.py::get_wiki_text` would need to be rewritten to emit `{{DPLA metadata}}` with explicit params instead of an `{{Artwork}}` block:
-
-```wikitext
-== {{int:filedesc}} ==
-{{DPLA metadata
- |title       = ...
- |description = ...
- |creator     = ...
- |date        = ...
- |institution = ...
- |subject     = ...
-}}
-
-== {{int:license-header}} ==
-{{<permissions-template>}}
-```
+**Done in PR #291:** `ingest_wikimedia/wikimedia.py::get_wiki_text` was switched from `{{Artwork}}` to `{{DPLA metadata}}` as the wrapper template. The inner parameter set kept the same shape (title / description / date / permission / source-via-`{{DPLA|...}}` / Institution / Creator-via-`InFi`), so no rewrite was needed — just the one-line wrapper-name change. The yellow user-contributed box on a fresh upload is now populated by these params automatically; SDC sync layers the blue box on top in the subsequent phase.
 
 The template also accepts `author` and `artist` as aliases for `creator` (for editor familiarity with `{{Information}}` and `{{Artwork}}` conventions); `creator` is preferred because of the [archival-records sense the SAA assigns to it](https://dictionary.archivists.org/entry/creator.html), which matches DPLA's source collections better than "Author."
 
-The licensing line stays separate because Commons' file-curation conventions require the license template to be visible in the wikitext (not just SDC) for human review.
-
-The cleanup edit (step 3 of the lifecycle) would be a new piece of code — likely a separate maintenance pass that runs at some interval after SDC sync, scans for files where SDC and wikitext params agree, and strips the params.
+**Remaining for step 3 (cleanup):** a new maintenance pass (e.g. `tools/strip_redundant_params.py`) that runs at some interval after SDC sync, scans for files where SDC and wikitext params agree, and strips the params, leaving `{{DPLA metadata}}` as a bare invocation. The licensing template stays separate because Commons' file-curation conventions require the license to remain visible in the wikitext (not just SDC) for human review.
 
 ### Workstreams the transition would touch
 
-- `ingest_wikimedia/wikimedia.py::get_wiki_text` — new template body with explicit params.
+- ~~`ingest_wikimedia/wikimedia.py::get_wiki_text` — new template body with explicit params.~~ Done in PR #291.
 - A new maintenance pass (e.g. `tools/strip_redundant_params.py`) for step 3.
 - The adoption-migration path in `tools/uploader.py::Uploader._resolve_hash_drift` — extend the rename branches to salvage the original editor's wikitext into yellow-box params.
 - Commons-side [`Template:DPLA metadata/doc`](https://commons.wikimedia.org/wiki/Template:DPLA_metadata/doc) — already documents the planned lifecycle.
@@ -152,10 +140,10 @@ A summary diagram:
    ┌──────────────────────────────────────────────┐
    │  Commons file page                           │
    │                                              │
-   │  {{Artwork}} block (today's primary display) │
-   │  + (optionally) {{DPLA metadata}} block      │
-   │    rendered by Module:DPLA from SDC          │
+   │  {{DPLA metadata}} block with explicit       │
+   │    params (yellow box) + SDC-driven render   │
+   │    via Module:DPLA (blue box)                │
    └──────────────────────────────────────────────┘
 ```
 
-In the planned future state, the left branch goes away — the uploader writes only `{{DPLA metadata}}`, and everything else comes from the SDC sync's writes via `Module:DPLA`.
+In the planned future state (step 3 of the lifecycle), the left branch's wikitext params get stripped — the file page wikitext becomes a bare `{{DPLA metadata}}` invocation, and all displayed metadata comes from the SDC sync's writes via `Module:DPLA`. Until that pass exists, the explicit params and the SDC carry redundant copies of the same values.


### PR DESCRIPTION
## Summary

Tighten the \`Planned transition\` section in [docs/templates.md](docs/templates.md) so it accurately describes:

1. The **per-file 3-step lifecycle** for new uploads under the planned workflow: (a) upload with explicit \`{{DPLA metadata}}\` params, (b) SDC sync posts the same values as MediaInfo, (c) a one-time follow-up edit strips the now-redundant wikitext params, leaving SDC as the single source of truth.
2. The **adoption flow** for files a Commons editor uploaded directly (from a partner catalog or Flickr) that the duplicate-detection pipeline then adopts into DPLA's namespace — the planned step is to migrate the editor's existing wikitext metadata into the template's yellow-box parameters during the rename.

Both are explicitly marked as future work; neither is implemented yet. Today's pipeline still emits \`{{Artwork}}\` at upload and the duplicate-detection logic only handles rename + \`{{Duplicate}}\` tagging.

Companion edit landed on Commons at [Template:DPLA metadata/doc](https://commons.wikimedia.org/wiki/Template:DPLA_metadata/doc) (revision 1228647985) which now describes the same lifecycle from the user perspective.

## Why now

The previous wording hedged "explicit params today, gradual dropping of params as SDC coverage stabilises" without spelling out that the cleanup is one deliberate edit per file, not a slow drift. A reader (who happens to be the template's designer) asked what an earlier hedge about "small number of legacy flows" meant — the honest answer was that I'd invented the hedge to cover uncertainty about a workflow that doesn't exist yet. This PR replaces the hedge with the actual plan.

## Test plan

- [x] Doc only; no code changes; no CI failures expected.
- [ ] Reviewer eyeballs to confirm the lifecycle description matches your design intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation-only PR

This PR tightens docs/templates.md to clarify the planned 3-step per-file lifecycle for moving from uploader-generated wikitext to SDC-backed rendering and to document the planned adoption flow for community-uploaded files. It is documentation-only; no runtime code changes are introduced by this PR.

High-level changes
- Adds an explicit per-file 3-step lifecycle (upload → SDC sync → cleanup):
  1. Upload writes {{DPLA metadata}} with explicit wikitext params (yellow-box).
  2. SDC sync posts the same metadata as MediaInfo statements (blue-box).
  3. Planned one-time cleanup edit strips redundant wikitext params so SDC is the single source of truth.
- Documents an adoption flow for files a Commons editor uploaded directly that are later adopted by the pipeline: during the rename/adoption, the editor’s existing wikitext would be migrated into {{DPLA metadata}} yellow-box params and SDC would provide blue-box authoritative values. This migration is explicitly marked as future work.
- Clarifies that explicit template params override SDC display and therefore stale params must be removed after sync.
- Expands upload-time wiring notes (wrapper template, conditional creator row, |source={{DPLA|...}}, permission/license mapping, Institution rendering) and explains behavior for files uploaded before the change.
- Updates repo/workstreams list and diagrams to reflect the planned lifecycle and where remaining work will live.

Commit-level notes
- Replaced |author= with |creator= in the planned uploader template example (author/artist remain accepted aliases).
- Qualified _resolve_hash_drift as Uploader._resolve_hash_drift to reflect the method’s actual location.
- Notes that PR `#291` changed the uploader to emit {{DPLA metadata}} (wrapper-name change); inner parameter set remained compatible with prior {{Artwork}} output.

Test plan and reviewer request
- Doc-only change; no CI changes expected. Reviewer eyeballs requested to confirm the lifecycle wording matches design intent.

Operational impact (explicit)
- Current pipeline behavior unchanged: uploads still render the yellow-box params and SDC sync still writes MediaInfo statements; duplicate-detection still handles rename + {{Duplicate}} tagging only.
- No manual pipeline trigger or ECS redeployment required.
- No environment variables or AWS Secrets Manager key changes.
- No database migrations.
- No shared infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM) changes.
- No public API shape changes.
- No security-sensitive auth/credential handling changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->