### PR TITLE
legacy-artwork: stop duplicating filedesc heading on Artwork → DPLA metadata migration

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -694,18 +694,45 @@ def entity_was_already_migrated(entity: dict) -> bool:
     return False
 
 
+def _extract_dpla_metadata_template(block: str) -> str:
+    """Pull just the ``{{DPLA metadata ...}}`` template out of
+    ``block``. ``block`` is typically the full upload-form output of
+    :func:`ingest_wikimedia.wikimedia.get_wiki_text`, which includes a
+    leading ``== {{int:filedesc}} ==`` heading and a blank-line
+    separator. The migration rewrite only needs the template invocation
+    itself — the section heading already exists in the page being
+    migrated, and substituting the full block in place of ``{{Artwork}}``
+    duplicates the heading (the original above the legacy template
+    survives, and the new heading lands inline where the template was).
+
+    Falls back to the original block unchanged when no
+    ``{{DPLA metadata}}`` template is found in it — a defensive
+    no-op for callers that already pass just the template.
+    """
+    wikicode = mwparserfromhell.parse(block)
+    for tpl in wikicode.filter_templates():
+        if _template_name(tpl).casefold() == "dpla metadata":
+            return str(tpl)
+    return block
+
+
 def render_migrated_wikitext(
     original_text: str,
     new_template_block: str,
 ) -> str:
     """Replace the first legacy-template invocation in ``original_text``
-    with ``new_template_block``, preserving everything else verbatim.
+    with the ``{{DPLA metadata}}`` template invocation extracted from
+    ``new_template_block``, preserving everything else verbatim.
 
     ``new_template_block`` is the full ``{{DPLA metadata ...}}``
-    rendering, typically produced by
-    :func:`ingest_wikimedia.wikimedia.get_wiki_text`. The caller is
-    responsible for any param-stripping pass (Goal 1's
-    :mod:`wikitext_normalize`) — this helper just swaps the wrapper.
+    rendering as produced by
+    :func:`ingest_wikimedia.wikimedia.get_wiki_text` — including the
+    section heading and blank-line separator that's only relevant for
+    new uploads. Only the inner template invocation is substituted
+    here; the original ``== {{int:filedesc}} ==`` heading above the
+    legacy template stays put. The caller is responsible for any
+    param-stripping or whitespace canonicalisation pass
+    (:mod:`wikitext_normalize`) — this helper just swaps the wrapper.
 
     Returns the original text untouched when no legacy template is
     present (defensive — the executor's caller has already gated this
@@ -724,7 +751,8 @@ def render_migrated_wikitext(
             break
     if template is None:
         return original_text
-    wikicode.replace(template, new_template_block)
+    replacement = _extract_dpla_metadata_template(new_template_block)
+    wikicode.replace(template, replacement)
     return str(wikicode)
 
 
@@ -834,6 +862,17 @@ def migrate_legacy_file(
 
     new_block = get_wiki_text(dpla_id, item_metadata, provider, data_provider)
     rewritten = render_migrated_wikitext(file_page.text, new_block)
+    # Canonical-whitespace pass: ``render_migrated_wikitext`` substitutes
+    # only the template node, so any leading whitespace the legacy
+    # ``{{Artwork}}`` block carried (the pre-#291 pretty-printed indent
+    # of "     {{ Artwork") survives as a Text node before the new
+    # ``{{DPLA metadata}}`` template. ``canonicalize`` left-justifies the
+    # template and forces the canonical blank line between the section
+    # heading and the template, matching the shape ``get_wiki_text`` now
+    # emits for fresh uploads.
+    from .wikitext_normalize import canonicalize
+
+    rewritten = canonicalize(rewritten)
     wikitext_changed = rewritten != file_page.text
     if wikitext_changed:
         file_page.text = rewritten

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -711,7 +711,7 @@ def _extract_dpla_metadata_template(block: str) -> str:
     """
     wikicode = mwparserfromhell.parse(block)
     for tpl in wikicode.filter_templates():
-        if _template_name(tpl).casefold() == "dpla metadata":
+        if _template_name(tpl) == "dpla metadata":
             return str(tpl)
     return block
 

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -693,6 +693,58 @@ def test_render_migrated_wikitext_swaps_information_template_too():
     assert "{{DPLA metadata|description=bar}}" in result
 
 
