### PR TITLE
wikitext: left-justify get_wiki_text + enable post-SDC strip by default

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -496,27 +496,32 @@ def get_wiki_text(
     """
     params = dpla_metadata_params(dpla_id, item_metadata, provider, data_provider)
 
+    # Template literal is left-justified — the leading whitespace of
+    # the Python source indentation would otherwise carry through into
+    # the rendered wikitext. The wiki parser ignores leading whitespace
+    # on template-param lines (so the previous indented form rendered
+    # the same), but anything reading the page source — editors using
+    # the wikitext editor, future scripts diffing the wikitext, the
+    # ``wikitext_normalize`` comparator — sees the noise.
     if params["creator"]:
-        creator_row = """
-        | creator = $creator"""
+        creator_row = "\n| creator = $creator"
     else:
         creator_row = ""
 
     template_string = (
-        """== {{int:filedesc}} ==
-     {{ DPLA metadata"""
+        "== {{int:filedesc}} ==\n"
+        "{{DPLA metadata"
         + creator_row
-        + """
-        | title = $title
-        | description = $description
-        | date = $date_string
-        | permission = $permission
-        | hub = $hub
-        | institution = $institution
-        | url = $url
-        | dpla_id = $dpla_id
-        | local_id = $local_id
-     }}"""
+        + "\n| title = $title"
+        "\n| description = $description"
+        "\n| date = $date_string"
+        "\n| permission = $permission"
+        "\n| hub = $hub"
+        "\n| institution = $institution"
+        "\n| url = $url"
+        "\n| dpla_id = $dpla_id"
+        "\n| local_id = $local_id"
+        "\n}}"
     )
 
     return Template(template_string).substitute(

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -1139,12 +1139,13 @@ def test_get_wiki_text_emits_dpla_metadata_template():
         provider={"Wikidata": "Q1"},
         data_provider={"Wikidata": "Q2"},
     )
-    # The whole-template name appears with leading whitespace from the
-    # template_string formatting; assert on the unambiguous fragment.
-    assert "{{ DPLA metadata" in result, (
+    # The template literal is left-justified — no leading whitespace
+    # before ``{{DPLA metadata`` (the indented form leaked Python
+    # source-code indentation into the rendered wikitext).
+    assert "{{DPLA metadata" in result, (
         f"get_wiki_text must emit {{{{DPLA metadata}}}}; got:\n{result}"
     )
-    assert "{{ Artwork" not in result, (
+    assert "{{Artwork" not in result, (
         "get_wiki_text must NOT emit {{Artwork}} (replaced by "
         f"{{{{DPLA metadata}}}}); got:\n{result}"
     )
@@ -1190,3 +1191,12 @@ def test_get_wiki_text_emits_flat_param_shape():
     assert "{{ DPLA |" not in result and "{{DPLA|" not in result
     assert "{{ Institution " not in result and "{{Institution " not in result
     assert "{{ InFi " not in result and "{{InFi " not in result
+    # No leading whitespace on any param row — the rendered wikitext
+    # is left-justified. Python-source indentation in the previous
+    # triple-quoted template literal leaked into the output, which
+    # editors viewing the page source saw as cosmetic noise.
+    for line in result.splitlines():
+        if line.startswith(" ") or line.startswith("\t"):
+            raise AssertionError(
+                f"line has leading whitespace: {line!r} in:\n{result}"
+            )

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -44,13 +44,14 @@ rights: dict
 subject_ids: dict
 _s3_partner: str | None = None
 _s3_client = None
-# When True (set by `--normalize-wikitext`), `_run_partner_mode` runs a
-# post-SDC wikitext-cleanup edit per item, stripping template params
-# whose values are now redundant against the SDC just written. Default
-# False during the rollout: enable per-partner after a smoke run, then
-# flip the global default once we've confirmed no regressions on a real
-# batch.
-_normalize_wikitext_enabled: bool = False
+# When True (the default; see ``--normalize-wikitext`` in ``_build_parser``),
+# ``_run_partner_mode`` runs a post-SDC wikitext-cleanup edit per item,
+# stripping ``{{DPLA metadata}}`` params whose values are now redundant
+# against the SDC just written. This is the documented end of the
+# per-file lifecycle (upload → SDC → wikitext cleanup). ``--no-normalize-
+# wikitext`` disables it for diagnostic runs that need the pre-strip
+# wikitext intact.
+_normalize_wikitext_enabled: bool = True
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -139,12 +140,15 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--normalize-wikitext",
         dest="normalize_wikitext",
-        action="store_true",
-        default=False,
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help=(
             "After SDC sync, strip {{DPLA metadata}} template params whose "
-            "values are now redundant with SDC. Off by default while the "
-            "behavior is being rolled out per-partner."
+            "values are now redundant with SDC. On by default — the "
+            "strip is the documented end of the per-file lifecycle "
+            "(upload → SDC → wikitext cleanup). Pass --no-normalize-wikitext "
+            "to disable for diagnostic runs that need the pre-strip wikitext "
+            "intact."
         ),
     )
     return p


### PR DESCRIPTION
## Summary

Two related cosmetic / behavioural fixes on the wikitext the uploader emits and how it's cleaned up post-SDC.

### 1. Left-justify the `get_wiki_text` template (cosmetic)

The triple-quoted Python source in `get_wiki_text` was carrying its source-code indentation through into the rendered wikitext as leading whitespace on every param line. The wiki parser ignored it (blue/yellow box rendering was unchanged), but anyone viewing the page source via the wikitext editor saw cosmetic noise.

**Before:**
```
== {{int:filedesc}} ==
     {{ DPLA metadata
        | creator = ...
        | title = ...
        ...
     }}
```

**After:**
```
== {{int:filedesc}} ==
{{DPLA metadata
| creator = ...
| title = ...
...
}}
```

### 2. Flip `--normalize-wikitext` default to True (behavioural)

The wikitext strip — the documented end of the per-file lifecycle (upload → SDC → wikitext cleanup) — has been gated behind a default-off CLI flag since #292's "per-partner rollout" caveat. `scripts/wikimedia_launch.py` calls `sdc-sync` without the flag, so every production upload since #296 has left the wikitext in pre-strip form. Module:DPLA's renderer handles pre-strip wikitext correctly (the recent yellow-box redundancy suppression covers it), so the displayed page is fine — but the stored wikitext stays unclean indefinitely.

The rollout caveat is long satisfied. Flip the default:

- **Argparse** switched to `argparse.BooleanOptionalAction` — `--normalize-wikitext` on by default, `--no-normalize-wikitext` as the explicit opt-out for diagnostic runs that need pre-strip wikitext intact.
- **Module-level `_normalize_wikitext_enabled`** default also flipped to match.
- No `wikimedia_launch.py` change required — it doesn't pass any value, so it gets the new default.

### Test plan

- [x] `test_get_wiki_text_emits_dpla_metadata_template` updated for the new `{{DPLA metadata` (no leading space) form.
- [x] `test_get_wiki_text_emits_flat_param_shape` gains a no-leading-whitespace assertion — locks the new shape in.
- [x] 596/596 tests pass.
- [x] ruff clean.
- [ ] After merge: a manual `sdc-sync --partner <slug>` run will exercise the new default (no flag needed). Future uploads through `wikimedia_launch.py` get the strip automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Refactors get_wiki_text to remove unintended leading whitespace from generated wikitext. The previous triple-quoted Python literal preserved source-code indentation and produced leading spaces on every template-parameter line; the new implementation builds the template from explicit "\n"-separated string fragments so output is left-justified (cosmetic change only; MediaWiki rendering is unchanged).

This PR also flips the default for post-SDC wikitext normalization in tools/sdc_sync to enabled (adds a --no-normalize-wikitext opt-out).

Impact notes (explicit checks requested):
- Manual pipeline trigger / ECS redeploy: None required.
- Environment variables / AWS Secrets Manager keys: None added, removed, or renamed.
- Database migrations: None.
- Shared infra (CodePipeline, CodeBuild, ECS task defs, IAM): No changes.
- Public API shapes / endpoints: No changes.
- Security implications: None introduced (no auth/credential handling changes; only cosmetic wikitext formatting and a CLI default change).

## Changes

ingest_wikimedia/wikimedia.py
- Rewrote template assembly in get_wiki_text to build the {{DPLA metadata ...}} block from explicit "\n"-prefixed lines rather than a triple-quoted literal.
- Introduced a conditional creator_row fragment that prepends "\n| creator = $creator" only when creator is present.
- Output is now left-justified (no leading spaces on template/parameter lines).

tests/test_wikimedia.py
- Updated test_get_wiki_text_emits_dpla_metadata_template to expect "{{DPLA metadata" (no leading space).
- Added assertion in test_get_wiki_text_emits_flat_param_shape that no emitted line begins with whitespace.

tools/sdc_sync.py
- Changed module-level default _normalize_wikitext_enabled from False → True.
- Updated CLI to default to --normalize-wikitext enabled, with a --no-normalize-wikitext opt-out (using argparse.BooleanOptionalAction).

## Testing & Validation

- All tests pass: 596/596
- Linting: ruff clean
- No public API or infra changes; behavior change is cosmetic to emitted wikitext and a CLI default flip (opt-out available).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->