### PR TITLE
uploader: emit flat-shape {{DPLA metadata}} params + dual-path comparator

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -419,13 +419,17 @@ def dpla_metadata_params(
     redundant params or, worse, strip params that don't actually match
     the rendered output.
 
-    Returned shape mirrors the wikitext structure: top-level params are
-    string-valued, sub-template params (``source``, ``institution``,
-    ``creator``) are nested dicts whose ``name`` field carries the
-    sub-template's name and ``params`` carries its argument dict. A
-    sub-template entry whose ``params`` is empty (or whose ``creator``
-    value is the empty string) signals "do not emit this param" — both
-    the writer and the comparator skip it identically.
+    Every parameter is a flat string. The previous ``source`` and
+    ``institution`` sub-template dicts have been collapsed into flat
+    ``hub`` / ``institution`` (Q-IDs) / ``url`` / ``dpla_id`` /
+    ``local_id`` scalars, and ``creator`` is now a plain creator-name
+    string. Module:DPLA's yellow box reads each flat param directly
+    via the same parametric helpers that drive the SDC-backed blue
+    box; no nested ``{{DPLA|...}}`` / ``{{Institution|...}}`` /
+    ``{{InFi|...}}`` sub-templates are emitted in the wikitext, which
+    eliminates the table-syntax-in-cell rendering bug those sub-
+    templates caused when their wikitext-table output landed inside
+    Module:DPLA's HTML ``<td>``.
 
     The non-rendered ``languages`` key carries the per-item allowlist
     of ISO 639-1 codes the comparator may safely unwrap. Always
@@ -462,31 +466,17 @@ def dpla_metadata_params(
             source_resource, DC_DATE_FIELD_NAME, EDM_TIMESPAN_DISPLAY_DATE
         ),
         "permission": permission_value,
-        "creator": {
-            "name": "InFi",
-            "params": {
-                # Positional args 1 and 2 — the {{InFi}} idiom is
-                # `{{InFi|<field-label>|<value>|id=fileinfotpl_aut}}`.
-                "1": "Creator",
-                "2": extract_strings(source_resource, DC_CREATOR_FIELD_NAME),
-                "id": "fileinfotpl_aut",
-            },
-        },
-        "source": {
-            "name": "DPLA",
-            "params": {
-                # Positional arg 1 — the data-provider Wikidata Q-ID.
-                "1": data_provider_wiki_q,
-                "hub": provider_wiki_q,
-                "url": escape_wiki_strings(get_str(item_metadata, EDM_IS_SHOWN_AT)),
-                "dpla_id": dpla_id,
-                "local_id": extract_strings(source_resource, DC_IDENTIFIER_FIELD_NAME),
-            },
-        },
-        "institution": {
-            "name": "Institution",
-            "params": {"wikidata": data_provider_wiki_q},
-        },
+        "creator": extract_strings(source_resource, DC_CREATOR_FIELD_NAME),
+        # Flat source-row params — Module:DPLA's yellow box reads each
+        # directly. ``institution`` and ``hub`` are Wikidata Q-IDs;
+        # the institution Q-ID doubles as the Institution row driver
+        # (Module:DPLA expands ``{{Institution|wikidata=<inst>}}`` on
+        # its side, not in the wikitext).
+        "hub": provider_wiki_q,
+        "institution": data_provider_wiki_q,
+        "url": escape_wiki_strings(get_str(item_metadata, EDM_IS_SHOWN_AT)),
+        "dpla_id": dpla_id,
+        "local_id": extract_strings(source_resource, DC_IDENTIFIER_FIELD_NAME),
         "languages": _extract_unwrap_languages(item_metadata),
     }
 
