### PR TITLE
legacy_artwork: expand wikitext templates + dedup imports against DPLA SDC

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -550,9 +550,119 @@ def fetch_revision_snapshots(file_page) -> list[RevisionSnapshot]:
     return snapshots
 
 
+_QID_HEURISTIC = "Q61848113"
+_QID_CIRCA = "Q5727902"
+_PID_DPLA_DETERMINATION = "P459"
+_PID_SOURCING_CIRCUMSTANCES = "P1480"
+
+
+def _expand_wikitext_for_date_parse(raw_date: str, site) -> str:
+    """If ``raw_date`` contains MediaWiki template markup, expand
+    templates server-side and return the rendered text. Otherwise
+    pass through unchanged.
+
+    The legacy ``{{Artwork}}`` ``| date = …`` value can legitimately
+    carry editor-applied template wrappers — most commonly
+    ``{{other date|~|1911}}``, ``{{circa|1911}}``, ``{{date|1911}}``
+    etc. Storing the raw markup in the SDC ``P1932`` qualifier (1)
+    defeats the dedup check below, because the renderer-style
+    "circa 1911" string never compares equal to "{{other date|~|
+    1911}}", and (2) renders as literal template text in
+    Module:DPLA's yellow-box row (Module:DPLA mitigates this at
+    display time but the upstream fix is to not store wikitext in a
+    structured-data string in the first place).
+
+    Falls back to the raw value when ``site`` is None, when no
+    template markup is detected (fast path), or when the API call
+    raises. The HTML residue that MediaWiki sometimes appends to a
+    template's plain-text rendering (e.g. the hidden
+    ``<div ...>date QS:P,…</div>`` micro-format ``{{other date}}``
+    emits) is stripped before return — that scaffolding is for the
+    rendered page, not for a normalised value string.
+    """
+    if not raw_date or "{{" not in raw_date or site is None:
+        return raw_date
+    try:
+        expanded = site.expand_text(raw_date)
+    except Exception:
+        return raw_date
+    # Strip any hidden HTML residue (QuickStatements micro-format etc.)
+    # the template's expansion may have appended; we want the plain
+    # human-readable rendering only.
+    import re
+
+    expanded = re.sub(r"<[^>]+>.*?</[^>]+>", "", expanded, flags=re.DOTALL)
+    expanded = re.sub(r"<[^>]+/?>", "", expanded)
+    return expanded.strip() or raw_date
+
+
+def _existing_dpla_date_matches_parsed(
+    entity: dict | None, prop: str, parsed: dict
+) -> bool:
+    """Return True iff ``entity`` already has a DPLA-attributed
+    statement on ``prop`` whose Wikibase time value and circa-flag
+    match ``parsed``.
+
+    "DPLA-attributed" means a ``P459 = Q61848113`` (determination
+    method = heuristic) qualifier — the same signal Module:DPLA's
+    ``dplaStatements`` uses to scope the blue-box render. The check
+    deliberately doesn't compare reference shape: the editor-edited
+    legacy value is a different source than DPLA's own sync, but if
+    the *semantic* value and approximate-flag match, there's no
+    user-contributed information to preserve — the editor's edit was
+    just a re-formatting of the DPLA value.
+
+    Match contract: ``time`` string and ``precision`` integer must
+    be exactly equal, AND ``parsed.approximate`` must agree with
+    whether the existing statement carries a
+    ``P1480 = Q5727902`` (circa) qualifier. Wikibase normalises the
+    time string at write time, so byte equality is the right test —
+    same-day with different ``before``/``after`` etc. would represent
+    a different uncertainty bound and should not be deduped.
+    """
+    if not entity or not parsed or not parsed.get("value"):
+        return False
+    parsed_value = parsed["value"]
+    parsed_time = parsed_value.get("time")
+    parsed_precision = parsed_value.get("precision")
+    if parsed_time is None or parsed_precision is None:
+        return False
+    parsed_circa = bool(parsed.get("approximate"))
+    statements = entity.get("statements") or entity.get("claims") or {}
+    for stmt in statements.get(prop, []):
+        # DPLA-attributed only.
+        is_dpla = False
+        for q in (stmt.get("qualifiers") or {}).get(_PID_DPLA_DETERMINATION, []):
+            qv = q.get("datavalue", {}).get("value", {}) or {}
+            if qv.get("id") == _QID_HEURISTIC:
+                is_dpla = True
+                break
+        if not is_dpla:
+            continue
+        ms = stmt.get("mainsnak") or {}
+        dv = ms.get("datavalue") or {}
+        if dv.get("type") != "time":
+            continue
+        v = dv.get("value") or {}
+        if v.get("time") != parsed_time or v.get("precision") != parsed_precision:
+            continue
+        existing_circa = False
+        for q in (stmt.get("qualifiers") or {}).get(_PID_SOURCING_CIRCUMSTANCES, []):
+            qv = q.get("datavalue", {}).get("value", {}) or {}
+            if qv.get("id") == _QID_CIRCA:
+                existing_circa = True
+                break
+        if existing_circa == parsed_circa:
+            return True
+    return False
+
+
 def materialize_pending_date_claim(
     placeholder: dict,
     today: datetime.date | None = None,
+    *,
+    site=None,
+    existing_entity: dict | None = None,
 ) -> dict | None:
     """Take a Phase-3a ``_phase3a_pending_date_parse`` placeholder claim
     and materialise it into a real Wikibase P571 (inception) statement.
@@ -577,6 +687,28 @@ def materialize_pending_date_claim(
     sentinel keys — the caller drops the claim from the import set
     and the value stays in wikitext until a later phase.
 
+    When ``site`` is provided, any template markup in the raw value
+    is expanded via MediaWiki's ``expandtemplates`` API before
+    parsing AND before being stored in the P1932 qualifier — see
+    :func:`_expand_wikitext_for_date_parse`. The DPLA-date parser
+    can't structurally read shapes like ``{{other date|~|1911}}``,
+    but DOES recognise the expanded ``circa 1911`` form, so the
+    expansion turns the somevalue fallback into a real value-typed
+    statement and avoids storing wikitext markup in a structured-
+    data string. Falls back to the raw value when no ``site`` is
+    passed or expansion fails.
+
+    When ``existing_entity`` is provided and the parser commits to a
+    structured value, the function checks whether ``entity`` already
+    carries a DPLA-attributed statement on the same property with the
+    same time + precision + circa flag — see
+    :func:`_existing_dpla_date_matches_parsed`. If so, returns None
+    to signal that the legacy import is a no-op duplicate (the
+    editor merely re-formatted the DPLA-supplied value as a wikitext
+    template; no community-contributed information would be lost by
+    dropping the import). Callers that don't provide
+    ``existing_entity`` get the pre-existing always-import behaviour.
+
     ``today`` is accepted (currently unused) for symmetry with other
     claim builders so a later phase can add a P813 retrieved-on
     reference snak if useful without changing call sites.
@@ -590,17 +722,35 @@ def materialize_pending_date_claim(
     if not raw_date or not prop or not permalink_from:
         return None
 
-    parsed = parse_dpla_date(raw_date)
+    # Expand any template markup so the value reflects what the editor
+    # actually saw on the page, not the raw wikitext syntax. The
+    # expanded form goes into both the parser and the P1932 qualifier;
+    # the raw markup is never stored as structured data.
+    value_for_parse = _expand_wikitext_for_date_parse(raw_date, site)
+    parsed = parse_dpla_date(value_for_parse)
+
+    # Dedup-against-DPLA: if the editor's wikitext value parses to
+    # something we already have on the entity as a DPLA-attributed
+    # claim, the migration import would be a literal duplicate. Drop
+    # it rather than create a parallel statement that the
+    # community-imports comparator can never strip cleanly.
+    if parsed is not None and _existing_dpla_date_matches_parsed(
+        existing_entity, prop, parsed
+    ):
+        return None
+
     qualifiers: dict[str, list[dict]] = {
-        # P1932 (stated as) preserves the verbatim source string so a
-        # reader can recover what the editor actually wrote, even when
-        # the structured time has reduced precision.
+        # P1932 (stated as) preserves the source string so a reader can
+        # recover what the editor actually wrote, even when the
+        # structured time has reduced precision. The pre-expansion
+        # form is what surfaces here when no expansion ran (no site,
+        # no template markup, or expand_text failed).
         "P1932": [
             {
                 "snaktype": "value",
                 "property": "P1932",
                 "datatype": "string",
-                "datavalue": {"type": "string", "value": raw_date},
+                "datavalue": {"type": "string", "value": value_for_parse},
             }
         ]
     }
@@ -642,7 +792,12 @@ def materialize_pending_date_claim(
     }
 
 
-def materialize_import_claims(claims: list[dict]) -> list[dict]:
+def materialize_import_claims(
+    claims: list[dict],
+    *,
+    site=None,
+    existing_entity: dict | None = None,
+) -> list[dict]:
     """Walk an import-claim list and substitute every Phase-3a date
     placeholder for a real P571 time statement.
 