+def test_render_migrated_wikitext_does_not_duplicate_section_heading():
+    """Regression for the bug where ``new_template_block`` carrying a
+    leading ``== {{int:filedesc}} ==`` heading (as produced by
+    :func:`get_wiki_text`) was substituted verbatim in place of the
+    legacy ``{{Artwork}}`` template, ending up with two consecutive
+    headings on the page (the original above + the new one inline).
+
+    The fix extracts just the ``{{DPLA metadata ...}}`` template from
+    ``new_template_block`` before substituting, so the section heading
+    that was already in the page above the legacy template stays put
+    and isn't duplicated below it.
+    """
+    original = (
+        "== {{int:filedesc}} ==\n"
+        "     {{ Artwork\n"
+        "        | title = Old\n"
+        "        | source = {{DPLA|Q1|hub=Q2|dpla_id=abc|local_id=loc|url=http://x}}\n"
+        "     }}\n"
+        "{{PD-USGov}}\n"
+        "[[Category:Foo]]"
+    )
+    # Real ``get_wiki_text`` output — full upload form including heading.
+    new_block = (
+        "== {{int:filedesc}} ==\n\n{{DPLA metadata\n| title = New\n| dpla_id = abc\n}}"
+    )
+    result = render_migrated_wikitext(original, new_block)
+    # Only one section heading in the result.
+    assert result.count("== {{int:filedesc}} ==") == 1, (
+        f"section heading duplicated:\n{result}"
+    )
+    # The new template invocation landed where the Artwork block was.
+    assert "{{DPLA metadata" in result
+    assert "{{Artwork" not in result
+    # Page-level content survives.
+    assert "{{PD-USGov}}" in result
+    assert "[[Category:Foo]]" in result
+
+
+def test_render_migrated_wikitext_accepts_template_only_block_for_back_compat():
+    """The previous test asserts the new caller contract — but the
+    extraction step must also be a no-op on the old caller contract
+    (a bare ``{{DPLA metadata|...}}`` invocation with no heading
+    wrapper). Locks in the back-compat path so an existing in-process
+    caller that pre-strips the heading still works."""
+    original = "== {{int:filedesc}} ==\n{{Artwork|title=Old}}\n[[Category:Foo]]"
+    new_block = "{{DPLA metadata|title=New}}"
+    result = render_migrated_wikitext(original, new_block)
+    assert result.count("== {{int:filedesc}} ==") == 1
+    assert "{{DPLA metadata|title=New}}" in result
+    assert "{{Artwork" not in result
+
+
 # --- post_legacy_import_claims --------------------------------------------
 
 
@@ -924,3 +976,65 @@ def test_legacy_migration_edit_summary_mentions_q131783016():
     """The edit summary should mention the inferred-from-Wikitext
     Wikidata item so reviewers can trace the migration's intent."""
     assert "Q131783016" in LEGACY_MIGRATION_EDIT_SUMMARY
