### PR TITLE
sdc-sync: recover from null pageid + defensive cleanup guard against empty-SDC strip

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -394,11 +394,17 @@ def notify_upload_complete(
         header=f"*Wikimedia {header_phrase}: {effective_label}*{dry_run_note}",
         plain_text=f"Wikimedia {plain_phrase}: {effective_label}",
         stats_lines=[
-            f"UPLOADED: {tracker.count(Result.UPLOADED):,}",
-            f"SKIPPED:  {tracker.count(Result.SKIPPED):,}",
-            f"FAILED:   {total_failed:,}",
-            f"BYTES:    {_format_bytes(tracker.count(Result.BYTES))}",
-            f"Runtime:  {runtime}",
+            f"UPLOADED:      {tracker.count(Result.UPLOADED):,}",
+            f"SKIPPED:       {tracker.count(Result.SKIPPED):,}",
+            # Per-class breakdown of the aggregate SKIPPED above. Lets
+            # operators tell upstream-gap skips (no S3 asset, downloader
+            # didn't stage) from MIME / ineligibility skips so the fix
+            # routes to the right team.
+            f"  not present: {tracker.count(Result.UPLOAD_SKIPPED_NOT_PRESENT):,}",
+            f"  ineligible:  {tracker.count(Result.UPLOAD_SKIPPED_INELIGIBLE):,}",
+            f"FAILED:        {total_failed:,}",
+            f"BYTES:         {_format_bytes(tracker.count(Result.BYTES))}",
+            f"Runtime:       {runtime}",
         ],
     )
 

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -441,6 +441,7 @@ def notify_sdc_complete(
         plain_text=f"Wikimedia SDC complete: {effective_label}",
         stats_lines=[
             f"ITEMS SYNCED:         {tracker.count(Result.SDC_ITEMS_SYNCED):,}",
+            f"ITEMS PARTIAL:        {tracker.count(Result.SDC_ITEMS_PARTIALLY_SYNCED):,}",
             f"CLAIMS ADDED:         {tracker.count(Result.SDC_CLAIMS_ADDED):,}",
             f"REFS ADDED:           {tracker.count(Result.SDC_REFS_ADDED):,}",
             f"REMOVALS:             {tracker.count(Result.SDC_REMOVALS):,}",

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -442,6 +442,7 @@ def notify_sdc_complete(
             f"SKIPPED (mapping):    {tracker.count(Result.SDC_ITEMS_SKIPPED_MAPPING):,}",
             f"SKIPPED (error):      {tracker.count(Result.SDC_ITEMS_SKIPPED_ERROR):,}",
             f"ORDINAL MISSING:      {tracker.count(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY):,}",
+            f"ORDINAL NO PAGEID:    {tracker.count(Result.SDC_ORDINALS_SKIPPED_MISSING_PAGEID):,}",
             f"ORDINAL ERRORS:       {tracker.count(Result.SDC_ORDINALS_SKIPPED_ERROR):,}",
             f"Runtime:              {runtime}",
         ],

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -31,6 +31,15 @@ class Result(Enum):
     SDC_REMOVALS = auto()
     SDC_ITEMS_SKIPPED_NO_SIDECAR = auto()
     SDC_ITEMS_SKIPPED_MAPPING = auto()
+    # Items where at least one ordinal synced cleanly AND at least
+    # one sibling ordinal hit ``had_ordinal_error`` (the typical
+    # shape: one ordinal's null-pageid skip + the rest succeeding).
+    # Distinguished from full-sync ``SDC_ITEMS_SYNCED`` so dashboards
+    # keying on "items fully done" don't accidentally count partial
+    # results as healthy. Items in this bucket DO get post-SDC
+    # cleanup on their synced ordinals — the partial state is real
+    # progress, not a failure to be retried wholesale.
+    SDC_ITEMS_PARTIALLY_SYNCED = auto()
     # Ordinals whose SDC sync raised an unexpected exception
     # (pywikibot APIError, network timeout, deep KeyError, etc.).
     # Per-ordinal granularity so transient failures don't abort the

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -37,6 +37,13 @@ class Result(Enum):
     # (claim rejection, throttle, etc.) stay distinguishable from
     # not-our-problem skips.
     SDC_ORDINALS_SKIPPED_MISSING_ENTITY = auto()
+    # Ordinals where upload-result.json carries a missing / null / zero
+    # ``pageid`` and sdc-sync's title→pageid fallback couldn't resolve
+    # it from Commons either (page actually doesn't exist, API error,
+    # etc.). Distinguished from the generic ERROR bucket so operators
+    # can spot uploader sidecar defects in the Slack summary rather
+    # than having them blend in with runtime API failures.
+    SDC_ORDINALS_SKIPPED_MISSING_PAGEID = auto()
     # Items where every eligible ordinal hit the per-ordinal exception
     # path — i.e., the item didn't fail due to malformed data
     # (MAPPING) or missing sidecars (NO_SIDECAR), but because all of

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -5,6 +5,15 @@ class Result(Enum):
     DOWNLOADED = auto()
     FAILED = auto()
     SKIPPED = auto()
+    # Uploader skip-class breakdowns. Both also bump ``SKIPPED`` so
+    # legacy dashboards keep working — the granular counters add
+    # detail without replacing the aggregate. ``NOT_PRESENT`` covers
+    # the upstream gap (no S3 asset, downloader didn't stage the
+    # file). ``INELIGIBLE`` covers files that exist in S3 but the
+    # uploader chose not to upload (bad MIME, missing extension,
+    # download-only formats staged for conversion).
+    UPLOAD_SKIPPED_NOT_PRESENT = auto()
+    UPLOAD_SKIPPED_INELIGIBLE = auto()
     UPLOADED = auto()
     BYTES = auto()
     ITEM_NOT_PRESENT = auto()

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -3864,3 +3864,57 @@ def test_post_sdc_cleanup_for_page_strips_when_entity_has_dpla_sdc(monkeypatch):
     )
 
     assert len(strip_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Item-level outcome classification: partial-sync items distinct from
+# fully-synced. Per CR review on PR #302 — mixed-result items (one ordinal
+# synced, sibling ordinal hit MISSING_PAGEID / SKIPPED_ERROR) shouldn't be
+# silently counted as fully ``SDC_ITEMS_SYNCED``.
+# ---------------------------------------------------------------------------
+
+
+def test_classify_item_outcome_full_sync():
+    """All ordinals synced cleanly → full ``SDC_ITEMS_SYNCED``."""
+    from tools.sdc_sync import _classify_item_outcome
+
+    assert (
+        _classify_item_outcome(synced_this_item=True, had_ordinal_error=False)
+        == Result.SDC_ITEMS_SYNCED
+    )
+
+
+def test_classify_item_outcome_partial_sync():
+    """Live-bug regression: at least one ordinal synced AND at
+    least one sibling ordinal hit the error / null-pageid skip
+    path → ``SDC_ITEMS_PARTIALLY_SYNCED``, not the full-sync
+    bucket. Dashboards keying on full-sync as "items healthy"
+    correctly excluded."""
+    from tools.sdc_sync import _classify_item_outcome
+
+    assert (
+        _classify_item_outcome(synced_this_item=True, had_ordinal_error=True)
+        == Result.SDC_ITEMS_PARTIALLY_SYNCED
+    )
+
+
+def test_classify_item_outcome_all_errored():
+    """No ordinals synced but at least one raised → error bucket,
+    not the no-progress mapping bucket."""
+    from tools.sdc_sync import _classify_item_outcome
+
+    assert (
+        _classify_item_outcome(synced_this_item=False, had_ordinal_error=True)
+        == Result.SDC_ITEMS_SKIPPED_ERROR
+    )
+
+
+def test_classify_item_outcome_no_progress():
+    """No ordinals synced AND no ordinals errored — every eligible
+    ordinal silently no-op'd somewhere. Mapping skip."""
+    from tools.sdc_sync import _classify_item_outcome
+
+    assert (
+        _classify_item_outcome(synced_this_item=False, had_ordinal_error=False)
+        == Result.SDC_ITEMS_SKIPPED_MAPPING
+    )

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1382,6 +1382,7 @@ def test_post_sdc_cleanup_dispatches_to_strip_on_new_template(monkeypatch):
 
     fake_page = MagicMock(name="FilePage")
     fake_page.exists.return_value = True
+    fake_page.pageid = 42
     fake_page.text = "{{DPLA metadata\n| title = A Title\n| dpla_id = dpla-1\n}}"
 
     migrate_calls = []
@@ -1395,6 +1396,34 @@ def test_post_sdc_cleanup_dispatches_to_strip_on_new_template(monkeypatch):
         wikitext_normalize,
         "normalize_page",
         lambda *a, **kw: strip_calls.append((a, kw)),
+    )
+    # The cleanup guard fetches the entity to verify it carries
+    # DPLA-attributed SDC before stripping. Stub a passing entity so
+    # this test exercises the existing dispatch behaviour; the guard's
+    # refusal-on-empty-entity case has its own dedicated regression.
+    monkeypatch.setattr(
+        sdc_sync,
+        "_fetch_entity_for_cleanup_guard",
+        lambda mid: {
+            "statements": {
+                "P1476": [
+                    {
+                        "mainsnak": {"snaktype": "value"},
+                        "qualifiers": {
+                            "P459": [
+                                {
+                                    "snaktype": "value",
+                                    "datavalue": {
+                                        "value": {"id": "Q61848113"},
+                                        "type": "wikibase-entityid",
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                ]
+            }
+        },
     )
 
     sdc_sync._post_sdc_cleanup_for_page(
@@ -3589,3 +3618,249 @@ def test_flush_emits_type_statement_on_every_non_removal_fragment():
         "P813 refresh fragment must preserve existing qualifiers"
     )
     sdc_sync._reset_per_file_accumulators()
+
+
+# ---------------------------------------------------------------------------
+# pageid recovery + cleanup-guard: null-pageid live bug repro
+# (https://commons.wikimedia.org/wiki/File:Southern_Railway_Company,_Valuation_Section_22_-_DPLA_-_e314839e2ca3906b29bcbecc3d615740_(page_1).tiff)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_pageid_from_title_returns_pid_on_existing_page(monkeypatch):
+    """The fallback for upload-result.json sidecars with null/0
+    pageid: query Commons for the page id given the title."""
+    from tools import sdc_sync
+
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value.submit.return_value = {
+        "query": {"pages": {"193644002": {"pageid": 193644002, "title": "File:X.tiff"}}}
+    }
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+
+    assert sdc_sync._resolve_pageid_from_title("File:X.tiff") == 193644002
+
+
+def test_resolve_pageid_from_title_returns_none_on_missing_page(monkeypatch):
+    """Page genuinely doesn't exist on Commons (upload silently
+    failed): no pageid to recover, caller drops into the existing
+    skip-with-counter path."""
+    from tools import sdc_sync
+
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value.submit.return_value = {
+        "query": {"pages": {"-1": {"missing": "", "title": "File:Nope.tiff"}}}
+    }
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+
+    assert sdc_sync._resolve_pageid_from_title("File:Nope.tiff") is None
+
+
+def test_resolve_pageid_from_title_returns_none_on_api_error(monkeypatch):
+    """API failure during the fallback shouldn't crash the partner
+    batch — just signal "couldn't recover" so the call site falls
+    into its existing skip path."""
+    from tools import sdc_sync
+
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value.submit.side_effect = RuntimeError("boom")
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+
+    assert sdc_sync._resolve_pageid_from_title("File:X.tiff") is None
+
+
+def test_resolve_pageid_from_title_returns_none_on_empty_title(monkeypatch):
+    """Bare empty/None title shouldn't even hit the API."""
+    from tools import sdc_sync
+
+    fake_site = MagicMock()
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+
+    assert sdc_sync._resolve_pageid_from_title("") is None
+    assert sdc_sync._resolve_pageid_from_title(None) is None  # type: ignore[arg-type]
+    assert fake_site.simple_request.call_count == 0
+
+
+def test_entity_has_dpla_attributed_claims_finds_p459_q61848113():
+    """The cleanup guard's notion of "has DPLA SDC" matches
+    Module:DPLA's ``isDplaDetermined`` filter: at least one statement
+    with P459 = Q61848113 qualifier."""
+    from tools import sdc_sync
+
+    entity = {
+        "statements": {
+            "P195": [
+                {
+                    "mainsnak": {"snaktype": "value"},
+                    "qualifiers": {
+                        "P459": [
+                            {
+                                "snaktype": "value",
+                                "datavalue": {
+                                    "value": {"id": "Q61848113"},
+                                    "type": "wikibase-entityid",
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    }
+    assert sdc_sync._entity_has_dpla_attributed_claims(entity) is True
+
+
+def test_entity_has_dpla_attributed_claims_false_on_empty_entity():
+    """An empty entity (no-such-entity post-fetch, or zero claims) is
+    the bug shape the guard exists to catch — return False so the
+    cleanup refuses to strip wikitext."""
+    from tools import sdc_sync
+
+    assert sdc_sync._entity_has_dpla_attributed_claims({}) is False
+    assert sdc_sync._entity_has_dpla_attributed_claims({"statements": {}}) is False
+
+
+def test_entity_has_dpla_attributed_claims_false_on_unrelated_p459_value():
+    """Other heuristic determination Q-IDs (e.g. P459 = Q131783016
+    for inferred-from-Wikitext community-import claims) don't count
+    as DPLA-attributed."""
+    from tools import sdc_sync
+
+    entity = {
+        "statements": {
+            "P1476": [
+                {
+                    "mainsnak": {"snaktype": "value"},
+                    "qualifiers": {
+                        "P459": [
+                            {
+                                "snaktype": "value",
+                                "datavalue": {
+                                    "value": {"id": "Q131783016"},
+                                    "type": "wikibase-entityid",
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    }
+    assert sdc_sync._entity_has_dpla_attributed_claims(entity) is False
+
+
+def test_post_sdc_cleanup_for_page_refuses_strip_when_entity_has_no_dpla_sdc(
+    monkeypatch,
+):
+    """Live-bug regression
+    (https://commons.wikimedia.org/wiki/File:Southern_Railway_Company,_Valuation_Section_22_-_DPLA_-_e314839e2ca3906b29bcbecc3d615740_(page_1).tiff):
+    when the per-ordinal SDC write was skipped (upstream null pageid)
+    but the post-SDC cleanup ran anyway, the strip removed every
+    wikitext param matching the DPLA canonical value, leaving the
+    page with no metadata in either representation. The defensive
+    guard fetches the entity and refuses to strip when it has zero
+    DPLA-attributed claims."""
+    from ingest_wikimedia import wikimedia, wikitext_normalize
+    from tools import sdc_sync
+
+    fake_page = MagicMock(name="FilePage")
+    fake_page.exists.return_value = True
+    fake_page.pageid = 193644002
+    fake_page.title.return_value = "File:Southern Railway.tiff"
+    fake_page.text = (
+        "{{DPLA metadata\n"
+        "| title = Southern Railway Company, Valuation Section 22\n"
+        "| dpla_id = e314839e2ca3906b29bcbecc3d615740\n"
+        "}}"
+    )
+
+    monkeypatch.setattr(
+        wikimedia,
+        "dpla_metadata_params",
+        lambda *a, **kw: {"title": "Southern Railway Company, Valuation Section 22"},
+    )
+    # Entity exists but is empty — no DPLA-attributed claims.
+    monkeypatch.setattr(
+        sdc_sync, "_fetch_entity_for_cleanup_guard", lambda mid: {"statements": {}}
+    )
+
+    strip_calls = []
+    monkeypatch.setattr(
+        wikitext_normalize,
+        "normalize_page",
+        lambda *a, **kw: strip_calls.append((a, kw)),
+    )
+
+    sdc_sync._post_sdc_cleanup_for_page(
+        fake_page,
+        "e314839e2ca3906b29bcbecc3d615740",
+        {
+            "sourceResource": {
+                "title": ["Southern Railway Company, Valuation Section 22"]
+            }
+        },
+        {"Wikidata": "Q518155"},
+        {"Wikidata": "Q59661038"},
+    )
+
+    assert strip_calls == [], (
+        "strip must not run against an entity with no DPLA-attributed SDC"
+    )
+
+
+def test_post_sdc_cleanup_for_page_strips_when_entity_has_dpla_sdc(monkeypatch):
+    """Happy path: the entity DOES carry DPLA-attributed SDC, the
+    guard passes, and the strip runs as before. Locks the guard in
+    as a *defensive* layer that only activates on the bug shape."""
+    from ingest_wikimedia import wikimedia, wikitext_normalize
+    from tools import sdc_sync
+
+    fake_page = MagicMock(name="FilePage")
+    fake_page.exists.return_value = True
+    fake_page.pageid = 12345
+    fake_page.title.return_value = "File:Healthy.tiff"
+    fake_page.text = "{{DPLA metadata\n| title = X\n}}"
+
+    monkeypatch.setattr(
+        wikimedia, "dpla_metadata_params", lambda *a, **kw: {"title": "X"}
+    )
+    monkeypatch.setattr(
+        sdc_sync,
+        "_fetch_entity_for_cleanup_guard",
+        lambda mid: {
+            "statements": {
+                "P1476": [
+                    {
+                        "mainsnak": {"snaktype": "value"},
+                        "qualifiers": {
+                            "P459": [
+                                {
+                                    "snaktype": "value",
+                                    "datavalue": {
+                                        "value": {"id": "Q61848113"},
+                                        "type": "wikibase-entityid",
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                ]
+            }
+        },
+    )
+
+    strip_calls = []
+    monkeypatch.setattr(
+        wikitext_normalize,
+        "normalize_page",
+        lambda *a, **kw: strip_calls.append((a, kw)),
+    )
+
+    sdc_sync._post_sdc_cleanup_for_page(
+        fake_page,
+        "dpla-id",
+        {"sourceResource": {"title": ["X"]}},
+        {"Wikidata": "Q1"},
+        {"Wikidata": "Q2"},
+    )
+
+    assert len(strip_calls) == 1

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -332,12 +332,23 @@ def test_notify_upload_complete_non_retry_label_keeps_upload_only_header(tmp_pat
             "WIKIMEDIA_SESSION_LABEL": "si",
             "WIKIMEDIA_PARTNER_DIR": str(tmp_path),
         },
-        tracker_counts={Result.UPLOADED: 5, Result.SKIPPED: 10, Result.FAILED: 2},
+        tracker_counts={
+            Result.UPLOADED: 5,
+            Result.SKIPPED: 10,
+            Result.UPLOAD_SKIPPED_NOT_PRESENT: 3,
+            Result.UPLOAD_SKIPPED_INELIGIBLE: 7,
+            Result.FAILED: 2,
+        },
     )
     assert "Wikimedia Upload Complete" in captured["header"]
     assert "Retry Complete" not in captured["header"]
     failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
-    assert failed_lines == ["FAILED:   2"]
+    assert failed_lines == ["FAILED:        2"]
+    # Granular skip-class breakdown shows up under the aggregate
+    # SKIPPED. Lets operators distinguish upstream-gap (downloader
+    # didn't stage) from MIME / eligibility skips.
+    assert any("not present: 3" in s for s in captured["stats_lines"])
+    assert any("ineligible:  7" in s for s in captured["stats_lines"])
 
 
 def test_notify_upload_complete_with_retry_label_combines_failed_count(tmp_path):
@@ -363,12 +374,12 @@ def test_notify_upload_complete_with_retry_label_combines_failed_count(tmp_path)
     assert "Wikimedia Retry Complete" in captured["header"]
     assert "Upload Complete" not in captured["header"]
     failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
-    assert failed_lines == ["FAILED:   1"]
+    assert failed_lines == ["FAILED:        1"]
     # SKIPPED and UPLOADED stay as upload-phase only — each phase's SKIPPED
     # means a different thing (download = "already in S3"; upload = "already
     # on Commons") and conflating them would obscure the picture.
     skipped_lines = [s for s in captured["stats_lines"] if s.startswith("SKIPPED:")]
-    assert skipped_lines == ["SKIPPED:  80"]
+    assert skipped_lines == ["SKIPPED:       80"]
 
 
 def test_notify_upload_complete_with_retry_label_but_no_log_file(tmp_path):
@@ -388,7 +399,7 @@ def test_notify_upload_complete_with_retry_label_but_no_log_file(tmp_path):
     # Falls back gracefully — upload-only header, FAILED unchanged.
     assert "Wikimedia Upload Complete" in captured["header"]
     failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
-    assert failed_lines == ["FAILED:   0"]
+    assert failed_lines == ["FAILED:        0"]
 
 
 def test_notify_upload_complete_upload_only_retry_ignores_stale_download_log(
@@ -416,7 +427,7 @@ def test_notify_upload_complete_upload_only_retry_ignores_stale_download_log(
     assert "Wikimedia Upload Complete" in captured["header"]
     assert "Retry Complete" not in captured["header"]
     failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
-    assert failed_lines == ["FAILED:   0"]
+    assert failed_lines == ["FAILED:        0"]
 
 
 def _capture_sdc_completion_message(env: dict, tracker_counts: dict) -> dict:
@@ -558,4 +569,4 @@ def test_notify_upload_complete_clean_retry_still_titled_retry_complete(tmp_path
     assert "Wikimedia Retry Complete" in captured["header"]
     assert "Upload Complete" not in captured["header"]
     failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
-    assert failed_lines == ["FAILED:   0"]
+    assert failed_lines == ["FAILED:        0"]

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -475,6 +475,7 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
             Result.SDC_ITEMS_SKIPPED_MAPPING: 1,
             Result.SDC_ITEMS_SKIPPED_ERROR: 3,
             Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY: 5,
+            Result.SDC_ORDINALS_SKIPPED_MISSING_PAGEID: 6,
             Result.SDC_ORDINALS_SKIPPED_ERROR: 7,
         },
     )
@@ -487,6 +488,7 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
     assert any("SKIPPED (mapping)" in s and "1" in s for s in stats)
     assert any("SKIPPED (error)" in s and "3" in s for s in stats)
     assert any("ORDINAL MISSING:" in s and "5" in s for s in stats)
+    assert any("ORDINAL NO PAGEID:" in s and "6" in s for s in stats)
     assert any("ORDINAL ERRORS:" in s and "7" in s for s in stats)
     assert any("Runtime:" in s and "42s" in s for s in stats)
 

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -479,6 +479,7 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
         },
         tracker_counts={
             Result.SDC_ITEMS_SYNCED: 100,
+            Result.SDC_ITEMS_PARTIALLY_SYNCED: 9,
             Result.SDC_CLAIMS_ADDED: 250,
             Result.SDC_REFS_ADDED: 30,
             Result.SDC_REMOVALS: 4,
@@ -492,6 +493,7 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
     )
     stats = captured["stats_lines"]
     assert any(s.startswith("ITEMS SYNCED:") and "100" in s for s in stats)
+    assert any(s.startswith("ITEMS PARTIAL:") and "9" in s for s in stats)
     assert any(s.startswith("CLAIMS ADDED:") and "250" in s for s in stats)
     assert any(s.startswith("REFS ADDED:") and "30" in s for s in stats)
     assert any(s.startswith("REMOVALS:") and "4" in s for s in stats)

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1121,12 +1121,25 @@ def test_track_ordinal_skip_bumps_both_legacy_and_granular_counters():
 # ---------------------------------------------------------------------------
 
 
+def _uploader_for_helper_tests():
+    """Build an ``Uploader`` instance bypassing ``__init__`` for direct
+    invocation of internal helpers — sufficient when the helper only
+    touches ``self.site`` and doesn't need a real tracker / S3 / DPLA
+    wiring."""
+    from tools.uploader import Uploader
+
+    uploader = Uploader.__new__(Uploader)
+    uploader.site = MagicMock(name="site")
+    return uploader
+
+
 def test_pageid_refresh_retries_until_indexed(monkeypatch):
     """Live-bug regression: the post-upload pageid refresh races
-    Commons indexing on large (chunked) uploads. First attempt
-    returns 0; subsequent attempts (after backoff) return the real
-    pageid. The retry loop must keep trying up to
-    ``PAGEID_REFRESH_MAX_ATTEMPTS`` before giving up."""
+    Commons indexing on large (chunked) uploads. First attempts
+    return 0; a subsequent attempt (after backoff) returns the real
+    pageid. Calls the actual ``_refresh_pageid_with_retries`` helper
+    on the ``Uploader`` class — per CR #302 review, an inline copy of
+    the retry loop would silently pass while production diverges."""
     from tools import uploader as uploader_mod
 
     # Three FilePage instances returned in sequence by get_page —
@@ -1146,29 +1159,15 @@ def test_pageid_refresh_retries_until_indexed(monkeypatch):
     monkeypatch.setattr(uploader_mod, "PAGEID_REFRESH_MAX_ATTEMPTS", 3)
     monkeypatch.setattr(uploader_mod, "PAGEID_REFRESH_BACKOFF_SECS", 0)
 
-    # Inline a minimised version of the retry loop the uploader runs,
-    # since the surrounding upload flow is too heavy to exercise here.
-    # The contract under test is the retry pattern itself.
-    resolved_pageid = None
-    for attempt in range(1, uploader_mod.PAGEID_REFRESH_MAX_ATTEMPTS + 1):
-        fresh_page = uploader_mod.get_page(None, "File:X.tiff")
-        fresh_page.exists()
-        candidate = fresh_page.pageid
-        if candidate:
-            resolved_pageid = candidate
-            break
-
-    assert resolved_pageid == 193644002, (
-        "retry loop must keep trying until indexing lag closes; "
-        f"got {resolved_pageid!r}"
-    )
+    uploader = _uploader_for_helper_tests()
+    assert uploader._refresh_pageid_with_retries("File:X.tiff") == 193644002
 
 
 def test_pageid_refresh_gives_up_after_max_attempts(monkeypatch):
     """Indexing lag that exceeds the retry budget (or a genuinely
-    deleted page) leaves ``resolved_pageid = None``. The upload itself
-    still succeeded; the sidecar carries ``pageid: null`` and
-    sdc-sync's title→pageid fallback recovers on the next run."""
+    deleted page) returns ``None``. The upload itself still
+    succeeded; the sidecar carries ``pageid: null`` and sdc-sync's
+    title→pageid fallback recovers on the next run."""
     from tools import uploader as uploader_mod
 
     perpetually_lagging = MagicMock(pageid=0)
@@ -1181,13 +1180,52 @@ def test_pageid_refresh_gives_up_after_max_attempts(monkeypatch):
     monkeypatch.setattr(uploader_mod, "PAGEID_REFRESH_MAX_ATTEMPTS", 3)
     monkeypatch.setattr(uploader_mod, "PAGEID_REFRESH_BACKOFF_SECS", 0)
 
-    resolved_pageid = None
-    for attempt in range(1, uploader_mod.PAGEID_REFRESH_MAX_ATTEMPTS + 1):
-        fresh_page = uploader_mod.get_page(None, "File:X.tiff")
-        fresh_page.exists()
-        candidate = fresh_page.pageid
-        if candidate:
-            resolved_pageid = candidate
-            break
+    uploader = _uploader_for_helper_tests()
+    assert uploader._refresh_pageid_with_retries("File:X.tiff") is None
 
-    assert resolved_pageid is None
+
+def test_pageid_refresh_returns_none_on_persistent_api_error(monkeypatch):
+    """API failure on every attempt (network down, persistent rate
+    limit) returns ``None`` rather than raising — the upload itself
+    succeeded so the call must not bubble the refresh failure up
+    through ``process_file``."""
+    from tools import uploader as uploader_mod
+
+    def raise_always(site, title):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(uploader_mod, "get_page", raise_always)
+    monkeypatch.setattr(uploader_mod.time, "sleep", lambda s: None)
+    monkeypatch.setattr(uploader_mod, "PAGEID_REFRESH_MAX_ATTEMPTS", 3)
+    monkeypatch.setattr(uploader_mod, "PAGEID_REFRESH_BACKOFF_SECS", 0)
+
+    uploader = _uploader_for_helper_tests()
+    assert uploader._refresh_pageid_with_retries("File:X.tiff") is None
+
+
+def test_pageid_refresh_returns_immediately_on_first_success(monkeypatch):
+    """Small-file fast path: typical pageid lookup succeeds on
+    attempt 1 with zero added latency. Pin no-sleep + single
+    ``get_page`` call so a future regression that always sleeps
+    (or always retries) is caught."""
+    from tools import uploader as uploader_mod
+
+    fresh_page = MagicMock(pageid=42)
+    fresh_page.exists.return_value = True
+
+    get_page_calls = []
+
+    def stub_get_page(site, title):
+        get_page_calls.append(title)
+        return fresh_page
+
+    sleep_calls = []
+    monkeypatch.setattr(uploader_mod, "get_page", stub_get_page)
+    monkeypatch.setattr(uploader_mod.time, "sleep", lambda s: sleep_calls.append(s))
+    monkeypatch.setattr(uploader_mod, "PAGEID_REFRESH_MAX_ATTEMPTS", 3)
+    monkeypatch.setattr(uploader_mod, "PAGEID_REFRESH_BACKOFF_SECS", 4)
+
+    uploader = _uploader_for_helper_tests()
+    assert uploader._refresh_pageid_with_retries("File:X.tiff") == 42
+    assert len(get_page_calls) == 1
+    assert sleep_calls == [], "no sleep on first-attempt-success path"

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1084,3 +1084,110 @@ def test_case1_move_suppresses_commonsdelinker_when_actual_is_sibling():
     assert action == "moved"
     kwargs = mock_move.call_args.kwargs
     assert kwargs.get("post_commonsdelinker") is False
+
+
+# ---------------------------------------------------------------------------
+# Granular skip-class counters: NOT_PRESENT vs INELIGIBLE both bump the
+# legacy ``SKIPPED`` aggregate AND a granular counter.
+# ---------------------------------------------------------------------------
+
+
+def test_track_ordinal_skip_bumps_both_legacy_and_granular_counters():
+    """``_track_ordinal_skip(kind)`` increments ``Result.SKIPPED``
+    (so legacy dashboards keep working) AND the granular ``kind``
+    counter (so the Slack summary's breakdown is non-zero). Pinned
+    so future refactors of the helper don't silently regress one of
+    the two increments."""
+    from tools.uploader import Uploader
+
+    tracker = Tracker()
+    uploader = Uploader.__new__(Uploader)  # bypass full __init__
+    uploader.tracker = tracker
+
+    uploader._track_ordinal_skip(Result.UPLOAD_SKIPPED_NOT_PRESENT)
+    assert tracker.count(Result.SKIPPED) == 1
+    assert tracker.count(Result.UPLOAD_SKIPPED_NOT_PRESENT) == 1
+    assert tracker.count(Result.UPLOAD_SKIPPED_INELIGIBLE) == 0
+
+    uploader._track_ordinal_skip(Result.UPLOAD_SKIPPED_INELIGIBLE)
+    assert tracker.count(Result.SKIPPED) == 2
+    assert tracker.count(Result.UPLOAD_SKIPPED_NOT_PRESENT) == 1
+    assert tracker.count(Result.UPLOAD_SKIPPED_INELIGIBLE) == 1
+
+
+# ---------------------------------------------------------------------------
+# Post-upload pageid refresh retry: live bug repro on a 327 MB TIFF where
+# Commons indexing lag returned pageid=0 on the first attempt.
+# ---------------------------------------------------------------------------
+
+
+def test_pageid_refresh_retries_until_indexed(monkeypatch):
+    """Live-bug regression: the post-upload pageid refresh races
+    Commons indexing on large (chunked) uploads. First attempt
+    returns 0; subsequent attempts (after backoff) return the real
+    pageid. The retry loop must keep trying up to
+    ``PAGEID_REFRESH_MAX_ATTEMPTS`` before giving up."""
+    from tools import uploader as uploader_mod
+
+    # Three FilePage instances returned in sequence by get_page —
+    # first two have .pageid=0 (indexing lag), third has the real id.
+    fresh_pages = [
+        MagicMock(pageid=0),
+        MagicMock(pageid=0),
+        MagicMock(pageid=193644002),
+    ]
+    for p in fresh_pages:
+        p.exists.return_value = True
+
+    monkeypatch.setattr(
+        uploader_mod, "get_page", lambda site, title: fresh_pages.pop(0)
+    )
+    monkeypatch.setattr(uploader_mod.time, "sleep", lambda s: None)
+    monkeypatch.setattr(uploader_mod, "PAGEID_REFRESH_MAX_ATTEMPTS", 3)
+    monkeypatch.setattr(uploader_mod, "PAGEID_REFRESH_BACKOFF_SECS", 0)
+
+    # Inline a minimised version of the retry loop the uploader runs,
+    # since the surrounding upload flow is too heavy to exercise here.
+    # The contract under test is the retry pattern itself.
+    resolved_pageid = None
+    for attempt in range(1, uploader_mod.PAGEID_REFRESH_MAX_ATTEMPTS + 1):
+        fresh_page = uploader_mod.get_page(None, "File:X.tiff")
+        fresh_page.exists()
+        candidate = fresh_page.pageid
+        if candidate:
+            resolved_pageid = candidate
+            break
+
+    assert resolved_pageid == 193644002, (
+        "retry loop must keep trying until indexing lag closes; "
+        f"got {resolved_pageid!r}"
+    )
+
+
+def test_pageid_refresh_gives_up_after_max_attempts(monkeypatch):
+    """Indexing lag that exceeds the retry budget (or a genuinely
+    deleted page) leaves ``resolved_pageid = None``. The upload itself
+    still succeeded; the sidecar carries ``pageid: null`` and
+    sdc-sync's title→pageid fallback recovers on the next run."""
+    from tools import uploader as uploader_mod
+
+    perpetually_lagging = MagicMock(pageid=0)
+    perpetually_lagging.exists.return_value = True
+
+    monkeypatch.setattr(
+        uploader_mod, "get_page", lambda site, title: perpetually_lagging
+    )
+    monkeypatch.setattr(uploader_mod.time, "sleep", lambda s: None)
+    monkeypatch.setattr(uploader_mod, "PAGEID_REFRESH_MAX_ATTEMPTS", 3)
+    monkeypatch.setattr(uploader_mod, "PAGEID_REFRESH_BACKOFF_SECS", 0)
+
+    resolved_pageid = None
+    for attempt in range(1, uploader_mod.PAGEID_REFRESH_MAX_ATTEMPTS + 1):
+        fresh_page = uploader_mod.get_page(None, "File:X.tiff")
+        fresh_page.exists()
+        candidate = fresh_page.pageid
+        if candidate:
+            resolved_pageid = candidate
+            break
+
+    assert resolved_pageid is None

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -3850,7 +3850,19 @@ def _run_partner_mode(partner, ids_file):
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
                 continue
 
-            synced_this_item = False
+            # Per-ordinal sync tracking. ``synced_ord_strs`` records
+            # which ordinals' ``process_one_from_sdc`` returned without
+            # raising — i.e. the ordinals the cleanup pass *should*
+            # touch. Filtering on this set when calling
+            # ``_post_sdc_cleanup_for_item`` keeps cleanup from
+            # running against ordinals that were skipped earlier in
+            # this same item (null pageid, missing-entity skip, etc.) —
+            # the defensive entity-guard inside ``_post_sdc_cleanup_for_page``
+            # would refuse the strip anyway, but routing past it
+            # avoids the wasted entity fetch and keeps the contract
+            # explicit. ``synced_this_item`` derives from the set
+            # below; classification is unchanged.
+            synced_ord_strs: set[str] = set()
             # Tracks whether any ordinal hit the per-ordinal exception
             # path (runtime failure) so an item with all-failed ordinals
             # is classified under SDC_ITEMS_SKIPPED_ERROR rather than
@@ -4027,11 +4039,15 @@ def _run_partner_mode(partner, ids_file):
                         logging.warning(
                             f" -- Failed to touch '{title}' for category refresh: {e!r}"
                         )
-                synced_this_item = True
+                synced_ord_strs.add(ord_str)
             # Item-level bucket classification + cleanup dispatch.
             # ``_classify_item_outcome`` returns the bucket; cleanup
-            # runs for any progress-made outcome (full or partial).
-            outcome = _classify_item_outcome(synced_this_item, had_ordinal_error)
+            # runs for any progress-made outcome (full or partial),
+            # against ONLY the ordinals that synced — partial-sync
+            # items must not retry cleanup on the ordinals that
+            # were skipped earlier in this loop (null pageid,
+            # missing entity, etc.).
+            outcome = _classify_item_outcome(bool(synced_ord_strs), had_ordinal_error)
             tracker.increment(outcome)
             if (
                 outcome
@@ -4041,7 +4057,10 @@ def _run_partner_mode(partner, ids_file):
                 )
                 and _normalize_wikitext_enabled
             ):
-                _post_sdc_cleanup_for_item(s3, partner, dpla_id, ordinal_items)
+                synced_items = [
+                    (o, d) for o, d in ordinal_items if o in synced_ord_strs
+                ]
+                _post_sdc_cleanup_for_item(s3, partner, dpla_id, synced_items)
         completed = True
     except BaseException as exc:
         # The per-ordinal try/except above already swallows every routine

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -240,6 +240,30 @@ def _entity_has_dpla_attributed_claims(entity: dict) -> bool:
     return False
 
 
+def _classify_item_outcome(synced_this_item: bool, had_ordinal_error: bool) -> Result:
+    """Map (synced_this_item, had_ordinal_error) to the item-level
+    tracker bucket the partner-mode loop should increment.
+
+    Three "made-progress" outcomes — full sync, partial sync, all-
+    ordinals-errored — plus one no-progress outcome (mapping skip).
+    The partial-sync case is broken out from full-sync so dashboards
+    keying on ``SDC_ITEMS_SYNCED`` as "items fully done" don't
+    silently treat mixed-result items (one ordinal synced, sibling
+    null-pageid / runtime-error ordinal skipped) as healthy. Both
+    full and partial outcomes still get the post-SDC cleanup pass
+    on whatever ordinals did sync; the partial state is real
+    progress, not a failure to retry wholesale. (Per CR review on
+    PR #302.)
+    """
+    if synced_this_item and had_ordinal_error:
+        return Result.SDC_ITEMS_PARTIALLY_SYNCED
+    if synced_this_item:
+        return Result.SDC_ITEMS_SYNCED
+    if had_ordinal_error:
+        return Result.SDC_ITEMS_SKIPPED_ERROR
+    return Result.SDC_ITEMS_SKIPPED_MAPPING
+
+
 def _resolve_pageid_from_title(title: str) -> int | None:
     """Look up the Commons page id for ``title`` via the live wiki API.
 
@@ -4004,26 +4028,20 @@ def _run_partner_mode(partner, ids_file):
                             f" -- Failed to touch '{title}' for category refresh: {e!r}"
                         )
                 synced_this_item = True
-            # Only count an item as synced if at least one ordinal actually
-            # made it past the pageid guard. An item whose every eligible
-            # ordinal lacked a pageid would otherwise inflate the synced
-            # counter and underreport mapping skips.
-            if synced_this_item:
-                tracker.increment(Result.SDC_ITEMS_SYNCED)
-                # Post-SDC wikitext cleanup. Best-effort — any failure
-                # inside is logged and swallowed by the helper, so a bad
-                # parse on one item can't abort the partner batch.
-                if _normalize_wikitext_enabled:
-                    _post_sdc_cleanup_for_item(s3, partner, dpla_id, ordinal_items)
-            elif had_ordinal_error:
-                # Every eligible ordinal raised at runtime — classify
-                # under the error bucket, not MAPPING. (Mixed-result
-                # items where some ordinals succeed go to SYNCED; the
-                # per-ordinal failures are still visible under
-                # SDC_ORDINALS_SKIPPED_ERROR.)
-                tracker.increment(Result.SDC_ITEMS_SKIPPED_ERROR)
-            else:
-                tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
+            # Item-level bucket classification + cleanup dispatch.
+            # ``_classify_item_outcome`` returns the bucket; cleanup
+            # runs for any progress-made outcome (full or partial).
+            outcome = _classify_item_outcome(synced_this_item, had_ordinal_error)
+            tracker.increment(outcome)
+            if (
+                outcome
+                in (
+                    Result.SDC_ITEMS_SYNCED,
+                    Result.SDC_ITEMS_PARTIALLY_SYNCED,
+                )
+                and _normalize_wikitext_enabled
+            ):
+                _post_sdc_cleanup_for_item(s3, partner, dpla_id, ordinal_items)
         completed = True
     except BaseException as exc:
         # The per-ordinal try/except above already swallows every routine

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -188,6 +188,104 @@ class _MissingEntityError(Exception):
     """
 
 
+def _fetch_entity_for_cleanup_guard(mediaid: str) -> dict:
+    """Read ``mediaid``'s MediaInfo entity, bypassing the per-file cache.
+
+    The post-SDC cleanup's defensive guard wants the post-write entity
+    state, not a snapshot from earlier in the same process_one run.
+    ``get_entity`` caches by M-id within a file's processing window;
+    this helper goes straight to wbgetentities. Returns an empty dict
+    on no-such-entity (caller treats that as "no DPLA SDC", which is
+    correct — a missing entity has zero of anything).
+    """
+    try:
+        raw = site.simple_request(action="wbgetentities", ids=mediaid).submit()
+    except Exception:
+        raise
+    entities = raw.get("entities", {})
+    if not isinstance(entities, dict):
+        return {}
+    ent = entities.get(mediaid, {})
+    if not isinstance(ent, dict):
+        return {}
+    return ent
+
+
+def _entity_has_dpla_attributed_claims(entity: dict) -> bool:
+    """True iff ``entity`` carries at least one statement with the
+    DPLA-attribution qualifier (``P459 = Q61848113``, "heuristic" →
+    "DPLA"). Mirrors :func:`Module:DPLA`'s ``isDplaDetermined`` filter
+    on Commons so the guard's notion of "has DPLA SDC" matches the
+    template renderer's notion exactly.
+    """
+    if not entity:
+        return False
+    statements = entity.get("statements") or entity.get("claims") or {}
+    if not isinstance(statements, dict):
+        return False
+    for stmt_list in statements.values():
+        if not isinstance(stmt_list, list):
+            continue
+        for stmt in stmt_list:
+            if not isinstance(stmt, dict):
+                continue
+            quals = stmt.get("qualifiers") or {}
+            for q in quals.get("P459", []):
+                dv = q.get("datavalue") if isinstance(q, dict) else None
+                if not isinstance(dv, dict):
+                    continue
+                val = dv.get("value")
+                if isinstance(val, dict) and val.get("id") == "Q61848113":
+                    return True
+    return False
+
+
+def _resolve_pageid_from_title(title: str) -> int | None:
+    """Look up the Commons page id for ``title`` via the live wiki API.
+
+    The fallback for upload-result.json sidecars where the uploader
+    recorded ``pageid: null`` or ``pageid: 0`` for a successfully
+    uploaded file (an upstream pywikibot FilePage-cache-invalidation
+    quirk). The file exists on Commons under ``title`` — Commons can
+    tell us the M-id; the uploader just failed to capture it.
+
+    Returns the pageid integer when the page exists and the API
+    answered with one. Returns ``None`` on any failure mode — page
+    actually doesn't exist (deleted, never uploaded), API error,
+    network blip — so the caller's existing skip path runs and the
+    skip is counted under :class:`Result.SDC_ORDINALS_SKIPPED_MISSING_PAGEID`.
+
+    Idempotent and safe to call from a hot loop — single ``query``
+    action against the live Commons API, no writes.
+    """
+    if not title:
+        return None
+    try:
+        result = site.simple_request(
+            action="query",
+            titles=title,
+            prop="info",
+        ).submit()
+    except Exception:
+        # Logged at the call site; let the caller drop into its
+        # existing skip path on any API failure.
+        return None
+    pages = result.get("query", {}).get("pages", {})
+    if not isinstance(pages, dict):
+        return None
+    for _api_key, page_info in pages.items():
+        if not isinstance(page_info, dict):
+            continue
+        if "missing" in page_info:
+            # Page genuinely doesn't exist on Commons — the upload
+            # presumably failed silently after recording UPLOADED.
+            return None
+        pid = page_info.get("pageid")
+        if isinstance(pid, int) and pid > 0:
+            return pid
+    return None
+
+
 def _truncate(text: str | None, limit: int = 500) -> str:
     """Return ``text`` shortened to ``limit`` chars with an ellipsis suffix.
 
@@ -3232,6 +3330,41 @@ def _post_sdc_cleanup_for_page(
                 " skipping strip."
             )
             return
+
+    # Defensive guard against the upstream null-pageid bug shape and
+    # any future regression: ``normalize_page`` strips wikitext params
+    # whose values match ``expected_params``, on the premise that the
+    # SDC just written carries the same value so the renderer will
+    # supply it. If the file's MediaInfo entity actually has no
+    # DPLA-attributed SDC (because the upload-result.json sidecar had
+    # a null/zero pageid, or the SDC write was silently dropped for
+    # some other reason, or the cleanup is racing a partial sync),
+    # the strip would leave the page with no metadata in EITHER
+    # representation. Refuse to strip in that state. The per-ordinal
+    # SDC writer is the only thing that should ever produce a
+    # DPLA-attributed claim; its absence is a reliable signal that
+    # this ordinal's SDC sync didn't actually fire.
+    mediaid = f"M{file_page.pageid}" if file_page.pageid else None
+    if mediaid:
+        try:
+            entity = _fetch_entity_for_cleanup_guard(mediaid)
+        except Exception:
+            # API failure during the guard is a hard skip — better
+            # than stripping against unknown SDC state.
+            logging.exception(
+                f" -- cleanup: entity fetch failed for {file_page.title()}"
+                f" ({mediaid}); skipping strip out of caution."
+            )
+            return
+        if not _entity_has_dpla_attributed_claims(entity):
+            logging.warning(
+                f" -- cleanup: '{file_page.title()}' ({mediaid}) for"
+                f" {dpla_id} has no DPLA-attributed SDC; skipping strip"
+                " to avoid wiping wikitext params without an SDC"
+                " counterpart (upstream sync likely never fired)."
+            )
+            return
+
     try:
         wikitext_normalize.normalize_page(
             file_page, expected_params, _NORMALIZE_EDIT_SUMMARY
@@ -3734,25 +3867,49 @@ def _run_partner_mode(partner, ids_file):
 
             for ord_str, data in ordinal_items:
                 pageid = data.get("pageid")
+                title = data.get("title", "?")
                 # `if not pageid` rather than `is None` — a recorded
                 # pageid of 0 is just as malformed as a missing one
                 # (no Commons MediaInfo entity has ID `M0`) and would
                 # otherwise propagate downstream as a confusing
                 # pywikibot APIError on the bogus mediaid. The
-                # uploader has historically written `pageid: 0` for
-                # successful new uploads when pywikibot's FilePage
-                # cache wasn't invalidated post-upload; treat that
-                # sidecar shape as a mapping skip until the upstream
-                # bug is fixed and the existing sidecars are
-                # backfilled.
+                # uploader has historically written ``pageid: 0`` (and
+                # since 2026-06 ``pageid: null``) for successful new
+                # uploads when pywikibot's FilePage cache wasn't
+                # invalidated post-upload.
+                #
+                # When ``title`` is present (which it almost always is —
+                # the uploader writes both fields), fall back to a
+                # Commons API lookup keyed on the title to recover the
+                # real pageid. Lets a re-run of ``sdc-sync`` self-heal
+                # past the upstream sidecar defect instead of silently
+                # repeating the same skip. ``_resolve_pageid_from_title``
+                # returns ``None`` on any failure (page deleted, API
+                # error) — in that case the original skip path runs.
+                if not pageid and title and title != "?":
+                    resolved = _resolve_pageid_from_title(title)
+                    if resolved:
+                        logging.info(
+                            f" -- Ordinal {ord_str}: upload-result pageid"
+                            f" was {data.get('pageid')!r}; resolved to"
+                            f" {resolved} via Commons title lookup."
+                        )
+                        pageid = resolved
                 if not pageid:
                     logging.warning(
                         f" -- Ordinal {ord_str}: missing/zero pageid"
-                        f" ({pageid!r}); skipping."
+                        f" ({data.get('pageid')!r}) for '{title}' and"
+                        " title→pageid fallback failed; skipping."
                     )
+                    tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_PAGEID)
+                    # Treat as an ordinal error for item-level bucket
+                    # classification — an item where every ordinal had
+                    # null pageid should not silently fall into the
+                    # MAPPING bucket; it's a real failure that needs
+                    # the upstream uploader fix.
+                    had_ordinal_error = True
                     continue
                 mediaid = f"M{pageid}"
-                title = data.get("title", "?")
                 logging.info(f" -- Ordinal {ord_str}: {mediaid} ({title})")
 
                 # Snapshot write counters so we can detect whether this

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -70,6 +70,14 @@ from ingest_wikimedia.wikimedia import (
 
 MAX_UPLOAD_RETRIES = 3
 UPLOAD_RETRY_BASE_DELAY_SECS = 5
+# Post-upload pageid-refresh retry budget. Commons accepts large
+# (chunked) uploads before its search/categorylinks index has caught
+# up; the immediate ``FilePage.exists()`` query then races indexing
+# and the resulting ``.pageid`` is missing or 0. A small bounded
+# retry closes the window for ~all realistic indexing-lag durations
+# without adding latency on the typical small-file fast path.
+PAGEID_REFRESH_MAX_ATTEMPTS = 3
+PAGEID_REFRESH_BACKOFF_SECS = 4
 UPLOAD_RETRY_MAX_DELAY_SECS = 60
 # pywikibot's async upload polls Commons indefinitely when the job queue is stuck.
 # This cap ensures a single hung upload never freezes the whole session.
@@ -190,6 +198,18 @@ class Uploader:
         self.dpla = dpla
         self.category_ensurer = category_ensurer
 
+    def _track_ordinal_skip(self, skip_kind: Result) -> None:
+        """Bump both the aggregate ``Result.SKIPPED`` (which legacy
+        Slack summaries and dashboards key on) and the granular
+        ``skip_kind`` counter so operators can distinguish "upstream
+        gap, no S3 asset" (``UPLOAD_SKIPPED_NOT_PRESENT``) from
+        "S3 asset present but uploader chose not to upload"
+        (``UPLOAD_SKIPPED_INELIGIBLE``). Previously the four ordinal
+        skip sites all incremented ``Result.SKIPPED`` flat, leaving
+        the breakdown unrecoverable from metrics."""
+        self.tracker.increment(Result.SKIPPED)
+        self.tracker.increment(skip_kind)
+
     def process_file(
         self,
         dpla_id: str,
@@ -225,7 +245,7 @@ class Uploader:
             upload_comment = f'Uploading DPLA ID "[[dpla:{dpla_id}|{dpla_id}]]".'
             if not self.s3_client.s3_file_exists(s3_path):
                 logging.info(f"{dpla_id} {ordinal} not present.")
-                self.tracker.increment(Result.SKIPPED)
+                self._track_ordinal_skip(Result.UPLOAD_SKIPPED_NOT_PRESENT)
                 return {"status": ORDINAL_NOT_PRESENT}
 
             s3_object = self.s3_client.get_s3().Object(S3_BUCKET, s3_path)
@@ -233,7 +253,7 @@ class Uploader:
 
             if file_size == 0:
                 logging.info(f"Skipping {dpla_id} {ordinal}: File size is 0.")
-                self.tracker.increment(Result.SKIPPED)
+                self._track_ordinal_skip(Result.UPLOAD_SKIPPED_NOT_PRESENT)
                 return {"status": ORDINAL_NOT_PRESENT}
 
             sha1 = s3_object.metadata.get(CHECKSUM, "")
@@ -267,19 +287,19 @@ class Uploader:
                     )
                     if not dry_run:
                         self.s3_client.get_s3().Object(S3_BUCKET, s3_path).delete()
-                    self.tracker.increment(Result.SKIPPED)
+                    self._track_ordinal_skip(Result.UPLOAD_SKIPPED_INELIGIBLE)
                     return {"status": ORDINAL_INELIGIBLE}
 
             if not check_content_type(mime):
                 logging.info(f"Skipping {dpla_id} {ordinal}: Bad content type: {mime}")
-                self.tracker.increment(Result.SKIPPED)
+                self._track_ordinal_skip(Result.UPLOAD_SKIPPED_INELIGIBLE)
                 return {"status": ORDINAL_INELIGIBLE}
 
             if is_download_only(mime):
                 logging.info(
                     f"Skipping {dpla_id} {ordinal}: {mime} staged for conversion, not uploaded."
                 )
-                self.tracker.increment(Result.SKIPPED)
+                self._track_ordinal_skip(Result.UPLOAD_SKIPPED_INELIGIBLE)
                 return {"status": ORDINAL_INELIGIBLE}
 
             ext = mimetypes.guess_extension(mime)
@@ -288,7 +308,7 @@ class Uploader:
                 logging.info(
                     f"Skipping {dpla_id} {ordinal}: Unable to guess extension for {mime}"
                 )
-                self.tracker.increment(Result.SKIPPED)
+                self._track_ordinal_skip(Result.UPLOAD_SKIPPED_INELIGIBLE)
                 return {"status": ORDINAL_INELIGIBLE}
 
             page_title = get_page_title(
@@ -516,7 +536,21 @@ class Uploader:
                         f"file_exists={file_exists}, "
                         f"force_ignore_warnings={force_ignore_warnings})."
                     )
-                upload_warnings = True if prefers_direct else IGNORE_WIKIMEDIA_WARNINGS
+                # ``ignore_warnings`` on ``site.upload()`` is union-typed: a
+                # bool (``True`` = suppress every warning class) or a list
+                # of warning codes (suppress only the listed classes).
+                # Direct (non-chunked) uploads of files small enough to
+                # fit under the warnings threshold are trusted — we
+                # accept whatever Commons returns. Chunked uploads go
+                # through the larger-file flow where some warning
+                # classes are real (size limits, hash drift) — only
+                # the vetted ``IGNORE_WIKIMEDIA_WARNINGS`` set is
+                # suppressed. Mixed-type literal is intentional; the
+                # explicit type annotation documents the union for
+                # readers and silences the static-analysis flag.
+                upload_warnings: bool | list[str] = (
+                    True if prefers_direct else IGNORE_WIKIMEDIA_WARNINGS
+                )
 
                 result = None
                 # Avoid the `with executor:` context manager — its __exit__ calls
@@ -622,31 +656,76 @@ class Uploader:
                 # drift detection). sdc-sync's `if not pageid` guard
                 # (added in #252) cleanly skips None as a mapping
                 # malformed record without raising.
+                # Indexing-lag race: Commons accepts the upload (especially
+                # for chunked uploads of files >100 MB) before its
+                # search/categorylinks index has caught up. The fresh
+                # ``FilePage.exists()`` query lands in that window and
+                # returns without a real ``.pageid`` (or returns 0).
+                # Live incident:
+                # https://commons.wikimedia.org/wiki/File:Southern_Railway_Company,_Valuation_Section_22_-_DPLA_-_e314839e2ca3906b29bcbecc3d615740_(page_1).tiff
+                # — a 327 MB TIFF whose first-ordinal pageid lookup
+                # raced indexing and produced ``pageid: null`` in the
+                # sidecar, cascading into a silent sdc-sync skip and
+                # eventually a wiped-wikitext page.
+                #
+                # Retry the refresh with bounded backoff so the lookup
+                # gets a few more shots before Commons has propagated.
+                # Typical case (small/medium files): first attempt
+                # succeeds, zero added latency. Large-file race case:
+                # 1-2 retries usually close the window. Hard failure
+                # (page genuinely deleted, API error, network down):
+                # falls through to the existing pageid=None branch and
+                # sdc-sync's title→pageid fallback picks up the slack
+                # on the next run.
                 resolved_pageid = None
-                try:
-                    fresh_page = get_page(self.site, page_title)
-                    fresh_page.exists()
-                    resolved_pageid = fresh_page.pageid
-                except Exception as refresh_ex:
-                    logging.warning(
-                        f"Uploaded {page_title} but post-upload pageid"
-                        f" refresh raised: {refresh_ex!r}. Recording"
-                        " pageid=None; sdc-sync will skip this ordinal"
-                        " as malformed."
-                    )
-                if not resolved_pageid:
-                    if resolved_pageid is not None:
-                        # Refresh returned but produced a falsy value
-                        # (typically 0). Normalize to None so the
-                        # sidecar shape is uniformly "missing" rather
-                        # than the legacy bug shape.
+                for attempt in range(1, PAGEID_REFRESH_MAX_ATTEMPTS + 1):
+                    try:
+                        fresh_page = get_page(self.site, page_title)
+                        fresh_page.exists()
+                        candidate = fresh_page.pageid
+                    except Exception as refresh_ex:
+                        if attempt < PAGEID_REFRESH_MAX_ATTEMPTS:
+                            logging.warning(
+                                f"Uploaded {page_title} but post-upload"
+                                f" pageid refresh (attempt {attempt}/"
+                                f"{PAGEID_REFRESH_MAX_ATTEMPTS}) raised:"
+                                f" {refresh_ex!r}. Retrying after"
+                                f" {PAGEID_REFRESH_BACKOFF_SECS}s."
+                            )
+                            time.sleep(PAGEID_REFRESH_BACKOFF_SECS)
+                            continue
+                        logging.warning(
+                            f"Uploaded {page_title} but post-upload"
+                            f" pageid refresh raised on final attempt"
+                            f" ({attempt}/{PAGEID_REFRESH_MAX_ATTEMPTS}):"
+                            f" {refresh_ex!r}. Recording pageid=None;"
+                            " sdc-sync's title→pageid fallback will"
+                            " recover on next run."
+                        )
+                        break
+                    if candidate:
+                        resolved_pageid = candidate
+                        break
+                    # Refresh returned but the pageid is still falsy
+                    # (typically 0, the indexing-lag shape). Retry
+                    # before giving up.
+                    if attempt < PAGEID_REFRESH_MAX_ATTEMPTS:
+                        logging.info(
+                            f"Uploaded {page_title}: post-upload pageid"
+                            f" refresh attempt {attempt}/"
+                            f"{PAGEID_REFRESH_MAX_ATTEMPTS} returned"
+                            f" {candidate!r}; retrying after"
+                            f" {PAGEID_REFRESH_BACKOFF_SECS}s (indexing lag)."
+                        )
+                        time.sleep(PAGEID_REFRESH_BACKOFF_SECS)
+                    else:
                         logging.warning(
                             f"Uploaded {page_title} but resolved pageid"
-                            f" is {resolved_pageid!r}; recording"
-                            " pageid=None, sdc-sync will skip this"
-                            " ordinal as malformed."
+                            f" is still {candidate!r} after"
+                            f" {PAGEID_REFRESH_MAX_ATTEMPTS} attempts;"
+                            " recording pageid=None, sdc-sync's"
+                            " title→pageid fallback will recover."
                         )
-                    resolved_pageid = None
                 return {
                     "status": ORDINAL_UPLOADED,
                     "title": page_title,

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -198,6 +198,74 @@ class Uploader:
         self.dpla = dpla
         self.category_ensurer = category_ensurer
 
+    def _refresh_pageid_with_retries(self, page_title: str) -> int | None:
+        """Resolve the Commons pageid for ``page_title`` post-upload,
+        retrying with bounded backoff to ride out the indexing-lag
+        race that Commons exhibits on large (chunked) uploads.
+
+        Returns the pageid on success, or ``None`` when the budget is
+        exhausted without a real id (page still indexing, page genuinely
+        doesn't exist, persistent API failure). Caller records
+        ``pageid: None`` in the sidecar; ``sdc-sync``'s title→pageid
+        fallback recovers from that state on the next run.
+
+        Extracted from the inline loop in ``process_file`` so it can
+        be exercised directly in tests (per CR feedback on PR #302):
+        previously the test inlined the loop, which would silently
+        pass while production diverged. Single source of truth here.
+
+        See https://commons.wikimedia.org/wiki/File:Southern_Railway_Company,_Valuation_Section_22_-_DPLA_-_e314839e2ca3906b29bcbecc3d615740_(page_1).tiff
+        for the live incident this retry exists to handle.
+        """
+        for attempt in range(1, PAGEID_REFRESH_MAX_ATTEMPTS + 1):
+            try:
+                fresh_page = get_page(self.site, page_title)
+                fresh_page.exists()
+                candidate = fresh_page.pageid
+            except Exception as refresh_ex:
+                if attempt < PAGEID_REFRESH_MAX_ATTEMPTS:
+                    logging.warning(
+                        f"Uploaded {page_title} but post-upload"
+                        f" pageid refresh (attempt {attempt}/"
+                        f"{PAGEID_REFRESH_MAX_ATTEMPTS}) raised:"
+                        f" {refresh_ex!r}. Retrying after"
+                        f" {PAGEID_REFRESH_BACKOFF_SECS}s."
+                    )
+                    time.sleep(PAGEID_REFRESH_BACKOFF_SECS)
+                    continue
+                logging.warning(
+                    f"Uploaded {page_title} but post-upload"
+                    f" pageid refresh raised on final attempt"
+                    f" ({attempt}/{PAGEID_REFRESH_MAX_ATTEMPTS}):"
+                    f" {refresh_ex!r}. Recording pageid=None;"
+                    " sdc-sync's title→pageid fallback will"
+                    " recover on next run."
+                )
+                return None
+            if candidate:
+                return candidate
+            # Refresh returned but the pageid is still falsy
+            # (typically 0, the indexing-lag shape). Retry before
+            # giving up.
+            if attempt < PAGEID_REFRESH_MAX_ATTEMPTS:
+                logging.info(
+                    f"Uploaded {page_title}: post-upload pageid"
+                    f" refresh attempt {attempt}/"
+                    f"{PAGEID_REFRESH_MAX_ATTEMPTS} returned"
+                    f" {candidate!r}; retrying after"
+                    f" {PAGEID_REFRESH_BACKOFF_SECS}s (indexing lag)."
+                )
+                time.sleep(PAGEID_REFRESH_BACKOFF_SECS)
+            else:
+                logging.warning(
+                    f"Uploaded {page_title} but resolved pageid"
+                    f" is still {candidate!r} after"
+                    f" {PAGEID_REFRESH_MAX_ATTEMPTS} attempts;"
+                    " recording pageid=None, sdc-sync's"
+                    " title→pageid fallback will recover."
+                )
+        return None
+
     def _track_ordinal_skip(self, skip_kind: Result) -> None:
         """Bump both the aggregate ``Result.SKIPPED`` (which legacy
         Slack summaries and dashboards key on) and the granular
@@ -677,55 +745,7 @@ class Uploader:
                 # falls through to the existing pageid=None branch and
                 # sdc-sync's title→pageid fallback picks up the slack
                 # on the next run.
-                resolved_pageid = None
-                for attempt in range(1, PAGEID_REFRESH_MAX_ATTEMPTS + 1):
-                    try:
-                        fresh_page = get_page(self.site, page_title)
-                        fresh_page.exists()
-                        candidate = fresh_page.pageid
-                    except Exception as refresh_ex:
-                        if attempt < PAGEID_REFRESH_MAX_ATTEMPTS:
-                            logging.warning(
-                                f"Uploaded {page_title} but post-upload"
-                                f" pageid refresh (attempt {attempt}/"
-                                f"{PAGEID_REFRESH_MAX_ATTEMPTS}) raised:"
-                                f" {refresh_ex!r}. Retrying after"
-                                f" {PAGEID_REFRESH_BACKOFF_SECS}s."
-                            )
-                            time.sleep(PAGEID_REFRESH_BACKOFF_SECS)
-                            continue
-                        logging.warning(
-                            f"Uploaded {page_title} but post-upload"
-                            f" pageid refresh raised on final attempt"
-                            f" ({attempt}/{PAGEID_REFRESH_MAX_ATTEMPTS}):"
-                            f" {refresh_ex!r}. Recording pageid=None;"
-                            " sdc-sync's title→pageid fallback will"
-                            " recover on next run."
-                        )
-                        break
-                    if candidate:
-                        resolved_pageid = candidate
-                        break
-                    # Refresh returned but the pageid is still falsy
-                    # (typically 0, the indexing-lag shape). Retry
-                    # before giving up.
-                    if attempt < PAGEID_REFRESH_MAX_ATTEMPTS:
-                        logging.info(
-                            f"Uploaded {page_title}: post-upload pageid"
-                            f" refresh attempt {attempt}/"
-                            f"{PAGEID_REFRESH_MAX_ATTEMPTS} returned"
-                            f" {candidate!r}; retrying after"
-                            f" {PAGEID_REFRESH_BACKOFF_SECS}s (indexing lag)."
-                        )
-                        time.sleep(PAGEID_REFRESH_BACKOFF_SECS)
-                    else:
-                        logging.warning(
-                            f"Uploaded {page_title} but resolved pageid"
-                            f" is still {candidate!r} after"
-                            f" {PAGEID_REFRESH_MAX_ATTEMPTS} attempts;"
-                            " recording pageid=None, sdc-sync's"
-                            " title→pageid fallback will recover."
-                        )
+                resolved_pageid = self._refresh_pageid_with_retries(page_title)
                 return {
                     "status": ORDINAL_UPLOADED,
                     "title": page_title,


### PR DESCRIPTION
## Summary

Three compounding bugs from one live incident at https://commons.wikimedia.org/wiki/File:Southern_Railway_Company,_Valuation_Section_22_-_DPLA_-_e314839e2ca3906b29bcbecc3d615740_(page_1).tiff — file uploaded fine, but the SDC sync silently skipped writing claims on it, the post-SDC cleanup stripped its wikitext params anyway, and a follow-up item-specific sync didn't self-heal or log a skip. AntiCompositeBot tagged the now-empty file `{{No license since}}` 24 minutes later.

**Root cause chain:**

1. **Upstream**: `upload-result.json`'s ordinal 1 carried `pageid: null` (uploader's known FilePage-cache-invalidation quirk, acknowledged at `tools/sdc_sync.py:3742-3746`).
2. **sdc-sync's pageid guard at 3748** was a bare `continue` — no counter, no `had_ordinal_error = True`. Skip was invisible to the Slack summary; item still classified as fully synced because ordinal 2 succeeded.
3. **`_post_sdc_cleanup_for_item` iterates every ordinal** in upload-result, including the one that got the silent continue. It builds `FilePage` from `title` (still valid) and calls `_post_sdc_cleanup_for_page` → `normalize_page`, which strips wikitext params whose values match the *DPLA-canonical* (`item_metadata`-derived) values — not against the entity's actual SDC contents. So strip ran on an entity with empty SDC.
4. **Re-run replayed the same continue.** No fallback to resolve pageid from title, so the silent skip happened again on the second pass.

## Fix

**Three layers of defense:**

1. **`_resolve_pageid_from_title(title)`** — when upload-result has `pageid: null/0`, query Commons by title to recover the real pageid. The file's title is already in hand. On success the sync proceeds normally; on failure (page genuinely deleted, API error) the skip path runs but now also:
2. **Increments `SDC_ORDINALS_SKIPPED_MISSING_PAGEID`** (new counter + new Slack line "ORDINAL NO PAGEID:") and **sets `had_ordinal_error = True`** so item bucket classification reflects partial failure.
3. **Defensive guard inside `_post_sdc_cleanup_for_page`** — before calling `normalize_page`, fetch the entity and refuse to strip if it carries zero DPLA-attributed claims (P459=Q61848113, matching `Module:DPLA`'s `isDplaDetermined` filter). Defense-in-depth: even if (1)+(2) regress in the future, the strip can't wipe wikitext on an entity it didn't actually populate.

## Test plan

- [x] `_resolve_pageid_from_title` — 4 cases (existing page, missing page, API error, empty title).
- [x] `_entity_has_dpla_attributed_claims` — 3 cases (P459=Q61848113 match, empty entity, unrelated heuristic Q-ID).
- [x] `_post_sdc_cleanup_for_page` — 2 cases (refuses to strip on empty entity, strips on entity with DPLA-attributed SDC).
- [x] Existing dispatch test updated with passing guard mock.
- [x] Slack-summary test asserts the new "ORDINAL NO PAGEID:" line.
- [x] Full suite: 626 passed.
- [x] `ruff check` + `ruff format` clean.

## Recovery for the live-affected file

User opted to leave manual restore to the fix: once this lands and the wiki EC2 picks up the new code, the next sdc-sync run resolves the real pageid via title lookup → writes the SDC → strip path then runs against a non-empty entity. AntiCompositeBot's NoLicense tag can be cleared by hand once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a live incident where upload-result.json ordinals with pageid=null caused sdc-sync to silently skip writing SDC claims, which in turn allowed post-sync cleanup to erroneously strip wikitext SDC params from entities that had no DPLA-attributed SDC, and left items classified as fully synced when a sibling ordinal succeeded.

High-level changes
- Pageid recovery: add _resolve_pageid_from_title(title) to query Commons by title when an upload-result pageid is falsy (including 0); use recovered pageid where possible, otherwise follow the skip path.
- Visible missing-pageid handling: unresolved pageid skips now increment Result.SDC_ORDINALS_SKIPPED_MISSING_PAGEID, set had_ordinal_error = True for the item, and surface an "ORDINAL NO PAGEID:" line in Slack SDC summaries so these skips are visible and items with mixed outcomes are not reported as fully synced.
- Cleanup safety guard: add _fetch_entity_for_cleanup_guard(mediaid) and _entity_has_dpla_attributed_claims(entity) and refuse to call wikitext_normalize.normalize_page (i.e., refuse to strip) when the live MediaInfo entity contains zero DPLA-attributed SDC claims (qualifier P459 = Q61848113), preventing wipes when SDC was not actually written.
- Item outcome classification: add Result.SDC_ITEMS_PARTIALLY_SYNCED and helper _classify_item_outcome(synced_this_item, had_ordinal_error) so partially-synced items are correctly classified and reported ("ITEMS PARTIAL:" in Slack).
- Cleanup dispatch tightening: post-SDC cleanup runs only for outcomes that had synced ordinals and is dispatched only against the subset of ordinals that actually synced (synced_ord_strs), avoiding unnecessary entity fetches and preserving partial-sync semantics.
- Uploader robustness & centralization: add Uploader._refresh_pageid_with_retries(page_title) with bounded attempts/backoff to mitigate Commons indexing lag after upload; record pageid=None on final failure. Add Uploader._track_ordinal_skip to increment both the legacy Result.SKIPPED aggregate and the new granular skip counters (UPLOAD_SKIPPED_NOT_PRESENT / UPLOAD_SKIPPED_INELIGIBLE). Constants PAGEID_REFRESH_MAX_ATTEMPTS and PAGEID_REFRESH_BACKOFF_SECS added.
- Slack / tracker: Slack summaries (ingest_wikimedia/slack.py) extended to show granular upload-skip breakdown and new SDC counters; Result enum (ingest_wikimedia/tracker.py) extended with new members: UPLOAD_SKIPPED_NOT_PRESENT, UPLOAD_SKIPPED_INELIGIBLE, SDC_ITEMS_PARTIALLY_SYNCED, SDC_ORDINALS_SKIPPED_MISSING_PAGEID.
- Tests: extensive tests added/updated covering pageid resolution (4 cases), entity-claim detection (3 cases), cleanup guard (2 cases), classify-item-outcome variants, uploader pageid refresh/retry behavior, and Slack summary expectations. Test suite passes locally; ruff/format clean.

Operational impact / checklist
- Deployment / runtime: No manual pipeline trigger or ECS redeploy required; behavior takes effect the next sdc-sync run (and uploader changes take effect when uploader is run with the updated code).
- Environment / secrets: No environment variables or AWS Secrets Manager keys added/removed/renamed.
- Database migrations: None.
- Shared infra: No changes to CodePipeline/CodeBuild/ECS task definitions, IAM policies, or other shared infra.
- Public API: No public-facing API response shape changes or new/removed endpoints.
- Security: No changes to credential handling or new sensitive credentials introduced; only additional Commons API queries for title→pageid resolution and wbgetentities guard fetch.

Recovery guidance
- After deployment, subsequent sdc-sync runs can resolve pageids via title lookup and write missing SDC claims; once SDC is present the cleanup strip will run safely. Manual remediation (e.g., clearing AntiCompositeBot tags) remains an operator step for items already affected.

Notable implementation details (for reviewers)
- New Result enum members: UPLOAD_SKIPPED_NOT_PRESENT, UPLOAD_SKIPPED_INELIGIBLE, SDC_ITEMS_PARTIALLY_SYNCED, SDC_ORDINALS_SKIPPED_MISSING_PAGEID.
- New functions in tools/sdc_sync.py: _fetch_entity_for_cleanup_guard, _entity_has_dpla_attributed_claims, _classify_item_outcome, _resolve_pageid_from_title.
- New uploader additions in tools/uploader.py: PAGEID_REFRESH_MAX_ATTEMPTS, PAGEID_REFRESH_BACKOFF_SECS, Uploader._refresh_pageid_with_retries, Uploader._track_ordinal_skip.
- Slack summary updates: notify_upload_complete and notify_sdc_complete include more granular SKIPPED lines and the new "ORDINAL NO PAGEID:" and "ITEMS PARTIAL:" lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->