@@ -494,59 +484,52 @@ def dpla_metadata_params(
 def get_wiki_text(
     dpla_id: str, item_metadata: dict, provider: dict, data_provider: dict
 ) -> str:
-    """Turns DPLA item info into a wikitext document."""
+    """Turns DPLA item info into a wikitext document.
+
+    Emits the flat-param ``{{DPLA metadata}}`` shape Module:DPLA
+    expects post the dual-path rewrite: every value is a plain
+    string (Q-ID, URL, or text), no nested sub-templates whose
+    wikitext-table output would leak raw ``{|`` markup inside
+    Module:DPLA's HTML ``<td>``. ``creator`` is conditionally
+    emitted — the row is suppressed entirely when DPLA has no
+    creator string to avoid a blank ``creator =`` row.
+    """
     params = dpla_metadata_params(dpla_id, item_metadata, provider, data_provider)
 
-    # Every literal that the comparator side derives from ``params`` is
-    # sourced from ``params`` here too. Drifting the two — e.g. changing
-    # the creator label in ``dpla_metadata_params`` and forgetting to
-    # change it here — is the failure mode the single-source-of-truth
-    # contract exists to prevent. So no hardcoded ``"Creator"``,
-    # ``"fileinfotpl_aut"``, ``{{Institution|wikidata=...}}`` shape, etc.
-    creator_params = params["creator"]["params"]
-    creator_value = creator_params["2"]
-    if creator_value:
-        creator_template = """
-        | Other fields 1 = {{ InFi | $creator_label | $creator | id=$creator_id}}"""
+    if params["creator"]:
+        creator_row = """
+        | creator = $creator"""
     else:
-        creator_template = ""
+        creator_row = ""
 
     template_string = (
         """== {{int:filedesc}} ==
      {{ DPLA metadata"""
-        + creator_template
+        + creator_row
         + """
         | title = $title
         | description = $description
         | date = $date_string
         | permission = $permission
-        | source = {{ DPLA
-            | $data_provider
-            | hub = $provider
-            | url = $is_shown_at
-            | dpla_id = $dpla_id
-            | local_id = $local_id
-        }}
-        | Institution = {{ Institution | wikidata = $institution_wikidata }}
+        | hub = $hub
+        | institution = $institution
+        | url = $url
+        | dpla_id = $dpla_id
+        | local_id = $local_id
      }}"""
     )
 
-    source_params = params["source"]["params"]
-    institution_params = params["institution"]["params"]
     return Template(template_string).substitute(
-        creator=creator_value,
-        creator_label=creator_params["1"],
-        creator_id=creator_params["id"],
         title=params["title"],
         description=params["description"],
         date_string=params["date"],
         permission=params["permission"],
-        data_provider=source_params["1"],
-        provider=source_params["hub"],
-        is_shown_at=source_params["url"],
-        dpla_id=source_params["dpla_id"],
-        local_id=source_params["local_id"],
-        institution_wikidata=institution_params["wikidata"],
+        creator=params["creator"],
+        hub=params["hub"],
+        institution=params["institution"],
+        url=params["url"],
+        dpla_id=params["dpla_id"],
+        local_id=params["local_id"],
     )
 
 
@@ -820,6 +803,15 @@ def merge_preserved_wikitext(existing_text: str, new_wikitext: str) -> str:
     scraper expecting that wrapper would miss a bare template.
 
     Duplicates within each preserved group are collapsed.
+
+    TODO (Goal 2 follow-up): the title-drift rescue currently
+    overwrites the metadata template wholesale, discarding any
+    community-contributed template params an editor added between
+    the original upload and the rescue. The same provenance-aware
+    migration logic from :mod:`ingest_wikimedia.legacy_artwork`
+    would let us preserve community values as SDC imports first,
+    then overwrite. Out of scope for the flat-shape uploader PR;
+    flagged here so the integration point doesn't get lost.
     """
     parts: list[str] = [new_wikitext.rstrip()]
     assessment = list(dict.fromkeys(_ASSESSMENT_TEMPLATE_RE.findall(existing_text)))

--- a/ingest_wikimedia/wikitext_normalize.py
+++ b/ingest_wikimedia/wikitext_normalize.py
@@ -143,50 +143,34 @@ def _value_matches(
     return False
 
 
-def _subtemplate_matches(wikitext_value: str, expected_subtemplate: dict) -> bool:
-    """Compare a sub-template param (e.g. ``| source = {{DPLA|...}}``) to
-    the canonical expectation.
+# Top-level scalar params on a flat-shape `{{DPLA metadata}}` invocation.
+# Every one is a string compared via `_value_matches`. The post-flat-shape
+# rewrite collapsed the previous `source` and `institution` sub-template
+# rows into flat scalars (hub / institution Q-ID / url / dpla_id /
+# local_id) so the comparator's dispatch is uniform across all rows.
+_SCALAR_PARAMS = (
+    "title",
+    "description",
+    "date",
+    "permission",
+    "creator",
+    "hub",
+    "institution",
+    "url",
+    "dpla_id",
+    "local_id",
+)
 
-    ``expected_subtemplate`` is the shape produced by
-    :func:`ingest_wikimedia.wikimedia.dpla_metadata_params` — ``name`` is
-    the inner template's name, ``params`` is its argument dict where
-    positional args are keyed by string indices (``"1"``, ``"2"``).
-
-    Returns True only when the wikitext value contains exactly one
-    template, that template's name matches, and every expected param is
-    present with the same value. Extra params on the wikitext side count
-    as a mismatch — we never strip when the editor added something we
-    don't know to match.
-    """
-    parsed = mwparserfromhell.parse(wikitext_value)
-    templates = parsed.filter_templates(recursive=False)
-    if len(templates) != 1:
-        return False
-    tpl = templates[0]
-    if not _matches_template_name(tpl, expected_subtemplate["name"]):
-        return False
-    expected_params = expected_subtemplate["params"]
-    wikitext_params = {
-        str(p.name).strip(): _canonical_value(str(p.value)) for p in tpl.params
-    }
-    if set(wikitext_params) != set(expected_params):
-        return False
-    return all(
-        wikitext_params[k] == _canonical_value(v) for k, v in expected_params.items()
-    )
-
-
-# Top-level params expected on a `{{DPLA metadata}}` invocation written by
-# the DPLA uploader, mapped to their kind (scalar vs. sub-template) so we
-# can dispatch to the right comparator. Names mirror what `get_wiki_text`
-# emits and what `dpla_metadata_params` returns.
-_SCALAR_PARAMS = ("title", "description", "date", "permission")
-_SUBTEMPLATE_PARAMS = ("source", "institution")
-# The uploader writes the creator on a numbered "Other fields" row
-# (``Other fields 1 = {{InFi|Creator|...}}``). Module:DPLA accepts both
-# that form and a top-level ``creator =`` param, but only the former is
-# what the current uploader emits, so that's what we look for here.
-_CREATOR_PARAM_NAME = "other fields 1"
+# Legacy param shapes that an older upload (pre-flat-shape) may carry.
+# Their canonical expectation comes from the same flat scalars in
+# `expected_params`; the comparator handles them in a fall-through path
+# at the bottom of `normalize` so the strip behavior is symmetric with
+# new-shape files. Each tuple is (wikitext-param-name, sub-template-name,
+# canonical-key-mapping) where the mapping says which inner sub-template
+# arg corresponds to which canonical-params key.
+_LEGACY_SOURCE_PARAM = "source"
+_LEGACY_INSTITUTION_PARAM = "Institution"
+_LEGACY_CREATOR_PARAM = "Other fields 1"
 
 
 def _find_dpla_metadata_template(wikicode):
@@ -254,37 +238,123 @@ def normalize(wikitext: str, expected_params: dict) -> tuple[str, list[str]]:
     # as redundant rather than as an editor contribution.
     languages = expected_params.get("languages", frozenset({"en"}))
 
+    # Flat-shape strip pass: every canonical param is a string scalar.
+    # ``creator`` is conditional — when DPLA has no creator value, the
+    # uploader doesn't emit the row, so an existing ``creator =`` row
+    # is an editor contribution we must preserve.
     for param_name in _SCALAR_PARAMS:
+        expected_value = expected_params.get(param_name, "")
+        if param_name == "creator" and not expected_value:
+            continue
         param = _find_param(template, param_name)
         if param is None:
             continue
-        if _value_matches(str(param.value), expected_params[param_name], languages):
+        if _value_matches(str(param.value), expected_value, languages):
             template.remove(param, keep_field=False)
             stripped.append(param_name)
 
-    for param_name in _SUBTEMPLATE_PARAMS:
-        param = _find_param(template, param_name)
-        if param is None:
-            continue
-        if _subtemplate_matches(str(param.value), expected_params[param_name]):
-            template.remove(param, keep_field=False)
-            stripped.append(param_name)
-
-    # Creator lives on `Other fields 1` as `{{InFi|Creator|<value>|id=...}}`.
-    # Only compare/strip when the expected creator is non-empty — when DPLA
-    # has no creator value, the uploader doesn't emit the row at all, so
-    # there's nothing to compare to.
-    creator_expected = expected_params["creator"]
-    creator_param = _find_param(template, _CREATOR_PARAM_NAME)
-    if (
-        creator_param is not None
-        and creator_expected["params"]["2"]
-        and _subtemplate_matches(str(creator_param.value), creator_expected)
-    ):
-        template.remove(creator_param, keep_field=False)
-        stripped.append(_CREATOR_PARAM_NAME)
+    # Legacy-shape strip pass. Pre-flat-shape uploads have
+    # ``source = {{DPLA|...}}`` / ``Institution = {{Institution|...}}``
+    # / ``Other fields 1 = {{InFi|Creator|...}}`` rows that carry the
+    # same canonical values in nested sub-template form. The
+    # comparator recognises each shape and strips when its inner
+    # values match the flat-canonical equivalents — same redundancy
+    # contract as the flat shape, just expressed via the legacy
+    # sub-template encoding.
+    _strip_legacy_source(template, expected_params, stripped)
+    _strip_legacy_institution(template, expected_params, stripped)
+    _strip_legacy_creator(template, expected_params, stripped)
 
     return str(wikicode), stripped
+
+
+def _strip_legacy_source(template, expected_params: dict, stripped: list[str]) -> None:
+    """Strip a legacy ``source = {{DPLA|<inst>|hub=...|url=...|dpla_id=...|local_id=...}}``
+    row when every inner param matches the flat-canonical equivalent.
+
+    The comparator compares the *parsed* sub-template params against
+    flat-canonical: hub→hub, positional-1→institution, url→url,
+    dpla_id→dpla_id, local_id→local_id. Extra args on the wikitext
+    side disqualify the strip (an editor may have added a param we
+    don't know to match)."""
+    param = _find_param(template, _LEGACY_SOURCE_PARAM)
+    if param is None:
+        return
+    parsed = _parse_inner_template(str(param.value), "dpla")
+    if parsed is None:
+        return
+    expected = {
+        "1": expected_params.get("institution", ""),
+        "hub": expected_params.get("hub", ""),
+        "url": expected_params.get("url", ""),
+        "dpla_id": expected_params.get("dpla_id", ""),
+        "local_id": expected_params.get("local_id", ""),
+    }
+    if set(parsed) != set(expected):
+        return
+    if all(parsed[k] == _canonical_value(v) for k, v in expected.items()):
+        template.remove(param, keep_field=False)
+        stripped.append(_LEGACY_SOURCE_PARAM)
+
+
+def _strip_legacy_institution(
+    template, expected_params: dict, stripped: list[str]
+) -> None:
+    """Strip a legacy ``Institution = {{Institution|wikidata=Q...}}`` row
+    when the inner Q-ID matches ``expected_params["institution"]``."""
+    param = _find_param(template, _LEGACY_INSTITUTION_PARAM)
+    if param is None:
+        return
+    parsed = _parse_inner_template(str(param.value), "institution")
+    if parsed is None:
+        return
+    if set(parsed) != {"wikidata"}:
+        return
+    if parsed["wikidata"] == _canonical_value(expected_params.get("institution", "")):
+        template.remove(param, keep_field=False)
+        stripped.append(_LEGACY_INSTITUTION_PARAM)
+
+
+def _strip_legacy_creator(template, expected_params: dict, stripped: list[str]) -> None:
+    """Strip a legacy ``Other fields 1 = {{InFi|Creator|<value>|id=fileinfotpl_aut}}``
+    row when its second positional arg matches ``expected_params["creator"]``.
+    Bails out when the expected creator is empty — same conservative
+    rule as the flat-shape creator strip."""
+    creator_expected = expected_params.get("creator", "")
+    if not creator_expected:
+        return
+    param = _find_param(template, _LEGACY_CREATOR_PARAM)
+    if param is None:
+        return
+    parsed = _parse_inner_template(str(param.value), "infi")
+    if parsed is None:
+        return
+    if parsed.get("1") != "Creator":
+        return
+    if parsed.get("2") != _canonical_value(creator_expected):
+        return
+    template.remove(param, keep_field=False)
+    stripped.append(_LEGACY_CREATOR_PARAM)
+
+
+def _parse_inner_template(value: str, expected_name: str) -> dict | None:
+    """Parse a single-template wikitext value into a flat
+    ``{param_name: stripped_value}`` dict, or None when the value
+    doesn't contain exactly one template with the given case-folded
+    name.
+
+    Positional args use string keys ``"1"``, ``"2"``, ... (matching
+    mwparserfromhell's convention). All values are whitespace-
+    stripped — the comparator wants to match the renderer's behavior,
+    not the source bytes."""
+    parsed = mwparserfromhell.parse(value)
+    templates = parsed.filter_templates(recursive=False)
+    if len(templates) != 1:
+        return None
+    tpl = templates[0]
+    if not _matches_template_name(tpl, expected_name):
+        return None
+    return {str(p.name).strip(): _canonical_value(str(p.value)) for p in tpl.params}
 
 
 def normalize_page(file_page, expected_params: dict, edit_summary: str) -> bool:

--- a/ingest_wikimedia/wikitext_normalize.py
+++ b/ingest_wikimedia/wikitext_normalize.py
@@ -329,7 +329,14 @@ def _strip_legacy_creator(template, expected_params: dict, stripped: list[str]) 
     parsed = _parse_inner_template(str(param.value), "infi")
     if parsed is None:
         return
+    # Match the exact-keys check the source/institution legacy strips
+    # do. Any extra arg an editor added (e.g. an inline ``|note=``)
+    # disqualifies the strip — preserving the editor's contribution.
+    if set(parsed) != {"1", "2", "id"}:
+        return
     if parsed.get("1") != "Creator":
+        return
+    if parsed.get("id") != "fileinfotpl_aut":
         return
     if parsed.get("2") != _canonical_value(creator_expected):
         return

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -1150,12 +1150,14 @@ def test_get_wiki_text_emits_dpla_metadata_template():
     )
 
 
-def test_get_wiki_text_preserves_artwork_parameters_under_new_template():
-    """Locking-in regression: the parameter set the upload-time
-    wikitext writes is unchanged from the prior {{Artwork}}-based form
-    — title, description, date, permission, source (with the DPLA
-    sub-template), Institution. Pin each so a structural refactor of
-    `get_wiki_text` can't silently drop a field."""
+def test_get_wiki_text_emits_flat_param_shape():
+    """Locking-in regression: the flat-param shape Module:DPLA's
+    dual-path renderer expects. No nested ``{{DPLA|...}}`` /
+    ``{{Institution|...}}`` / ``{{InFi|Creator|...}}`` sub-templates
+    inside the template params — those caused the ``{|`` wikitable
+    leakage inside Module:DPLA's HTML ``<td>``. Pin each flat row so a
+    structural refactor of ``get_wiki_text`` can't silently re-introduce
+    a nested form."""
     result = get_wiki_text(
         dpla_id="abc123",
         item_metadata=_minimal_item_metadata(),
@@ -1163,21 +1165,28 @@ def test_get_wiki_text_preserves_artwork_parameters_under_new_template():
         data_provider={"Wikidata": "Q2"},
     )
     for fragment in (
-        # Creator path: get_wiki_text conditionally emits `Other fields 1`
-        # with a Creator InFi template when the source record has any
-        # creator. Our fixture has one, so pin the full Creator fragment
-        # — otherwise a refactor that drops the conditional could
-        # silently lose every credited DPLA author.
-        "| Other fields 1 = {{ InFi | Creator | A Creator | id=fileinfotpl_aut}}",
+        # Creator row is conditional — emitted only when DPLA has a
+        # creator string. Our fixture does, so pin the flat row.
+        "| creator = A Creator",
         "| title = A Title",
         "| description = A description",
         "| date = 1900",
-        "| permission =",
-        "| source = {{ DPLA",
-        "| Institution = {{ Institution | wikidata = Q2 }}",
-        "| dpla_id = abc123",
+        "| permission = {{cc-zero}}",
         "| hub = Q1",
+        "| institution = Q2",
+        "| url = https://example.org/item/123",
+        "| dpla_id = abc123",
+        "| local_id = local-123",
     ):
         assert fragment in result, (
             f"missing expected fragment {fragment!r} in:\n{result}"
         )
+    # No nested sub-templates inside the param values (the outer
+    # ``{{ DPLA metadata`` is the wrapper itself, which is expected;
+    # what we're guarding against is a *nested* ``{{ DPLA |...}}``
+    # source sub-template, recognisable by the ``|`` immediately
+    # after the name).
+    assert "{{ DPLA\n" not in result and "{{DPLA\n" not in result
+    assert "{{ DPLA |" not in result and "{{DPLA|" not in result
+    assert "{{ Institution " not in result and "{{Institution " not in result
+    assert "{{ InFi " not in result and "{{InFi " not in result

--- a/tests/test_wikitext_normalize.py
+++ b/tests/test_wikitext_normalize.py
@@ -405,6 +405,11 @@ def test_normalize_preserves_legacy_creator_with_extra_param():
     new_text, stripped = normalize(wikitext, params)
     assert "Other fields 1" not in stripped
     assert "note=editor added" in new_text
+    # Row-by-row independence: the canonical title row still strips —
+    # an extra-param violation on one row doesn't suppress the strip
+    # on a different, clean row. Mirrors the assertion in
+    # ``test_normalize_preserves_url_with_edited_value``.
+    assert "title" in stripped
 
 
 def test_normalize_returns_original_text_unchanged_when_nothing_strips():

--- a/tests/test_wikitext_normalize.py
+++ b/tests/test_wikitext_normalize.py
@@ -389,6 +389,24 @@ def test_normalize_skips_legacy_creator_row_when_dpla_has_no_creator():
     assert "Other fields 1" not in stripped
 
 
+def test_normalize_preserves_legacy_creator_with_extra_param():
+    """Symmetry with the legacy-source and legacy-institution strips:
+    an editor-added arg inside the ``{{InFi|...}}`` sub-template (e.g.
+    ``|note=editor added``) disqualifies the strip even when the
+    Creator name and id args still match canonical. Stripping would
+    silently lose the editor contribution."""
+    params = dpla_metadata_params("abc123", _minimal_item(), _PROVIDER, _DATA_PROVIDER)
+    wikitext = (
+        "{{DPLA metadata\n"
+        "| Other fields 1 = {{InFi|Creator|A Creator|id=fileinfotpl_aut|note=editor added}}\n"
+        "| title = A Title\n"
+        "}}"
+    )
+    new_text, stripped = normalize(wikitext, params)
+    assert "Other fields 1" not in stripped
+    assert "note=editor added" in new_text
+
+
 def test_normalize_returns_original_text_unchanged_when_nothing_strips():
     """No-op preserves the input verbatim — important for the caller's
     "don't save if nothing changed" guard."""

--- a/tests/test_wikitext_normalize.py
+++ b/tests/test_wikitext_normalize.py
@@ -52,8 +52,11 @@ def test_dpla_metadata_params_has_every_expected_top_level_key():
         "date",
         "permission",
         "creator",
-        "source",
+        "hub",
         "institution",
+        "url",
+        "dpla_id",
+        "local_id",
         "languages",
     }
 
