### PR TITLE
legacy-artwork: strip params matching SDC inside the migration pass

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -862,16 +862,29 @@ def migrate_legacy_file(
 
     new_block = get_wiki_text(dpla_id, item_metadata, provider, data_provider)
     rewritten = render_migrated_wikitext(file_page.text, new_block)
+    # ``new_block`` is the full upload-form template with every param
+    # populated from ``item_metadata`` — appropriate for a fresh upload
+    # but not for migration, where the SDC just written already carries
+    # the DPLA-attributed values. Run the same strip pass the post-SDC
+    # cleanup path uses on ``{{DPLA metadata}}`` files so the migrated
+    # wikitext ends up in the post-strip steady state in one save,
+    # instead of leaving the params populated and depending on a
+    # follow-up sdc-sync run to strip them. Community-contributed
+    # values whose ``canonical_value`` differs from
+    # ``canonical_params`` won't match and are preserved — the strip
+    # is value-equality, not blanket removal.
+    #
     # Canonical-whitespace pass: ``render_migrated_wikitext`` substitutes
     # only the template node, so any leading whitespace the legacy
     # ``{{Artwork}}`` block carried (the pre-#291 pretty-printed indent
     # of "     {{ Artwork") survives as a Text node before the new
-    # ``{{DPLA metadata}}`` template. ``canonicalize`` left-justifies the
-    # template and forces the canonical blank line between the section
-    # heading and the template, matching the shape ``get_wiki_text`` now
-    # emits for fresh uploads.
-    from .wikitext_normalize import canonicalize
+    # ``{{DPLA metadata}}`` template. ``canonicalize`` left-justifies
+    # the template and forces the canonical blank line between the
+    # section heading and the template, matching the shape
+    # ``get_wiki_text`` emits for fresh uploads.
+    from .wikitext_normalize import canonicalize, normalize
 
+    rewritten, _stripped = normalize(rewritten, canonical_params)
     rewritten = canonicalize(rewritten)
     wikitext_changed = rewritten != file_page.text
     if wikitext_changed:

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1091,6 +1091,7 @@ def test_migrate_legacy_file_strips_params_matching_sdc_in_one_edit():
     # display will render from there.
     for key in (
         "title",
+        "description",
         "creator",
         "date",
         "permission",

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1038,3 +1038,72 @@ def test_migrate_legacy_file_emits_canonical_whitespace():
     assert "== {{int:filedesc}} ==\n\n{{DPLA metadata" in saved_text, (
         f"missing canonical blank-line separator:\n{saved_text!r}"
     )
+
+
+def test_migrate_legacy_file_strips_params_matching_sdc_in_one_edit():
+    """Regression for the live bug observed on
+    https://commons.wikimedia.org/wiki/File:Indian_portrait,_bust_-_DPLA_-_1c4a5c6601e7daec71e04483a5c304a7.gif
+    where migration produced a fully-populated ``{{DPLA metadata}}``
+    template with every param verbatim (creator, title, date,
+    permission, hub, institution, url, dpla_id, local_id) — the
+    pre-strip steady state, not the post-strip steady state.
+
+    For a DPLA-bot-only revision history (no community contributions),
+    every wikitext param value matches the canonical ``item_metadata``,
+    so the strip pass must remove all of them — the migrated file
+    should end at the post-strip steady state ``{{DPLA metadata}}``
+    in the same edit as the migrate, not two edits later after a
+    follow-up sdc-sync pass.
+    """
+
+    class _Rev1:
+        revid, user = 1, "DPLA_bot"
+        text = (
+            "== {{int:filedesc}} ==\n"
+            "     {{ Artwork\n"
+            "        | Other fields 1 = {{ InFi | Creator |"
+            " A Creator | id=fileinfotpl_aut}}\n"
+            "        | title = A Title\n"
+            "        | description = A description\n"
+            "        | date = 1900\n"
+            "        | permission = {{NoC-US | Q1}}\n"
+            "        | source = {{ DPLA | Q1 | hub = Q2 |"
+            " url = https://example.org/item/123 |"
+            " dpla_id = abc | local_id = local-1 }}\n"
+            "        | Institution = {{ Institution | wikidata = Q1 }}\n"
+            "     }}\n"
+        )
+
+    page = _mock_file_page("File:Foo.jpg", _Rev1.text, [_Rev1()])
+    item, provider, dp = _item_md()
+    site = _site_with_empty_entity()
+    migrate_legacy_file(
+        file_page=page,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    saved = page.text
+    # No DPLA-attributed params should remain in the wikitext. Each
+    # one is canonically present in SDC after the migration, so the
+    # display will render from there.
+    for key in (
+        "title",
+        "creator",
+        "date",
+        "permission",
+        "hub",
+        "institution",
+        "url",
+        "dpla_id",
+        "local_id",
+    ):
+        assert f"| {key}" not in saved, (
+            f"strip missed param {key!r}; full text:\n{saved}"
+        )
+    # The template itself is still present — collapsed to single line.
+    assert "{{DPLA metadata}}" in saved
+    # And only one save was issued.
+    assert page.save.call_count == 1


### PR DESCRIPTION
## Summary

Live bug on https://commons.wikimedia.org/wiki/File:Indian_portrait,_bust_-_DPLA_-_1c4a5c6601e7daec71e04483a5c304a7.gif — and ~all 93 files the previous PR #299 just cleaned up — left the migrated wikitext at the pre-strip steady state:

```
{{DPLA metadata
| creator = ...
| title = ...
| date = ...
| permission = ...
| hub = ...
| institution = ...
| url = ...
| dpla_id = ...
| local_id = ...
}}
```

…instead of the post-strip steady state `{{DPLA metadata}}` that the normal `{{DPLA metadata}}` path reaches after the post-SDC strip.

## Root cause

The post-SDC cleanup dispatcher (`_post_sdc_cleanup_for_page` in `tools/sdc_sync.py`) routes legacy files to `migrate_legacy_file()` and **returns** — it doesn't also run the strip path the non-legacy branch takes. `migrate_legacy_file` itself only does:

1. `render_migrated_wikitext` — swap `{{Artwork}}` for the full upload-form `{{DPLA metadata}}` block.
2. `canonicalize` — whitespace cleanup (added in #299).

No strip of params now redundant with the SDC just written. So the migration produces wikitext with every param still populated.

## Fix

Pull `wikitext_normalize.normalize` into `migrate_legacy_file` and run it between the template swap and the whitespace canonicalize. `canonical_params` is already computed at the top of `migrate_legacy_file` (for the migration plan), so reusing it for the strip costs nothing extra and keeps the whole migration as one edit per file.

Community-contributed values whose `canonical_value` differs from `canonical_params` won't match and are preserved verbatim — the strip is value-equality (same logic the post-SDC strip path uses), not blanket removal.

## Test plan

- [x] New regression `test_migrate_legacy_file_strips_params_matching_sdc_in_one_edit` — DPLA-bot-only history, asserts no DPLA-attributed param keys remain in the migrated wikitext and exactly one `page.save()` call.
- [x] All 63 existing `test_legacy_artwork.py` tests still pass.
- [x] Full suite: 617 passed.
- [x] `ruff check` + `ruff format` clean.

## Recovery

After this merges + the wiki EC2 picks up the new code, the 93 already-migrated files left in the pre-strip state will need a one-shot strip pass to reach the post-strip steady state. I have the recipe ready — extending the same scan-DPLA-bot-contribs approach used in #299's cleanup, but calling `normalize_page` instead of dedupe+canonicalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fixes legacy-artwork migration to strip redundant parameters in a single edit

### Summary
Resolves a bug where legacy Artwork migrations produced a fully populated (pre-strip) {{DPLA metadata}} block instead of the collapsed post-strip form in the same edit. Root cause: legacy pages were routed to migrate_legacy_file(), which performed the template swap but skipped the SDC parameter-strip path non-legacy migrations run. The fix runs wikitext_normalize.normalize(...) inside migrate_legacy_file between the template swap and whitespace canonicalization so redundant SDC parameters get stripped in the same edit (matching by canonical value; community-contributed values with differing canonical_value are preserved).

### Changes
- ingest_wikimedia/legacy_artwork.py: call normalize(rewritten, canonical_params) inside migrate_legacy_file (use normalized text and reuse precomputed canonical_params so no extra edits).
- tests/test_legacy_artwork.py: add regression test test_migrate_legacy_file_strips_params_matching_sdc_in_one_edit to assert redundant DPLA-attributed params are removed and only one page.save() occurs; existing legacy tests unchanged.

### Testing & Quality
- New regression test added; full suite reported 617 passing tests and existing 63 legacy tests remain passing.
- ruff formatting/lint checks clean.

### Post-deployment recovery
- Approximately 93 already-migrated files that were processed before this fix will require a one-shot strip pass after deployment (scan DPLA-bot contributions and call normalize_page()).

### Operational / infra / security notes (explicit)
- Requires no manual pipeline trigger or ECS redeployment beyond the normal code deployment process.
- Does not add, remove, or rename environment variables or AWS Secrets Manager keys.
- No database migration.
- No changes to shared infrastructure (CodePipeline/CodeBuild/ECS task definitions/IAM).
- No public API response shape or endpoint changes.
- No security implications beyond normal code changes (no new auth flows, credentials, or external input handling introduced).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->