@@ -650,11 +805,22 @@ def materialize_import_claims(claims: list[dict]) -> list[dict]:
     Placeholders whose date can't be expanded (parser failure paired
     with missing sentinel keys — should never happen for in-tree
     callers) are dropped silently rather than crashing the migration.
+
+    ``site`` and ``existing_entity`` are forwarded to
+    :func:`materialize_pending_date_claim` so the date materialiser
+    can (a) expand wikitext templates server-side before parsing and
+    (b) drop a community-import claim whose parsed value already
+    exists DPLA-attributed on the entity. Both are optional — when
+    neither is supplied, the function preserves the historical
+    always-import behaviour. The original caller signature is also
+    preserved for tests that pass only the claims list.
     """
     materialised: list[dict] = []
     for claim in claims:
         if "_phase3a_pending_date_parse" in claim:
-            real = materialize_pending_date_claim(claim)
+            real = materialize_pending_date_claim(
+                claim, site=site, existing_entity=existing_entity
+            )
             if real is not None:
                 materialised.append(real)
         else:
@@ -880,7 +1046,15 @@ def migrate_legacy_file(
     if entity_was_already_migrated(entity):
         return MigrationResult(skipped_reason="already-migrated", plan=plan)
 
-    claims = materialize_import_claims(build_legacy_import_claims(plan))
+    # Pass the just-fetched MediaInfo entity and the site through so the
+    # date materialiser can expand wikitext templates server-side AND
+    # skip importing a date that already exists DPLA-attributed on the
+    # entity (e.g. an editor reformatted the original ``1911?`` value
+    # as ``{{other date|~|1911}}`` — both parse to "circa 1911" so the
+    # legacy import would be a literal duplicate of the DPLA claim).
+    claims = materialize_import_claims(
+        build_legacy_import_claims(plan), site=site, existing_entity=entity
+    )
     # Pick the accurate summary for what this migration actually did,
     # unless the caller supplied a custom one. Without this, a
     # DPLA-bot-only history (no community values to import) would still

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -586,12 +586,27 @@ def _expand_wikitext_for_date_parse(raw_date: str, site) -> str:
         expanded = site.expand_text(raw_date)
     except Exception:
         return raw_date
-    # Strip any hidden HTML residue (QuickStatements micro-format etc.)
-    # the template's expansion may have appended; we want the plain
-    # human-readable rendering only.
+    # Targeted-strip pass: ONLY remove paired tags whose attributes mark
+    # them as hidden microformat scaffolding — ``style="display: none"``
+    # / ``aria-hidden="true"`` / a QuickStatements ``qs`` class. Visible
+    # text inside ordinary ``<span>``/``<i>``/``<sup>`` wrappers (e.g.
+    # ``<span>circa 1911</span>`` from a language- or formatting-
+    # focused template) must survive — only the QS / display-none
+    # noise the date templates inject for downstream tooling should
+    # disappear. Generic tag-strip on the second pass removes the
+    # remaining bare tags but preserves their inner text.
     import re
 
-    expanded = re.sub(r"<[^>]+>.*?</[^>]+>", "", expanded, flags=re.DOTALL)
+    expanded = re.sub(
+        r"<(span|div)[^>]*"
+        r"(?:style\s*=\s*[\"'][^\"']*display\s*:\s*none[^\"']*[\"']"
+        r"|aria-hidden\s*=\s*[\"']true[\"']"
+        r"|class\s*=\s*[\"'][^\"']*\bqs\b[^\"']*[\"'])"
+        r"[^>]*>.*?</\1>",
+        "",
+        expanded,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
     expanded = re.sub(r"<[^>]+/?>", "", expanded)
     return expanded.strip() or raw_date
 
@@ -623,9 +638,7 @@ def _existing_dpla_date_matches_parsed(
     if not entity or not parsed or not parsed.get("value"):
         return False
     parsed_value = parsed["value"]
-    parsed_time = parsed_value.get("time")
-    parsed_precision = parsed_value.get("precision")
-    if parsed_time is None or parsed_precision is None:
+    if not parsed_value.get("time") or parsed_value.get("precision") is None:
         return False
     parsed_circa = bool(parsed.get("approximate"))
     statements = entity.get("statements") or entity.get("claims") or {}
@@ -643,8 +656,16 @@ def _existing_dpla_date_matches_parsed(
         dv = ms.get("datavalue") or {}
         if dv.get("type") != "time":
             continue
-        v = dv.get("value") or {}
-        if v.get("time") != parsed_time or v.get("precision") != parsed_precision:
+        # Whole-value comparison (time, precision, before, after,
+        # timezone, calendarmodel) — divergence in any field implies
+        # a semantically different statement and must NOT dedup. Both
+        # sides go through ``_wikibase_time`` in ``ingest_wikimedia.sdc``,
+        # which pins ``before/after/timezone/calendarmodel`` to constants,
+        # so under normal pipeline use the dicts match exactly; a
+        # hand-edited statement with explicit uncertainty bounds would
+        # represent a different precision claim and is correctly
+        # excluded.
+        if (dv.get("value") or {}) != parsed_value:
             continue
         existing_circa = False
         for q in (stmt.get("qualifiers") or {}).get(_PID_SOURCING_CIRCUMSTANCES, []):

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -580,6 +580,194 @@ def test_materialize_pending_date_claim_unparseable_falls_back_to_somevalue():
     )
 
 
+class _FakeSite:
+    """Minimal ``site`` stub providing ``expand_text``."""
+
+    def __init__(self, expansions):
+        self._expansions = expansions
+
+    def expand_text(self, text):
+        return self._expansions.get(text, text)
+
+
+def _dpla_p571_statement(time_str, precision, *, circa=False):
+    """Build a wbgetentities-shaped DPLA-attributed P571 statement."""
+    quals = {
+        "P459": [
+            {
+                "snaktype": "value",
+                "property": "P459",
+                "datavalue": {
+                    "type": "wikibase-entityid",
+                    "value": {"id": "Q61848113"},
+                },
+            }
+        ]
+    }
+    if circa:
+        quals["P1480"] = [
+            {
+                "snaktype": "value",
+                "property": "P1480",
+                "datavalue": {
+                    "type": "wikibase-entityid",
+                    "value": {"id": "Q5727902"},
+                },
+            }
+        ]
+    return {
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P571",
+            "datavalue": {
+                "type": "time",
+                "value": {"time": time_str, "precision": precision},
+            },
+        },
+        "qualifiers": quals,
+    }
+
+
+def test_materialize_pending_date_claim_expands_other_date_template():
+    """``{{other date|~|1911}}`` expands to ``circa 1911`` which the
+    DPLA-date parser recognises — value-typed P571 + P1480 circa, and
+    the P1932 qualifier stores the expanded text, NOT the raw markup."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "{{other date|~|1911}}",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    site = _FakeSite({"{{other date|~|1911}}": "circa 1911"})
+    claim = materialize_pending_date_claim(placeholder, site=site)
+    assert claim is not None
+    assert claim["mainsnak"]["snaktype"] == "value"
+    assert claim["mainsnak"]["datavalue"]["value"]["time"] == "+1911-01-01T00:00:00Z"
+    assert claim["qualifiers"]["P1480"][0]["datavalue"]["value"]["id"] == "Q5727902"
+    # P1932 stores the expanded text, not the raw template markup.
+    assert claim["qualifiers"]["P1932"][0]["datavalue"]["value"] == "circa 1911"
+
+
+def test_materialize_pending_date_claim_strips_hidden_html_from_expansion():
+    """The hidden QuickStatements micro-format ``{{other date}}`` appends
+    (a ``<div style="display: none;">...</div>``) is scaffolding for the
+    rendered page; it must NOT survive into the P1932 string."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "{{other date|~|1911}}",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    site = _FakeSite(
+        {
+            "{{other date|~|1911}}": (
+                'circa 1911<div style="display: none;">'
+                "date QS:P,+1911-00-00T00:00:00Z/9,P1480,Q5727902</div>"
+            )
+        }
+    )
+    claim = materialize_pending_date_claim(placeholder, site=site)
+    assert claim is not None
+    assert claim["qualifiers"]["P1932"][0]["datavalue"]["value"] == "circa 1911"
+
+
+def test_materialize_pending_date_claim_skips_when_dpla_already_has_match():
+    """When the parsed editor-value matches an existing DPLA-attributed
+    P571 (same time + precision + circa flag), the import is a literal
+    duplicate of DPLA's own claim — return None so the caller drops it."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "{{other date|~|1911}}",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    site = _FakeSite({"{{other date|~|1911}}": "circa 1911"})
+    existing = {
+        "statements": {
+            "P571": [_dpla_p571_statement("+1911-01-01T00:00:00Z", 9, circa=True)]
+        }
+    }
+    claim = materialize_pending_date_claim(
+        placeholder, site=site, existing_entity=existing
+    )
+    assert claim is None
+
+
+def test_materialize_pending_date_claim_imports_when_dpla_value_differs():
+    """When the parsed editor-value parses to a DIFFERENT date than
+    DPLA's existing P571, the import is real community-contributed
+    information and must NOT be dropped."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "1925",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    existing = {
+        "statements": {
+            "P571": [_dpla_p571_statement("+1911-01-01T00:00:00Z", 9, circa=True)]
+        }
+    }
+    claim = materialize_pending_date_claim(placeholder, existing_entity=existing)
+    assert claim is not None
+    assert claim["mainsnak"]["datavalue"]["value"]["time"] == "+1925-01-01T00:00:00Z"
+
+
+def test_materialize_pending_date_claim_imports_when_circa_flag_differs():
+    """Same year, different circa flag — semantically distinct
+    (editor asserts "approximately 1911" while DPLA asserts "exactly
+    1911" or vice versa); do NOT dedup."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "ca. 1911",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    existing = {
+        "statements": {
+            "P571": [_dpla_p571_statement("+1911-01-01T00:00:00Z", 9, circa=False)]
+        }
+    }
+    claim = materialize_pending_date_claim(placeholder, existing_entity=existing)
+    assert claim is not None
+    assert "P1480" in claim["qualifiers"]
+
+
+def test_materialize_pending_date_claim_ignores_non_dpla_attributed_existing():
+    """A non-DPLA-attributed (no P459=Q61848113) existing P571 must NOT
+    trigger the dedup — that statement represents community-contributed
+    information of unknown provenance, NOT a value to dedup against."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "1911",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    # Build a P571 with the same value but NO P459 qualifier.
+    naked = _dpla_p571_statement("+1911-01-01T00:00:00Z", 9, circa=False)
+    naked["qualifiers"].pop("P459", None)
+    existing = {"statements": {"P571": [naked]}}
+    claim = materialize_pending_date_claim(placeholder, existing_entity=existing)
+    assert claim is not None
+
+
+def test_materialize_import_claims_forwards_site_and_entity():
+    """The list-level wrapper has to forward both kwargs so the dedup
+    behaviour applies in the migration pipeline, not only in the
+    per-claim helper. Verified by passing a dedup-triggering entity
+    and asserting the date placeholder gets dropped from the output."""
+    title_claim = {"type": "statement", "mainsnak": {"property": "P1476"}}
+    date_placeholder = {
+        "type": "statement",
+        "_phase3a_pending_date_parse": "1911",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    existing = {
+        "statements": {
+            "P571": [_dpla_p571_statement("+1911-01-01T00:00:00Z", 9, circa=False)]
+        }
+    }
+    out = materialize_import_claims(
+        [title_claim, date_placeholder], existing_entity=existing
+    )
+    assert out == [title_claim]  # date dropped, title preserved
+
+
 def test_materialize_import_claims_passes_through_non_date_claims():
     """A title claim doesn't carry the placeholder marker — pass through."""
     title_claim = {"type": "statement", "mainsnak": {"property": "P1476"}}

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -591,7 +591,11 @@ class _FakeSite:
 
 
 def _dpla_p571_statement(time_str, precision, *, circa=False):
-    """Build a wbgetentities-shaped DPLA-attributed P571 statement."""
+    """Build a wbgetentities-shaped DPLA-attributed P571 statement.
+    The ``value`` dict matches the canonical shape
+    ``ingest_wikimedia.sdc._wikibase_time`` emits — DPLA's own
+    pipeline always writes that exact shape, so the dedup
+    whole-value comparison sees identical dicts under normal use."""
     quals = {
         "P459": [
             {
@@ -621,7 +625,14 @@ def _dpla_p571_statement(time_str, precision, *, circa=False):
             "property": "P571",
             "datavalue": {
                 "type": "time",
-                "value": {"time": time_str, "precision": precision},
+                "value": {
+                    "time": time_str,
+                    "precision": precision,
+                    "before": 0,
+                    "after": 0,
+                    "timezone": 0,
+                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
+                },
             },
         },
         "qualifiers": quals,
@@ -745,9 +756,9 @@ def test_materialize_pending_date_claim_ignores_non_dpla_attributed_existing():
     assert claim is not None
 
 
-def test_materialize_import_claims_forwards_site_and_entity():
-    """The list-level wrapper has to forward both kwargs so the dedup
-    behaviour applies in the migration pipeline, not only in the
+def test_materialize_import_claims_forwards_existing_entity_for_dedup():
+    """The list-level wrapper has to forward ``existing_entity`` so the
+    dedup behaviour applies in the migration pipeline, not only in the
     per-claim helper. Verified by passing a dedup-triggering entity
     and asserting the date placeholder gets dropped from the output."""
     title_claim = {"type": "statement", "mainsnak": {"property": "P1476"}}
@@ -766,6 +777,58 @@ def test_materialize_import_claims_forwards_site_and_entity():
         [title_claim, date_placeholder], existing_entity=existing
     )
     assert out == [title_claim]  # date dropped, title preserved
+
+
+def test_materialize_import_claims_forwards_site_for_expansion():
+    """The list-level wrapper has to forward ``site`` so the template-
+    expansion behaviour applies in the migration pipeline. Verified by
+    passing a wikitext-template date placeholder and asserting the
+    expanded value appears in the materialised claim's P1932."""
+    date_placeholder = {
+        "type": "statement",
+        "_phase3a_pending_date_parse": "{{other date|~|1911}}",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    site = _FakeSite({"{{other date|~|1911}}": "circa 1911"})
+    out = materialize_import_claims([date_placeholder], site=site)
+    assert len(out) == 1
+    assert out[0]["qualifiers"]["P1932"][0]["datavalue"]["value"] == "circa 1911"
+
+
+def test_materialize_pending_date_claim_preserves_visible_inner_text():
+    """The hidden-microformat strip must not eat visible text inside
+    plain ``<span>``/``<i>`` wrappers (e.g. ``<span>circa 1911</span>``
+    from a formatting-focused template). Only display:none / aria-
+    hidden / QS-class scaffolding should disappear."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "{{some formatting template|1911}}",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    site = _FakeSite({"{{some formatting template|1911}}": "<span>circa 1911</span>"})
+    claim = materialize_pending_date_claim(placeholder, site=site)
+    assert claim is not None
+    # Visible inner text survived; outer <span> tag was stripped.
+    assert claim["qualifiers"]["P1932"][0]["datavalue"]["value"] == "circa 1911"
+
+
+def test_materialize_pending_date_claim_skips_when_existing_value_full_match():
+    """Full whole-value match required: same time / precision /
+    before / after / timezone / calendarmodel. Any divergence in
+    those bound fields disqualifies the dedup."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "1911",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    # Build an existing statement whose ``before`` bound differs from
+    # the parser's canonical 0. Should NOT dedup.
+    diverging = _dpla_p571_statement("+1911-01-01T00:00:00Z", 9, circa=False)
+    diverging["mainsnak"]["datavalue"]["value"]["before"] = 5
+    existing = {"statements": {"P571": [diverging]}}
+    claim = materialize_pending_date_claim(placeholder, existing_entity=existing)
+    assert claim is not None  # different uncertainty bound, import preserved
 
 
 def test_materialize_import_claims_passes_through_non_date_claims():


### PR DESCRIPTION
## Summary

Two related fixes to the legacy ``{{Artwork}}`` → ``{{DPLA metadata}}`` migration date-import path, motivated by a file where an editor had reformatted the original DPLA-supplied ``1911?`` date as ``{{other date|~|1911}}`` and the migration imported it as a second P571 statement with the literal template markup stored in the P1932 'stated as' qualifier.

**(B) Expand wikitext templates before parse/store.** When the raw ``| date = …`` value contains template markup, expand it via the MediaWiki ``expandtemplates`` API before passing to ``parse_dpla_date`` and before storing in P1932. The DPLA-date parser can't structurally read shapes like ``{{other date|~|1911}}`` but does recognise the expanded ``circa 1911`` form, so the somevalue fallback path turns into a real value-typed P571 claim. P1932 now holds the human-readable rendering, never raw wikitext. Hidden HTML residue ({{other date}}'s embedded QuickStatements ``<div style="display: none;">`` etc.) is stripped before storage.

**(C) Dedup community-imports against existing DPLA SDC.** After a successful parse, check whether the entity already has a DPLA-attributed P571 (``P459 = Q61848113`` qualifier) with the same time + precision + circa flag. If so, the editor's wikitext value is semantically identical to DPLA's own claim — the editor merely re-formatted the source value. Returning None tells the caller to drop the import; we don't create a parallel community-attributed claim that the strip comparator can never cleanly remove.

Both behaviours are opt-in via new keyword args (``site``, ``existing_entity``) on ``materialize_pending_date_claim`` and ``materialize_import_claims``. ``migrate_legacy_file`` now passes the ``site`` and the just-fetched MediaInfo ``entity`` through. Pre-existing callers that pass only the claims list keep the historical always-import behaviour.

Co-fix landed live on Commons: ``Module:DPLA``'s ``dateText`` now ``frame:preprocess()`` the P1932 string at render time, so files that already have raw-wikitext P1932 values (from before this PR) render correctly without a re-migration sweep.

## Test plan

- [x] ``pytest tests/test_legacy_artwork.py`` — 73/73 pass (66 existing + 7 new).
- [x] ``ruff check`` + ``ruff format --check`` clean.
- [x] New tests cover: template expansion, hidden-HTML residue strip, dedup-match (skip), dedup-mismatch on year (import), dedup-mismatch on circa flag (import), non-DPLA-attributed existing (import), and ``materialize_import_claims`` kwarg forwarding.
- [ ] Smoke test on a real legacy file post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the legacy `{{Artwork}} → {{DPLA metadata}}` date-import path in `ingest_wikimedia/legacy_artwork.py` to correctly handle DPLA-provided dates that editors reformat using wikitext templates, and to avoid creating redundant DPLA-attributed time statements.

### Feature 1: Expand wikitext templates before parse/store
When the raw `|date=` value contains template markup (e.g., `{{other date|~|1911}}`) and a `site` is provided, the pipeline now:
- Uses MediaWiki `expandtemplates` to render the template to human-readable text
- Strips hidden HTML scaffolding residue from the rendered result (targeted removal of hidden `<span>/<div>` structures) while preserving visible content
- Passes the expanded rendering to `parse_dpla_date`
- Stores the expanded, rendered string (rather than raw wikitext) into P1932 (“stated as”)

### Feature 2: Deduplicate against existing DPLA-attributed P571 claims
After parsing succeeds, and when an `existing_entity` is provided, the pipeline now checks for an existing DPLA-attributed `P571` (via `P459 = Q61848113`) whose structured time-value dict matches exactly (including bounds/timezone/calendarmodel/precision) and whose circa qualifier presence matches. If it’s a full match, the import is skipped (returns `None`) to prevent redundant community-attributed statements.

### Implementation details
- `materialize_pending_date_claim` now accepts keyword-only `site=None, existing_entity=None`
- `materialize_import_claims` now accepts keyword-only `site=None, existing_entity=None` and forwards both to `materialize_pending_date_claim`
- `migrate_legacy_file` passes the fetched MediaInfo entity and `site` into `materialize_import_claims`
- Module/DPLA on Commons was also co-fixed to preprocess P1932 renderings (to align template rendering expectations)

### Code changes
- `ingest_wikimedia/legacy_artwork.py`: +203/-8 (new helpers for template expansion + residue stripping, and entity-aware deduplication; helper updated for canonical time-value shape)
- `tests/test_legacy_artwork.py`: +251/-0 (adds `_FakeSite` to control `expand_text`, expands coverage for template expansion/storage, hidden residue stripping, and strict dedup semantics—including circa/no-circa and non-DPLA-attributed statements)

### Validation
- `pytest`: 73/73 pass (66 existing + 7 new)
- `ruff`: clean

## Deployment / risk checklist
- **Manual pipeline trigger / ECS redeploy required?** No (logic update; applies on subsequent ingest runs after the code is deployed).
- **Environment variables / AWS Secrets Manager keys changed?** No.
- **Database migrations?** No.
- **Shared infrastructure config changes (CodePipeline/CodeBuild/ECS/IAM)?** No.
- **Public-facing API response shape / endpoints changed?** No.
- **Security implications?** Low: introduces an optional call to MediaWiki template expansion when `site` is provided, using existing site connectivity; no new credentials handling or auth changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->