### PR TITLE
sdc-sync: Phase 3a — legacy {{Artwork}} migration foundation (Goal 2)

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -1,0 +1,482 @@
+"""Phase 3 foundation for migrating legacy ``{{Artwork}}`` files to the
+``{{DPLA metadata}}`` template.
+
+This module is pure logic — parsing, classification, and claim
+construction. No pywikibot API calls, no file I/O. Phase 3b will layer
+the actual wbeditentity dispatch and wikitext save on top.
+
+Goal 2 of the SDC ↔ wikitext integration: existing Commons files
+uploaded by DPLA in the legacy ``{{Artwork}}`` form need to be migrated
+to ``{{DPLA metadata}}`` while preserving anything Commons editors have
+contributed since the original upload (sometimes years ago). Naïve
+overwrite would discard those community edits; this module's job is to
+distinguish DPLA-originated values (safe to overwrite with canonical
+data) from community-contributed values (preserve by importing them
+into SDC as user-contributed statements before stripping them from the
+wikitext).
+
+Community-contributed values get a special reference shape on their SDC
+statement — ``P887→Q131783016`` (based on heuristic — "inferred from
+Wikitext") + ``P4656→<permalink-to-source-revision>`` (Wikimedia import
+URL with the source revision permalink, per Wikidata's recommendation
+for that property). They do **not** carry the standard DPLA qualifiers
+(P459/Q61848113 heuristic, P813 retrieved-on, etc.) — those would
+misrepresent the value as DPLA-sourced when it isn't.
+"""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass, field
+from typing import Iterable
+
+import mwparserfromhell
+
+# DPLA's Commons-bot account names. Revisions authored by these accounts
+# are treated as DPLA-originated for the purpose of provenance
+# classification — any param value they last touched is safe to
+# overwrite with canonical data. Other accounts are treated as
+# community contributors whose edits must be preserved (by importing
+# to SDC) before the wikitext is rewritten.
+#
+# Extend this set in a follow-up if older DPLA bot accounts are
+# discovered in the upload-history of long-tenure files. The set is
+# matched case-insensitively against the revision's ``user`` field;
+# add the canonical form a Commons revision history would display.
+DPLA_BOT_ACCOUNTS: frozenset[str] = frozenset(
+    {
+        "DPLA_bot",
+        "US National Archives bot",
+    }
+)
+
+# Wikidata items / properties used in the legacy-import reference shape.
+# Hardcoded here (not behind a config knob) because they are part of the
+# import's semantic contract — changing them would silently change the
+# meaning of every legacy-imported statement.
+QID_INFERRED_FROM_WIKITEXT = "Q131783016"  # the source-of-truth item
+PID_BASED_ON_HEURISTIC = "P887"
+PID_WIKIMEDIA_IMPORT_URL = "P4656"
+
+# Per-param Wikidata-property mapping for the SDC import. Each key is a
+# canonical-params key (matching what `dpla_metadata_params` returns);
+# each value is the property + value-builder kind. Kept narrow on
+# purpose — only the four scalar fields with unambiguous Wikidata
+# property mappings are in scope for Phase 3a. Subject, source URL,
+# institution, and rights/permission mappings involve richer Wikidata
+# semantics and are deferred to a later phase that can mirror the full
+# SDC pipeline's logic without duplicating it.
+LEGACY_IMPORT_PROPERTY: dict[str, tuple[str, str]] = {
+    # ``title`` → P1476 (title), monolingualtext
+    "title": ("P1476", "monolingualtext"),
+    # ``description`` → P10358 (description), monolingualtext. Long
+    # values are chunked via P1545 ordinals downstream; Phase 3a
+    # produces a single claim per value and lets the caller split as
+    # needed in Phase 3b.
+    "description": ("P10358", "monolingualtext"),
+    # ``date`` → P571 (inception), time. Phase 3a stores the raw string
+    # in a sentinel form so Phase 3b's claim builder can re-parse with
+    # the existing :func:`ingest_wikimedia.sdc.parse_dpla_date` helper.
+    "date": ("P571", "time"),
+    # ``creator`` (or ``author``/``artist`` aliases) → P2093 (creator —
+    # stated as), string. Avoids the Wikidata-reconciliation complexity
+    # of P170 (creator) for the common case of a string-only credit;
+    # editors can promote individual statements to P170 manually later.
+    "creator": ("P2093", "string"),
+}
+
+# Canonical mapping from legacy template param names (case-folded) to
+# the canonical-params keys both the writer and comparator use. Covers
+# the param sets the legacy DPLA-bot ``{{Artwork}}`` form emitted plus
+# the well-known aliases Commons editors use for the same fields.
+ARTWORK_PARAM_TO_CANONICAL_KEY: dict[str, str] = {
+    "title": "title",
+    "description": "description",
+    "date": "date",
+    # ``{{Artwork}}`` has historically used ``author`` for the creator
+    # row, and Commons editors freely use ``artist`` too. Both map to
+    # the same canonical key — the new template's idiomatic name is
+    # ``creator`` (matching DPLA's archival-records convention).
+    "author": "creator",
+    "artist": "creator",
+    "creator": "creator",
+    "source": "source",
+    "institution": "institution",
+    "permission": "permission",
+}
+
+# Template names (case-folded) whose params get walked during migration.
+# Order doesn't matter — if a page carries multiple, only the first
+# match is migrated; the others are left alone for a manual sweep.
+LEGACY_TEMPLATE_NAMES: tuple[str, ...] = ("artwork", "information", "photograph")
+
+
+@dataclass(frozen=True)
+class RevisionSnapshot:
+    """Minimal projection of a pywikibot Revision that the migration
+    logic needs. Phase 3b populates this from ``FilePage.revisions()``;
+    Phase 3a tests pass it in directly.
+    """
+
+    revid: int
+    user: str
+    text: str
+
+
+@dataclass
+class MigrationPlan:
+    """The output of :func:`plan_migration` — a structured description of
+    every action Phase 3b's executor needs to perform.
+
+    ``community_imports`` carries the field-by-field values that must
+    survive the migration. Each entry is keyed by canonical-params key
+    so Phase 3b can dispatch to the right SDC property without
+    re-doing the parsing work.
+
+    ``source_permalink`` is the value that gets stamped onto every
+    imported claim's P4656 reference. It points at the revision *that
+    contains* the community-contributed value — i.e. the page's latest
+    revision id at plan-construction time. This lets a reviewer trace
+    any imported statement back to its original wikitext source.
+    """
+
+    source_permalink: str
+    community_imports: dict[str, str] = field(default_factory=dict)
+    dpla_originated_params: dict[str, str] = field(default_factory=dict)
+    artwork_template_name: str = ""
+
+
+def _template_name(template) -> str:
+    return str(template.name).strip().casefold()
+
+
+def _normalize_param_name(param) -> str:
+    return str(param.name).strip().casefold()
+
+
+def find_legacy_template(wikitext: str):
+    """Locate the first legacy metadata template in ``wikitext``.
+
+    Returns the ``mwparserfromhell`` Template node, or None if no
+    legacy template is present. Order in :data:`LEGACY_TEMPLATE_NAMES`
+    is honored — ``{{Artwork}}`` wins over ``{{Information}}`` when
+    both are present (rare but defensible: a page already migrated
+    once that someone added an Information block to).
+    """
+    wikicode = mwparserfromhell.parse(wikitext)
+    for tpl in wikicode.filter_templates():
+        if _template_name(tpl) in LEGACY_TEMPLATE_NAMES:
+            return tpl
+    return None
+
+
+def parse_artwork_params(wikitext: str) -> dict[str, str]:
+    """Extract the canonical-key → value dict from a legacy template
+    invocation in ``wikitext``.
+
+    Returns ``{}`` when no legacy template is found, or when one is
+    present but carries no recognised params. Values are whitespace-
+    stripped (matching the renderer's behavior); the unrecognised
+    param names are dropped silently — those don't have a canonical
+    target and the wikitext-rewrite step preserves them by leaving
+    the template untouched if the param wasn't migrated.
+    """
+    template = find_legacy_template(wikitext)
+    if template is None:
+        return {}
+    parsed: dict[str, str] = {}
+    for param in template.params:
+        canonical = ARTWORK_PARAM_TO_CANONICAL_KEY.get(_normalize_param_name(param))
+        if canonical is None:
+            continue
+        value = str(param.value).strip()
+        if value:
+            # On duplicate canonical keys (e.g. both ``author`` and
+            # ``creator`` set), the *last* wins — matches the renderer
+            # behavior under MediaWiki, where the later assignment
+            # overrides the earlier.
+            parsed[canonical] = value
+    return parsed
+
+
+def _is_dpla_bot(user: str) -> bool:
+    """Case-insensitive match against :data:`DPLA_BOT_ACCOUNTS`."""
+    return user.casefold() in {a.casefold() for a in DPLA_BOT_ACCOUNTS}
+
+
+def trace_param_provenance(
+    revisions: Iterable[RevisionSnapshot],
+) -> dict[str, str]:
+    """Walk revisions oldest→newest to find which editor last set each
+    legacy-template param to its current value.
+
+    Returns ``{canonical_key: editor_user}`` for every param whose
+    current value can be traced to at least one revision. Params
+    introduced and unchanged since the very first revision are
+    attributed to that revision's editor. Params whose value couldn't
+    be traced (e.g. they vanished and reappeared in some intermediate
+    state mwparserfromhell can't reconstruct) are omitted; the caller
+    treats absence as "no provenance found → preserve conservatively."
+
+    The walk is forward in time so each per-key entry is overwritten
+    as the value changes — the dict at the end holds the *last*
+    revision that touched each current value, which is exactly the
+    provenance attribution the classifier needs.
+
+    Pure: takes pre-fetched snapshots and returns a dict; doesn't
+    interact with pywikibot.
+    """
+    sorted_revs = sorted(revisions, key=lambda r: r.revid)
+    if not sorted_revs:
+        return {}
+
+    final_params = parse_artwork_params(sorted_revs[-1].text)
+    if not final_params:
+        return {}
+
+    provenance: dict[str, str] = {}
+    prior_seen: dict[str, str] = {}
+    for rev in sorted_revs:
+        rev_params = parse_artwork_params(rev.text)
+        for key, value in rev_params.items():
+            if value != prior_seen.get(key):
+                provenance[key] = rev.user
+                prior_seen[key] = value
+    # Only return entries whose tracked value still matches the final
+    # value — a param that was edited and then reverted back to a prior
+    # form would otherwise carry stale provenance.
+    return {
+        key: editor
+        for key, editor in provenance.items()
+        if prior_seen.get(key) == final_params.get(key)
+    }
+
+
+def classify_param_provenance(
+    provenance: dict[str, str],
+    bot_accounts: frozenset[str] = DPLA_BOT_ACCOUNTS,
+) -> dict[str, str]:
+    """For each param, label its provenance as ``"dpla"`` or
+    ``"community"`` based on whose account introduced its current value.
+
+    ``bot_accounts`` is parameterised purely so tests can pass a
+    custom allowlist. Production callers should accept the module
+    default; new bot accounts get added to :data:`DPLA_BOT_ACCOUNTS`
+    rather than the per-call argument.
+    """
+    bot_set_cf = {a.casefold() for a in bot_accounts}
+    return {
+        key: ("dpla" if editor.casefold() in bot_set_cf else "community")
+        for key, editor in provenance.items()
+    }
+
+
+def plan_migration(
+    file_title: str,
+    revisions: Iterable[RevisionSnapshot],
+    canonical_params: dict,
+    bot_accounts: frozenset[str] = DPLA_BOT_ACCOUNTS,
+) -> MigrationPlan | None:
+    """Compute the migration plan for a legacy-Artwork file.
+
+    Walks the revision history to attribute each legacy-template param,
+    classifies each value as DPLA-originated vs community-contributed,
+    and packages the result as a :class:`MigrationPlan` describing
+    everything Phase 3b's executor needs to do.
+
+    Returns None when there's nothing to migrate — no legacy template
+    on the page, or no revisions supplied.
+
+    ``canonical_params`` is the dict returned by
+    :func:`ingest_wikimedia.wikimedia.dpla_metadata_params` for this
+    file's DPLA item. Values are compared against the wikitext to
+    detect cases where a "community" provenance is actually a
+    community editor re-stating what DPLA already has — in that case
+    nothing is imported (the value is redundant with canonical).
+    """
+    sorted_revs = sorted(revisions, key=lambda r: r.revid)
+    if not sorted_revs:
+        return None
+    latest = sorted_revs[-1]
+    if find_legacy_template(latest.text) is None:
+        return None
+
+    wikitext_params = parse_artwork_params(latest.text)
+    provenance = trace_param_provenance(sorted_revs)
+    classified = classify_param_provenance(provenance, bot_accounts)
+
+    community_imports: dict[str, str] = {}
+    dpla_originated: dict[str, str] = {}
+
+    for key, value in wikitext_params.items():
+        canonical_value = _canonical_value_for_key(canonical_params, key)
+        if classified.get(key) == "community" and value != canonical_value:
+            # Only import community values that *differ* from canonical
+            # — a community editor restating DPLA's title verbatim is
+            # not an import we want to record (it's redundant). Same
+            # invariant as Goal 1: if it matches, it's strip-eligible.
+            community_imports[key] = value
+        else:
+            dpla_originated[key] = value
+
+    legacy_template = find_legacy_template(latest.text)
+    return MigrationPlan(
+        source_permalink=_build_permalink(file_title, latest.revid),
+        community_imports=community_imports,
+        dpla_originated_params=dpla_originated,
+        artwork_template_name=_template_name(legacy_template),
+    )
+
+
+def _canonical_value_for_key(canonical_params: dict, key: str) -> str:
+    """Pull the comparable canonical value for a key.
+
+    Scalar keys (title/description/date/permission) live at the top
+    level. The creator key is special: ``dpla_metadata_params`` emits
+    creator inside the ``{{InFi|Creator|...}}`` sub-template shape, so
+    the comparable canonical value is the second positional. Source,
+    institution, etc. are sub-template valued and not handled in
+    Phase 3a's scalar mapping — return empty so the equality check
+    correctly classifies them as "different" and they fall through
+    to community-import or dpla-originated based on provenance only.
+    """
+    if key in ("title", "description", "date", "permission"):
+        return str(canonical_params.get(key, ""))
+    if key == "creator":
+        creator = canonical_params.get("creator", {})
+        return str(creator.get("params", {}).get("2", ""))
+    return ""
+
+
+def _build_permalink(file_title: str, oldid: int) -> str:
+    """Return the Commons permalink for ``<file_title>`` at revision
+    ``<oldid>``. Used as the P4656 (Wikimedia import URL) reference
+    value; permalinks are required by the property's usage notes."""
+    encoded = file_title.replace(" ", "_")
+    return f"https://commons.wikimedia.org/w/index.php?title={encoded}&oldid={oldid}"
+
+
+# ---------------------------------------------------------------------------
+# SDC claim construction (Wikidata-API-ready dicts)
+# ---------------------------------------------------------------------------
+
+
+def _reference_snaks(permalink: str) -> dict:
+    """Return the two-snak reference block stamped onto every legacy-
+    imported statement: P887→Q131783016 + P4656→<permalink>.
+
+    The order matters cosmetically (snaks-order is what Wikibase
+    serializes back when reading), and matches the order
+    :func:`format_legacy_import_claim` writes.
+    """
+    return {
+        "snaks": {
+            PID_BASED_ON_HEURISTIC: [
+                {
+                    "snaktype": "value",
+                    "property": PID_BASED_ON_HEURISTIC,
+                    "datatype": "wikibase-item",
+                    "datavalue": {
+                        "type": "wikibase-entityid",
+                        "value": {
+                            "entity-type": "item",
+                            "id": QID_INFERRED_FROM_WIKITEXT,
+                        },
+                    },
+                }
+            ],
+            PID_WIKIMEDIA_IMPORT_URL: [
+                {
+                    "snaktype": "value",
+                    "property": PID_WIKIMEDIA_IMPORT_URL,
+                    "datatype": "url",
+                    "datavalue": {"type": "string", "value": permalink},
+                }
+            ],
+        },
+        "snaks-order": [PID_BASED_ON_HEURISTIC, PID_WIKIMEDIA_IMPORT_URL],
+    }
+
+
+def _monolingualtext_datavalue(text: str, language: str = "en") -> dict:
+    return {
+        "type": "monolingualtext",
+        "value": {"text": text, "language": language},
+    }
+
+
+def _string_datavalue(text: str) -> dict:
+    return {"type": "string", "value": text}
+
+
+def format_legacy_import_claim(
+    canonical_key: str,
+    value: str,
+    permalink: str,
+    today: datetime.date | None = None,
+) -> dict | None:
+    """Build a Wikibase ``wbeditentity``-ready claim dict for one
+    legacy-imported value.
+
+    Returns None when ``canonical_key`` isn't in
+    :data:`LEGACY_IMPORT_PROPERTY`'s narrow allowlist; the caller
+    then leaves the value in wikitext rather than guessing at a
+    property mapping.
+
+    ``today`` is accepted (and currently unused) for symmetry with
+    other claim builders that stamp ``P813`` retrieved-on — kept in
+    the signature so a later phase can decide whether to add a
+    secondary P813 reference snak without changing call sites.
+    """
+    mapping = LEGACY_IMPORT_PROPERTY.get(canonical_key)
+    if mapping is None:
+        return None
+    prop, kind = mapping
+    if kind == "monolingualtext":
+        datavalue = _monolingualtext_datavalue(value)
+        datatype = "monolingualtext"
+    elif kind == "string":
+        datavalue = _string_datavalue(value)
+        datatype = "string"
+    elif kind == "time":
+        # Phase 3a doesn't parse the date — Phase 3b will pass the
+        # raw string through `parse_dpla_date` before constructing
+        # the time datavalue. Surface the placeholder shape here so
+        # the caller can detect and post-process.
+        return {
+            "type": "statement",
+            "rank": "normal",
+            "_phase3a_pending_date_parse": value,
+            "_property": prop,
+            "_permalink": permalink,
+        }
+    else:  # pragma: no cover — guarded by the LEGACY_IMPORT_PROPERTY set
+        return None
+
+    return {
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": prop,
+            "datatype": datatype,
+            "datavalue": datavalue,
+        },
+        "references": [_reference_snaks(permalink)],
+    }
+
+
+def build_legacy_import_claims(plan: MigrationPlan) -> list[dict]:
+    """Materialise every community-import in ``plan`` as a list of
+    Wikibase claim dicts ready for a ``wbeditentity`` POST.
+
+    Skips canonical keys with no mapping in
+    :data:`LEGACY_IMPORT_PROPERTY` — those values stay in wikitext
+    until a later phase widens the supported set.
+    """
+    claims: list[dict] = []
+    for key, value in plan.community_imports.items():
+        claim = format_legacy_import_claim(key, value, plan.source_permalink)
+        if claim is not None:
+            claims.append(claim)
+    return claims

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import datetime
 from dataclasses import dataclass, field
 from typing import Iterable