@@ -97,29 +100,24 @@ def test_dpla_metadata_params_permission_is_template_wrapped():
     assert params["permission"] == "{{cc-zero}}"
 
 
-def test_dpla_metadata_params_source_subtemplate_carries_positional_and_named():
+def test_dpla_metadata_params_flat_source_fields():
+    """Source fields are flat scalars on the canonical-params dict —
+    no more nested ``source = {{DPLA|...}}`` sub-template. Each value
+    mirrors the wikitext key the uploader emits."""
     params = dpla_metadata_params("abc123", _minimal_item(), _PROVIDER, _DATA_PROVIDER)
-    source = params["source"]
-    assert source["name"] == "DPLA"
-    # Positional 1 is the data-provider Q-ID, mirroring the wikitext form
-    # `{{DPLA|<data_provider_qid>|hub=...|url=...|dpla_id=...|local_id=...}}`.
-    assert source["params"]["1"] == "Q2"
-    assert source["params"]["hub"] == "Q1"
-    assert source["params"]["dpla_id"] == "abc123"
-    assert source["params"]["local_id"] == "local-123"
-    assert source["params"]["url"] == "https://example.org/item/123"
+    assert params["institution"] == "Q2"
+    assert params["hub"] == "Q1"
+    assert params["dpla_id"] == "abc123"
+    assert params["local_id"] == "local-123"
+    assert params["url"] == "https://example.org/item/123"
 
 
-def test_dpla_metadata_params_creator_subtemplate_uses_infi_shape():
-    """``creator`` is emitted as ``{{InFi|Creator|<value>|id=fileinfotpl_aut}}``
-    on the wikitext side, so the canonical-params shape must mirror that
-    positional+named layout."""
+def test_dpla_metadata_params_creator_is_flat_string():
+    """``creator`` is a plain string on the canonical-params dict —
+    no ``{{InFi|Creator|...}}`` sub-template shape. Module:DPLA reads
+    the flat value directly."""
     params = dpla_metadata_params("abc123", _minimal_item(), _PROVIDER, _DATA_PROVIDER)
