### PR TITLE
sdc-sync: Phase 3b — pywikibot executor + CLI for legacy migration (Goal 2)

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -506,3 +506,361 @@ def build_legacy_import_claims(plan: MigrationPlan) -> list[dict]:
         if claim is not None:
             claims.append(claim)
     return claims
+
+
+# ---------------------------------------------------------------------------
+# Phase 3b integration layer — pywikibot + wbeditentity + wikitext rewrite.
+#
+# Everything above this line is pure logic over plain dicts and the
+# RevisionSnapshot dataclass. Everything below talks to pywikibot,
+# Wikibase, or the in-tree DPLA-API parser. Keeping the boundary
+# explicit lets the test suite cover the pure layer without mocks and
+# lets future callers (a separate maintenance tool, a one-shot
+# migration script) reuse the planner standalone.
+# ---------------------------------------------------------------------------
+
+
+def fetch_revision_snapshots(file_page) -> list[RevisionSnapshot]:
+    """Pull the full revision history of ``file_page`` into
+    :class:`RevisionSnapshot` records the planner consumes.
+
+    Requests revision text (``content=True``) so the planner can parse
+    each historical wikitext. On a long-tenure file with thousands of
+    revisions this is a non-trivial pywikibot call; callers running
+    against a partner batch should expect minutes of wall time per
+    high-traffic file. The cost is paid once at plan time — the result
+    of :func:`plan_migration` is a small dict the executor walks
+    cheaply.
+
+    Missing per-revision metadata (suppressed-author revisions, missing
+    text) is tolerated: empty user names become ``""`` and absent text
+    becomes ``""``, so :func:`parse_artwork_params` simply finds no
+    params and the revision contributes nothing to provenance.
+    """
+    snapshots: list[RevisionSnapshot] = []
+    for rev in file_page.revisions(content=True):
+        snapshots.append(
+            RevisionSnapshot(
+                revid=getattr(rev, "revid", 0),
+                user=getattr(rev, "user", "") or "",
+                text=getattr(rev, "text", "") or "",
+            )
+        )
+    return snapshots
+
+
+def materialize_pending_date_claim(
+    placeholder: dict,
+    today: datetime.date | None = None,
+) -> dict | None:
+    """Take a Phase-3a ``_phase3a_pending_date_parse`` placeholder claim
+    and materialise it into a real Wikibase P571 (inception) statement.
+
+    Reuses :func:`ingest_wikimedia.sdc.parse_dpla_date` for the parse —
+    the DPLA-date parser is the in-tree source of truth for the dozens
+    of display-date formats Commons receives, so duplicating it here
+    would just drift. When the parser commits to a structured time,
+    the claim is value-typed at the parser's chosen precision; when it
+    doesn't, the claim is left at ``somevalue`` with the raw string
+    preserved as a P1932 (stated as) qualifier. The P1480 circa
+    qualifier is stamped when the parser flagged the source as
+    approximate.
+
+    Reference shape is the legacy-import P887→Q131783016 +
+    P4656→permalink shape from :func:`_reference_snaks` — *not* the
+    DPLA-standard refs used by :mod:`ingest_wikimedia.sdc`'s
+    ``_build_date_claim``. The whole point of legacy-import is that
+    the value didn't come from DPLA and must not be misattributed.
+
+    Returns None when ``placeholder`` doesn't carry the expected
+    sentinel keys — the caller drops the claim from the import set
+    and the value stays in wikitext until a later phase.
+
+    ``today`` is accepted (currently unused) for symmetry with other
+    claim builders so a later phase can add a P813 retrieved-on
+    reference snak if useful without changing call sites.
+    """
+    from .sdc import parse_dpla_date  # late import to avoid cycle
+
+    del today  # currently unused; see docstring
+    raw_date = placeholder.get("_phase3a_pending_date_parse")
+    prop = placeholder.get("_property")
+    permalink_from = placeholder.get("_permalink")
+    if not raw_date or not prop or not permalink_from:
+        return None
+
+    parsed = parse_dpla_date(raw_date)
+    qualifiers: dict[str, list[dict]] = {
+        # P1932 (stated as) preserves the verbatim source string so a
+        # reader can recover what the editor actually wrote, even when
+        # the structured time has reduced precision.
+        "P1932": [
+            {
+                "snaktype": "value",
+                "property": "P1932",
+                "datatype": "string",
+                "datavalue": {"type": "string", "value": raw_date},
+            }
+        ]
+    }
+    if parsed is not None:
+        mainsnak = {
+            "snaktype": "value",
+            "property": prop,
+            "datatype": "time",
+            "datavalue": {"type": "time", "value": parsed["value"]},
+        }
+        if parsed.get("approximate"):
+            # P1480 (sourcing circumstances) = Q5727902 (circa); same
+            # encoding as ingest_wikimedia.sdc._build_date_claim.
+            qualifiers["P1480"] = [
+                {
+                    "snaktype": "value",
+                    "property": "P1480",
+                    "datatype": "wikibase-item",
+                    "datavalue": {
+                        "type": "wikibase-entityid",
+                        "value": {"entity-type": "item", "id": "Q5727902"},
+                    },
+                }
+            ]
+    else:
+        # ``somevalue`` preserves the legacy behaviour for un-parseable
+        # dates — the statement asserts "there is *some* inception
+        # value" without committing to which, and the P1932 qualifier
+        # carries the editor's display string.
+        mainsnak = {"snaktype": "somevalue", "property": prop, "datatype": "time"}
+
+    return {
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": mainsnak,
+        "qualifiers": qualifiers,
+        "qualifiers-order": list(qualifiers.keys()),
+        "references": [_reference_snaks(permalink_from)],
+    }
+
+
+def materialize_import_claims(claims: list[dict]) -> list[dict]:
+    """Walk an import-claim list and substitute every Phase-3a date
+    placeholder for a real P571 time statement.
+
+    Claims without a placeholder marker pass through unchanged.
+    Placeholders whose date can't be expanded (parser failure paired
+    with missing sentinel keys — should never happen for in-tree
+    callers) are dropped silently rather than crashing the migration.
+    """
+    materialised: list[dict] = []
+    for claim in claims:
+        if "_phase3a_pending_date_parse" in claim:
+            real = materialize_pending_date_claim(claim)
+            if real is not None:
+                materialised.append(real)
+        else:
+            materialised.append(claim)
+    return materialised
+
+
+def entity_was_already_migrated(entity: dict) -> bool:
+    """Return True when ``entity`` (a wbgetentities-shaped MediaInfo
+    JSON blob) already carries at least one legacy-import statement.
+
+    Idempotency guard: if the executor's previous run posted SDC for a
+    file but crashed before rewriting the wikitext, a re-run sees the
+    page still in legacy form, would re-plan, and would re-post the
+    same claims — creating duplicates. Detecting our own reference
+    signature on any of the import properties is enough to bail out
+    cleanly; the operator then re-runs *just* the wikitext rewrite
+    via a follow-up tool (Phase 3b doesn't expose that yet, so the
+    today-practice is a manual re-edit).
+
+    Looks for a P887 reference snak whose target is exactly
+    :data:`QID_INFERRED_FROM_WIKITEXT` on any statement of any
+    Phase-3a-mapped property. Subtle: a non-DPLA editor could in
+    principle stamp the same ref shape on a hand-authored claim, but
+    that's the same semantic ("inferred from Wikitext") and the
+    skip-on-detect behaviour is still correct — we just don't add
+    duplicates.
+    """
+    statements = entity.get("statements") or entity.get("claims") or {}
+    for prop, _ in LEGACY_IMPORT_PROPERTY.values():
+        for stmt in statements.get(prop, []):
+            for ref in stmt.get("references", []):
+                for snak in ref.get("snaks", {}).get(PID_BASED_ON_HEURISTIC, []):
+                    target = snak.get("datavalue", {}).get("value", {}).get("id")
+                    if target == QID_INFERRED_FROM_WIKITEXT:
+                        return True
+    return False
+
+
+def render_migrated_wikitext(
+    original_text: str,
+    new_template_block: str,
+) -> str:
+    """Replace the first legacy-template invocation in ``original_text``
+    with ``new_template_block``, preserving everything else verbatim.
+
+    ``new_template_block`` is the full ``{{DPLA metadata ...}}``
+    rendering, typically produced by
+    :func:`ingest_wikimedia.wikimedia.get_wiki_text`. The caller is
+    responsible for any param-stripping pass (Goal 1's
+    :mod:`wikitext_normalize`) — this helper just swaps the wrapper.
+
+    Returns the original text untouched when no legacy template is
+    present (defensive — the executor's caller has already gated this
+    via the migration plan, but a stale text snapshot between plan and
+    write would otherwise mangle a non-legacy page).
+
+    Uses mwparserfromhell so license tags, categories, and any other
+    page-level structure survive in their original positions. Only
+    the legacy-template node itself is replaced.
+    """
+    wikicode = mwparserfromhell.parse(original_text)
+    template = None
+    for tpl in wikicode.filter_templates():
+        if _template_name(tpl) in LEGACY_TEMPLATE_NAMES:
+            template = tpl
+            break
+    if template is None:
+        return original_text
+    wikicode.replace(template, new_template_block)
+    return str(wikicode)
+
+
+# Edit summary the migration executor stamps on every wikitext save +
+# wbeditentity edit. Centralised so a future change to the wording
+# (e.g. linking to the Commons documentation page) doesn't need to be
+# hunted down across multiple call sites.
+LEGACY_MIGRATION_EDIT_SUMMARY = (
+    "Migrate legacy {{Artwork}} to {{DPLA metadata}} per DPLA SDC sync; "
+    "community-contributed metadata preserved as SDC statements with "
+    "[[d:Q131783016|inferred-from-Wikitext]] reference."
+)
+
+
+@dataclass
+class MigrationResult:
+    """End-state report from :func:`migrate_legacy_file`.
+
+    ``imports_posted`` is the number of community-import claims
+    actually written to the entity (post-materialisation, post-skip
+    for date-parse failures). ``wikitext_changed`` is whether the
+    page text was edited.
+    """
+
+    skipped_reason: str = ""
+    imports_posted: int = 0
+    wikitext_changed: bool = False
+    plan: MigrationPlan | None = None
+
+
+def post_legacy_import_claims(
+    mediaid: str,
+    claims: list[dict],
+    site,
+    summary: str = LEGACY_MIGRATION_EDIT_SUMMARY,
+) -> None:
+    """POST ``claims`` to ``mediaid`` as a single ``wbeditentity`` edit.
+
+    Mirrors :func:`tools.sdc_sync._submit_sdc_write`'s call pattern —
+    CSRF token from ``site.tokens['csrf']``, ``bot=True``, atomic
+    bundle — without importing it (the sdc_sync helper reads a
+    module-level ``site`` global; we want the explicit-argument form
+    so callers can pass a mocked site in tests).
+
+    Raises :class:`pywikibot.exceptions.APIError` on Wikibase rejection
+    — the caller catches it per-file so a single failure doesn't kill
+    the partner batch.
+    """
+    import json as _json
+
+    site.simple_request(
+        action="wbeditentity",
+        id=mediaid,
+        bot=True,
+        token=site.tokens["csrf"],
+        data=_json.dumps({"claims": claims}),
+        summary=summary,
+    ).submit()
+
+
+def migrate_legacy_file(
+    *,
+    file_page,
+    item_metadata: dict,
+    provider: dict,
+    data_provider: dict,
+    dpla_id: str,
+    site,
+    bot_accounts: frozenset[str] = DPLA_BOT_ACCOUNTS,
+    summary: str = LEGACY_MIGRATION_EDIT_SUMMARY,
+) -> MigrationResult:
+    """End-to-end legacy-Artwork migration for a single file.
+
+    The order is load-bearing:
+
+    1. Plan from the live revision history.
+    2. Idempotency check against the file's MediaInfo entity — bail
+       out if a previous run already imported (avoids duplicates).
+    3. POST community-import SDC statements *first*. If this fails
+       the wikitext stays in legacy form, the next run will detect
+       no SDC, and a retry produces the same outcome.
+    4. *Then* rewrite the wikitext. If this fails after step 3
+       succeeded, the file carries the imported SDC but still has
+       the legacy template — a follow-up wikitext-only sweep would
+       complete the migration. The reverse order (rewrite first,
+       then SDC) would discard the wikitext provenance before the
+       SDC import landed, irrecoverably losing community values if
+       the SDC POST then failed.
+    """
+    from .wikimedia import dpla_metadata_params, get_wiki_text
+
+    title = file_page.title()
+    revisions = fetch_revision_snapshots(file_page)
+    canonical_params = dpla_metadata_params(
+        dpla_id, item_metadata, provider, data_provider
+    )
+    plan = plan_migration(title, revisions, canonical_params, bot_accounts)
+    if plan is None:
+        return MigrationResult(skipped_reason="no-legacy-template")
+
+    mediaid = f"M{file_page.pageid}"
+    entity = _fetch_entity_or_empty(site, mediaid)
+    if entity_was_already_migrated(entity):
+        return MigrationResult(skipped_reason="already-migrated", plan=plan)
+
+    claims = materialize_import_claims(build_legacy_import_claims(plan))
+    if claims:
+        post_legacy_import_claims(mediaid, claims, site, summary=summary)
+
+    new_block = get_wiki_text(dpla_id, item_metadata, provider, data_provider)
+    rewritten = render_migrated_wikitext(file_page.text, new_block)
+    wikitext_changed = rewritten != file_page.text
+    if wikitext_changed:
+        file_page.text = rewritten
+        file_page.save(summary=summary, minor=False, bot=True)
+
+    return MigrationResult(
+        imports_posted=len(claims),
+        wikitext_changed=wikitext_changed,
+        plan=plan,
+    )
+
+
+def _fetch_entity_or_empty(site, mediaid: str) -> dict:
+    """Pull ``mediaid``'s MediaInfo entity via ``wbgetentities``, or
+    return an empty dict when the entity doesn't exist (file uploaded
+    but no SDC ever written).
+
+    Doesn't surface the missing-entity case as an error — for legacy
+    migration, "no SDC yet" is the most common starting state, and an
+    empty entity simply means
+    :func:`entity_was_already_migrated` returns False and the
+    executor proceeds to post the imports as fresh statements.
+    """
+    try:
+        raw = site.simple_request(action="wbgetentities", ids=mediaid).submit()
+    except Exception:  # noqa: BLE001 — best-effort fetch
+        return {}
+    entities = raw.get("entities", {})
+    return entities.get(mediaid, {}) if isinstance(entities, dict) else {}

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -27,6 +27,7 @@ misrepresent the value as DPLA-sourced when it isn't.
 from __future__ import annotations
 
 import datetime