+from urllib.parse import urlencode
 
 import mwparserfromhell
 
@@ -238,6 +239,17 @@ def trace_param_provenance(
     prior_seen: dict[str, str] = {}
     for rev in sorted_revs:
         rev_params = parse_artwork_params(rev.text)
+        # Drop entries from prior_seen for params the current revision
+        # no longer carries. Without this, a delete → re-add of the
+        # same string at a later revision looks like "unchanged" (the
+        # post-delete value still matches the pre-delete value in
+        # prior_seen) and stays attributed to the original setter —
+        # misclassifying a community restoration as DPLA-originated
+        # and putting it on the strip list when the canonical value
+        # drifts. Pop them on disappearance so re-add registers as a
+        # fresh change attributed to the editor who restored it.
+        for stale in tuple(prior_seen.keys() - rev_params.keys()):
+            prior_seen.pop(stale, None)
         for key, value in rev_params.items():
             if value != prior_seen.get(key):
                 provenance[key] = rev.user
@@ -351,9 +363,23 @@ def _canonical_value_for_key(canonical_params: dict, key: str) -> str:
 def _build_permalink(file_title: str, oldid: int) -> str:
     """Return the Commons permalink for ``<file_title>`` at revision
     ``<oldid>``. Used as the P4656 (Wikimedia import URL) reference
-    value; permalinks are required by the property's usage notes."""
-    encoded = file_title.replace(" ", "_")
-    return f"https://commons.wikimedia.org/w/index.php?title={encoded}&oldid={oldid}"
+    value; permalinks are required by the property's usage notes.
+
+    Uses :func:`urllib.parse.urlencode` so reserved characters in the
+    title — particularly ``&`` (legal in Commons filenames like
+    ``File:Foo & Bar.jpg``), but also ``?``, ``#``, ``+`` — are
+    percent-encoded.  Hand-rolled "just replace spaces" encoding lets
+    such titles produce a URL the query-string parser truncates at
+    the literal ``&``, silently breaking the P4656 reference for an
+    arbitrary subset of filenames.
+
+    Spaces are converted to underscores first (Commons URL convention)
+    so the percent-encoded form mirrors what
+    ``[[Special:Permalink/<oldid>]]`` actually serves at the link.
+    """
+    return "https://commons.wikimedia.org/w/index.php?" + urlencode(
+        {"title": file_title.replace(" ", "_"), "oldid": oldid}
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -165,6 +165,48 @@ def test_trace_provenance_drops_reverted_intermediate_values():
     assert provenance == {"title": "Editor2"}
 
 
+def test_trace_provenance_delete_then_readd_attributes_to_restorer():
+    """Regression: a param that DPLA_bot originally set, then a
+    community editor deleted, then a different community editor
+    re-added with the same string value, must attribute to the
+    *re-adder* — not stay attributed to DPLA_bot.
+
+    Pre-fix, ``prior_seen`` was never cleared on deletion, so the
+    re-add looked like "value unchanged" and the provenance stayed
+    on DPLA_bot. A subsequent canonical-DPLA value change would have
+    then classified the re-added value as DPLA-originated and
+    stripped it — losing the community restoration.
+    """
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=Original}}"),
+        (2, "Deleter", "{{Artwork|}}"),  # title param deleted entirely
+        (3, "Restorer", "{{Artwork|title=Original}}"),  # community re-add
+    )
+    provenance = trace_param_provenance(revs)
+    assert provenance == {"title": "Restorer"}
+
+
+def test_plan_migration_imports_restored_community_value_when_canonical_differs():
+    """End-to-end of the delete-readd fix: when the canonical DPLA
+    title has since changed, the re-added community value is now an
+    actual community contribution that must be imported, not
+    discarded as DPLA-originated."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=Original}}"),
+        (2, "Deleter", "{{Artwork|}}"),
+        (3, "Restorer", "{{Artwork|title=Original}}"),
+    )
+    # Canonical title has since been updated by DPLA — so "Original"
+    # is now a community-only value.
+    plan = plan_migration(
+        "File:Foo.jpg",
+        revs,
+        _canonical_params(title="Updated Canonical Title"),
+    )
+    assert plan is not None
+    assert plan.community_imports == {"title": "Original"}
+
+
 def test_trace_provenance_sorts_by_revid_not_input_order():
     """Out-of-order input still produces a chronologically correct
     walk — defensive against any caller that doesn't pre-sort."""
