### PR TITLE
legacy-artwork: drop boilerplate 'community-preserved' clause when no community claims were posted

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -760,11 +760,35 @@ def render_migrated_wikitext(
 # wbeditentity edit. Centralised so a future change to the wording
 # (e.g. linking to the Commons documentation page) doesn't need to be
 # hunted down across multiple call sites.
+#
+# ``LEGACY_MIGRATION_EDIT_SUMMARY`` is the with-community-claims form;
+# the base form (no community-preservation clause) is used when every
+# wikitext value already matched the DPLA-canonical value, so the
+# migration produced zero community-import claims. ``build_migration_summary``
+# picks the right form for the actual edit, so the wikitext save's
+# summary doesn't promise SDC-preservation behaviour that didn't fire.
+LEGACY_MIGRATION_BASE_SUMMARY = (
+    "Migrate legacy {{Artwork}} to {{DPLA metadata}} per DPLA SDC sync."
+)
 LEGACY_MIGRATION_EDIT_SUMMARY = (
-    "Migrate legacy {{Artwork}} to {{DPLA metadata}} per DPLA SDC sync; "
-    "community-contributed metadata preserved as SDC statements with "
+    LEGACY_MIGRATION_BASE_SUMMARY
+    + " Community-contributed metadata preserved as SDC statements with "
     "[[d:Q131783016|inferred-from-Wikitext]] reference."
 )
+
+
+def build_migration_summary(community_claim_count: int) -> str:
+    """Return the edit summary describing what this migration did.
+
+    Pass the number of community-import claims actually posted on
+    this file. Zero (DPLA-bot-only history, every wikitext value
+    already DPLA-canonical) → :data:`LEGACY_MIGRATION_BASE_SUMMARY`.
+    Non-zero → :data:`LEGACY_MIGRATION_EDIT_SUMMARY` with the
+    community-preservation clause appended.
+    """
+    if community_claim_count <= 0:
+        return LEGACY_MIGRATION_BASE_SUMMARY
+    return LEGACY_MIGRATION_EDIT_SUMMARY
 
 
 @dataclass
@@ -820,7 +844,7 @@ def migrate_legacy_file(
     dpla_id: str,
     site,
     bot_accounts: frozenset[str] = DPLA_BOT_ACCOUNTS,
-    summary: str = LEGACY_MIGRATION_EDIT_SUMMARY,
+    summary: str | None = None,
 ) -> MigrationResult:
     """End-to-end legacy-Artwork migration for a single file.
 
@@ -857,6 +881,14 @@ def migrate_legacy_file(
         return MigrationResult(skipped_reason="already-migrated", plan=plan)
 
     claims = materialize_import_claims(build_legacy_import_claims(plan))
+    # Pick the accurate summary for what this migration actually did,
+    # unless the caller supplied a custom one. Without this, a
+    # DPLA-bot-only history (no community values to import) would still
+    # carry the boilerplate "community-contributed metadata preserved"
+    # clause on its wikitext save, promising SDC-preservation behaviour
+    # that didn't fire on this file.
+    if summary is None:
+        summary = build_migration_summary(len(claims))
     if claims:
         post_legacy_import_claims(mediaid, claims, site, summary=summary)
 

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -507,8 +507,10 @@ def test_artwork_param_aliases_normalize_via_casefolded_lookup(alias, canonical)
 from unittest.mock import MagicMock  # noqa: E402
 
 from ingest_wikimedia.legacy_artwork import (  # noqa: E402
+    LEGACY_MIGRATION_BASE_SUMMARY,
     LEGACY_MIGRATION_EDIT_SUMMARY,
     MigrationResult,
+    build_migration_summary,
     entity_was_already_migrated,
     fetch_revision_snapshots,
     materialize_import_claims,
@@ -976,6 +978,66 @@ def test_legacy_migration_edit_summary_mentions_q131783016():
     """The edit summary should mention the inferred-from-Wikitext
     Wikidata item so reviewers can trace the migration's intent."""
     assert "Q131783016" in LEGACY_MIGRATION_EDIT_SUMMARY
+
+
+def test_build_migration_summary_omits_community_clause_when_zero_claims():
+    """A DPLA-bot-only history where every wikitext value matched
+    the DPLA canonical value posts zero community-import claims —
+    the summary must not promise SDC-preservation behaviour that
+    didn't fire. Pre-fix, every migration carried the boilerplate
+    "community-contributed metadata preserved..." clause regardless
+    of whether any community values were actually imported."""
+    summary = build_migration_summary(0)
+    assert summary == LEGACY_MIGRATION_BASE_SUMMARY
+    assert "Q131783016" not in summary
+    assert "community-contributed" not in summary
+    assert "preserved" not in summary
+
+
+def test_build_migration_summary_includes_community_clause_when_claims_posted():
+    """A history with at least one community-edited wikitext value
+    posts that value as an SDC statement under the community-import
+    reference shape, and the summary documents that."""
+    summary = build_migration_summary(1)
+    assert "Q131783016" in summary
+    assert "preserved" in summary
+
+
+def test_migrate_legacy_file_uses_honest_summary_on_dpla_only_history():
+    """End-to-end: when no community values were detected on a file
+    (DPLA-bot-only revision history, every param matches canonical),
+    the wikitext save's edit summary uses the base form without the
+    community-preservation clause. Regression for the live case where
+    every Valuation Section / Smithsonian negative file carried the
+    misleading boilerplate."""
+
+    class _Rev1:
+        revid, user = 1, "DPLA_bot"
+        text = (
+            "== {{int:filedesc}} ==\n"
+            "{{ Artwork\n"
+            "| title = A Title\n"
+            "| source = {{ DPLA | Q1 | hub = Q2 |"
+            " url = https://example.org/item/123 |"
+            " dpla_id = abc | local_id = local-1 }}\n"
+            "| Institution = {{ Institution | wikidata = Q1 }}\n"
+            "}}\n"
+        )
+
+    page = _mock_file_page("File:Foo.jpg", _Rev1.text, [_Rev1()])
+    item, provider, dp = _item_md()
+    site = _site_with_empty_entity()
+    migrate_legacy_file(
+        file_page=page,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    save_summary = page.save.call_args.kwargs["summary"]
+    assert save_summary == LEGACY_MIGRATION_BASE_SUMMARY
+    assert "Q131783016" not in save_summary
 
 
 def test_migrate_legacy_file_emits_canonical_whitespace():


### PR DESCRIPTION
## Summary

Live observation on https://commons.wikimedia.org/w/index.php?title=File:Valuation_Section_10,_Sheet_4_-_DPLA_-_c6d139a3184f4378bf61adf3a0a17c91.jpg&diff=prev&oldid=1229258534 — and on every migrated file with a DPLA-bot-only revision history (which is the common case): the migration edit summary always reads:

> Migrate legacy {{Artwork}} to {{DPLA metadata}} per DPLA SDC sync; community-contributed metadata preserved as SDC statements with [[d:Q131783016|inferred-from-Wikitext]] reference.

Even when the migration plan found **no** community-edited values, no community-import claims got POSTed, and no SDC edit with the `P887→Q131783016` reference shape exists on the file. The wikitext save promised behaviour that didn't fire on this file.

For the linked file (M129419992): 0 community-imported claims, 14 standard DPLA-attributed claims — but the summary says preservation happened.

## Cause

`LEGACY_MIGRATION_EDIT_SUMMARY` was a single static module-level constant used verbatim as the default `summary` for both the wbeditentity post (when claims existed) and the wikitext save (always).

## Fix

- New `LEGACY_MIGRATION_BASE_SUMMARY` — the "no community claims" form.
- `LEGACY_MIGRATION_EDIT_SUMMARY` retained as the with-community-claims form (source-compatible — existing imports keep working, `post_legacy_import_claims`'s default still matches its actual contract).
- New `build_migration_summary(community_claim_count)` picks the right form.
- `migrate_legacy_file`'s `summary` kwarg defaults to `None`; if not overridden it's computed from `len(claims)` at edit time. Both the wbeditentity post (when claims exist) and the wikitext save get the same accurate summary.

## Test plan

- [x] `build_migration_summary(0)` → base form, no Q131783016, no "preserved".
- [x] `build_migration_summary(1)` → community form, Q131783016 + "preserved" both present.
- [x] End-to-end `test_migrate_legacy_file_uses_honest_summary_on_dpla_only_history`: DPLA-bot-only history → wikitext save's `summary` kwarg matches `LEGACY_MIGRATION_BASE_SUMMARY`.
- [x] All 66 `test_legacy_artwork.py` tests pass.
- [x] Full suite: 620 passed.
- [x] `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

This PR refines the legacy artwork migration process to avoid including a misleading "community-contributed metadata preserved" clause in edit summaries when no community claims were actually posted.

### Problem Addressed

The migration wikitext edit summary always included text about "community-contributed metadata preserved as SDC statements with [[d:Q131783016|inferred-from-Wikitext]] reference" even when the revision history contained only DPLA-bot-contributed values with no community-edited content. This occurred because `LEGACY_MIGRATION_EDIT_SUMMARY` was a static module-level constant applied uniformly to both Wikibase edit posts and wikitext saves.

### Implementation

The solution introduces a conditional summary scheme:

- **Added** `LEGACY_MIGRATION_BASE_SUMMARY`: A constant containing the base form without any "community-contributed" or Q131783016 references
- **Added** `build_migration_summary(community_claim_count: int)`: A helper function that returns the appropriate summary based on whether community claims exist
  - Returns `LEGACY_MIGRATION_BASE_SUMMARY` when `community_claim_count == 0`
  - Returns `LEGACY_MIGRATION_EDIT_SUMMARY` when `community_claim_count > 0`
- **Updated** `migrate_legacy_file()`: Changed the `summary` parameter from a default of `LEGACY_MIGRATION_EDIT_SUMMARY` to `None`, allowing the function to compute the correct summary at edit time based on the actual number of community claims

Both wbeditentity posts and wikitext saves now receive the appropriate summary, ensuring DPLA-bot-only histories are not misrepresented as containing preserved community metadata.

### Testing

- Unit tests verify `build_migration_summary()` behavior for both zero and non-zero community claim counts
- End-to-end test confirms `migrate_legacy_file()` uses the honest base summary when processing revision histories with only DPLA-bot values
- All 66 tests in test_legacy_artwork.py pass; full test suite: 620 passed
- Code passes ruff checks and formatting validation

### Scope Notes

This change is a localized internal logic correction affecting only the generated wikitext edit summaries for legacy artwork file migrations. It does not involve environment variables, database migrations, infrastructure changes, public API modifications, or security implications. No manual pipeline trigger or redeployment is required beyond normal code deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->