-    creator = params["creator"]
-    assert creator["name"] == "InFi"
-    assert creator["params"]["1"] == "Creator"
-    assert creator["params"]["2"] == "A Creator"
-    assert creator["params"]["id"] == "fileinfotpl_aut"
+    assert params["creator"] == "A Creator"
 
 
 def test_dpla_metadata_params_drives_get_wiki_text_unchanged():
@@ -131,6 +129,14 @@ def test_dpla_metadata_params_drives_get_wiki_text_unchanged():
     # Every canonical param value appears in the rendered wikitext.
     for expected in ("A Title", "A description", "1900", "{{cc-zero}}", "Q2", "Q1"):
         assert expected in rendered
+    # Flat shape: no ``{{DPLA|...}}`` sub-template inside the
+    # template params, no ``{{Institution|wikidata=...}}`` sub-template
+    # inside the params, no ``{{InFi|Creator|...}}`` sub-template inside
+    # the params. The wikitext that wraps ``{{DPLA metadata}}`` itself
+    # is still that template; we're only checking the param values.
+    assert "source = {{" not in rendered
+    assert "Institution = {{" not in rendered
+    assert "Other fields 1 = {{" not in rendered
 
 
 # ---------------------------------------------------------------------------
@@ -139,30 +145,52 @@ def test_dpla_metadata_params_drives_get_wiki_text_unchanged():
 
 
 def _build_full_wikitext(params: dict) -> str:
-    """Produce a `{{DPLA metadata}}` wikitext block carrying every param
-    at its canonical value — i.e. the worst-case "fresh DPLA-bot upload
-    with nothing user-touched" case where every param is strippable."""
-    creator = params["creator"]["params"]["2"]
-    source_p = params["source"]["params"]
-    inst_p = params["institution"]["params"]
+    """Produce a flat-shape `{{DPLA metadata}}` wikitext block carrying
+    every param at its canonical value — i.e. the worst-case "fresh
+    DPLA-bot upload with nothing user-touched" case where every param
+    is strippable. Matches what ``get_wiki_text`` actually emits."""
     return (
         "== {{int:filedesc}} ==\n"
         "{{DPLA metadata\n"
-        f"| Other fields 1 = {{{{InFi|Creator|{creator}|id=fileinfotpl_aut}}}}\n"
+        f"| creator = {params['creator']}\n"
         f"| title = {params['title']}\n"
         f"| description = {params['description']}\n"
         f"| date = {params['date']}\n"
         f"| permission = {params['permission']}\n"
-        f"| source = {{{{DPLA|{source_p['1']}|hub={source_p['hub']}"
-        f"|url={source_p['url']}|dpla_id={source_p['dpla_id']}"
-        f"|local_id={source_p['local_id']}}}}}\n"
-        f"| Institution = {{{{Institution|wikidata={inst_p['wikidata']}}}}}\n"
+        f"| hub = {params['hub']}\n"
+        f"| institution = {params['institution']}\n"
+        f"| url = {params['url']}\n"
+        f"| dpla_id = {params['dpla_id']}\n"
+        f"| local_id = {params['local_id']}\n"
+        "}}\n"
+    )
+
+
+def _build_legacy_wikitext(params: dict) -> str:
+    """Produce a *legacy-shape* ``{{DPLA metadata}}`` wikitext block —
+    the pre-flat-shape form an existing Commons page may carry. Tests
+    the dual-path strip behaviour: every legacy-shape param should
+    strip identically to its flat-shape equivalent when the canonical
+    values match."""
+    return (
+        "== {{int:filedesc}} ==\n"
+        "{{DPLA metadata\n"
+        f"| Other fields 1 = {{{{InFi|Creator|{params['creator']}|id=fileinfotpl_aut}}}}\n"
+        f"| title = {params['title']}\n"
+        f"| description = {params['description']}\n"
+        f"| date = {params['date']}\n"
+        f"| permission = {params['permission']}\n"
+        f"| source = {{{{DPLA|{params['institution']}|hub={params['hub']}"
+        f"|url={params['url']}|dpla_id={params['dpla_id']}"
+        f"|local_id={params['local_id']}}}}}\n"
+        f"| Institution = {{{{Institution|wikidata={params['institution']}}}}}\n"
         "}}\n"
     )
 
 
 def test_normalize_strips_every_param_on_a_pristine_dpla_bot_upload():
