### PR TITLE
sdc-sync: prepend File: namespace prefix in _resolve_pageid_from_title

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -3680,6 +3680,56 @@ def test_resolve_pageid_from_title_returns_none_on_empty_title(monkeypatch):
     assert fake_site.simple_request.call_count == 0
 
 
+def test_resolve_pageid_from_title_prepends_file_namespace(monkeypatch):
+    """Live-bug regression on the post-#302 deploy: ``upload-result.json``
+    stores titles WITHOUT the ``File:`` namespace prefix — that's the
+    form pywikibot's ``FilePage.title(with_ns=False)`` returns and what
+    the uploader serialises. A bare ``titles=<bare title>`` query
+    against the Commons API resolves to the *main* namespace, where
+    DPLA media files don't live; the response reports ``missing`` and
+    the fallback returned ``None`` even on files that actually exist
+    (e.g. the Southern Railway file the PR was supposed to self-heal).
+
+    Fix: the fallback prepends ``File:`` when absent so the lookup
+    lands in the correct namespace."""
+    from tools import sdc_sync
+
+    captured_titles = []
+
+    def stub_submit():
+        # Mirror MediaWiki's response shape for a File:-namespace hit.
+        return {
+            "query": {
+                "pages": {
+                    "193644002": {
+                        "pageid": 193644002,
+                        "ns": 6,
+                        "title": "File:X.tiff",
+                    }
+                }
+            }
+        }
+
+    def stub_simple_request(**kwargs):
+        captured_titles.append(kwargs.get("titles"))
+        m = MagicMock()
+        m.submit.side_effect = stub_submit
+        return m
+
+    fake_site = MagicMock()
+    fake_site.simple_request.side_effect = stub_simple_request
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+
+    # Bare title — what upload-result.json actually stores.
+    assert sdc_sync._resolve_pageid_from_title("X.tiff") == 193644002
+    # Already-prefixed title — pass through unchanged.
+    assert sdc_sync._resolve_pageid_from_title("File:X.tiff") == 193644002
+
+    assert captured_titles == ["File:X.tiff", "File:X.tiff"], (
+        "both bare and File:-prefixed inputs must query File:X.tiff"
+    )
+
+
 def test_entity_has_dpla_attributed_claims_finds_p459_q61848113():
     """The cleanup guard's notion of "has DPLA SDC" matches
     Module:DPLA's ``isDplaDetermined`` filter: at least one statement

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -284,6 +284,18 @@ def _resolve_pageid_from_title(title: str) -> int | None:
     """
     if not title:
         return None
+    # ``upload-result.json`` records page titles WITHOUT the ``File:``
+    # namespace prefix — that's the form pywikibot's
+    # ``FilePage.title(with_ns=False)`` returns and what the uploader
+    # serialises into the sidecar. A bare ``titles=`` query against
+    # the Commons API resolves to the *main* namespace, which never
+    # contains DPLA file pages — so without this prefix the lookup
+    # always reports the title as missing and the fallback returns
+    # ``None`` on files that DO exist. Prepend the namespace
+    # explicitly when absent so the query lands in the File:
+    # namespace where the uploaded media actually lives.
+    if not title.lower().startswith("file:"):
+        title = "File:" + title
     try:
         result = site.simple_request(
             action="query",


### PR DESCRIPTION
## Summary

Live regression on PR #302's deploy. The title→pageid fallback returned `None` for every null-pageid ordinal even on files that actually exist.

**Smoking gun (today's `sdc-sync` log on EC2 for `e314839e2ca3906b29bcbecc3d615740`):**

```
[WARNING] 14:41:23:  -- Ordinal 1: missing/zero pageid (None) for 'Southern Railway Company, Valuation Section 22 - DPLA - e314839e2ca3906b29bcbecc3d615740 (page 1).tiff' and title→pageid fallback failed; skipping.
```

The file is live at https://commons.wikimedia.org/wiki/File:Southern_Railway_Company,_Valuation_Section_22_-_DPLA_-_e314839e2ca3906b29bcbecc3d615740_(page_1).tiff (M193644002) — pageid resolvable in seconds via direct API call. So why did the fallback miss?

## Root cause

`upload-result.json` records page titles **without** the `File:` namespace prefix — that's the form `pywikibot.FilePage.title(with_ns=False)` returns and what the uploader serialises:

```json
"1": {
  "status": "UPLOADED",
  "title": "Southern Railway Company, Valuation Section 22 - DPLA - e314839e2ca3906b29bcbecc3d615740 (page 1).tiff",
  "pageid": null
}
```

When `_resolve_pageid_from_title` passes that bare title to `site.simple_request(action="query", titles=…)`, MediaWiki resolves it to the **main** namespace (the default). The main namespace doesn't contain DPLA media files → the API reports the page as `missing` → fallback returns `None` → null-pageid skip path runs → no SDC edit ever lands.

## Fix

Prepend `File:` when the title doesn't already start with that prefix (case-insensitive). Bare-title input from `upload-result.json` now lands in the correct namespace; an already-prefixed input passes through unchanged.

```python
if not title.lower().startswith("file:"):
    title = "File:" + title
```

## Test plan

- [x] New `test_resolve_pageid_from_title_prepends_file_namespace` — both bare and File:-prefixed inputs land on `File:X.tiff` in the captured query.
- [x] Existing 4 `_resolve_pageid_from_title` tests still pass (the `File:X.tiff` inputs are unchanged).
- [x] Full suite: 639 passed.
- [x] `ruff check` + `ruff format` clean.

## Recovery for the Southern Railway file

Once this lands and the wiki EC2 picks up the new code, re-running `sdc-sync` on `e314839e2ca3906b29bcbecc3d615740` resolves the real pageid via the title lookup → writes the SDC → cleanup pass runs against a non-empty entity → file rendering picks up its DPLA-attributed claims. The AntiCompositeBot's `{{No license since}}` tag stays until manually cleared but the underlying state is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix for regression in file title resolution

This PR fixes a regression introduced in PR `#302` where the `_resolve_pageid_from_title` fallback mechanism was failing to resolve page IDs for Wikimedia Commons files.

### Root Cause
The `upload-result.json` file records page titles without the `"File:"` namespace prefix. When these bare titles (e.g., `"X.tiff"`) were passed directly to the MediaWiki query API, they were being resolved against the main namespace instead of the File namespace, causing the API to report pages as missing and the fallback to return `None`. This resulted in existing files being skipped during processing.

### Solution
Modified `_resolve_pageid_from_title()` in `tools/sdc_sync.py` to prepend the `"File:"` namespace prefix to any title that doesn't already include it (case-insensitive check). This ensures API queries target the correct namespace where DPLA media files are stored.

### Testing
- Added regression test `test_resolve_pageid_from_title_prepends_file_namespace` that validates both bare titles (e.g., `"X.tiff"`) and already-prefixed titles (e.g., `"File:X.tiff"`) are handled correctly
- Existing `_resolve_pageid_from_title` tests remain passing
- Full test suite: 639 tests passed
- Code quality checks (ruff) clean

### Changes
- **tools/sdc_sync.py**: +12 lines (namespace prefix logic in `_resolve_pageid_from_title`)
- **tests/test_sdc_sync.py**: +50 lines (new regression test)

### Post-merge action
After deployment, re-running sdc-sync for affected uploads will resolve their page IDs and complete SDC metadata writing, allowing subsequent cleanup and rendering to properly reflect DPLA attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->