### PR TITLE
wikimedia: emit {{DPLA metadata}} at upload + title-drift overwrite

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -343,7 +343,7 @@ def get_wiki_text(
 
     template_string = (
         """== {{int:filedesc}} ==
-     {{ Artwork"""
+     {{ DPLA metadata"""
         + creator_template
         + """
         | title = $title
@@ -623,13 +623,16 @@ def merge_preserved_wikitext(existing_text: str, new_artwork: str) -> str:
     """Append preserved metadata from existing_text to new_artwork.
 
     Used when the uploader rewrites a file description after a title-drift
-    move or redirect-overwrite. The new {{Artwork}} wikitext is authoritative
-    for the file's description, but page-level metadata that pre-existed —
-    PD-USGov license tags, Image-extracted parent links, category
-    membership, and assessment-class templates — must survive the rewrite.
+    move or redirect-overwrite. The new {{DPLA metadata}} wikitext is
+    authoritative for the file's description, but page-level metadata that
+    pre-existed — PD-USGov license tags, Image-extracted parent links,
+    category membership, and assessment-class templates — must survive the
+    rewrite.
 
     Result order (matches Commons page-structure convention):
-        1. new_artwork (the freshly generated {{Artwork}} block)
+        1. new_artwork (the freshly generated {{DPLA metadata}} block; the
+           parameter name `new_artwork` is historical from the prior
+           {{Artwork}}-emitting code path)
         2. preserved Assessment block (=={{Assessment}}== header + any
            {{Media of the day|...}}, {{Picture of the day|...}},
            {{Featured picture}}, {{Quality image}}, {{Valued image}},

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -5,6 +5,7 @@ from ingest_wikimedia.wikimedia import (
     build_title_drift_move_reason,
     get_site,
     get_page_title,
+    get_wiki_text,
     license_to_markup_code,
     get_permissions_template,
     get_permissions,
@@ -1097,3 +1098,80 @@ def test_tag_as_duplicate_idempotency_does_not_match_unrelated_templates():
     tag_as_duplicate(site, file_page, "Correct.jpg", "reason")
     # First tag still applied — the unrelated template should not count.
     assert site.editpage.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# get_wiki_text: the wikitext the uploader writes for new files and for the
+# title-drift metadata-rescue overwrite path.
+# ---------------------------------------------------------------------------
+
+
+def _minimal_item_metadata():
+    """Just-enough DPLA-item metadata to drive get_wiki_text without
+    blowing up. Exercises the typical-record path (creator + title +
+    description + date + permission + source) so the emitted template
+    has every parameter we care about."""
+    return {
+        "rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+        "isShownAt": "https://example.org/item/123",
+        "sourceResource": {
+            "creator": ["A Creator"],
+            "title": ["A Title"],
+            "description": ["A description"],
+            "date": [{"displayDate": "1900"}],
+            "identifier": ["local-123"],
+        },
+    }
+
+
+def test_get_wiki_text_emits_dpla_metadata_template():
+    """The uploader writes a {{DPLA metadata}} block (not {{Artwork}}).
+
+    DPLA's Commons template was designed to fully replicate the
+    {{Artwork}} parameter set the uploader had been emitting, so the
+    transition is a one-line template-name swap with no parameter
+    changes. This test pins the name so a future refactor or revert
+    can't quietly flip back to {{Artwork}}.
+    """
+    result = get_wiki_text(
+        dpla_id="abc123",
+        item_metadata=_minimal_item_metadata(),
+        provider={"Wikidata": "Q1"},
+        data_provider={"Wikidata": "Q2"},
+    )
+    # The whole-template name appears with leading whitespace from the
+    # template_string formatting; assert on the unambiguous fragment.
+    assert "{{ DPLA metadata" in result, (
+        f"get_wiki_text must emit {{{{DPLA metadata}}}}; got:\n{result}"
+    )
+    assert "{{ Artwork" not in result, (
+        "get_wiki_text must NOT emit {{Artwork}} (replaced by "
+        f"{{{{DPLA metadata}}}}); got:\n{result}"
+    )
+
+
+def test_get_wiki_text_preserves_artwork_parameters_under_new_template():
+    """Locking-in regression: the parameter set the upload-time
+    wikitext writes is unchanged from the prior {{Artwork}}-based form
+    — title, description, date, permission, source (with the DPLA
+    sub-template), Institution. Pin each so a structural refactor of
+    `get_wiki_text` can't silently drop a field."""
+    result = get_wiki_text(
+        dpla_id="abc123",
+        item_metadata=_minimal_item_metadata(),
+        provider={"Wikidata": "Q1"},
+        data_provider={"Wikidata": "Q2"},
+    )
+    for fragment in (
+        "| title = A Title",
+        "| description = A description",
+        "| date = 1900",
+        "| permission =",
+        "| source = {{ DPLA",
+        "| Institution = {{ Institution | wikidata = Q2 }}",
+        "| dpla_id = abc123",
+        "| hub = Q1",
+    ):
+        assert fragment in result, (
+            f"missing expected fragment {fragment!r} in:\n{result}"
+        )

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -1163,6 +1163,12 @@ def test_get_wiki_text_preserves_artwork_parameters_under_new_template():
         data_provider={"Wikidata": "Q2"},
     )
     for fragment in (
+        # Creator path: get_wiki_text conditionally emits `Other fields 1`
+        # with a Creator InFi template when the source record has any
+        # creator. Our fixture has one, so pin the full Creator fragment
+        # — otherwise a refactor that drops the conditional could
+        # silently lose every credited DPLA author.
+        "| Other fields 1 = {{ InFi | Creator | A Creator | id=fileinfotpl_aut}}",
         "| title = A Title",
         "| description = A description",
         "| date = 1900",

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -806,7 +806,7 @@ class Uploader:
             if moved_page.exists() and not moved_page.isRedirectPage():
                 # After the move, moved_page carries the original page's
                 # wikitext. Preserve license, Image-extracted, and category
-                # metadata from it before replacing with the DPLA Artwork block.
+                # metadata from it before replacing with the {{DPLA metadata}} block.
                 moved_page.text = merge_preserved_wikitext(
                     moved_page.text or "", wiki_markup
                 )


### PR DESCRIPTION
## Summary

Switch the uploader's emitted template from `{{Artwork}}` to `{{DPLA metadata}}` in a single one-line change. The DPLA-owned template was designed to fully replicate the `{{Artwork}}` parameter set the pipeline had been emitting (title, description, date, permission, source via the DPLA sub-template, Institution, dpla_id, hub) — so no parameter or formatting changes are needed, just the wrapper name.

## Effects

- **New uploads** write `{{DPLA metadata}}` as the file's descriptive template.
- **Title-drift metadata-rescue overwrites** (`_resolve_redirect_overwrite`, `_move_to_correct_title`) write `{{DPLA metadata}}` too — they share `get_wiki_text`'s output.

## Not in scope

- **Backfill of past uploads.** Pages already on Commons keep their existing `{{Artwork}}` blocks until they're individually edited by another path (e.g. a future title-drift correction would migrate them via the rescue overwrite).

## Tests

Two new tests in `tests/test_wikimedia.py`:

- **`test_get_wiki_text_emits_dpla_metadata_template`** — pins the new template name, asserts `{{Artwork}}` no longer appears in the emitted wikitext.
- **`test_get_wiki_text_preserves_artwork_parameters_under_new_template`** — pins every parameter (`title`, `description`, `date`, `permission`, `source`, `Institution`, `dpla_id`, `hub`) so a structural refactor of `get_wiki_text` can't silently drop a field while the wrapper name is being changed.

- [x] `ruff check` / `ruff format --check` clean
- [ ] Next upload run should write a `{{DPLA metadata}}` block; next title-drift rescue should rewrite to the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR renames the top-level file-descriptive template the uploader emits from {{Artwork}} to {{DPLA metadata}} and updates tests/comments/docstrings accordingly.

What changed
- ingest_wikimedia/wikimedia.py
  - get_wiki_text now emits a {{DPLA metadata ...}} wrapper under the == {{int:filedesc}} == header instead of {{Artwork}}.
  - merge_preserved_wikitext docstring updated to refer to the new {{DPLA metadata}} block (and notes the historical parameter name).
  - No parameter names, parameter formatting, or emitted fragments were removed — the intent is to preserve the existing {{Artwork}} parameter set under the new wrapper.
- tests/test_wikimedia.py
  - Adds tests:
    - test_get_wiki_text_emits_dpla_metadata_template — asserts output uses {{DPLA metadata}} and no longer contains {{Artwork}}.
    - test_get_wiki_text_preserves_artwork_parameters_under_new_template — pins title, description, date, permission, source (DPLA sub-template), Institution, dpla_id, hub/provider values to ensure no fields are dropped by the rename.
  - A test-focused commit updated the parameter-pinning test to include the conditional "Creator / Other fields 1" fragment to ensure creators are not silently dropped.
- tools/uploader.py
  - Updated an inline comment describing post-move metadata replacement to reference {{DPLA metadata}} rather than the older label. No runtime logic changed.

Behavioral effects
- New uploads and title-drift metadata-rescue paths that call get_wiki_text will write {{DPLA metadata}} as the file descriptive template.
- Existing Commons pages already containing {{Artwork}} are not modified by this change unless edited later by other code paths; there is no backfill.

Tests & lint
- New unit tests added; ruff lint checks pass per the PR description.
- Runtime verification (future upload/title-drift rescue runs) will start producing the new template.

Impact on operations, infra, security, and data
- No manual pipeline trigger, ECS redeploy, or other deployment-step is required beyond the normal service deployment for this code change.
- No environment variables or AWS Secrets Manager keys were added, removed, or renamed.
- No database migrations were included.
- No changes to shared infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM policies) or public API shapes/endpoints.
- No credential or authentication handling changes; no new external-unsafe inputs introduced. Security posture unchanged.

Other notes
- Change is purely a template wrapper rename (plus test/doc/comment updates). No exported APIs or public interfaces were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->