+import json
 from dataclasses import dataclass, field
 from typing import Iterable
 from urllib.parse import urlencode
@@ -772,14 +773,12 @@ def post_legacy_import_claims(
     — the caller catches it per-file so a single failure doesn't kill
     the partner batch.
     """
-    import json as _json
-
     site.simple_request(
         action="wbeditentity",
         id=mediaid,
         bot=True,
         token=site.tokens["csrf"],
-        data=_json.dumps({"claims": claims}),
+        data=json.dumps({"claims": claims}),
         summary=summary,
     ).submit()
 

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -43,6 +43,16 @@ class Result(Enum):
     # its SDC writes raised at runtime. Without this counter such items
     # would be misclassified as MAPPING skips.
     SDC_ITEMS_SKIPPED_ERROR = auto()
+    # Phase-3b legacy-Artwork migration counters. Driven by
+    # tools/sdc_sync.py::_run_legacy_migration_mode (and any future
+    # standalone migration tool). Each is per-ordinal (one Commons
+    # file = one count) because that's the level at which the
+    # migration succeeds or fails.
+    LEGACY_MIGRATED = auto()  # wikitext rewritten + any imports posted
+    LEGACY_IMPORTS_POSTED = auto()  # community-import claims (sum across files)
+    LEGACY_SKIPPED_NOT_LEGACY = auto()  # page didn't carry a legacy template
+    LEGACY_SKIPPED_ALREADY = auto()  # already migrated (idempotency hit)
+    LEGACY_SKIPPED_ERROR = auto()  # raised at runtime, isolated by exc boundary
 
 
 class Tracker:

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -45,9 +45,11 @@ class Result(Enum):
     SDC_ITEMS_SKIPPED_ERROR = auto()
     # Phase-3b legacy-Artwork migration counters. Driven by
     # tools/sdc_sync.py::_run_legacy_migration_mode (and any future
-    # standalone migration tool). Each is per-ordinal (one Commons
-    # file = one count) because that's the level at which the
-    # migration succeeds or fails.
+    # standalone migration tool). Tracking is at per-ordinal
+    # granularity — one Commons file = one migration attempt — with
+    # the exception of LEGACY_IMPORTS_POSTED, which sums the count
+    # of import claims across all files (same shape as
+    # SDC_CLAIMS_ADDED / BYTES — see the inline comment for that one).
     LEGACY_MIGRATED = auto()  # wikitext rewritten + any imports posted
     LEGACY_IMPORTS_POSTED = auto()  # community-import claims (sum across files)
     LEGACY_SKIPPED_NOT_LEGACY = auto()  # page didn't carry a legacy template

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -496,3 +496,431 @@ def test_artwork_param_aliases_normalize_via_casefolded_lookup(alias, canonical)
     advertised alias resolves to its canonical key regardless of
     source casing."""
     assert ARTWORK_PARAM_TO_CANONICAL_KEY.get(alias.casefold()) == canonical
+
+
+# ---------------------------------------------------------------------------
+# Phase 3b: integration layer (date materialisation, idempotency,
+# wikitext-rewrite, end-to-end executor)
+# ---------------------------------------------------------------------------
+
+
+from unittest.mock import MagicMock  # noqa: E402
+
+from ingest_wikimedia.legacy_artwork import (  # noqa: E402
+    LEGACY_MIGRATION_EDIT_SUMMARY,
+    MigrationResult,
+    entity_was_already_migrated,
+    fetch_revision_snapshots,
+    materialize_import_claims,
+    materialize_pending_date_claim,
+    migrate_legacy_file,
+    post_legacy_import_claims,
+    render_migrated_wikitext,
+)
+
+
+# --- materialize_pending_date_claim ---------------------------------------
+
+
+def test_materialize_pending_date_claim_parses_year_to_p571_value_typed():
+    """The placeholder expands to a value-typed P571 statement with the
+    structured wikibase time datavalue and the original string
+    preserved as a P1932 (stated as) qualifier."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "1900",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+        "type": "statement",
+    }
+    claim = materialize_pending_date_claim(placeholder)
+    assert claim is not None
+    assert claim["mainsnak"]["snaktype"] == "value"
+    assert claim["mainsnak"]["property"] == "P571"
+    assert claim["mainsnak"]["datatype"] == "time"
+    assert claim["mainsnak"]["datavalue"]["type"] == "time"
+    # P1932 preserves the verbatim source string.
+    assert claim["qualifiers"]["P1932"][0]["datavalue"]["value"] == "1900"
+    # Reference uses P887/P4656, NOT DPLA-standard refs.
+    refs = claim["references"]
+    assert len(refs) == 1
+    assert set(refs[0]["snaks"]) == {"P887", "P4656"}
+
+
+def test_materialize_pending_date_claim_circa_stamps_p1480():
+    """Approximate dates ("ca. 1900") get the P1480 (sourcing
+    circumstances → Q5727902 circa) qualifier alongside P1932."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "ca. 1900",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    claim = materialize_pending_date_claim(placeholder)
+    assert claim is not None
+    assert "P1480" in claim["qualifiers"]
+    assert claim["qualifiers"]["P1480"][0]["datavalue"]["value"]["id"] == "Q5727902"
+
+
+def test_materialize_pending_date_claim_unparseable_falls_back_to_somevalue():
+    """When parse_dpla_date can't commit, the mainsnak goes ``somevalue``
+    so the statement still asserts an inception exists, with the
+    original string preserved on P1932."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "sometime in the 1800s maybe",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    claim = materialize_pending_date_claim(placeholder)
+    assert claim is not None
+    assert claim["mainsnak"]["snaktype"] == "somevalue"
+    assert "datavalue" not in claim["mainsnak"]
+    assert claim["qualifiers"]["P1932"][0]["datavalue"]["value"] == (
+        "sometime in the 1800s maybe"
+    )
+
+
+def test_materialize_import_claims_passes_through_non_date_claims():
+    """A title claim doesn't carry the placeholder marker — pass through."""
+    title_claim = {"type": "statement", "mainsnak": {"property": "P1476"}}
+    out = materialize_import_claims([title_claim])
+    assert out == [title_claim]
+
+
+def test_materialize_import_claims_swaps_only_date_placeholder():
+    """Mixed list — one pass-through, one materialised. Order preserved."""
+    title_claim = {"type": "statement", "mainsnak": {"property": "P1476"}}
+    date_placeholder = {
+        "type": "statement",
+        "_phase3a_pending_date_parse": "1900",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    out = materialize_import_claims([title_claim, date_placeholder])
+    assert len(out) == 2
+    assert out[0] == title_claim
+    assert out[1]["mainsnak"]["property"] == "P571"
+    assert "_phase3a_pending_date_parse" not in out[1]
+
+
+# --- entity_was_already_migrated ------------------------------------------
+
+
+def _entity_with_legacy_import(prop: str) -> dict:
+    return {
+        "statements": {
+            prop: [
+                {
+                    "mainsnak": {"property": prop},
+                    "references": [
+                        {
+                            "snaks": {
+                                "P887": [
+                                    {
+                                        "datavalue": {
+                                            "value": {
+                                                "entity-type": "item",
+                                                "id": "Q131783016",
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+
+
+def test_entity_was_already_migrated_detects_p887_q131783016_ref():
+    entity = _entity_with_legacy_import("P1476")
+    assert entity_was_already_migrated(entity) is True
+
+
+def test_entity_was_already_migrated_false_for_empty_entity():
+    assert entity_was_already_migrated({}) is False
+    assert entity_was_already_migrated({"statements": {}}) is False
+
+
+def test_entity_was_already_migrated_false_for_unrelated_p887_ref():
+    """A P887 ref pointing at a DIFFERENT Wikidata item doesn't count —
+    only the Q131783016 signature triggers the bail-out."""
+    entity = _entity_with_legacy_import("P1476")
+    entity["statements"]["P1476"][0]["references"][0]["snaks"]["P887"][0]["datavalue"][
+        "value"
+    ]["id"] = "Q99999999"
+    assert entity_was_already_migrated(entity) is False
+
+
+def test_entity_was_already_migrated_accepts_claims_key_legacy_shape():
+    """Some pywikibot helpers return MediaInfo entities with statements
+    under ``claims`` (the older key) rather than ``statements``. Read
+    either."""
+    entity = _entity_with_legacy_import("P1476")
+    entity["claims"] = entity.pop("statements")
+    assert entity_was_already_migrated(entity) is True
+
+
+# --- render_migrated_wikitext ---------------------------------------------
+
+
+def test_render_migrated_wikitext_swaps_artwork_for_dpla_metadata():
+    original = (
+        "== {{int:filedesc}} ==\n{{Artwork|title=Old}}\n{{PD-USGov}}\n[[Category:Foo]]"
+    )
+    new_block = "{{DPLA metadata|title=New}}"
+    result = render_migrated_wikitext(original, new_block)
+    assert "{{Artwork" not in result
+    assert "{{DPLA metadata|title=New}}" in result
+    # Page-level metadata survives.
+    assert "{{PD-USGov}}" in result
+    assert "[[Category:Foo]]" in result
+
+
+def test_render_migrated_wikitext_noop_when_no_legacy_template():
+    """Defensive: a page already migrated (or never legacy) is left
+    byte-identical so the caller's wikitext-changed comparison
+    behaves correctly."""
+    original = "{{DPLA metadata|title=Already there}}\n"
+    result = render_migrated_wikitext(original, "{{DPLA metadata|title=Other}}")
+    assert result == original
+
+
+def test_render_migrated_wikitext_swaps_information_template_too():
+    original = "{{Information|description=foo}}"
+    result = render_migrated_wikitext(original, "{{DPLA metadata|description=bar}}")
+    assert "{{Information" not in result
+    assert "{{DPLA metadata|description=bar}}" in result
+
+
+# --- post_legacy_import_claims --------------------------------------------
+
+
+def test_post_legacy_import_claims_submits_atomic_wbeditentity():
+    """One ``wbeditentity`` POST with all claims bundled. The request
+    action, id, csrf token, and JSON-serialised ``data`` payload are
+    the contract."""
+    import json as _json
+
+    site = MagicMock()
+    site.tokens = {"csrf": "CSRFTOKEN"}
+    request = MagicMock()
+    site.simple_request.return_value = request
+
+    claims = [{"type": "statement", "mainsnak": {"property": "P1476"}}]
+    post_legacy_import_claims("M42", claims, site)
+
+    site.simple_request.assert_called_once()
+    kwargs = site.simple_request.call_args.kwargs
+    assert kwargs["action"] == "wbeditentity"
+    assert kwargs["id"] == "M42"
+    assert kwargs["bot"] is True
+    assert kwargs["token"] == "CSRFTOKEN"
+    assert _json.loads(kwargs["data"]) == {"claims": claims}
+    request.submit.assert_called_once()
+
+
+# --- fetch_revision_snapshots ---------------------------------------------
+
+
+def test_fetch_revision_snapshots_projects_revid_user_text():
+    """The pywikibot Revision object's three relevant fields are
+    projected into the dataclass; anything else is dropped. Also pins
+    that content=True is the call shape (without it pywikibot doesn't
+    populate .text)."""
+
+    class _Rev:
+        def __init__(self, revid, user, text):
+            self.revid, self.user, self.text = revid, user, text
+
+    file_page = MagicMock()
+    file_page.revisions.return_value = [
+        _Rev(1, "DPLA_bot", "{{Artwork|title=A}}"),
+        _Rev(2, "Editor1", "{{Artwork|title=B}}"),
+    ]
+    snapshots = fetch_revision_snapshots(file_page)
+    assert len(snapshots) == 2
+    assert snapshots[0].revid == 1 and snapshots[0].user == "DPLA_bot"
+    assert snapshots[1].text == "{{Artwork|title=B}}"
+    file_page.revisions.assert_called_once_with(content=True)
+
+
+def test_fetch_revision_snapshots_tolerates_missing_user_and_text():
+    """Suppressed-author revisions can have ``user=None`` and missing
+    text. Coerce both to ``""`` so the planner just sees no params
+    for that revision."""
+
+    class _Rev:
+        revid = 7
+        user = None
+        text = None
+
+    file_page = MagicMock()
+    file_page.revisions.return_value = [_Rev()]
+    snapshots = fetch_revision_snapshots(file_page)
+    assert len(snapshots) == 1
+    assert snapshots[0].user == "" and snapshots[0].text == ""
+
+
+# --- migrate_legacy_file end-to-end ---------------------------------------
+
+
+def _mock_file_page(title: str, text: str, revisions: list):
+    page = MagicMock()
+    page.title.return_value = title
+    page.text = text
+    page.pageid = 42
+    page.revisions.return_value = revisions
+    return page
+
+
+def _site_with_empty_entity():
+    site = MagicMock()
+    site.tokens = {"csrf": "CSRFTOKEN"}
+    site.simple_request.return_value.submit.return_value = {"entities": {"M42": {}}}
+    return site
+
+
+def _item_md(title="A Title"):
+    return (
+        {
+            "rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "isShownAt": "https://example.org/item/123",
+            "sourceResource": {
+                "title": [title],
+                "description": ["A description"],
+                "date": [{"displayDate": "1900"}],
+                "creator": ["A Creator"],
+                "identifier": ["local-1"],
+            },
+        },
+        {"Wikidata": "Q1"},
+        {"Wikidata": "Q2"},
+    )
+
+
+def test_migrate_legacy_file_skips_when_no_legacy_template():
+    """A page already on the new template form returns the no-legacy
+    skip reason without POSTing anything to Wikibase."""
+
+    class _Rev:
+        revid, user, text = 1, "DPLA_bot", "{{DPLA metadata|title=A Title}}"
+
+    page = _mock_file_page("File:Foo.jpg", _Rev.text, [_Rev()])
+    item, provider, dp = _item_md()
+    site = _site_with_empty_entity()
+    result = migrate_legacy_file(
+        file_page=page,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    assert isinstance(result, MigrationResult)
+    assert result.skipped_reason == "no-legacy-template"
+    # No wbeditentity POST anywhere in the call history.
+    assert all(
+        c.kwargs.get("action") != "wbeditentity"
+        for c in site.simple_request.call_args_list
+    )
+
+
+def test_migrate_legacy_file_skips_when_already_migrated():
+    """The idempotency check spots an existing P887/Q131783016 ref on
+    a P1476 statement and bails out before POSTing duplicates."""
+
+    class _Rev:
+        revid, user, text = 1, "DPLA_bot", "{{Artwork|title=A Title}}"
+
+    page = _mock_file_page("File:Foo.jpg", _Rev.text, [_Rev()])
+    item, provider, dp = _item_md()
+    site = MagicMock()
+    site.tokens = {"csrf": "CSRFTOKEN"}
+    site.simple_request.return_value.submit.return_value = {
+        "entities": {"M42": _entity_with_legacy_import("P1476")}
+    }
+    result = migrate_legacy_file(
+        file_page=page,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    assert result.skipped_reason == "already-migrated"
+    page.save.assert_not_called()
+
+
+def test_migrate_legacy_file_dpla_only_history_writes_no_imports():
+    """No community history → no imports, but the wikitext still gets
+    rewritten to the new template form so the canonical state is
+    consistent."""
+
+    class _Rev:
+        revid, user, text = 1, "DPLA_bot", "{{Artwork|title=A Title}}"
+
+    page = _mock_file_page("File:Foo.jpg", _Rev.text, [_Rev()])
+    item, provider, dp = _item_md()
+    site = _site_with_empty_entity()
+    result = migrate_legacy_file(
+        file_page=page,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    assert result.imports_posted == 0
+    assert result.wikitext_changed is True
+    page.save.assert_called_once()
+    save_summary = page.save.call_args.kwargs.get("summary", "")
+    assert "Migrate legacy" in save_summary
+
+
+def test_migrate_legacy_file_imports_community_value_and_rewrites_wikitext():
+    """End-to-end happy path: DPLA_bot wrote the original, a community
+    editor changed the title, we import that community value and
+    rewrite the wikitext."""
+
+    class _Rev1:
+        revid, user, text = 1, "DPLA_bot", "{{Artwork|title=A Title}}"
+
+    class _Rev2:
+        revid, user, text = 2, "EditorOne", "{{Artwork|title=A Better Title}}"
+
+    page = _mock_file_page("File:Foo.jpg", _Rev2.text, [_Rev1(), _Rev2()])
+    item, provider, dp = _item_md()
+    site = _site_with_empty_entity()
+    result = migrate_legacy_file(
+        file_page=page,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    assert result.imports_posted == 1
+    assert result.wikitext_changed is True
+
+    import json as _json
+
+    wbeditentity_calls = [
+        c
+        for c in site.simple_request.call_args_list
+        if c.kwargs.get("action") == "wbeditentity"
+    ]
+    assert len(wbeditentity_calls) == 1
+    posted = _json.loads(wbeditentity_calls[0].kwargs["data"])
+    assert len(posted["claims"]) == 1
+    assert posted["claims"][0]["mainsnak"]["property"] == "P1476"
+    assert (
+        posted["claims"][0]["mainsnak"]["datavalue"]["value"]["text"]
+        == "A Better Title"
+    )
+
+
+def test_legacy_migration_edit_summary_mentions_q131783016():
+    """The edit summary should mention the inferred-from-Wikitext
+    Wikidata item so reviewers can trace the migration's intent."""
+    assert "Q131783016" in LEGACY_MIGRATION_EDIT_SUMMARY

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -3232,10 +3232,19 @@ def _run_legacy_migration_mode(partner: str, ids_file: str) -> None:
          ``{{DPLA metadata}}``.
 
     Per-file exception boundary: any pywikibot APIError, S3 read
-    failure, or runtime error is logged with a traceback and counted
-    under :class:`Result.LEGACY_SKIPPED_ERROR`. The partner batch
-    keeps walking — same isolation pattern as
-    :func:`_run_partner_mode`'s ordinal loop.
+    failure, or runtime error on a single Commons file is logged with
+    a traceback and counted under
+    :class:`Result.LEGACY_SKIPPED_ERROR`. The remaining files for the
+    same item, and the partner batch as a whole, keep walking — same
+    per-ordinal isolation pattern as :func:`_run_partner_mode`. The
+    boundary lives inside :func:`_migrate_one_dpla_item`'s file loop,
+    not around the whole item, so one bad ordinal doesn't skip the
+    other ordinals' migration.
+
+    Item-level errors (e.g. S3 read failures on the
+    ``dpla-map.json`` / ``upload-result.json`` sidecars themselves)
+    skip the whole item — same as :func:`_run_partner_mode`. These
+    are caught in the outer loop below.
     """
     from botocore.exceptions import ClientError
 
@@ -3262,21 +3271,19 @@ def _run_legacy_migration_mode(partner: str, ids_file: str) -> None:
             logging.info(f"DPLA ID: {dpla_id} ({local_count}/{len(dpla_ids)})")
             try:
                 _migrate_one_dpla_item(s3, partner, dpla_id)
-            except _MissingEntityError:
-                # The MediaInfo entity doesn't exist — treat as "not
-                # legacy" (file gone, nothing to migrate). The migration
-                # only operates on existing pages.
-                logging.info(
-                    f" -- {dpla_id}: Commons MediaInfo entity missing; skipping."
-                )
-                tracker.increment(Result.LEGACY_SKIPPED_NOT_LEGACY)
             except ClientError as e:
+                # Item-level sidecar read failure — affects every file
+                # for this item identically, so skip the whole item.
+                # Per-file errors are caught inside _migrate_one_dpla_item.
                 logging.warning(
                     f" -- S3 error during migration of {partner}/{dpla_id}:"
                     f" {e!r}; skipping."
                 )
                 tracker.increment(Result.LEGACY_SKIPPED_ERROR)
             except Exception:
+                # Item-level setup error (DPLA.get_provider_and_data_provider,
+                # JSON parse, etc.). Per-file errors are already isolated
+                # inside the loop and shouldn't reach here.
                 logging.exception(f" -- {dpla_id}: legacy migration failed; skipping.")
                 tracker.increment(Result.LEGACY_SKIPPED_ERROR)
         completed = True
@@ -3304,12 +3311,16 @@ def _run_legacy_migration_mode(partner: str, ids_file: str) -> None:
 
 
 def _migrate_one_dpla_item(s3, partner: str, dpla_id: str) -> None:
-    """Inner per-item handler for :func:`_run_legacy_migration_mode`.
+    """Inner handler for :func:`_run_legacy_migration_mode` — sidecar
+    loading, provider resolution, and the per-file migration loop.
 
-    Extracted so the per-item exception boundary in the outer loop
-    can wrap a single call and the body stays readable. All counter
-    updates happen here so the outer loop sees clean semantics —
-    "did we raise or not" is the only signal it needs.
+    The per-file exception boundary lives inside the loop here (not in
+    the outer caller) so one bad Commons file inside a multi-ordinal
+    item doesn't skip its siblings — same per-ordinal isolation
+    pattern :func:`_run_partner_mode` uses. Item-level setup errors
+    (missing sidecars, provider lookup failures) propagate up to the
+    outer loop, which classifies them under the same tracker bucket
+    but skips the whole item rather than individual files.
     """
     from ingest_wikimedia.dpla import DPLA
     from ingest_wikimedia.legacy_artwork import migrate_legacy_file
@@ -3349,18 +3360,37 @@ def _migrate_one_dpla_item(s3, partner: str, dpla_id: str) -> None:
         return
 
     for title in eligible_titles:
-        page = pywikibot.FilePage(site, title)
-        if not page.exists():
+        # Per-file exception boundary: a transient pywikibot APIError on
+        # one ordinal must not abort the remaining ordinals for this item.
+        # Matches the per-ordinal pattern in _run_partner_mode. The
+        # MissingEntity case is folded into NOT_LEGACY rather than ERROR
+        # because the file is just gone, not a real failure.
+        try:
+            page = pywikibot.FilePage(site, title)
+            if not page.exists():
+                tracker.increment(Result.LEGACY_SKIPPED_NOT_LEGACY)
+                continue
+            result = migrate_legacy_file(
+                file_page=page,
+                item_metadata=item_metadata,
+                provider=provider,
+                data_provider=data_provider,
+                dpla_id=dpla_id,
+                site=site,
+            )
+        except _MissingEntityError:
+            logging.info(
+                f" -- '{title}' for {dpla_id}: MediaInfo entity missing; skipping."
+            )
             tracker.increment(Result.LEGACY_SKIPPED_NOT_LEGACY)
             continue
-        result = migrate_legacy_file(
-            file_page=page,
-            item_metadata=item_metadata,
-            provider=provider,
-            data_provider=data_provider,
-            dpla_id=dpla_id,
-            site=site,
-        )
+        except Exception:
+            logging.exception(
+                f" -- '{title}' for {dpla_id}: legacy migration failed; skipping."
+            )
+            tracker.increment(Result.LEGACY_SKIPPED_ERROR)
+            continue
+
         if result.skipped_reason == "no-legacy-template":
             tracker.increment(Result.LEGACY_SKIPPED_NOT_LEGACY)
         elif result.skipped_reason == "already-migrated":

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -124,6 +124,19 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
+        "--migrate-legacy",
+        dest="migrate_legacy",
+        action="store_true",
+        default=False,
+        help=(
+            "Instead of running SDC sync, migrate legacy {{Artwork}} files to "
+            "{{DPLA metadata}} for the supplied --partner. Walks each file's "
+            "revision history to distinguish DPLA-bot values (overwrite-safe) "
+            "from community contributions (preserved as SDC statements with "
+            "P887→Q131783016 + P4656 refs), then rewrites the wikitext."
+        ),
+    )
+    p.add_argument(
         "--normalize-wikitext",
         dest="normalize_wikitext",
         action="store_true",
@@ -3199,6 +3212,171 @@ def _normalize_wikitext_for_item(
             )
 
 
+def _run_legacy_migration_mode(partner: str, ids_file: str) -> None:
+    """Drive the legacy ``{{Artwork}}`` → ``{{DPLA metadata}}`` migration
+    for a whole partner.
+
+    Iterates the partner's IDs CSV — same input shape as
+    :func:`_run_partner_mode`'s SDC sync path. For each DPLA item:
+
+    1. Read ``dpla-map.json`` (canonical DPLA record) from S3 to drive
+       provenance comparison and produce the new template wikitext.
+    2. Read ``upload-result.json`` to discover the Commons file titles
+       this DPLA item maps to.
+    3. For each Commons file:
+       * Resolve the ``FilePage`` and walk its revision history.
+       * Plan the migration (DPLA-bot vs community provenance).
+       * Post any community-import SDC statements with the legacy
+         reference shape (P887→Q131783016 + P4656).
+       * Rewrite the wikitext, swapping the legacy template for
+         ``{{DPLA metadata}}``.
+
+    Per-file exception boundary: any pywikibot APIError, S3 read
+    failure, or runtime error is logged with a traceback and counted
+    under :class:`Result.LEGACY_SKIPPED_ERROR`. The partner batch
+    keeps walking — same isolation pattern as
+    :func:`_run_partner_mode`'s ordinal loop.
+    """
+    from botocore.exceptions import ClientError
+
+    from ingest_wikimedia.s3 import S3Client
+
+    # Mirrors _run_partner_mode's start-of-pipeline setup. Operators
+    # see the same phase-start / phase-complete Slack messages so
+    # wikimedia_upload_status can detect progress identically.
+    setup_logging(partner, "legacy-migration", logging.INFO)
+    notify_phase_start(partner, "legacy-migration")
+    start_time = time.time()
+    tracker.reset()
+
+    s3 = S3Client()
+    with open(ids_file) as f:
+        dpla_ids = [line.strip() for line in f if line.strip()]
+    logging.info(
+        f"Legacy-migration mode: {partner} — {len(dpla_ids)} items from {ids_file}"
+    )
+
+    completed = False
+    try:
+        for local_count, dpla_id in enumerate(dpla_ids, start=1):
+            logging.info(f"DPLA ID: {dpla_id} ({local_count}/{len(dpla_ids)})")
+            try:
+                _migrate_one_dpla_item(s3, partner, dpla_id)
+            except _MissingEntityError:
+                # The MediaInfo entity doesn't exist — treat as "not
+                # legacy" (file gone, nothing to migrate). The migration
+                # only operates on existing pages.
+                logging.info(
+                    f" -- {dpla_id}: Commons MediaInfo entity missing; skipping."
+                )
+                tracker.increment(Result.LEGACY_SKIPPED_NOT_LEGACY)
+            except ClientError as e:
+                logging.warning(
+                    f" -- S3 error during migration of {partner}/{dpla_id}:"
+                    f" {e!r}; skipping."
+                )
+                tracker.increment(Result.LEGACY_SKIPPED_ERROR)
+            except Exception:
+                logging.exception(f" -- {dpla_id}: legacy migration failed; skipping.")
+                tracker.increment(Result.LEGACY_SKIPPED_ERROR)
+        completed = True
+    except BaseException as exc:
+        logging.exception(
+            "Legacy migration aborted with unhandled exception (%s)",
+            type(exc).__name__,
+        )
+        raise
+    finally:
+        elapsed = time.time() - start_time
+        if completed:
+            logging.info("\n" + str(tracker))
+            logging.info(f"{elapsed} seconds.")
+            # No dedicated Slack notification helper yet — reuse the SDC
+            # phase's `notify_sdc_complete` is wrong semantically (this
+            # isn't an SDC sync), so just log to the local file. A
+            # later phase can add a `notify_legacy_complete` if this
+            # mode becomes routine.
+        else:
+            logging.warning(
+                "Legacy migration aborted before completion; suppressing"
+                " terminal COUNTS dump."
+            )
+
+
+def _migrate_one_dpla_item(s3, partner: str, dpla_id: str) -> None:
+    """Inner per-item handler for :func:`_run_legacy_migration_mode`.
+
+    Extracted so the per-item exception boundary in the outer loop
+    can wrap a single call and the body stays readable. All counter
+    updates happen here so the outer loop sees clean semantics —
+    "did we raise or not" is the only signal it needs.
+    """
+    from ingest_wikimedia.dpla import DPLA
+    from ingest_wikimedia.legacy_artwork import migrate_legacy_file
+
+    item_raw = s3.get_item_metadata(partner, dpla_id)
+    if not item_raw:
+        logging.info(f" -- {dpla_id}: no dpla-map.json on S3; skipping.")
+        tracker.increment(Result.LEGACY_SKIPPED_NOT_LEGACY)
+        return
+    item_metadata = json.loads(item_raw)
+
+    upload_raw = s3.get_upload_result(partner, dpla_id)
+    if not upload_raw:
+        logging.info(f" -- {dpla_id}: no upload-result.json on S3; skipping.")
+        tracker.increment(Result.LEGACY_SKIPPED_NOT_LEGACY)
+        return
+    upload_result = json.loads(upload_raw)
+
+    provider, data_provider = DPLA.get_provider_and_data_provider(item_metadata, hubs)
+    ordinals = upload_result.get("ordinals", {})
+    if not isinstance(ordinals, dict):
+        logging.warning(
+            f" -- {dpla_id}: upload-result.json has non-mapping ordinals; skipping."
+        )
+        tracker.increment(Result.LEGACY_SKIPPED_ERROR)
+        return
+
+    eligible_titles = [
+        data.get("title")
+        for data in ordinals.values()
+        if isinstance(data, dict)
+        and data.get("status") in ("UPLOADED", "SKIPPED")
+        and data.get("title")
+    ]
+    if not eligible_titles:
+        tracker.increment(Result.LEGACY_SKIPPED_NOT_LEGACY)
+        return
+
+    for title in eligible_titles:
+        page = pywikibot.FilePage(site, title)
+        if not page.exists():
+            tracker.increment(Result.LEGACY_SKIPPED_NOT_LEGACY)
+            continue
+        result = migrate_legacy_file(
+            file_page=page,
+            item_metadata=item_metadata,
+            provider=provider,
+            data_provider=data_provider,
+            dpla_id=dpla_id,
+            site=site,
+        )
+        if result.skipped_reason == "no-legacy-template":
+            tracker.increment(Result.LEGACY_SKIPPED_NOT_LEGACY)
+        elif result.skipped_reason == "already-migrated":
+            tracker.increment(Result.LEGACY_SKIPPED_ALREADY)
+        else:
+            tracker.increment(Result.LEGACY_MIGRATED)
+            if result.imports_posted:
+                tracker.increment(
+                    Result.LEGACY_IMPORTS_POSTED, amount=result.imports_posted
+                )
+            logging.info(
+                f" -- Migrated '{title}': {result.imports_posted} community"
+                f" import(s), wikitext_changed={result.wikitext_changed}"
+            )
+
+
 def _run_partner_mode(partner, ids_file):
     """Drive the SDC phase from precomputed S3 sidecars for a whole partner.
 
@@ -3669,12 +3847,20 @@ def main() -> None:
                 break
 
     elif args.partner:
-        # Partner-driven SDC phase (PR 4). Iterates the partner's IDs CSV and
-        # syncs each item's precomputed sdc.json against Commons. Designed to
-        # be the last step in a `get-ids-es → downloader → uploader → sdc-sync`
-        # pipeline chain.
         _ids_file = args.ids_file or os.path.join(args.partner, f"{args.partner}.csv")
-        _run_partner_mode(args.partner, _ids_file)
+        if args.migrate_legacy:
+            # Phase 3b: legacy {{Artwork}} → {{DPLA metadata}} migration. A
+            # one-time operation per file, separate from the SDC sync that
+            # ``_run_partner_mode`` performs. Both walk the same partner IDs
+            # CSV; the migration mode is gated behind --migrate-legacy so
+            # an operator has to ask for it explicitly.
+            _run_legacy_migration_mode(args.partner, _ids_file)
+        else:
+            # Partner-driven SDC phase (PR 4). Iterates the partner's IDs CSV
+            # and syncs each item's precomputed sdc.json against Commons.
+            # Designed to be the last step in a
+            # `get-ids-es → downloader → uploader → sdc-sync` pipeline chain.
+            _run_partner_mode(args.partner, _ids_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

End-to-end legacy `{{Artwork}}` → `{{DPLA metadata}}` migration on top of #294's pure-logic foundation. Completes Goal 2 of the SDC ↔ wikitext integration: a `sdc-sync --migrate-legacy --partner <slug>` run walks each Commons file's revision history, distinguishes DPLA-bot values from community contributions, imports the community values as SDC statements with the `P887→Q131783016` + `P4656→permalink` reference shape, then rewrites the wikitext to the new template form.

## What it adds

### `ingest_wikimedia/legacy_artwork.py` — integration layer

Below an explicit comment delimiter separating pure logic from side effects:

| Helper | What it does |
|---|---|
| `fetch_revision_snapshots(file_page)` | pywikibot `revisions(content=True)` → list of `RevisionSnapshot` dataclasses. Tolerates suppressed-author and missing-text revisions. |
| `materialize_pending_date_claim(placeholder)` | Phase 3a's sentinel `_phase3a_pending_date_parse` claim → real P571 time statement. Reuses `parse_dpla_date` (single source of truth for DPLA date formats). Approximate dates get `P1480→Q5727902` circa; unparseable dates fall back to `somevalue` with the original on P1932. |
| `materialize_import_claims(claims)` | Walks a claims list, swaps date placeholders in place, passes through everything else. |
| `entity_was_already_migrated(entity)` | Idempotency guard. Detects any P1476/P10358/P2093/P571 statement carrying a `P887→Q131783016` reference signature. Prevents duplicate posts on retry. |
| `render_migrated_wikitext(original, new_block)` | Surgically swaps the legacy-template node for the new `{{DPLA metadata}}` block; license, categories, other templates survive in place. |
| `post_legacy_import_claims(mediaid, claims, site)` | One atomic `wbeditentity` POST. Explicit `site` arg so tests can pass a mock. |
| `migrate_legacy_file(...)` | End-to-end executor. **Order is load-bearing:** plan → idempotency check → SDC POST → THEN wikitext save. The reverse order would lose the provenance the SDC import depends on if the `wbeditentity` then failed. |

### `tools/sdc_sync.py` — CLI mode

- New `--migrate-legacy` flag triggering `_run_legacy_migration_mode` alongside the existing partner mode (same IDs CSV input shape; same per-item exception boundary pattern as `_run_partner_mode`).
- New `_migrate_one_dpla_item` inner handler so the per-item try/except wraps one call.

### `ingest_wikimedia/tracker.py` — counters

`LEGACY_MIGRATED` / `LEGACY_IMPORTS_POSTED` / `LEGACY_SKIPPED_NOT_LEGACY` / `LEGACY_SKIPPED_ALREADY` / `LEGACY_SKIPPED_ERROR`. Surfaced in the terminal COUNTS dump same as the SDC counters.

## Why the SDC-then-wikitext order matters

If wikitext rewrite ran first and SDC POST then failed, the file would carry the new template form but no community-import statements — and the next migration run would see "no legacy template" and skip, permanently losing the community values. SDC first means a wikitext-save failure leaves the legacy template intact (still detectable on retry), and the entity-idempotency check prevents duplicate SDC on the retry.

## Test plan

- [x] **20 new tests** on top of Phase 3a's 39. Coverage:
  - `materialize_pending_date_claim`: value-typed parse, circa P1480, somevalue fallback, P887/P4656 ref shape
  - `materialize_import_claims`: pass-through + swap with order preservation
  - `entity_was_already_migrated`: positive, empty entity, unrelated P887 target, `claims` legacy-key shape
  - `render_migrated_wikitext`: Artwork→DPLA metadata with license/category preservation, no-op on non-legacy, `{{Information}}` also in scope
  - `post_legacy_import_claims`: action/id/token/data contract pinned
  - `fetch_revision_snapshots`: projection + suppressed-author tolerance
  - `migrate_legacy_file` end-to-end: no-legacy skip, already-migrated skip, DPLA-only writes no imports (still rewrites wikitext), community-import happy path posts P1476 with editor's value
- [x] **592/592 total tests pass** (Phase 3a's 39 + 20 new for Phase 3b + 533 existing)
- [x] `ruff check` + `ruff format` clean
- [ ] Smoke run on EC2 against a single legacy partner file (`sdc-sync --partner <slug> --migrate-legacy`) before opening to the full partner batch

## What's still ahead

This completes the SDC ↔ wikitext integration's three goals end-to-end:
- **Goal 1** (#292) — strip redundant `{{DPLA metadata}}` params after SDC
- **Goal 2** (#294 + this PR) — migrate legacy `{{Artwork}}` files
- **Goal 3** (#293) — per-item language-aware unwrapping

Future widening of Phase 3's narrow scalar property mapping (`title`/`description`/`date`/`creator`) to also cover `source`/`institution`/`permission` can layer on top without changing the executor's contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Phase 3b Legacy Migration — Integration & CLI

This PR implements the Phase 3b end-to-end migration flow to convert legacy Commons {{Artwork}} / {{Information}} template data into structured SDC imports and replace the template with {{DPLA metadata}}. It adds a pywikibot executor, a new sdc-sync CLI migration mode, tracker counters, and tests to exercise orchestration and integration boundaries.

### What was added
- ingest_wikimedia/legacy_artwork.py
  - End-to-end executor and helpers (+ ~865 lines): fetch_revision_snapshots, materialize_pending_date_claim, materialize_import_claims, entity_was_already_migrated, render_migrated_wikitext, post_legacy_import_claims, migrate_legacy_file, MigrationResult dataclass, LEGACY_MIGRATION_EDIT_SUMMARY, and an internal _fetch_entity_or_empty.
  - Behavior highlights:
    - Loads file revision snapshots (coercing missing user/text).
    - Materializes Phase‑3a date sentinels into P571 with P1932 stated-as qualifier and P1480 circa when parser marks approximate; unparseable dates become somevalue with original text preserved.
    - Idempotency detection by scanning for legacy-import reference signature (P887 → Q131783016) on the MediaInfo entity.
    - Posts community-contributed import statements in a single atomic wbeditentity POST (uses site CSRF token) and then rewrites the wikitext, replacing only the first legacy-template node and preserving license/categories/other templates.
    - Orchestration ordering: post SDC imports first, then save rewritten wikitext (so structured provenance is kept if a later save fails).
- ingest_wikimedia/tracker.py
  - New Result enum members and tracking: LEGACY_MIGRATED, LEGACY_IMPORTS_POSTED (cumulative across files), LEGACY_SKIPPED_NOT_LEGACY, LEGACY_SKIPPED_ALREADY, LEGACY_SKIPPED_ERROR.
- tools/sdc_sync.py
  - New CLI flag --migrate-legacy and two helpers: _run_legacy_migration_mode(partner, ids_file) and _migrate_one_dpla_item(s3, partner, dpla_id).
  - Iterates partner IDs, reads dpla-map.json / upload-result.json from S3, selects eligible file ordinals (UPLOADED/SKIPPED), opens FilePage, calls migrate_legacy_file per file with per-file exception isolation, and updates tracker counters accordingly.
  - Per-file exception boundary moved inside the file loop so a failure on one file does not skip later files; MissingEntityError for a file is now classified as NOT_LEGACY for that file.
- tests/test_legacy_artwork.py
  - ~20 new unit tests covering claim materialization (date parsing, circa, somevalue fallback), idempotency detection, wikitext rewriting behavior, post_legacy_import_claims payload and CSRF use, fetch_revision_snapshots behavior, and end-to-end migrate_legacy_file outcomes.
- Misc: small commit fixes (moved json import to top-level, clarified tracker comment about LEGACY_IMPORTS_POSTED, and adjusted try/except placement). Full test suite reported 592/592 passing; ruff clean.

### Deployment & operational notes (explicit)
- Operator action required: migration is gated behind the explicit CLI flag --migrate-legacy. To run a partner migration: sdc-sync --migrate-legacy --partner <partner_slug>.
- No ECS redeployment or pipeline trigger required to make the code available — this is a CLI mode in the sdc-sync tool (entry point already present).
- No new environment variables or AWS Secrets Manager keys added, and no IAM/policy/task-definition/CodeBuild/CodePipeline changes.
- No database migrations.
- S3 dependency: the mode reads existing dpla-map.json and upload-result.json from S3 (uses existing S3 client/credentials).
- Security/credentials: the code uses existing pywikibot login/session tokens (wbeditentity with site CSRF token) — no new secret storage changes. The migration processes wikitext and posts structured claims; standard Wikimedia credential scopes and CSRF protections apply.
- Post-before-wikitext ordering: SDC claims are posted before the wikitext rewrite to preserve provenance on the MediaInfo entity.
- Smoke testing: a smoke run on EC2 against a single legacy partner file is noted as pending; recommend running that before high-volume partner runs.

### Risks / considerations
- Idempotency relies on a specific legacy-import reference signature (P887 → Q131783016); changing that signature would affect detection.
- The migration posts structured claims to Commons/Wikidata via wbeditentity — exercise normal rollout caution and verify bot credentials/ratelimits.
- Although per-file failures are isolated, operator should run the pending smoke test and review tracker counts when running at scale.

### Summary of impact
- New operational capability: one-shot partner legacy migration via CLI.
- No infra/config changes required to enable; no public API changes; test coverage added and tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->