-    """The all-match case: every param is canonical, every param goes."""
+    """The all-match case on flat shape: every param is canonical,
+    every param goes."""
     params = dpla_metadata_params("abc123", _minimal_item(), _PROVIDER, _DATA_PROVIDER)
     wikitext = _build_full_wikitext(params)
     new_text, stripped = normalize(wikitext, params)
@@ -171,13 +199,41 @@ def test_normalize_strips_every_param_on_a_pristine_dpla_bot_upload():
         "description",
         "date",
         "permission",
-        "source",
+        "creator",
+        "hub",
         "institution",
-        "other fields 1",
+        "url",
+        "dpla_id",
+        "local_id",
     }
     # Every value is gone from the new wikitext.
     for absent in ("A Title", "A description", "1900", "Q1", "Q2", "abc123"):
         assert absent not in new_text
+
+
+def test_normalize_strips_every_param_on_a_legacy_shape_upload():
+    """The all-match case on legacy shape: a file with the pre-flat
+    ``source = {{DPLA|...}}`` / ``Institution = {{Institution|...}}``
+    / ``Other fields 1 = {{InFi|Creator|...}}`` rows still strips
+    each row when its inner values match the flat-canonical
+    equivalents. Same redundancy contract, different encoding."""
+    params = dpla_metadata_params("abc123", _minimal_item(), _PROVIDER, _DATA_PROVIDER)
+    wikitext = _build_legacy_wikitext(params)
+    new_text, stripped = normalize(wikitext, params)
+    # The legacy rows strip under their legacy keys; the flat rows
+    # absent in legacy-shape wikitext stay absent from `stripped`.
+    assert "source" in stripped
+    assert "Institution" in stripped
+    assert "Other fields 1" in stripped
+    assert "title" in stripped
+    assert "description" in stripped
+    assert "date" in stripped
+    assert "permission" in stripped
+    # Inner sub-template values are gone — the legacy strip removed
+    # the full row, not just the canonical text inside.
+    assert "{{DPLA|" not in new_text
+    assert "{{Institution|" not in new_text
+    assert "{{InFi|" not in new_text
 
 
 def test_normalize_preserves_param_with_edited_value():