+
+
+def test_migrate_legacy_file_emits_canonical_whitespace():
+    """End-to-end regression for the live bug observed on
+    https://commons.wikimedia.org/wiki/File:Possibly_Carlisle_Indian_School_football_team_-_DPLA_-_0037596b6b4904655f0f949db0a1ab8b_(page_2).tiff
+    where ``migrate_legacy_file`` produced wikitext with:
+
+    1. A duplicated ``== {{int:filedesc}} ==`` heading (the new
+       upload-form block was substituted verbatim in place of the
+       legacy template, on top of the existing heading); AND
+    2. The duplicated heading indented (the leading whitespace before
+       the original ``{{ Artwork`` block survived as a Text node).
+
+    The migration must produce the same canonical shape
+    :func:`get_wiki_text` emits for new uploads: section heading
+    left-justified at column 0, exactly one blank line, then the
+    template left-justified at column 0.
+    """
+
+    class _Rev1:
+        revid, user = 1, "DPLA_bot"
+        text = (
+            "== {{int:filedesc}} ==\n"
+            "     {{ Artwork\n"
+            "        | title = Possibly Carlisle Indian School football team\n"
+            "        | source = {{ DPLA | Q59661040 | hub = Q518155 |"
+            " url = http://x | dpla_id = abc | local_id = 123 }}\n"
+            "     }}\n"
+        )
+
+    page = _mock_file_page("File:Foo.jpg", _Rev1.text, [_Rev1()])
+    item, provider, dp = _item_md()
+    site = _site_with_empty_entity()
+    migrate_legacy_file(
+        file_page=page,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    saved_text = page.text
+    # Exactly one section heading.
+    assert saved_text.count("== {{int:filedesc}} ==") == 1, (
+        f"section heading duplicated:\n{saved_text}"
+    )
+    # Heading left-justified — no leading indent on the heading line.
+    assert saved_text.startswith("== {{int:filedesc}} =="), (
+        f"heading not at column 0:\n{saved_text!r}"
+    )
+    # Template left-justified — no leading whitespace before the
+    # opening braces or before any param line.
+    for line in saved_text.splitlines():
+        if line.startswith("{{DPLA metadata") or line.startswith("| ") or line == "}}":
+            continue
+        assert not (line.startswith(" ") or line.startswith("\t")), (
+            f"line carries leading whitespace: {line!r}"
+        )
+    # Canonical blank line between the heading and the template.
+    assert "== {{int:filedesc}} ==\n\n{{DPLA metadata" in saved_text, (
+        f"missing canonical blank-line separator:\n{saved_text!r}"
+    )


### PR DESCRIPTION
## Summary

Live bug on https://commons.wikimedia.org/wiki/File:Possibly_Carlisle_Indian_School_football_team_-_DPLA_-_0037596b6b4904655f0f949db0a1ab8b_(page_2).tiff — the legacy-Artwork migration produced wikitext with a duplicated, indented `== {{int:filedesc}} ==` heading on top of the new `{{DPLA metadata}}` template:

```
== {{int:filedesc}} ==
     == {{int:filedesc}} ==

{{DPLA metadata
| ... params ...
}}
```

Two compounding causes:

1. **`render_migrated_wikitext` substituted full-upload-form payload into the template node.** `get_wiki_text(...)` returns `== heading ==\n\n{{DPLA metadata...}}` (full upload form, used for new uploads). `mwparserfromhell.replace(legacy_template_node, new_text)` only swaps the template **node** — so the original heading above the legacy `{{Artwork}}` block stays put, and the new heading lands inline where the template was → two consecutive headings.

2. **Leading whitespace before the legacy template survived the swap.** The pre-#291 pretty-printed `     {{ Artwork` block carried 5-space indent as a Text node before the template node. After `wikicode.replace`, that Text node persisted and indented the newly substituted heading.

## Fix

- New internal `_extract_dpla_metadata_template(block)` pulls just the `{{DPLA metadata ...}}` template invocation out of the upload-form block. `render_migrated_wikitext` calls it before substituting so the page's existing heading is preserved as-is.
- `migrate_legacy_file` runs `canonicalize()` after the rewrite — the same canonical-whitespace pass the per-file SDC strip path uses — to left-justify the template and enforce the canonical blank-line separator between heading and template.

## Test plan

- [x] `test_render_migrated_wikitext_does_not_duplicate_section_heading` — regression using real `get_wiki_text`-shaped payload (heading + blank line + template).
- [x] `test_render_migrated_wikitext_accepts_template_only_block_for_back_compat` — extraction is a no-op on bare template payload (existing in-process callers stay working).
- [x] `test_migrate_legacy_file_emits_canonical_whitespace` — end-to-end: original page has indented `{{ Artwork`; after migration the page has exactly one heading at column 0, the template is left-justified, and the canonical blank-line separator is present.
- [x] Existing `render_migrated_wikitext` + `migrate_legacy_file` tests still pass (62/62 in `test_legacy_artwork.py`).
- [x] Full suite: 616 passed.
- [x] `ruff check` + `ruff format` clean.

## Recovery

There are ~N already-broken pages from the migration code introduced in #298. A separate replacement script (to be run after this PR merges + the wiki EC2 picks up the new code) will fix them — same canonical-whitespace + dedupe-heading shape this PR enforces going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Bug Fix: Duplicated Section Headings in Legacy Artwork Migration

This PR fixes a live bug where the legacy-Artwork → DPLA metadata migration produced duplicated, indented `== {{int:filedesc}} ==` section headings on migrated Wikimedia Commons file pages.

### Root Causes Addressed
1. Template substitution: render_migrated_wikitext() was substituting the entire upload-form payload (heading + blank line + template) into the position of the legacy template, leaving the page's original heading and inserting a second heading inline.
2. Whitespace persistence: Leading pretty-printed indentation before the legacy `{{Artwork}}` template persisted as a Text node and, after replacement, caused the substituted heading/template to be indented.

### Implementation
- Added internal _extract_dpla_metadata_template(block) to extract only the `{{DPLA metadata ...}}` template invocation from an upload-form block; render_migrated_wikitext() now substitutes that template instead of the full block, preserving the page's original heading.
- After rewrite, migrate_legacy_file() runs canonicalize() (wikitext_normalize.canonicalize) to left-justify the template and enforce a canonical single blank-line separator between the heading and the `{{DPLA metadata ...}}` template.

### Tests
- Added regression tests:
  - test_render_migrated_wikitext_does_not_duplicate_section_heading
  - test_render_migrated_wikitext_accepts_template_only_block_for_back_compat
  - test_migrate_legacy_file_emits_canonical_whitespace
- Existing legacy_artwork tests (62/62) still pass; full test suite: 616 passed.
- ruff checks and formatting are clean.

A separate recovery script will be run post-merge to fix pages already affected by the earlier migration.

### Deployment & Impact
- No manual pipeline trigger or ECS redeployment required.
- No environment variable or AWS Secrets Manager key changes.
- No database migrations.
- No shared infrastructure configuration changes (CodePipeline/CodeBuild/ECS/IAM).
- No public API changes or endpoints affected.
- No security-sensitive changes introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->