### PR TITLE
sdc-sync: run post-SDC strip/migrate on every trigger mode + auto-migrate legacy

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -510,9 +510,7 @@ def get_wiki_text(
 
     template_string = (
         "== {{int:filedesc}} ==\n"
-        "{{DPLA metadata"
-        + creator_row
-        + "\n| title = $title"
+        "{{DPLA metadata" + creator_row + "\n| title = $title"
         "\n| description = $description"
         "\n| date = $date_string"
         "\n| permission = $permission"

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -508,8 +508,13 @@ def get_wiki_text(
     else:
         creator_row = ""
 
+    # Blank line between the section heading and the template — the
+    # canonical shape ``wikitext_normalize`` enforces on save, so emit
+    # it from the start. Without the blank line, every post-SDC strip
+    # / migrate pass would re-save the page just to insert it.
     template_string = (
         "== {{int:filedesc}} ==\n"
+        "\n"
         "{{DPLA metadata" + creator_row + "\n| title = $title"
         "\n| description = $description"
         "\n| date = $date_string"

--- a/ingest_wikimedia/wikitext_normalize.py
+++ b/ingest_wikimedia/wikitext_normalize.py
@@ -375,31 +375,114 @@ def _parse_inner_template(value: str, expected_name: str) -> dict | None:
     return {str(p.name).strip(): _canonical_value(str(p.value)) for p in tpl.params}
 
 
+def canonicalize(wikitext: str) -> str:
+    """Enforce the canonical whitespace shape on a ``{{DPLA metadata}}``
+    page.
+
+    The canonical shape is what :func:`ingest_wikimedia.wikimedia.get_wiki_text`
+    emits for a fresh upload:
+
+    .. code-block:: text
+
+        == {{int:filedesc}} ==
+
+        {{DPLA metadata
+        | title = ...
+        ...
+        }}
+
+    Specifically: left-justified template with no leading whitespace
+    on any line, exactly one blank line between the section heading
+    and the template, no space between the opening braces and the
+    template name, params one per line on ``| key = value``, closing
+    ``}}`` on its own line — or, when every param has been stripped,
+    the template collapses to single-line ``{{DPLA metadata}}``.
+
+    Pure: takes a wikitext string, returns a wikitext string. The
+    surrounding page-level metadata (license tags, categories,
+    assessment blocks, the section heading itself) is left untouched.
+    Files that don't contain a ``{{DPLA metadata}}`` template are
+    returned unchanged.
+    """
+    wikicode = mwparserfromhell.parse(wikitext)
+    template = _find_dpla_metadata_template(wikicode)
+    if template is None:
+        return wikitext
+
+    # Collect params, dropping leading/trailing whitespace from both
+    # name and value so the canonical form matches the renderer's
+    # whitespace-tolerant parse. Values may legitimately contain
+    # internal whitespace (multi-line descriptions, etc.) — only
+    # outer whitespace is trimmed.
+    params: list[tuple[str, str]] = []
+    for p in template.params:
+        params.append((str(p.name).strip(), str(p.value).strip()))
+
+    if not params:
+        canonical_template = "{{DPLA metadata}}"
+    else:
+        lines = ["{{DPLA metadata"]
+        for k, v in params:
+            lines.append(f"| {k} = {v}")
+        lines.append("}}")
+        canonical_template = "\n".join(lines)
+
+    wikicode.replace(template, canonical_template)
+    text = str(wikicode)
+
+    # Ensure exactly one blank line between the section heading and
+    # the template. The default ``get_wiki_text`` output emits this
+    # blank line; older pages may have a different separator (no
+    # blank line, indentation, multiple blank lines), which the
+    # regex normalises.
+    text = re.sub(
+        r"(==\s*\{\{int:filedesc\}\}\s*==)\s*\n\s*(\{\{DPLA metadata)",
+        r"\1\n\n\2",
+        text,
+    )
+
+    return text
+
+
 def normalize_page(file_page, expected_params: dict, edit_summary: str) -> bool:
-    """Apply :func:`normalize` to a pywikibot ``FilePage`` and save if changed.
+    """Strip redundant params + canonicalize whitespace on a pywikibot
+    ``FilePage``; save if any change resulted.
 
     Returns True when a save was performed, False when the page is a
-    redirect, already canonical, or otherwise out of scope (no params
-    to strip). All exceptions propagate to the caller, which is expected
-    to wrap this in a per-file try/except so a normalize failure doesn't
-    abort the SDC-sync batch.
+    redirect or the wikitext is already canonical and has no
+    redundant params. All exceptions propagate to the caller, which
+    is expected to wrap this in a per-file try/except so a normalize
+    failure doesn't abort the SDC-sync batch.
 
-    Redirect guard: pywikibot reads a redirect page's ``.text`` as the
-    redirect target's wikitext, but ``.save()`` writes to the redirect
-    page itself — saving would replace the ``#REDIRECT`` line with the
-    target's content and break the redirect. Skip redirects entirely;
-    the SDC sync targeted the target page anyway via its M-id.
+    Saves on any change — including whitespace-only canonicalisation
+    — so files where the params don't strip but the template was
+    written with non-canonical indentation (a hand-edit, a legacy
+    pre-#297 upload) get cleaned up on the same pass. The previous
+    behaviour gated the save on ``stripped`` being non-empty, which
+    left those pages permanently mis-formatted.
+
+    Redirect guard: pywikibot reads a redirect page's ``.text`` as
+    the redirect target's wikitext, but ``.save()`` writes to the
+    redirect page itself — saving would replace the ``#REDIRECT``
+    line with the target's content and break the redirect.
     """
     if file_page.isRedirectPage():
         return False
     original = file_page.text or ""
-    new_text, stripped = normalize(original, expected_params)
-    if not stripped:
+    stripped_text, stripped = normalize(original, expected_params)
+    canonical_text = canonicalize(stripped_text)
+    if canonical_text == original:
         return False
-    file_page.text = new_text
-    logging.info(
-        f" -- {file_page.title()}: stripping redundant DPLA-metadata params: "
-        f"{', '.join(stripped)}"
-    )
+    file_page.text = canonical_text
+    if stripped:
+        logging.info(
+            f" -- {file_page.title()}: stripping redundant DPLA-metadata params: "
+            f"{', '.join(stripped)}"
+        )
+    else:
+        logging.info(
+            f" -- {file_page.title()}: canonicalising DPLA-metadata template"
+            " whitespace (no redundant params to strip)."
+        )
     file_page.save(summary=edit_summary, minor=True, bot=True)
     return True

--- a/ingest_wikimedia/wikitext_normalize.py
+++ b/ingest_wikimedia/wikitext_normalize.py
@@ -181,6 +181,17 @@ def _find_dpla_metadata_template(wikicode):
     return None
 
 
+def has_dpla_metadata_template(wikitext: str) -> bool:
+    """Public test for ``{{DPLA metadata}}`` presence in a wikitext string.
+
+    Lets ``tools/sdc_sync.py``'s post-SDC cleanup dispatcher decide
+    between the strip path (this module) and the migrate path
+    (:mod:`ingest_wikimedia.legacy_artwork`) without paying the cost
+    of a full parse + strip pass when the file isn't on the new
+    template form. Pure — no API calls."""
+    return _find_dpla_metadata_template(mwparserfromhell.parse(wikitext)) is not None
+
+
 def _normalize_param_name(param) -> str:
     return str(param.name).strip().casefold()
 

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1138,6 +1138,309 @@ def test_safe_process_one_categorises_generic_error(monkeypatch):
     fake_tracker.increment.assert_called_once_with(Result.SDC_ORDINALS_SKIPPED_ERROR)
 
 
+def test_safe_process_one_runs_post_sdc_cleanup_when_file_page_supplied(monkeypatch):
+    """The legacy ``--file`` / ``--cat`` / ``--list`` paths pass a
+    ``file_page`` so the same post-SDC cleanup (strip-or-migrate) the
+    partner mode does also runs here. Locks in the wire from
+    ``_safe_process_one`` → ``_post_sdc_cleanup_for_legacy_mode`` so a
+    refactor of either function can't silently drop the cleanup hook
+    on the legacy paths."""
+    from tools import sdc_sync
+
+    monkeypatch.setattr(sdc_sync, "tracker", MagicMock())
+    monkeypatch.setattr(sdc_sync, "process_one", lambda *a: None)
+    monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", True)
+
+    cleanup_calls = []
+    monkeypatch.setattr(
+        sdc_sync,
+        "_post_sdc_cleanup_for_legacy_mode",
+        lambda page, dpla_id: cleanup_calls.append((page, dpla_id)),
+    )
+
+    fake_page = MagicMock(name="FilePage")
+    sdc_sync._safe_process_one("M1", "dpla-1", file_page=fake_page)
+
+    assert cleanup_calls == [(fake_page, "dpla-1")]
+
+
+def test_safe_process_one_skips_cleanup_when_no_file_page(monkeypatch):
+    """Backwards-compat: callers that didn't update to pass file_page
+    still work (no cleanup attempted; no AttributeError on the
+    ``None`` page handle)."""
+    from tools import sdc_sync
+
+    monkeypatch.setattr(sdc_sync, "tracker", MagicMock())
+    monkeypatch.setattr(sdc_sync, "process_one", lambda *a: None)
+    monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", True)
+
+    called = []
+    monkeypatch.setattr(
+        sdc_sync,
+        "_post_sdc_cleanup_for_legacy_mode",
+        lambda *a: called.append(a),
+    )
+
+    sdc_sync._safe_process_one("M1", "dpla-1")  # no file_page
+
+    assert called == []
+
+
+def test_safe_process_one_skips_cleanup_when_disabled(monkeypatch):
+    """The ``--no-normalize-wikitext`` opt-out short-circuits the
+    cleanup even when ``file_page`` is supplied. Diagnostic runs that
+    explicitly disable the strip / migrate must not surprise the
+    operator with post-SDC edits."""
+    from tools import sdc_sync
+
+    monkeypatch.setattr(sdc_sync, "tracker", MagicMock())
+    monkeypatch.setattr(sdc_sync, "process_one", lambda *a: None)
+    monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", False)
+
+    called = []
+    monkeypatch.setattr(
+        sdc_sync,
+        "_post_sdc_cleanup_for_legacy_mode",
+        lambda *a: called.append(a),
+    )
+
+    sdc_sync._safe_process_one("M1", "dpla-1", file_page=MagicMock())
+
+    assert called == []
+
+
+def test_safe_process_one_skips_cleanup_on_missing_entity(monkeypatch):
+    """A file whose MediaInfo entity is gone (deleted by a Commons
+    curator, etc.) raises ``_MissingEntityError`` from ``process_one``.
+    The cleanup must NOT run on that page — saving wikitext to a
+    deleted page would either fail loudly or undelete it. Mirrors the
+    early-return on the error path."""
+    from tools import sdc_sync
+
+    monkeypatch.setattr(sdc_sync, "tracker", MagicMock())
+    monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", True)
+
+    def raise_missing(*a):
+        raise sdc_sync._MissingEntityError("M1")
+
+    monkeypatch.setattr(sdc_sync, "process_one", raise_missing)
+
+    called = []
+    monkeypatch.setattr(
+        sdc_sync,
+        "_post_sdc_cleanup_for_legacy_mode",
+        lambda *a: called.append(a),
+    )
+
+    sdc_sync._safe_process_one("M1", "dpla-1", file_page=MagicMock())
+
+    assert called == []
+
+
+# ---------------------------------------------------------------------------
+# _post_sdc_cleanup_for_page — strip-or-migrate dispatcher
+# ---------------------------------------------------------------------------
+
+
+def _make_canonical_item():
+    """Minimal DPLA item dict the canonical-params helper accepts."""
+    return {
+        "rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+        "isShownAt": "https://example.org/item/1",
+        "sourceResource": {
+            "title": ["A Title"],
+            "description": ["A description"],
+            "date": [{"displayDate": "1900"}],
+            "creator": ["A Creator"],
+            "identifier": ["local-1"],
+        },
+    }
+
+
+def test_post_sdc_cleanup_dispatches_to_migrate_on_legacy_template(monkeypatch):
+    """A file whose current wikitext carries ``{{Artwork}}`` (the
+    legacy DPLA-bot wrapper) routes to the
+    ``legacy_artwork.migrate_legacy_file`` migration path, not the
+    strip path. Locks in the dispatch order — the migrate check has
+    to come first because the strip is a no-op on legacy-shaped
+    files, but the migrate is the actual cleanup."""
+    from ingest_wikimedia import legacy_artwork, wikitext_normalize
+    from tools import sdc_sync
+
+    # _post_sdc_cleanup_for_page passes the module-level ``site``
+    # global to migrate_legacy_file. ``_initialize()`` populates it in
+    # production but tests don't run init — set a stub here.
+    monkeypatch.setattr(sdc_sync, "site", MagicMock(name="Site"), raising=False)
+
+    fake_page = MagicMock(name="FilePage")
+    fake_page.exists.return_value = True
+    fake_page.text = "{{Artwork|title=A Title}}\n[[Category:Foo]]"
+
+    migrate_calls = []
+    monkeypatch.setattr(
+        legacy_artwork,
+        "migrate_legacy_file",
+        lambda **kw: migrate_calls.append(kw),
+    )
+    strip_calls = []
+    monkeypatch.setattr(
+        wikitext_normalize,
+        "normalize_page",
+        lambda *a, **kw: strip_calls.append((a, kw)),
+    )
+
+    sdc_sync._post_sdc_cleanup_for_page(
+        fake_page,
+        "dpla-1",
+        _make_canonical_item(),
+        {"Wikidata": "Q1"},
+        {"Wikidata": "Q2"},
+    )
+
+    assert len(migrate_calls) == 1
+    assert strip_calls == []
+
+
+def test_post_sdc_cleanup_dispatches_to_strip_on_new_template(monkeypatch):
+    """A file already on ``{{DPLA metadata}}`` routes to the strip
+    path. The migrate path's revision-history walk is expensive and
+    would be wasted work on a file that's already on the new shape."""
+    from ingest_wikimedia import legacy_artwork, wikitext_normalize
+    from tools import sdc_sync
+
+    fake_page = MagicMock(name="FilePage")
+    fake_page.exists.return_value = True
+    fake_page.text = "{{DPLA metadata\n| title = A Title\n| dpla_id = dpla-1\n}}"
+
+    migrate_calls = []
+    monkeypatch.setattr(
+        legacy_artwork,
+        "migrate_legacy_file",
+        lambda **kw: migrate_calls.append(kw),
+    )
+    strip_calls = []
+    monkeypatch.setattr(
+        wikitext_normalize,
+        "normalize_page",
+        lambda *a, **kw: strip_calls.append((a, kw)),
+    )
+
+    sdc_sync._post_sdc_cleanup_for_page(
+        fake_page,
+        "dpla-1",
+        _make_canonical_item(),
+        {"Wikidata": "Q1"},
+        {"Wikidata": "Q2"},
+    )
+
+    assert migrate_calls == []
+    assert len(strip_calls) == 1
+
+
+def test_post_sdc_cleanup_skips_when_neither_template_present(monkeypatch):
+    """A file with neither template (hand-written wikitext, a stub,
+    a file that was never DPLA-uploaded) gets a quiet no-op. The
+    strip would also be a no-op in that case — short-circuiting saves
+    a parse + a save attempt."""
+    from ingest_wikimedia import legacy_artwork, wikitext_normalize
+    from tools import sdc_sync
+
+    fake_page = MagicMock(name="FilePage")
+    fake_page.exists.return_value = True
+    fake_page.text = "Just some prose, no template."
+
+    migrate_calls = []
+    monkeypatch.setattr(
+        legacy_artwork,
+        "migrate_legacy_file",
+        lambda **kw: migrate_calls.append(kw),
+    )
+    strip_calls = []
+    monkeypatch.setattr(
+        wikitext_normalize,
+        "normalize_page",
+        lambda *a, **kw: strip_calls.append((a, kw)),
+    )
+
+    sdc_sync._post_sdc_cleanup_for_page(
+        fake_page,
+        "dpla-1",
+        _make_canonical_item(),
+        {"Wikidata": "Q1"},
+        {"Wikidata": "Q2"},
+    )
+
+    assert migrate_calls == []
+    # Note: normalize_page would itself no-op on no-template wikitext,
+    # so we don't gate strictly on call_count==0 — but ``normalize_page``
+    # IS still called in the strip branch; the dispatcher took the strip
+    # path because the legacy template wasn't found.
+    assert len(strip_calls) == 1
+
+
+def test_post_sdc_cleanup_skips_when_page_missing(monkeypatch):
+    """A page that doesn't exist on Commons (race, deletion) gets no
+    cleanup attempt at all."""
+    from ingest_wikimedia import legacy_artwork, wikitext_normalize
+    from tools import sdc_sync
+
+    fake_page = MagicMock(name="FilePage")
+    fake_page.exists.return_value = False
+
+    migrate_calls = []
+    strip_calls = []
+    monkeypatch.setattr(
+        legacy_artwork,
+        "migrate_legacy_file",
+        lambda **kw: migrate_calls.append(kw),
+    )
+    monkeypatch.setattr(
+        wikitext_normalize,
+        "normalize_page",
+        lambda *a, **kw: strip_calls.append((a, kw)),
+    )
+
+    sdc_sync._post_sdc_cleanup_for_page(
+        fake_page,
+        "dpla-1",
+        _make_canonical_item(),
+        {"Wikidata": "Q1"},
+        {"Wikidata": "Q2"},
+    )
+
+    assert migrate_calls == []
+    assert strip_calls == []
+
+
+def test_post_sdc_cleanup_for_page_isolates_migrate_failure(monkeypatch):
+    """A migration that raises is logged and swallowed — the post-SDC
+    cleanup is best-effort. The outer SDC sync result has already
+    committed; a stripper-side failure must not surface as a SDC sync
+    error."""
+    from ingest_wikimedia import legacy_artwork
+    from tools import sdc_sync
+
+    monkeypatch.setattr(sdc_sync, "site", MagicMock(name="Site"), raising=False)
+
+    fake_page = MagicMock(name="FilePage")
+    fake_page.exists.return_value = True
+    fake_page.text = "{{Artwork|title=A Title}}"
+
+    def raise_migrate(**kw):
+        raise RuntimeError("simulated migration failure")
+
+    monkeypatch.setattr(legacy_artwork, "migrate_legacy_file", raise_migrate)
+
+    # Should NOT propagate.
+    sdc_sync._post_sdc_cleanup_for_page(
+        fake_page,
+        "dpla-1",
+        _make_canonical_item(),
+        {"Wikidata": "Q1"},
+        {"Wikidata": "Q2"},
+    )
+
+
 # ---------------------------------------------------------------------------
 # pywikibot retry budget — bounded by _initialize()
 # ---------------------------------------------------------------------------

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1237,6 +1237,78 @@ def test_safe_process_one_skips_cleanup_on_missing_entity(monkeypatch):
     assert called == []
 
 
+def test_safe_process_one_clears_doc_cache_on_missing_entity(monkeypatch):
+    """If ``process_one`` populates the doc cache via ``parsed()`` and
+    then raises ``_MissingEntityError`` before cleanup runs, the
+    ``finally`` in ``_safe_process_one`` must drop the cached entry —
+    otherwise the doc leaks across files in long ``--list`` runs."""
+    from tools import sdc_sync
+
+    monkeypatch.setattr(sdc_sync, "tracker", MagicMock())
+    monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", True)
+
+    def populate_then_raise(*_a):
+        sdc_sync._legacy_mode_doc_cache["dpla-1"] = {"some": "doc"}
+        raise sdc_sync._MissingEntityError("M1")
+
+    monkeypatch.setattr(sdc_sync, "process_one", populate_then_raise)
+    monkeypatch.setattr(sdc_sync, "_post_sdc_cleanup_for_legacy_mode", lambda *a: None)
+    sdc_sync._legacy_mode_doc_cache.clear()
+
+    sdc_sync._safe_process_one("M1", "dpla-1", file_page=MagicMock())
+
+    assert "dpla-1" not in sdc_sync._legacy_mode_doc_cache
+
+
+def test_post_sdc_cleanup_for_legacy_mode_reuses_cached_doc(monkeypatch):
+    """The doc ``parsed()`` cached during ``process_one`` gets popped
+    and reused in the cleanup helper — no second S3 / api.dp.la fetch.
+    Locks in the optimisation so a refactor can't silently regress to
+    re-fetching the same doc."""
+    from ingest_wikimedia.dpla import DPLA
+    from tools import sdc_sync
+
+    cached_doc = {"id": "dpla-1", "sourceResource": {}, "provider": {"name": "p"}}
+    sdc_sync._legacy_mode_doc_cache.clear()
+    sdc_sync._legacy_mode_doc_cache["dpla-1"] = cached_doc
+
+    s3_fetches = []
+    api_fetches = []
+    monkeypatch.setattr(
+        sdc_sync,
+        "_fetch_dpla_doc_from_s3",
+        lambda *a, **kw: s3_fetches.append(a) or None,
+    )
+    monkeypatch.setattr(
+        sdc_sync,
+        "_fetch_dpla_doc_from_api",
+        lambda *a, **kw: api_fetches.append(a) or None,
+    )
+
+    dispatch_calls = []
+
+    def fake_dispatch(file_page, dpla_id, doc, provider, data_provider):
+        dispatch_calls.append((dpla_id, doc, provider, data_provider))
+
+    monkeypatch.setattr(sdc_sync, "_post_sdc_cleanup_for_page", fake_dispatch)
+    monkeypatch.setattr(
+        DPLA,
+        "get_provider_and_data_provider",
+        staticmethod(lambda doc, hubs: ({"name": "p"}, {"name": "d"})),
+    )
+    monkeypatch.setattr(sdc_sync, "hubs", {}, raising=False)
+
+    sdc_sync._post_sdc_cleanup_for_legacy_mode(MagicMock(name="FilePage"), "dpla-1")
+
+    assert s3_fetches == []
+    assert api_fetches == []
+    assert len(dispatch_calls) == 1
+    assert dispatch_calls[0][1] is cached_doc
+    # Pop-on-read drains the cache so a second cleanup call on the
+    # same dpla_id (re-entry) would fall through to the fetch path.
+    assert "dpla-1" not in sdc_sync._legacy_mode_doc_cache
+
+
 # ---------------------------------------------------------------------------
 # _post_sdc_cleanup_for_page — strip-or-migrate dispatcher
 # ---------------------------------------------------------------------------

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1339,10 +1339,12 @@ def test_post_sdc_cleanup_dispatches_to_strip_on_new_template(monkeypatch):
 
 def test_post_sdc_cleanup_skips_when_neither_template_present(monkeypatch):
     """A file with neither template (hand-written wikitext, a stub,
-    a file that was never DPLA-uploaded) gets a quiet no-op. The
-    strip would also be a no-op in that case — short-circuiting saves
-    a parse + a save attempt."""
-    from ingest_wikimedia import legacy_artwork, wikitext_normalize
+    a file that was never DPLA-uploaded) gets a quiet no-op: the
+    dispatcher uses ``has_dpla_metadata_template`` to short-circuit
+    before computing ``expected_params`` or calling ``normalize_page``,
+    saving the parse + the rights-URI / hub-label resolution work
+    that ``dpla_metadata_params`` would do."""
+    from ingest_wikimedia import legacy_artwork, wikimedia, wikitext_normalize
     from tools import sdc_sync
 
     fake_page = MagicMock(name="FilePage")
@@ -1361,6 +1363,12 @@ def test_post_sdc_cleanup_skips_when_neither_template_present(monkeypatch):
         "normalize_page",
         lambda *a, **kw: strip_calls.append((a, kw)),
     )
+    params_calls = []
+    monkeypatch.setattr(
+        wikimedia,
+        "dpla_metadata_params",
+        lambda *a, **kw: params_calls.append((a, kw)) or {},
+    )
 
     sdc_sync._post_sdc_cleanup_for_page(
         fake_page,
@@ -1371,11 +1379,8 @@ def test_post_sdc_cleanup_skips_when_neither_template_present(monkeypatch):
     )
 
     assert migrate_calls == []
-    # Note: normalize_page would itself no-op on no-template wikitext,
-    # so we don't gate strictly on call_count==0 — but ``normalize_page``
-    # IS still called in the strip branch; the dispatcher took the strip
-    # path because the legacy template wasn't found.
-    assert len(strip_calls) == 1
+    assert strip_calls == []
+    assert params_calls == []
 
 
 def test_post_sdc_cleanup_skips_when_page_missing(monkeypatch):

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -1197,6 +1197,4 @@ def test_get_wiki_text_emits_flat_param_shape():
     # editors viewing the page source saw as cosmetic noise.
     for line in result.splitlines():
         if line.startswith(" ") or line.startswith("\t"):
-            raise AssertionError(
-                f"line has leading whitespace: {line!r} in:\n{result}"
-            )
+            raise AssertionError(f"line has leading whitespace: {line!r} in:\n{result}")

--- a/tests/test_wikitext_normalize.py
+++ b/tests/test_wikitext_normalize.py
@@ -16,7 +16,7 @@ Two layers under test:
 from __future__ import annotations
 
 from ingest_wikimedia.wikimedia import dpla_metadata_params, get_wiki_text
-from ingest_wikimedia.wikitext_normalize import normalize
+from ingest_wikimedia.wikitext_normalize import canonicalize, normalize
 
 
 def _minimal_item():
@@ -529,3 +529,87 @@ def test_normalize_preserves_langswitch_even_with_single_named_param():
     new_text, stripped = normalize(wikitext, params)
     assert "description" not in stripped
     assert "{{LangSwitch|en=A description|es=Una descripción}}" in new_text
+
+
+# ---------------------------------------------------------------------------
+# canonicalize — whitespace shape enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_canonicalize_collapses_fully_stripped_template_to_single_line():
+    """When every param has been stripped from the ``{{DPLA metadata}}``
+    template, the canonical form is a single-line ``{{DPLA metadata}}``
+    invocation — not the multi-line skeleton mwparserfromhell leaves
+    behind after :func:`normalize`'s ``template.remove`` calls."""
+    indented_after_strip = "== {{int:filedesc}} ==\n     {{ DPLA metadata\n        }}\n"
+    result = canonicalize(indented_after_strip)
+    assert "{{DPLA metadata}}" in result
+    # The non-canonical residue is gone.
+    assert "{{ DPLA metadata" not in result
+    assert "        }}" not in result
+
+
+def test_canonicalize_inserts_blank_line_between_heading_and_template():
+    """The canonical shape has exactly one blank line between
+    ``== {{int:filedesc}} ==`` and ``{{DPLA metadata``. Files written
+    by the pre-#298 ``get_wiki_text`` (no blank line) get normalised."""
+    no_blank_line = "== {{int:filedesc}} ==\n{{DPLA metadata\n| title = Foo\n}}"
+    result = canonicalize(no_blank_line)
+    assert "== {{int:filedesc}} ==\n\n{{DPLA metadata" in result
+
+
+def test_canonicalize_left_justifies_indented_template():
+    """A historical upload that emitted the template indented (the
+    pre-#297 form, e.g. ``     {{ DPLA metadata``) gets left-justified
+    in canonical form, no leading whitespace on the ``{{`` or on any
+    ``| key = value`` line."""
+    indented = (
+        "== {{int:filedesc}} ==\n"
+        "     {{ DPLA metadata\n"
+        "        | title = Foo\n"
+        "        | dpla_id = abc123\n"
+        "     }}\n"
+    )
+    result = canonicalize(indented)
+    for line in result.splitlines():
+        # Lines that aren't the section header line shouldn't have
+        # leading whitespace either.
+        if line.startswith(" ") or line.startswith("\t"):
+            raise AssertionError(f"line has leading whitespace: {line!r}")
+    assert "{{DPLA metadata\n| title = Foo\n| dpla_id = abc123\n}}" in result
+
+
+def test_canonicalize_drops_space_between_opening_braces_and_name():
+    """``{{ DPLA metadata`` (with space) gets collapsed to
+    ``{{DPLA metadata``. mwparserfromhell preserves the source-text
+    whitespace inside template-name slots; the canonicalize pass
+    overrides it with the no-space form."""
+    spaced = "{{ DPLA metadata\n| title = Foo\n}}"
+    result = canonicalize(spaced)
+    assert "{{DPLA metadata" in result
+    assert "{{ DPLA metadata" not in result
+
+
+def test_canonicalize_no_op_on_already_canonical_text():
+    """The canonical shape is idempotent — running it on text that's
+    already canonical returns byte-identical output. Necessary for
+    the ``normalize_page`` "save only on change" guard not to fire
+    spuriously on files already in good shape."""
+    canonical = (
+        "== {{int:filedesc}} ==\n"
+        "\n"
+        "{{DPLA metadata\n"
+        "| title = Foo\n"
+        "| dpla_id = abc123\n"
+        "}}"
+    )
+    assert canonicalize(canonical) == canonical
+
+
+def test_canonicalize_returns_input_unchanged_when_no_dpla_metadata_template():
+    """Files without ``{{DPLA metadata}}`` (legacy ``{{Artwork}}``,
+    hand-written stubs, etc.) are out of scope for whitespace
+    canonicalisation here — that's the legacy-migrate dispatcher's
+    job upstream."""
+    untouched = "Just some prose.\n{{Artwork|title=Foo}}\n[[Category:Foo]]"
+    assert canonicalize(untouched) == untouched

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -20,6 +20,7 @@ from ingest_wikimedia.sdc import (
     parse_dpla_date,
     parse_nara_access_level,
 )
+from ingest_wikimedia import legacy_artwork, wikimedia, wikitext_normalize
 from ingest_wikimedia.slack import notify_phase_start, notify_sdc_complete
 from ingest_wikimedia.tracker import Result, Tracker
 from ingest_wikimedia.wikimedia import extract_dpla_id_from_commons_title
@@ -44,6 +45,12 @@ rights: dict
 subject_ids: dict
 _s3_partner: str | None = None
 _s3_client = None
+# Legacy-mode (``--file`` / ``--cat`` / ``--list``) DPLA-doc cache.
+# ``parsed()`` populates it during ``process_one``; the post-SDC
+# cleanup helper pops on read so the same S3 / api.dp.la doc isn't
+# re-fetched. One entry per in-flight ``dpla_id``; the pop keeps the
+# cache from growing past one entry in practice.
+_legacy_mode_doc_cache: dict[str, dict] = {}
 # When True (the default; see ``--normalize-wikitext`` in ``_build_parser``),
 # ``_run_partner_mode`` runs a post-SDC wikitext-cleanup edit per item,
 # stripping ``{{DPLA metadata}}`` params whose values are now redundant
@@ -2745,6 +2752,11 @@ def parsed(dpla_id, dpla_api):
 
     if dpla is None:
         return None
+    # Stash the raw doc so ``_post_sdc_cleanup_for_legacy_mode`` can
+    # reuse it after ``process_one`` returns, skipping a redundant
+    # S3 / api.dp.la fetch on the same dpla_id. Cache is per dpla_id
+    # and pop-on-read in the cleanup helper so it doesn't grow.
+    _legacy_mode_doc_cache[dpla_id] = dpla
     return _parse_dpla_doc(dpla, dpla_id)
 
 
@@ -3174,8 +3186,6 @@ def _post_sdc_cleanup_for_page(
     in so a multi-ordinal item doesn't redundantly recompute per
     ordinal.
     """
-    from ingest_wikimedia import legacy_artwork, wikimedia, wikitext_normalize
-
     if not file_page.exists():
         return
 
@@ -3314,30 +3324,32 @@ def _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id: str) -> None:
     """Post-SDC cleanup for the ``--file`` / ``--cat`` / ``--list`` paths.
 
     Mirrors :func:`_post_sdc_cleanup_for_item` for single-file modes:
-    fetches the DPLA item doc (from S3 if --from-s3 is configured, else
-    api.dp.la), resolves provider / data_provider, then dispatches via
-    :func:`_post_sdc_cleanup_for_page`. The doc fetch is the same one
-    ``parsed()`` already made during ``process_one``; calling it again
-    here is a redundant HTTP round-trip per file, accepted as the cost
-    of keeping the cleanup helper signature symmetric across modes
-    (these modes are admin-only and not high-volume).
+    reuses the DPLA item doc ``parsed()`` cached during ``process_one``
+    (popped on read from :data:`_legacy_mode_doc_cache`), resolves
+    provider / data_provider, then dispatches via
+    :func:`_post_sdc_cleanup_for_page`. On a cache miss (e.g. process_one
+    early-returned on a missing-ID before the cache populated, or the
+    cache was cleared by an earlier cleanup) the doc is fetched fresh
+    from S3 / api.dp.la so the cleanup still runs.
 
     Best-effort: any failure is logged but doesn't raise.
     """
     from ingest_wikimedia.dpla import DPLA
 
-    try:
-        if _s3_partner is not None:
-            doc = _fetch_dpla_doc_from_s3(_s3_client, _s3_partner, dpla_id)
-            if doc is None:
+    doc = _legacy_mode_doc_cache.pop(dpla_id, None)
+    if doc is None:
+        try:
+            if _s3_partner is not None:
+                doc = _fetch_dpla_doc_from_s3(_s3_client, _s3_partner, dpla_id)
+                if doc is None:
+                    doc = _fetch_dpla_doc_from_api(dpla_id, dpla_api)
+            else:
                 doc = _fetch_dpla_doc_from_api(dpla_id, dpla_api)
-        else:
-            doc = _fetch_dpla_doc_from_api(dpla_id, dpla_api)
-    except Exception:
-        logging.exception(
-            f" -- cleanup: DPLA-doc fetch failed for {dpla_id}; skipping."
-        )
-        return
+        except Exception:
+            logging.exception(
+                f" -- cleanup: DPLA-doc fetch failed for {dpla_id}; skipping."
+            )
+            return
     if not doc:
         return
 
@@ -3931,21 +3943,31 @@ def _safe_process_one(mediaid: str, dpla_id: str, file_page=None) -> None:
     ``--list``) ends with the same per-file cleanup.
     """
     try:
-        process_one(mediaid, dpla_id)
-    except _MissingEntityError:
-        logging.info(
-            f" -- {mediaid} for {dpla_id}: Commons MediaInfo entity"
-            " does not exist; skipping (not an error)."
-        )
-        tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY)
-        return
-    except Exception:
-        logging.exception(f" -- {mediaid} for {dpla_id}: SDC sync failed; skipping.")
-        tracker.increment(Result.SDC_ORDINALS_SKIPPED_ERROR)
-        return
+        try:
+            process_one(mediaid, dpla_id)
+        except _MissingEntityError:
+            logging.info(
+                f" -- {mediaid} for {dpla_id}: Commons MediaInfo entity"
+                " does not exist; skipping (not an error)."
+            )
+            tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY)
+            return
+        except Exception:
+            logging.exception(
+                f" -- {mediaid} for {dpla_id}: SDC sync failed; skipping."
+            )
+            tracker.increment(Result.SDC_ORDINALS_SKIPPED_ERROR)
+            return
 
-    if _normalize_wikitext_enabled and file_page is not None:
-        _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id)
+        if _normalize_wikitext_enabled and file_page is not None:
+            _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id)
+    finally:
+        # Drop any stash ``parsed()`` left in the cache so a process_one
+        # error path (or a cleanup skip when ``file_page`` is None /
+        # normalize-wikitext disabled) doesn't leak the doc across files.
+        # On the happy path the cleanup helper already popped — the
+        # ``default=None`` makes this a no-op there.
+        _legacy_mode_doc_cache.pop(dpla_id, None)
 
 
 def main() -> None:

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -3202,9 +3202,15 @@ def _post_sdc_cleanup_for_page(
             )
         return
 
-    # Strip path. ``normalize_page`` is a no-op for files without
-    # ``{{DPLA metadata}}`` (a hand-written stub, a file that was
-    # never DPLA-uploaded), so it's safe to call unconditionally here.
+    # Strip path. Bail before computing ``expected_params`` when the
+    # file has no ``{{DPLA metadata}}`` template either — a hand-written
+    # stub, or a non-DPLA upload that happens to share a Commons file
+    # title. ``dpla_metadata_params`` does real work (resolves the
+    # rights URI, builds the hub label, etc.) and would be wasted on
+    # a page that ``normalize_page`` is going to no-op anyway.
+    if not wikitext_normalize.has_dpla_metadata_template(text):
+        return
+
     if expected_params is None:
         try:
             expected_params = wikimedia.dpla_metadata_params(

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -3134,33 +3134,120 @@ _NORMALIZE_EDIT_SUMMARY = (
 )
 
 
-def _normalize_wikitext_for_item(
+def _post_sdc_cleanup_for_page(
+    file_page,
+    dpla_id: str,
+    item_metadata: dict,
+    provider: dict,
+    data_provider: dict,
+    *,
+    expected_params: dict | None = None,
+) -> None:
+    """Post-SDC wikitext cleanup for one Commons file page.
+
+    Dispatches based on the file's current wikitext shape:
+
+    * **Has** ``{{Artwork}}`` / ``{{Information}}`` / ``{{Photograph}}``
+      (the legacy DPLA wrappers): run
+      :func:`ingest_wikimedia.legacy_artwork.migrate_legacy_file` — walks
+      revision history, classifies community contributions vs DPLA-bot
+      values, imports community values as SDC statements with the
+      ``P887→Q131783016`` + ``P4656→<permalink>`` reference shape, then
+      rewrites the wikitext from the legacy form to ``{{DPLA metadata}}``.
+
+    * **Has** ``{{DPLA metadata}}`` (the post-#291 form): run
+      :func:`ingest_wikimedia.wikitext_normalize.normalize_page` — strips
+      template params whose values are now redundant with the
+      DPLA-attributed SDC just written.
+
+    * **Has neither** (rare — a hand-written wikitext or a stub): skip
+      silently. The blue box still renders from SDC; nothing to clean
+      up in the wikitext.
+
+    The dispatch is order-sensitive: the legacy-template check comes
+    first because the migration's revision-history walk is expensive
+    (one ``revisions()`` call per file), so we don't want to fire it on
+    files that are clearly already on the new template form.
+
+    ``expected_params`` is optional — when not supplied, the dispatcher
+    computes it from ``dpla_metadata_params``. Partner mode passes it
+    in so a multi-ordinal item doesn't redundantly recompute per
+    ordinal.
+    """
+    from ingest_wikimedia import legacy_artwork, wikimedia, wikitext_normalize
+
+    if not file_page.exists():
+        return
+
+    text = file_page.text or ""
+
+    if legacy_artwork.find_legacy_template(text) is not None:
+        # Migrate path. legacy_artwork handles its own provenance walk,
+        # SDC import, and wikitext rewrite. Re-fetching expected_params
+        # here would be wasted work — migrate_legacy_file recomputes
+        # them internally from item_metadata.
+        try:
+            legacy_artwork.migrate_legacy_file(
+                file_page=file_page,
+                item_metadata=item_metadata,
+                provider=provider,
+                data_provider=data_provider,
+                dpla_id=dpla_id,
+                site=site,
+            )
+        except Exception:
+            logging.exception(
+                f" -- cleanup: legacy migration of '{file_page.title()}'"
+                f" for {dpla_id} failed; skipping."
+            )
+        return
+
+    # Strip path. ``normalize_page`` is a no-op for files without
+    # ``{{DPLA metadata}}`` (a hand-written stub, a file that was
+    # never DPLA-uploaded), so it's safe to call unconditionally here.
+    if expected_params is None:
+        try:
+            expected_params = wikimedia.dpla_metadata_params(
+                dpla_id, item_metadata, provider, data_provider
+            )
+        except Exception:
+            logging.exception(
+                f" -- cleanup: dpla_metadata_params failed for {dpla_id};"
+                " skipping strip."
+            )
+            return
+    try:
+        wikitext_normalize.normalize_page(
+            file_page, expected_params, _NORMALIZE_EDIT_SUMMARY
+        )
+    except Exception:
+        logging.exception(
+            f" -- cleanup: normalize_page on '{file_page.title()}' for"
+            f" {dpla_id} failed; skipping."
+        )
+
+
+def _post_sdc_cleanup_for_item(
     s3, partner: str, dpla_id: str, ordinal_items: list[tuple[str, dict]]
 ) -> None:
-    """Per-item post-SDC wikitext cleanup: strip redundant template params.
+    """Per-item post-SDC cleanup (partner mode).
 
-    Reads the item's dpla-map.json from S3 (no api.dp.la call), computes the
-    canonical ``{{DPLA metadata}}`` parameter dict via
-    :func:`ingest_wikimedia.wikimedia.dpla_metadata_params`, then walks every
-    ordinal's Commons page and asks
-    :func:`ingest_wikimedia.wikitext_normalize.normalize_page` to remove any
-    param whose value exactly matches the canonical value (i.e. is now
-    redundant with the SDC just written).
+    Reads ``dpla-map.json`` from S3, resolves provider / data_provider,
+    pre-computes the canonical params once for the item, then walks
+    every ordinal page through :func:`_post_sdc_cleanup_for_page`.
 
-    Best-effort: any S3 / pywikibot / parse failure is logged but never
-    raised. The SDC sync result is already committed and counted before
-    this runs; a normalize failure must not roll that back or fail the
-    partner batch.
+    Best-effort throughout: any S3 / pywikibot / parse failure is
+    logged but never raised. SDC sync has already committed and counted
+    before this runs; a cleanup failure must not roll that back or fail
+    the partner batch.
     """
-    from ingest_wikimedia import wikimedia, wikitext_normalize
+    from ingest_wikimedia import wikimedia
     from ingest_wikimedia.dpla import DPLA
 
     try:
         item_raw = s3.get_item_metadata(partner, dpla_id)
     except Exception as e:
-        logging.warning(
-            f" -- normalize-wikitext: S3 read failed for {dpla_id}: {e!r}; skipping."
-        )
+        logging.warning(f" -- cleanup: S3 read failed for {dpla_id}: {e!r}; skipping.")
         return
     if not item_raw:
         # dpla-map.json missing — get-ids-es never staged it, or the
@@ -3171,7 +3258,7 @@ def _normalize_wikitext_for_item(
         item_metadata = json.loads(item_raw)
     except json.JSONDecodeError as e:
         logging.warning(
-            f" -- normalize-wikitext: dpla-map.json parse failed for {dpla_id}: {e}; skipping."
+            f" -- cleanup: dpla-map.json parse failed for {dpla_id}: {e}; skipping."
         )
         return
 
@@ -3181,7 +3268,7 @@ def _normalize_wikitext_for_item(
         )
     except Exception as e:
         logging.warning(
-            f" -- normalize-wikitext: provider lookup failed for {dpla_id}: {e!r}; skipping."
+            f" -- cleanup: provider lookup failed for {dpla_id}: {e!r}; skipping."
         )
         return
 
@@ -3191,7 +3278,7 @@ def _normalize_wikitext_for_item(
         )
     except Exception as e:
         logging.warning(
-            f" -- normalize-wikitext: param compute failed for {dpla_id}: {e!r}; skipping."
+            f" -- cleanup: param compute failed for {dpla_id}: {e!r}; skipping."
         )
         return
 
@@ -3201,19 +3288,62 @@ def _normalize_wikitext_for_item(
             continue
         try:
             page = pywikibot.FilePage(site, title)
-            if not page.exists():
-                continue
-            wikitext_normalize.normalize_page(
-                page, expected_params, _NORMALIZE_EDIT_SUMMARY
-            )
         except Exception:
-            # Log with traceback so notify_pipeline_fail's log summary
-            # surfaces the root cause if one item's normalization repeatedly
-            # blows up. Per-ordinal isolation here, not per-item — one bad
-            # title in a multi-page item shouldn't skip the others.
             logging.exception(
-                f" -- normalize-wikitext: ordinal {ord_str} ({title}) for {dpla_id} failed; skipping."
+                f" -- cleanup: FilePage construction failed for ordinal"
+                f" {ord_str} ({title}) of {dpla_id}; skipping."
             )
+            continue
+        _post_sdc_cleanup_for_page(
+            page,
+            dpla_id,
+            item_metadata,
+            provider,
+            data_provider,
+            expected_params=expected_params,
+        )
+
+
+def _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id: str) -> None:
+    """Post-SDC cleanup for the ``--file`` / ``--cat`` / ``--list`` paths.
+
+    Mirrors :func:`_post_sdc_cleanup_for_item` for single-file modes:
+    fetches the DPLA item doc (from S3 if --from-s3 is configured, else
+    api.dp.la), resolves provider / data_provider, then dispatches via
+    :func:`_post_sdc_cleanup_for_page`. The doc fetch is the same one
+    ``parsed()`` already made during ``process_one``; calling it again
+    here is a redundant HTTP round-trip per file, accepted as the cost
+    of keeping the cleanup helper signature symmetric across modes
+    (these modes are admin-only and not high-volume).
+
+    Best-effort: any failure is logged but doesn't raise.
+    """
+    from ingest_wikimedia.dpla import DPLA
+
+    try:
+        if _s3_partner is not None:
+            doc = _fetch_dpla_doc_from_s3(_s3_client, _s3_partner, dpla_id)
+            if doc is None:
+                doc = _fetch_dpla_doc_from_api(dpla_id, dpla_api)
+        else:
+            doc = _fetch_dpla_doc_from_api(dpla_id, dpla_api)
+    except Exception:
+        logging.exception(
+            f" -- cleanup: DPLA-doc fetch failed for {dpla_id}; skipping."
+        )
+        return
+    if not doc:
+        return
+
+    try:
+        provider, data_provider = DPLA.get_provider_and_data_provider(doc, hubs)
+    except Exception as e:
+        logging.warning(
+            f" -- cleanup: provider lookup failed for {dpla_id}: {e!r}; skipping."
+        )
+        return
+
+    _post_sdc_cleanup_for_page(file_page, dpla_id, doc, provider, data_provider)
 
 
 def _run_legacy_migration_mode(partner: str, ids_file: str) -> None:
@@ -3709,7 +3839,7 @@ def _run_partner_mode(partner, ids_file):
                 # inside is logged and swallowed by the helper, so a bad
                 # parse on one item can't abort the partner batch.
                 if _normalize_wikitext_enabled:
-                    _normalize_wikitext_for_item(s3, partner, dpla_id, ordinal_items)
+                    _post_sdc_cleanup_for_item(s3, partner, dpla_id, ordinal_items)
             elif had_ordinal_error:
                 # Every eligible ordinal raised at runtime — classify
                 # under the error bucket, not MAPPING. (Mixed-result
@@ -3771,7 +3901,7 @@ def _run_partner_mode(partner, ids_file):
 # We can use a PWB generator to programatically make the list of files we are working on based on a set of criteria. Here, we are generating the page titles from a Wikimedia Commons search and categories. For other types of available page generators, see <https://doc.wikimedia.org/pywikibot/master/api_ref/pywikibot.html#module-pywikibot.pagegenerators>. As an additional step, we take the pageid provided by the generator and prepend "M" for the mediaid needed for posting SDC statements.
 
 
-def _safe_process_one(mediaid: str, dpla_id: str) -> None:
+def _safe_process_one(mediaid: str, dpla_id: str, file_page=None) -> None:
     """Run ``process_one`` with the per-file exception boundary the
     legacy ``--list`` / ``--files`` / ``--cat`` loops need.
 
@@ -3786,6 +3916,13 @@ def _safe_process_one(mediaid: str, dpla_id: str) -> None:
     line 2015 — so a deleted file's ``_MissingEntityError`` bypasses
     that handler and surfaces here. Categorise it as MISSING_ENTITY
     (clean skip) instead of folding it into the generic ERROR bucket.
+
+    When ``file_page`` is supplied and ``--normalize-wikitext`` is on
+    (the default — see ``_build_parser``), runs the post-SDC strip /
+    legacy-migrate dispatcher on that page after the SDC sync. Mirrors
+    the partner-mode cleanup so every trigger path (hub-level,
+    per-institution, per-collection, single-id, ``--file``, ``--cat``,
+    ``--list``) ends with the same per-file cleanup.
     """
     try:
         process_one(mediaid, dpla_id)
@@ -3795,9 +3932,14 @@ def _safe_process_one(mediaid: str, dpla_id: str) -> None:
             " does not exist; skipping (not an error)."
         )
         tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY)
+        return
     except Exception:
         logging.exception(f" -- {mediaid} for {dpla_id}: SDC sync failed; skipping.")
         tracker.increment(Result.SDC_ORDINALS_SKIPPED_ERROR)
+        return
+
+    if _normalize_wikitext_enabled and file_page is not None:
+        _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id)
 
 
 def main() -> None:
@@ -3829,9 +3971,14 @@ def main() -> None:
                 count += 1
                 print(f"{count}:\n - {args.lists}/{lists[x]} ({percent:.2f}% done)")
                 print("\n" + str(file).replace('""', '"'))
+                # Re-wrap as a FilePage so the post-SDC cleanup gets
+                # the right page-type handle. TextIOPageGenerator yields
+                # generic Page objects, but normalize_page / migrate
+                # both expect a FilePage (its .latest_file_info etc.).
+                file_page = pywikibot.FilePage(site, str(file))
                 mediaid = "M" + str(file.pageid)
                 dpla_id = _resolve_dpla_id(str(file), dpla_api)
-                _safe_process_one(mediaid, dpla_id)
+                _safe_process_one(mediaid, dpla_id, file_page=file_page)
 
             os.rename(working_file, os.path.join(args.lists, "COMPLETE-" + lists[x]))
 
@@ -3853,7 +4000,7 @@ def main() -> None:
     elif args.files:
         for title in args.files:
             print("\n" + title)
-            page = pywikibot.Page(site, title)
+            page = pywikibot.FilePage(site, title)
             if not page.exists():
                 print(f" -- Page not found on Commons: {title}")
                 continue
@@ -3861,7 +4008,7 @@ def main() -> None:
             dpla_id = _resolve_dpla_id(title, dpla_api)
             count += 1
             print(f"{count}: {mediaid}")
-            _safe_process_one(mediaid, dpla_id)
+            _safe_process_one(mediaid, dpla_id, file_page=page)
 
     elif args.cat:
         category = pywikibot.Category(site, args.cat)
@@ -3875,7 +4022,12 @@ def main() -> None:
             dpla_id = _resolve_dpla_id(title, dpla_api)
             count += 1
             print(f"{count}: {mediaid}")
-            _safe_process_one(mediaid, dpla_id)
+            # CategorizedPageGenerator yields generic Page objects;
+            # re-wrap as FilePage so the post-SDC cleanup gets the
+            # right type (its normalize / migrate helpers expect a
+            # FilePage handle).
+            file_page = pywikibot.FilePage(site, title)
+            _safe_process_one(mediaid, dpla_id, file_page=file_page)
             if args.limit and count >= args.limit:
                 print(f" -- Reached --limit {args.limit}, stopping.")
                 break


### PR DESCRIPTION
## Summary

Closes two gaps in the post-SDC wikitext cleanup so it runs uniformly across every trigger mode (hub-level, per-institution, per-collection, Q-id, single DPLA-ID, retry, plus the admin `--file` / `--cat` / `--list` paths), and so legacy `{{Artwork}}` files are auto-migrated to `{{DPLA metadata}}` as part of the same flow.

### Gap 1: legacy modes had no cleanup

Production triggers all funnel through `_run_partner_mode` (via `sdc-sync --partner <slug> --ids-file ...`), which runs the strip per item. The legacy admin paths — `sdc-sync --file <title>` / `--cat <category>` / `--list <dir>` — call `_safe_process_one` directly and skipped the cleanup entirely.

`_safe_process_one` now accepts a `file_page` kwarg and runs `_post_sdc_cleanup_for_legacy_mode` after SDC sync succeeds. The three call sites in `main()` pass their FilePage handle through (`CategorizedPageGenerator` yields generic Page objects, so the cat path re-wraps as `FilePage` first).

### Gap 2: legacy `{{Artwork}}` files didn't get auto-migrated

Pre-this-PR the cleanup was strip-only — files still on `{{Artwork}}` (which Module:DPLA's dual-path renderer handles correctly) sat untouched indefinitely because the normalizer doesn't recognise the legacy form. Phase 3b's `legacy_artwork.migrate_legacy_file` existed but was gated behind a separate `--migrate-legacy` CLI flag operators had to remember to pass.

The new `_post_sdc_cleanup_for_page` dispatches per file:

| Wikitext has… | Action |
|---|---|
| `{{Artwork}}` / `{{Information}}` / `{{Photograph}}` | `legacy_artwork.migrate_legacy_file` — walks revisions, imports community values to SDC with P887/P4656 refs, rewrites wikitext to `{{DPLA metadata}}` |
| `{{DPLA metadata}}` | `wikitext_normalize.normalize_page` — strips redundant params |
| Neither | No-op |

Order is load-bearing: the legacy-template check comes first because the migration's revision-history walk is expensive and would be wasted work on files that are already on the new shape.

### Other changes

- `ingest_wikimedia.wikitext_normalize.has_dpla_metadata_template` is a new public helper for dispatchers that want the cheap "is this the new shape?" test without the full strip pass.
- Both the partner-mode (`_post_sdc_cleanup_for_item`) and legacy-mode (`_post_sdc_cleanup_for_legacy_mode`) wrappers funnel to the same per-page dispatcher, so the cleanup logic lives in one place.
- Cleanup is best-effort throughout: any S3 / pywikibot / parse / migrate / strip failure is logged but never raised. SDC sync has already committed before the cleanup runs; a cleanup failure must not surface as a SDC sync error.

### Test plan

- [x] 9 new tests on top of the existing 596:
  - `_safe_process_one`'s `file_page` kwarg + cleanup wire (4 tests: enabled, disabled, no-file_page, missing-entity-skip).
  - `_post_sdc_cleanup_for_page`'s dispatch (5 tests: migrate path, strip path, neither, missing page, migrate-failure isolation).
- [x] 605/605 tests pass.
- [x] ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR extends post-SDC wikitext cleanup across all sdc-sync trigger modes and implements automatic migration of legacy Artwork templates to the new DPLA metadata format. It also tightens canonicalization/whitespace behavior for DPLA metadata wikitext so normalization saves purely-formatting fixes.

### Changes Overview

- Runs post-SDC cleanup for every sdc-sync trigger mode (hub-level, per-institution, per-collection, Q-id, single DPLA-ID, retry, and the admin `--file` / `--cat` / `--list` paths). Legacy admin paths that previously bypassed cleanup now pass a pywikibot.FilePage into `_safe_process_one` so cleanup runs after successful SDC commits.
- Centralized per-page dispatcher `_post_sdc_cleanup_for_page`:
  - Detects legacy wrappers (`{{Artwork}}`, `{{Information}}`, `{{Photograph}}`) first and runs `legacy_artwork.migrate_legacy_file` (walks revisions, imports community values as SDC refs, rewrites to `{{DPLA metadata}}`).
  - If `{{DPLA metadata}}` present, runs `wikitext_normalize.normalize_page` to strip redundant parameters and canonicalize whitespace/shape.
  - No-ops when neither template is present. The legacy-template check is performed first as a cheap short-circuit.
- Adds cheap fast-path: `ingest_wikimedia.wikitext_normalize.has_dpla_metadata_template(wikitext: str) -> bool`.
- Introduces `canonicalize(wikitext: str) -> str` and wires normalization to canonicalize template/whitespace shape (collapse fully-stripped template to single-line, left-justify multi-line form, ensure one blank line after `== {{int:filedesc}} ==`) and to save even when only formatting changes occur. `get_wiki_text` was updated to emit the canonical blank line on upload.
- Adds partner-mode cleanup `_post_sdc_cleanup_for_item` that computes expected template params once per item (from s3 dpla-map.json) and iterates ordinals to dispatch per-file cleanup.
- Adds legacy-mode cleanup `_post_sdc_cleanup_for_legacy_mode(file_page, dpla_id)` for non-partner single-file paths; it first reuses a module-level per-DPLA parsed-doc cache populated by `process_one` (to avoid re-fetching), falls back to S3 or the public API on cache miss, resolves provider/data_provider, then delegates to the dispatcher.
- Hoists imports for `legacy_artwork`, `wikimedia`, and `wikitext_normalize` to module scope and introduces a short-lived module-level `_legacy_mode_doc_cache: dict[str, dict]` keyed by DPLA ID; cache entries are popped after use and always cleared (try/finally) to avoid cross-file leakage. Tests ensure the cache is reused and cleared.
- Both partner-mode and legacy-mode wrappers funnel to the same dispatcher; cleanup is best-effort and any failures are logged but do not raise or affect the already-committed SDC sync.

### Notable Code Changes

- tools/sdc_sync.py:
  - Added: `_post_sdc_cleanup_for_page`, `_post_sdc_cleanup_for_item`, `_post_sdc_cleanup_for_legacy_mode`.
  - Removed: `_normalize_wikitext_for_item`.
  - Updated: `_safe_process_one(mediaid, dpla_id, file_page=None)` signature; admin single-file loops now create and pass `pywikibot.FilePage` objects.
  - Added: `_legacy_mode_doc_cache: dict[str, dict] = {}`.
- ingest_wikimedia/wikitext_normalize.py:
  - Added: `has_dpla_metadata_template(wikitext: str) -> bool`, `canonicalize(wikitext: str) -> str`.
  - `normalize_page` now canonicalizes and saves on formatting-only diffs; logging distinguishes stripping vs canonicalizing actions.
- ingest_wikimedia/wikimedia.py:
  - Minor refactor to ensure canonical blank line between filedesc heading and DPLA metadata template in `get_wiki_text`.
- Tests:
  - ~9 new tests added covering legacy-mode post-processing, dispatcher behavior, canonicalize behaviors, and cache safety. Test suite remained green in PR context.

### Robustness & Failure Modes

- Cleanup runs after SDC sync commits and is intentionally best-effort; exceptions in migrate/normalize/logging/S3/pywikibot are logged and not raised, preserving SDC sync success.
- Legacy-template detection uses the new cheap fast-path to avoid unnecessary expensive revision-history walks.
- The module-level legacy-doc cache is short-lived and explicitly cleared to prevent cross-file leakage even in error cases.

### Deployment, Infrastructure & Security Impact

- No manual pipeline trigger or ECS redeployment required beyond the normal code deployment.
- No environment variables, AWS Secrets Manager keys added/removed/renamed.
- No database migrations.
- No changes to shared infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM policies).
- No public-facing API response shape or endpoint changes.
- No new security-sensitive credential handling introduced; changes are limited to ingest/tooling code and tests.

### Small/Ancillary Notes

- get_wiki_text now ensures a single blank line between the `== {{int:filedesc}} ==` heading and the `{{DPLA metadata}}` template on uploads to match canonicalize().
- Ruff/formatting clean; tests added for cache behavior and migration/no-op dispatch paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->