@@ -305,7 +347,10 @@ def test_plan_migration_records_source_permalink():
     """The permalink stamped onto every imported claim's P4656 ref
     points at the page's latest revision id at plan time, so a
     reviewer can trace any imported statement back to its wikitext
-    source."""
+    source. Spaces become underscores (Commons URL convention) and
+    the ``:`` namespace separator is percent-encoded (``%3A``) per
+    ``urllib.parse.urlencode`` semantics — that's the same form the
+    Wikipedia/Commons API responds with, so it's a recognisable URL."""
     revs = _make_revs(
         (1, "DPLA_bot", "{{Artwork|title=A Title}}"),
         (42, "Editor1", "{{Artwork|title=A Better Title}}"),
@@ -314,8 +359,30 @@ def test_plan_migration_records_source_permalink():
     assert plan is not None
     assert (
         plan.source_permalink
-        == "https://commons.wikimedia.org/w/index.php?title=File:Test_File.jpg&oldid=42"
+        == "https://commons.wikimedia.org/w/index.php?title=File%3ATest_File.jpg&oldid=42"
     )
+
+
+def test_plan_migration_permalink_encodes_ampersand_in_filename():
+    """Regression: filenames containing ``&`` are legal on Commons
+    (``File:Foo & Bar.jpg``). Hand-rolled spaces-only encoding put
+    the raw ``&`` into the URL, causing the query-string parser to
+    split there — ``title=File:Foo_`` would have been all the
+    permalink resolved to. ``urlencode`` percent-encodes it as
+    ``%26`` so the title round-trips through query parsing."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=A Title}}"),
+        (42, "Editor1", "{{Artwork|title=A Better Title}}"),
+    )
+    plan = plan_migration("File:Foo & Bar.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert "%26" in plan.source_permalink  # the ``&`` is encoded
+    # Sanity-check end-to-end query parsing matches what we expect.
+    from urllib.parse import parse_qs, urlsplit
+
+    parsed_qs = parse_qs(urlsplit(plan.source_permalink).query)
+    assert parsed_qs["title"] == ["File:Foo_&_Bar.jpg"]
+    assert parsed_qs["oldid"] == ["42"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1,0 +1,431 @@
+"""Tests for the Phase 3a legacy-Artwork migration foundation.
+
+Covers the pure-logic layer: parsing legacy templates, walking
+revision provenance, classifying DPLA-bot vs community edits, and
+constructing SDC import claims with the P887/P4656 reference shape.
+
+Phase 3b's pywikibot integration (calling wbeditentity, saving
+wikitext) is out of scope here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ingest_wikimedia.legacy_artwork import (
+    ARTWORK_PARAM_TO_CANONICAL_KEY,
+    DPLA_BOT_ACCOUNTS,
+    PID_BASED_ON_HEURISTIC,
+    PID_WIKIMEDIA_IMPORT_URL,
+    QID_INFERRED_FROM_WIKITEXT,
+    MigrationPlan,
+    RevisionSnapshot,
+    build_legacy_import_claims,
+    classify_param_provenance,
+    find_legacy_template,
+    format_legacy_import_claim,
+    parse_artwork_params,
+    plan_migration,
+    trace_param_provenance,
+)
+
+
+# ---------------------------------------------------------------------------
+# find_legacy_template / parse_artwork_params
+# ---------------------------------------------------------------------------
+
+
+def test_find_legacy_template_returns_artwork_node():
+    wikitext = (
+        "== {{int:filedesc}} ==\n"
+        "{{Artwork|title=A Title|author=A Creator}}\n"
+        "{{PD-USGov}}"
+    )
+    tpl = find_legacy_template(wikitext)
+    assert tpl is not None
+    assert str(tpl.name).strip().casefold() == "artwork"
+
+
+def test_find_legacy_template_falls_back_to_information():
+    """When no Artwork is present, the helper still finds an
+    ``{{Information}}`` block (the other shape DPLA bots emitted in the
+    past)."""
+    wikitext = "{{Information|description=foo|date=1900}}"
+    tpl = find_legacy_template(wikitext)
+    assert tpl is not None
+    assert str(tpl.name).strip().casefold() == "information"
+
+
+def test_find_legacy_template_returns_none_on_dpla_metadata_only():
+    """A page already on the new template form is not in scope for the
+    legacy migrator."""
+    wikitext = "{{DPLA metadata|title=Already migrated}}"
+    assert find_legacy_template(wikitext) is None
+
+
+def test_parse_artwork_params_extracts_known_params():
+    wikitext = (
+        "{{Artwork\n"
+        "| title = A Title\n"
+        "| description = A description\n"
+        "| date = 1900\n"
+        "| author = An Author\n"
+        "}}"
+    )
+    params = parse_artwork_params(wikitext)
+    assert params == {
+        "title": "A Title",
+        "description": "A description",
+        "date": "1900",
+        "creator": "An Author",
+    }
+
+
+def test_parse_artwork_params_aliases_author_artist_creator_to_creator():
+    """``{{Artwork}}`` editors use any of these three names. All three
+    map to the canonical ``creator`` key."""
+    for label in ("author", "artist", "creator"):
+        params = parse_artwork_params(f"{{{{Artwork|{label}=Smith}}}}")
+        assert params == {"creator": "Smith"}
+
+
+def test_parse_artwork_params_drops_unknown_params():
+    """A param name without a canonical-key mapping is silently
+    dropped — the migrator leaves it in the wikitext untouched."""
+    wikitext = "{{Artwork|title=A|other versions=See foo.jpg|something=else}}"
+    params = parse_artwork_params(wikitext)
+    assert "title" in params
+    assert "other versions" not in params
+    assert "something" not in params
+
+
+def test_parse_artwork_params_returns_empty_when_no_template():
+    assert parse_artwork_params("Just some text") == {}
+
+
+def test_parse_artwork_params_drops_empty_values():
+    """Editors sometimes leave a param key with no value
+    (``| date = ``). That isn't useful provenance to import — drop."""
+    params = parse_artwork_params("{{Artwork|title=A|date=}}")
+    assert params == {"title": "A"}
+
+
+# ---------------------------------------------------------------------------
+# trace_param_provenance — revision-history walker
+# ---------------------------------------------------------------------------
+
+
+def _make_revs(*entries: tuple[int, str, str]) -> list[RevisionSnapshot]:
+    """Helper: build a list of RevisionSnapshot from (revid, user, text)
+    tuples in chronological order."""
+    return [RevisionSnapshot(revid=r, user=u, text=t) for r, u, t in entries]
+
+
+def test_trace_provenance_attributes_each_param_to_last_setting_revision():
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=Original|date=1900}}"),
+        (2, "Editor1", "{{Artwork|title=Original|date=1900|description=A note}}"),
+        (3, "Editor2", "{{Artwork|title=Better|date=1900|description=A note}}"),
+    )
+    provenance = trace_param_provenance(revs)
+    assert provenance == {
+        "title": "Editor2",  # last touched the title
+        "date": "DPLA_bot",  # never touched after initial set
+        "description": "Editor1",  # added then unchanged
+    }
+
+
+def test_trace_provenance_returns_empty_for_no_revisions():
+    assert trace_param_provenance([]) == {}
+
+
+def test_trace_provenance_returns_empty_when_latest_has_no_artwork():
+    """If the latest revision dropped the Artwork template, there's
+    nothing to attribute. (Caller will skip the file.)"""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=Original}}"),
+        (2, "Cleanup", "Some text without any template"),
+    )
+    assert trace_param_provenance(revs) == {}
+
+
+def test_trace_provenance_drops_reverted_intermediate_values():
+    """A param that was edited and then reverted back to the original
+    DPLA value still attributes to the DPLA bot — not to the editor
+    who briefly changed it. The end-state attribution is what matters."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=Original}}"),
+        (2, "Editor1", "{{Artwork|title=Changed}}"),
+        (3, "Editor2", "{{Artwork|title=Original}}"),
+    )
+    provenance = trace_param_provenance(revs)
+    # Editor2's revert puts the title back to "Original" — but it was
+    # Editor2 who set the current value, not DPLA_bot. The walker
+    # records the *most recent* setter of the current value.
+    assert provenance == {"title": "Editor2"}
+
+
+def test_trace_provenance_sorts_by_revid_not_input_order():
+    """Out-of-order input still produces a chronologically correct
+    walk — defensive against any caller that doesn't pre-sort."""
+    revs = _make_revs(
+        (3, "Editor2", "{{Artwork|title=Final}}"),
+        (1, "DPLA_bot", "{{Artwork|title=Original}}"),
+        (2, "Editor1", "{{Artwork|title=Intermediate}}"),
+    )
+    provenance = trace_param_provenance(revs)
+    assert provenance == {"title": "Editor2"}
+
+
+# ---------------------------------------------------------------------------
+# classify_param_provenance
+# ---------------------------------------------------------------------------
+
+
+def test_classify_uses_dpla_bot_allowlist():
+    provenance = {
+        "title": "DPLA_bot",
+        "description": "Editor1",
+        "creator": "US National Archives bot",
+    }
+    classified = classify_param_provenance(provenance)
+    assert classified == {
+        "title": "dpla",
+        "description": "community",
+        "creator": "dpla",  # US National Archives bot is on the allowlist
+    }
+
+
+def test_classify_is_case_insensitive_against_allowlist():
+    provenance = {"title": "dpla_BOT"}
+    assert classify_param_provenance(provenance) == {"title": "dpla"}
+
+
+def test_classify_respects_explicit_bot_accounts_argument():
+    """Tests can pass a custom allowlist for hypothetical-future or
+    deprecated-historical bot accounts without mutating module state."""
+    provenance = {"title": "AncientBot"}
+    classified = classify_param_provenance(
+        provenance, bot_accounts=frozenset({"AncientBot"})
+    )
+    assert classified == {"title": "dpla"}
+
+
+def test_dpla_bot_allowlist_contains_known_accounts():
+    """Pin the known accounts so a typo'd rename can't silently lose
+    classification coverage for the long-tenure files those bots
+    uploaded."""
+    assert "DPLA_bot" in DPLA_BOT_ACCOUNTS
+    assert "US National Archives bot" in DPLA_BOT_ACCOUNTS
+
+
+# ---------------------------------------------------------------------------
+# plan_migration
+# ---------------------------------------------------------------------------
+
+
+def _canonical_params(**overrides) -> dict:
+    """Minimal canonical-params dict matching what
+    ``dpla_metadata_params`` produces for our test fixtures."""
+    base = {
+        "title": "A Title",
+        "description": "A description",
+        "date": "1900",
+        "permission": "{{Cc-zero}}",
+        "creator": {
+            "name": "InFi",
+            "params": {"1": "Creator", "2": "A Creator", "id": "fileinfotpl_aut"},
+        },
+        "source": {"name": "DPLA", "params": {}},
+        "institution": {"name": "Institution", "params": {}},
+        "languages": frozenset({"en"}),
+    }
+    base.update(overrides)
+    return base
+
+
+def test_plan_migration_returns_none_with_no_revisions():
+    assert plan_migration("File:Foo.jpg", [], _canonical_params()) is None
+
+
+def test_plan_migration_returns_none_with_no_artwork_in_latest():
+    revs = _make_revs((1, "Cleanup", "Just text"))
+    assert plan_migration("File:Foo.jpg", revs, _canonical_params()) is None
+
+
+def test_plan_migration_classifies_bot_value_as_dpla_originated():
+    """When DPLA_bot set every param and no one else has touched the
+    file, every param is dpla-originated — no community imports."""
+    revs = _make_revs(
+        (
+            1,
+            "DPLA_bot",
+            "{{Artwork|title=A Title|description=A description|date=1900}}",
+        )
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert plan.community_imports == {}
+    assert plan.dpla_originated_params == {
+        "title": "A Title",
+        "description": "A description",
+        "date": "1900",
+    }
+
+
+def test_plan_migration_imports_community_value_that_differs_from_canonical():
+    """An editor changed the title to something different from DPLA's
+    canonical title. That value must go into ``community_imports``
+    (and Phase 3b will record it as an SDC statement with P887/P4656)."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=A Title}}"),
+        (2, "Editor1", "{{Artwork|title=A Better Title}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert plan.community_imports == {"title": "A Better Title"}
+    assert "title" not in plan.dpla_originated_params
+
+
+def test_plan_migration_skips_community_value_that_matches_canonical():
+    """An editor restated DPLA's value verbatim (maybe by re-saving
+    after a typo fix-and-revert). That's redundant — no import,
+    treated as dpla-originated for the migration purposes."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=A Title}}"),
+        (2, "Editor1", "{{Artwork|title=A Title}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert plan.community_imports == {}
+    assert plan.dpla_originated_params["title"] == "A Title"
+
+
+def test_plan_migration_records_source_permalink():
+    """The permalink stamped onto every imported claim's P4656 ref
+    points at the page's latest revision id at plan time, so a
+    reviewer can trace any imported statement back to its wikitext
+    source."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=A Title}}"),
+        (42, "Editor1", "{{Artwork|title=A Better Title}}"),
+    )
+    plan = plan_migration("File:Test File.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert (
+        plan.source_permalink
+        == "https://commons.wikimedia.org/w/index.php?title=File:Test_File.jpg&oldid=42"
+    )
+
+
+# ---------------------------------------------------------------------------
+# format_legacy_import_claim / build_legacy_import_claims
+# ---------------------------------------------------------------------------
+
+
+def test_format_claim_for_title_emits_monolingualtext_with_p887_p4656_refs():
+    claim = format_legacy_import_claim(
+        "title",
+        "A Better Title",
+        "https://commons.wikimedia.org/w/index.php?title=Foo.jpg&oldid=42",
+    )
+    assert claim is not None
+    assert claim["type"] == "statement"
+    assert claim["rank"] == "normal"
+    assert claim["mainsnak"]["property"] == "P1476"
+    assert claim["mainsnak"]["datatype"] == "monolingualtext"
+    assert claim["mainsnak"]["datavalue"] == {
+        "type": "monolingualtext",
+        "value": {"text": "A Better Title", "language": "en"},
+    }
+    # Reference block has exactly the two snaks (P887 + P4656), no
+    # standard DPLA refs (P459/P973/P813) — the import isn't
+    # DPLA-sourced and must not be misrepresented as such.
+    refs = claim["references"]
+    assert len(refs) == 1
+    assert set(refs[0]["snaks"]) == {PID_BASED_ON_HEURISTIC, PID_WIKIMEDIA_IMPORT_URL}
+    p887_snak = refs[0]["snaks"][PID_BASED_ON_HEURISTIC][0]
+    assert p887_snak["datavalue"]["value"]["id"] == QID_INFERRED_FROM_WIKITEXT
+    p4656_snak = refs[0]["snaks"][PID_WIKIMEDIA_IMPORT_URL][0]
+    assert p4656_snak["datatype"] == "url"
+    assert "oldid=42" in p4656_snak["datavalue"]["value"]
+
+
+def test_format_claim_for_description_uses_p10358():
+    claim = format_legacy_import_claim(
+        "description", "A desc", "https://example/permalink"
+    )
+    assert claim is not None
+    assert claim["mainsnak"]["property"] == "P10358"
+    assert claim["mainsnak"]["datatype"] == "monolingualtext"
+
+
+def test_format_claim_for_creator_uses_p2093_string():
+    """``P2093`` (creator — stated as) is the string form, used when
+    we have no Wikidata item match. Editors can later promote to
+    P170 manually."""
+    claim = format_legacy_import_claim(
+        "creator", "Jane Doe", "https://example/permalink"
+    )
+    assert claim is not None
+    assert claim["mainsnak"]["property"] == "P2093"
+    assert claim["mainsnak"]["datatype"] == "string"
+
+
+def test_format_claim_for_date_emits_phase3a_placeholder():
+    """Phase 3a doesn't parse dates — Phase 3b will pass them through
+    the existing ``parse_dpla_date`` helper. The placeholder lets a
+    caller detect "this needs post-processing" without crashing."""
+    claim = format_legacy_import_claim("date", "1900", "https://example/permalink")
+    assert claim is not None
+    assert claim.get("_phase3a_pending_date_parse") == "1900"
+    assert claim["_property"] == "P571"
+
+
+def test_format_claim_for_unmapped_key_returns_none():
+    """Source / institution / permission are out of scope for Phase 3a's
+    narrow scalar mapping — caller treats None as "leave in wikitext."""
+    assert format_legacy_import_claim("source", "anything", "https://x") is None
+    assert format_legacy_import_claim("institution", "anything", "https://x") is None
+    assert format_legacy_import_claim("permission", "anything", "https://x") is None
+
+
+def test_build_legacy_import_claims_iterates_community_imports():
+    """End-to-end: a plan with two community imports produces two
+    claim dicts, skipping any keys outside the import mapping."""
+    plan = MigrationPlan(
+        source_permalink="https://example/permalink",
+        community_imports={
+            "title": "Community Title",
+            "creator": "Community Creator",
+            "source": "should be skipped",
+        },
+    )
+    claims = build_legacy_import_claims(plan)
+    assert len(claims) == 2
+    props = {c["mainsnak"]["property"] for c in claims}
+    assert props == {"P1476", "P2093"}
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: ARTWORK_PARAM_TO_CANONICAL_KEY sanity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "alias, canonical",
+    [
+        ("title", "title"),
+        ("Title", "title"),
+        ("AUTHOR", "creator"),
+        ("artist", "creator"),
+        ("creator", "creator"),
+        ("description", "description"),
+        ("date", "date"),
+    ],
+)
+def test_artwork_param_aliases_normalize_via_casefolded_lookup(alias, canonical):
+    """The mapping is consulted via case-folded keys — confirm every
+    advertised alias resolves to its canonical key regardless of
+    source casing."""
+    assert ARTWORK_PARAM_TO_CANONICAL_KEY.get(alias.casefold()) == canonical

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -3118,7 +3118,7 @@ _NORMALIZE_EDIT_SUMMARY = (
 
 
 def _normalize_wikitext_for_item(
-    s3, partner: str, dpla_id: str, ordinal_items: list
+    s3, partner: str, dpla_id: str, ordinal_items: list[tuple[str, dict]]
 ) -> None:
     """Per-item post-SDC wikitext cleanup: strip redundant template params.
 
@@ -3257,7 +3257,8 @@ def _run_partner_mode(partner, ids_file):
                 sdc_raw = s3.get_sdc_json(partner, dpla_id)
             except ClientError as e:
                 logging.warning(
-                    f" -- S3 error reading sdc.json for {dpla_id}: {e!r}; skipping."
+                    f" -- S3 error reading sdc.json for {partner}/{dpla_id}:"
+                    f" {e!r}; skipping."
                 )
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
                 continue
@@ -3276,7 +3277,8 @@ def _run_partner_mode(partner, ids_file):
                 upload_raw = s3.get_upload_result(partner, dpla_id)
             except ClientError as e:
                 logging.warning(
-                    f" -- S3 error reading upload-result.json for {dpla_id}: {e!r}; skipping."
+                    f" -- S3 error reading upload-result.json for {partner}/{dpla_id}:"
+                    f" {e!r}; skipping."
                 )
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
                 continue
@@ -3304,7 +3306,7 @@ def _run_partner_mode(partner, ids_file):
                 file_list = s3.get_file_list(partner, dpla_id)
             except ClientError as e:
                 logging.warning(
-                    f" -- S3 error reading file-list.txt for {dpla_id}: {e!r};"
+                    f" -- S3 error reading file-list.txt for {partner}/{dpla_id}: {e!r};"
                     " continuing without P2699 qualifiers."
                 )
                 file_list = []
@@ -3346,8 +3348,18 @@ def _run_partner_mode(partner, ids_file):
             try:
                 ordinal_items = sorted(eligible.items(), key=lambda kv: int(kv[0]))
             except (TypeError, ValueError):
+                # Surface the offending key so operators can trace the
+                # data-quality issue back to upload-result.json. The sort
+                # key raises on the first int() that fails, but Python's
+                # sorted() doesn't expose which one — so we re-scan the
+                # keys here purely to find the culprit for logging.
+                bad_keys = [
+                    repr(k) for k in eligible if not str(k).lstrip("-").isdigit()
+                ]
                 logging.warning(
-                    f" -- upload-result ordinals malformed for {dpla_id}; skipping."
+                    f" -- upload-result ordinals malformed for {dpla_id}"
+                    f" (non-integer key(s): {', '.join(bad_keys) or '<unknown>'});"
+                    " skipping."
                 )
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
                 continue


### PR DESCRIPTION
## Summary

Pure-logic foundation for the multi-PR Goal 2 work — migrating legacy `{{Artwork}}` files to `{{DPLA metadata}}` while preserving community contributions. This PR delivers the parser, provenance walker, classifier, and SDC claim constructor as a self-contained module with full test coverage.

**Phase 3b** (follow-up): pywikibot integration — fetch live revisions, post `wbeditentity` for community imports, save migrated wikitext, CLI subcommand `migrate-legacy --partner <slug>`. Out of this PR so the review stays tractable.

### New module `ingest_wikimedia/legacy_artwork.py`

- **`DPLA_BOT_ACCOUNTS`** — frozenset allowlist (`DPLA_bot`, `US National Archives bot`). Extend as older accounts are discovered in long-tenure files.
- **`parse_artwork_params`** — extracts canonical-key → value dict from `{{Artwork}}` / `{{Information}}` / `{{Photograph}}`, case-folded param matching, with `author`/`artist`/`creator` aliasing.
- **`RevisionSnapshot` + `trace_param_provenance`** — pure revision-history walker. For each currently-set param, returns the editor who last set it to its current value. Handles revert-to-original correctly (the reverter gets credit).
- **`classify_param_provenance`** — pure DPLA-vs-community classifier.
- **`plan_migration`** — top-level entry point. Returns a `MigrationPlan` with `community_imports` (values to SDC-import), `dpla_originated_params` (safe to discard), and `source_permalink`. Critically: a community value that *coincides* with canonical DPLA is treated as dpla-originated (no redundant import) — same invariant as Goal 1.
- **`format_legacy_import_claim` / `build_legacy_import_claims`** — emit `wbeditentity`-ready claim dicts with the two-snak reference block (`P887→Q131783016` "inferred from Wikitext" + `P4656→<permalink>` "Wikimedia import URL"). **No** DPLA-standard refs (P459/P973/P813), which would misrepresent the value as DPLA-sourced. Phase 3a maps: title→P1476, description→P10358, creator→P2093 (stated-as string), date→P571 (placeholder pending Phase 3b's date-parse step). Source/institution/permission deferred.

### Bundled: 5 GH AI Code findings on `tools/sdc_sync.py`

All directly on code I touched in #292; the rest of the 13 GH findings in the broader codebase are unrelated to current scope and skipped.

1. `_normalize_wikitext_for_item.ordinal_items` got `list[tuple[str, dict]]` element type hint.
2-4. Three `ClientError` messages in `_run_partner_mode` (sdc.json / upload-result.json / file-list.txt) now include `{partner}/{dpla_id}` instead of just `{dpla_id}` so operators can directly inspect the failing S3 object.
5. The malformed-ordinals warning now names the offending key(s) so the data-quality issue is traceable upstream.

## Test plan

- [x] **36 new tests** in `tests/test_legacy_artwork.py`: parse coverage, provenance walk (incl. revert-to-original, out-of-order input, empty-value drop), classifier (case-insensitive matching, explicit-bot-accounts override, allowlist pinned), plan construction (empty input, no-Artwork-in-latest, dpla-only file, community-edit import, redundant-restate skip, permalink format), SDC claim construction (reference shape, narrow property mapping, None-on-unmapped-key).
- [x] **569/569 existing tests** still pass.
- [x] ruff clean.
- [ ] Phase 3b PR adds pywikibot integration + CLI; this PR is library-only.

## Design context

Goal 2 of the SDC ↔ wikitext integration discussed in #290's design thread. The reference shape (P887→Q131783016 + P4656→permalink) was verified against the property usage notes at design time. Community-imported statements land in the yellow box on the file page (per `Module:DPLA`'s existing rendering); the wikitext-strip step happens after SDC import succeeds, so a failure here never leaves the file in a half-migrated state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Phase 3a Legacy Artwork Migration Foundation

### Overview
Adds a pure-logic foundation to migrate legacy Commons templates ({{Artwork}} / {{Information}} / {{Photograph}}) into DPLA/SDC workflows while preserving community contributions. Phase 3b (separate PR) will add pywikibot integration (fetch live revisions, post wbeditentity, save migrated wikitext, CLI).

Notable fixes included in this PR:
- Corrected provenance walker bug so deleted-then-readded params are attributed to the re-adding editor (prevents misclassifying community restores as DPLA-originated).
- Fixed permalink encoding by switching to urllib.parse.urlencode to percent-encode reserved characters.

### New module: ingest_wikimedia/legacy_artwork.py (+508 lines)
Core capabilities:
- Template parsing
  - find_legacy_template(wikitext) to locate legacy templates (falls back Artwork → Information).
  - parse_artwork_params(wikitext) to extract canonical-key → value mappings with case-folding and aliasing (author/artist/creator → creator); drops unknown/empty params.
- Provenance tracking
  - RevisionSnapshot dataclass and trace_param_provenance(revisions) walk revision history (sorted by revid) to attribute each final param to the editor who last set it, correctly handling reverts and delete-then-readd cases.
- Classification
  - DPLA_BOT_ACCOUNTS allowlist (frozenset) and classify_param_provenance(provenance, bot_accounts=...) to mark params as DPLA-originated or community-contributed (case-insensitive matching; does not mutate module state).
- Migration planning
  - plan_migration(file_title, revisions, canonical_params, bot_accounts=...) → MigrationPlan with:
    - community_imports: community values to import to SDC (skips values identical to canonical/DPLA values)
    - dpla_originated_params: params safe to treat as DPLA-originated
    - source_permalink: deterministic permalink based on latest oldid (properly URL-encoded)
- SDC / Wikibase claim construction (Phase 3a mappings)
  - format_legacy_import_claim(canonical_key, value, permalink, today=None) → wbeditentity-ready claim dict (supported mappings: title→P1476 monolingualtext with P887/P4656 ref block; description→P10358; creator→P2093 stated-as string; date→P571 placeholder)
  - build_legacy_import_claims(plan) → list of claim dicts for community_imports (skips unmapped keys)
- Constants: DPLA_BOT_ACCOUNTS, QID_INFERRED_FROM_WIKITEXT, PID_BASED_ON_HEURISTIC, PID_WIKIMEDIA_IMPORT_URL, LEGACY_IMPORT_PROPERTY, ARTWORK_PARAM_TO_CANONICAL_KEY, LEGACY_TEMPLATE_NAMES

Implementation notes:
- Phase 3a intentionally omits DPLA-standard refs/qualifiers (P459/P973/P813) to avoid attributing community-sourced values to DPLA metadata.
- Date handling for Phase 3a uses a placeholder path; full date modeling is left for later phases.

### Tests: tests/test_legacy_artwork.py (+498 lines, 36 tests)
Coverage includes:
- Template detection and fallback
- Parameter parsing and alias normalization (including casefolded alias resolution)
- Provenance tracing across revision histories, revert handling, delete-then-readd regression
- Classification using bot allowlist and custom override without mutating global state
- Migration planning semantics (community vs DPLA-originated, canonical-value deduping, deterministic source permalink, proper percent-encoding)
- Claim construction and skipping of unmapped keys

All existing tests still pass (569 total). ruff clean.

### Minor updates: tools/sdc_sync.py (+17/-5 lines)
- Improved type annotation: ordinal_items → list[tuple[str, dict]]
- Partner-mode logging enhancements: include partner path segment in S3 fetch failure logs and file-list error logging; log specific non-integer ordinal keys detected in malformed upload-result.json handling.

### Infrastructure, deployment, and security impact
- No manual pipeline trigger or ECS redeployment required.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No shared infrastructure (CodePipeline/CodeBuild/ECS/IAM) changes.
- No public API response shape changes or endpoint additions/removals.
- No security-sensitive changes (no new credential handling or auth model changes). The module processes external data (Wikimedia revision text), but Phase 3a is pure-logic and does not perform network requests or credential usage.

### Summary judgement
Pure-logic foundation ready for Phase 3b integration with pywikibot. Code review effort: High (new logic + provenance edge cases); tests are comprehensive and include regression fixes implemented here.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->