@@ -244,17 +300,32 @@ def test_normalize_unwraps_language_tagged_canonical_english():
     assert "{{en|A description}}" not in new_text
 
 
-def test_normalize_preserves_source_with_edited_subparam():
-    """If the source sub-template's ``url`` was edited away from the
-    canonical value, the whole source param must survive — partial
-    matches don't count.
+def test_normalize_preserves_url_with_edited_value():
+    """If a flat-shape ``url`` was edited away from the canonical
+    value, that row must survive. Other flat rows still strip — the
+    per-row preservation is independent.
 
     Test fixture uses a non-URL-shaped edit token so CodeQL's
     ``py/incomplete-url-substring-sanitization`` rule doesn't pattern-
-    match the ``substring in url`` shape as a security check.
-    """
+    match the ``substring in url`` shape as a security check."""
     params = dpla_metadata_params("abc123", _minimal_item(), _PROVIDER, _DATA_PROVIDER)
     wikitext = _build_full_wikitext(params).replace(
+        "| url = https://example.org/item/123",
+        "| url = https://example.org/item/EDITED-BY-A-HUMAN-456",
+    )
+    new_text, stripped = normalize(wikitext, params)
+    assert "url" not in stripped
+    assert "EDITED-BY-A-HUMAN-456" in new_text
+    # title still strips — preservation is row-by-row.
+    assert "title" in stripped
+
+
+def test_normalize_preserves_legacy_source_with_edited_subparam():
+    """The dual-path strip on the legacy ``source = {{DPLA|...}}``
+    row still respects per-inner-arg matching: if any sub-template
+    arg is edited away from canonical, the whole row survives."""
+    params = dpla_metadata_params("abc123", _minimal_item(), _PROVIDER, _DATA_PROVIDER)
+    wikitext = _build_legacy_wikitext(params).replace(
         "url=https://example.org/item/123",
         "url=https://example.org/item/EDITED-BY-A-HUMAN-456",
     )
@@ -263,11 +334,11 @@ def test_normalize_preserves_source_with_edited_subparam():
     assert "EDITED-BY-A-HUMAN-456" in new_text
 
 
-def test_normalize_preserves_source_with_extra_param():
+def test_normalize_preserves_legacy_source_with_extra_param():
     """An editor-added sub-template arg the bot doesn't know about
     counts as a mismatch — strip would lose the editor's addition."""
     params = dpla_metadata_params("abc123", _minimal_item(), _PROVIDER, _DATA_PROVIDER)
-    wikitext = _build_full_wikitext(params).replace(
+    wikitext = _build_legacy_wikitext(params).replace(
         "|local_id=local-123}}",
         "|local_id=local-123|note=editor added}}",
     )
@@ -287,12 +358,26 @@ def test_normalize_no_dpla_metadata_template_is_a_noop():
     assert new_text == wikitext
 
 
-def test_normalize_skips_creator_row_when_dpla_has_no_creator():
+def test_normalize_skips_flat_creator_row_when_dpla_has_no_creator():
     """When DPLA has no creator, the canonical creator value is empty —
-    so an existing ``Other fields 1`` row (added by an editor) is
+    so an existing flat ``creator =`` row (added by an editor) is
     treated as a community contribution and preserved."""
     item = _minimal_item()
     item["sourceResource"]["creator"] = []  # no canonical creator
+    params = dpla_metadata_params("abc123", item, _PROVIDER, _DATA_PROVIDER)
+    wikitext = (
+        "{{DPLA metadata\n| creator = Editor-added creator\n| title = A Title\n}}"
+    )
+    _, stripped = normalize(wikitext, params)
+    assert "creator" not in stripped
+
+
+def test_normalize_skips_legacy_creator_row_when_dpla_has_no_creator():
+    """Same preservation rule for the legacy
+    ``Other fields 1 = {{InFi|Creator|...}}`` row: empty canonical
+    creator means any existing row is community-contributed."""
+    item = _minimal_item()
+    item["sourceResource"]["creator"] = []
     params = dpla_metadata_params("abc123", item, _PROVIDER, _DATA_PROVIDER)
     wikitext = (
         "{{DPLA metadata\n"
@@ -301,7 +386,7 @@ def test_normalize_skips_creator_row_when_dpla_has_no_creator():
         "}}"
     )
     _, stripped = normalize(wikitext, params)
-    assert "other fields 1" not in stripped
+    assert "Other fields 1" not in stripped
 
 
 def test_normalize_returns_original_text_unchanged_when_nothing_strips():


### PR DESCRIPTION
## Summary

Fixes the broken `{|` markup that appeared on every new DPLA-bot upload since PR #291 (paired with the Module:DPLA dual-path update already live at rev 1229220858).

### Root cause

Previous wikitext emitted nested sub-templates inside `{{DPLA metadata}}` params:

```
| source = {{DPLA|...}}
| Institution = {{Institution|wikidata=Q...}}
| Other fields 1 = {{InFi|Creator|...|id=fileinfotpl_aut}}
```

The `{{DPLA}}` sub-template's expansion includes `{{DPLA/layout}}`'s `{| ... |}` wikitable syntax. MediaWiki only parses `{|` as a table at line-start positions in wikitext context, not inside an HTML `<td>` cell — which is exactly where Module:DPLA's outer renderer placed each param value. Result: raw `{|` markup leaked into the rendered Source field.

### Fix

`{{DPLA metadata}}` is only used by our bot, so we can redesign its param shape freely. The Module:DPLA dual-path update (Commons live edit, see history) added flat-param reading to the yellow box via the same parametric helpers (`sourceFieldFromUrls`, `partnershipFromQids`) the SDC-driven blue box uses. This PR ports the uploader to emit that flat shape:

```
{{DPLA metadata
| creator = U.S. Senate.
| title = ...
| description = ...
| date = 1836-01-01/1836-12-31
| permission = {{NoC-US|Q29381045}}
| hub = Q518155
| institution = Q29381045
| url = http://catalog.archives.gov/id/2127291
| dpla_id = 37620f9...
| local_id = 2127291
}}
```

All values are scalar strings — no sub-templates whose wikitable output would re-leak into an HTML cell.

### Dual-path comparator

`wikitext_normalize.normalize` now strips redundancy in **both** shapes:

- **Flat path**: walks every canonical scalar (title, description, date, permission, creator, hub, institution, url, dpla_id, local_id) and uses the same `_value_matches` comparator (language-unwrap rules from PR #293 still apply).
- **Legacy path**: detects pre-flat `source = {{DPLA|...}}`, `Institution = {{Institution|...}}`, `Other fields 1 = {{InFi|Creator|...}}` rows, parses each sub-template's inner args, and strips when the inner values match the flat-canonical equivalents.

This keeps the strip contract symmetric across shapes. A pre-flat file (~20 known as of rollout day; the broken Cherokee Petition pages today, plus any future legacy stragglers) goes through the same post-SDC cleanup as a new flat-shape upload — eventually transitioning to the flat shape on its next save.

### Title-drift integration

`merge_preserved_wikitext` gets a TODO comment flagging it as a future preservation-aware integration point. Today the title-drift rescue overwrites the metadata template wholesale, discarding any community-edited template params an editor added between the original upload and the rescue. The `legacy_artwork` plan-and-import logic from PR #294 could be adapted to preserve community values as SDC imports first, then overwrite. Out of scope for this PR; documented so the integration point isn't lost.

### Cleanup for today's ~20 broken files

After this PR lands and deploys, those files still carry the pre-flat `source = {{DPLA|...}}` wikitext. Two ways to fix them:
1. Wait for the next SDC sync cycle: `wikitext_normalize`'s legacy-strip pass will detect the redundancy and remove the broken rows, leaving a clean flat-shape file.
2. One-shot re-save script (5 min). I'd run this manually after the merge.

I'd recommend option 2 to clean up the visible-now display immediately.

## Test plan

- [x] 595/595 tests pass (was 592 + 3 new; 14 existing tests rewritten for flat shape)
- [x] ruff clean
- [x] Module:DPLA dual-path already live; flat-shape wikitext verified to render cleanly via parse API
- [ ] Re-save today's ~20 broken files after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes broken `{|` table markup leaking into DPLA-bot uploads by refactoring the uploader to emit a flat parameter shape for {{DPLA metadata}} and by adding a dual-path normalization comparator so both new flat and legacy nested-template forms strip symmetrically.

## Technical changes

- dpla_metadata_params (ingest_wikimedia/wikimedia.py):
  - Now returns flat scalar keys: creator, title, description, date, permission, hub, institution, url, dpla_id, local_id (languages remains an allowlist used only by the comparator).
- get_wiki_text (ingest_wikimedia/wikimedia.py):
  - Emits a flat {{DPLA metadata}} block (no nested sub-templates) so all param values are scalar strings. Creator row is included only when the canonical creator is non-empty.
- wikitext_normalize.normalize (ingest_wikimedia/wikitext_normalize.py):
  - Implements a dual-path strip:
    - Flat path: compares canonical scalar fields (including existing language-unwrap rules) and removes matching scalar params (creator is only stripped when the canonical creator is non-empty).
    - Legacy path: recognizes legacy nested-template rows (source = {{DPLA|...}}, Institution = {{Institution|...}}, Other fields 1 = {{InFi|Creator|...}}) and strips them only when their parsed inner args exactly match the flat canonical equivalents. New helpers added: _strip_legacy_source, _strip_legacy_institution, _strip_legacy_creator, and _parse_inner_template.
  - Conservative behaviour: extra or edited inner args prevent legacy-row stripping to preserve editor contributions.
- merge_preserved_wikitext (tools/uploader.py):
  - Marked TODO: current title-drift rescue can overwrite community-added template params; preservation-aware integration is out of scope for this PR.
- Tests:
  - Tests updated to assert flat emission and cover flat vs legacy normalization/preservation cases; a follow-up test assertion ensures row-by-row independence for creator/title stripping behavior.

## Tests & status

- Tests reported passing in PR description: 595/595 (follow-up commit reported 596/596). Ruff clean.

## Post-merge / cleanup

- Remaining cleanup options for affected pages:
  - Wait for the next SDC sync (legacy-strip runs will remove legacy rows when safe), or
  - Run the recommended one-shot re-save script to re-save affected pages immediately.

## Impact checklist (explicit)

- Manual pipeline trigger / ECS redeploy required? No — code-only change.
- Environment variables / AWS Secrets Manager keys added/removed/renamed? No.
- Database migrations? None.
- Shared infra (CodePipeline/CodeBuild/ECS/IAM) changes? None.
- Public-facing API response shape / endpoints changed? No.
- Security implications (auth/credentials/new external inputs)? None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->