### PR TITLE
slack: surface real batch size (PAGES EDITED) + memory snapshot in status

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -442,6 +442,7 @@ def notify_sdc_complete(
         stats_lines=[
             f"ITEMS SYNCED:         {tracker.count(Result.SDC_ITEMS_SYNCED):,}",
             f"ITEMS PARTIAL:        {tracker.count(Result.SDC_ITEMS_PARTIALLY_SYNCED):,}",
+            f"PAGES EDITED:         {tracker.count(Result.SDC_PAGES_EDITED):,}",
             f"CLAIMS ADDED:         {tracker.count(Result.SDC_CLAIMS_ADDED):,}",
             f"REFS ADDED:           {tracker.count(Result.SDC_REFS_ADDED):,}",
             f"REMOVALS:             {tracker.count(Result.SDC_REMOVALS):,}",

--- a/ingest_wikimedia/ssm.py
+++ b/ingest_wikimedia/ssm.py
@@ -54,6 +54,42 @@ def ssm_run(client, cmd: str, *, as_root: bool = False) -> str:
     raise TimeoutError(f"SSM command {cmd_id} did not complete within polling window")
 
 
+def fetch_memory_snapshot(client) -> tuple[int, int] | None:
+    """Return ``(total_mb, available_mb)`` from ``free -m`` on the
+    instance, or ``None`` if the command failed or its output couldn't
+    be parsed.
+
+    Callers shape the numbers for their own context — ``wikimedia_launch``
+    /``wikimedia_retry`` gate their startup on a headroom percentage,
+    while ``wikimedia_upload_status`` formats it as a Slack readout —
+    so this helper deliberately returns the raw pair rather than a
+    formatted string or a derived percentage. Centralising the shell
+    command + parsing here keeps the three call sites from drifting on
+    output handling (e.g., the divide-by-zero guard that landed here
+    but isn't in the older inline copies).
+    """
+    import logging
+
+    try:
+        raw = ssm_run(client, "free -m | awk 'NR==2{print $2, $7}'")
+    except Exception:
+        logging.exception("Failed to fetch instance memory snapshot")
+        return None
+    parts = raw.split()
+    if len(parts) != 2:
+        logging.warning("Unexpected free -m output: %r", raw)
+        return None
+    try:
+        total_mb, available_mb = int(parts[0]), int(parts[1])
+    except ValueError:
+        logging.warning("Could not parse free -m output: %r", raw)
+        return None
+    if total_mb <= 0:
+        logging.warning("Non-positive total memory in free -m output: %r", raw)
+        return None
+    return total_mb, available_mb
+
+
 def stage_and_launch_tmux(client, *, script: str, session_name: str, cwd: str) -> str:
     """Stage `script` to a file on the instance, then launch a detached
     tmux session that runs it. Returns whatever ssm_run returns (stdout).

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -40,6 +40,15 @@ class Result(Enum):
     # cleanup on their synced ordinals — the partial state is real
     # progress, not a failure to be retried wholesale.
     SDC_ITEMS_PARTIALLY_SYNCED = auto()
+    # Qualifier-only ``wbeditentity`` fragments committed by the SDC
+    # dispatcher. Exists so the write-delta detection that feeds
+    # ``SDC_PAGES_EDITED`` doesn't miss a page edit whose only fragment
+    # was a qualifier amend (rare — needs every DPLA claim on the file
+    # to already carry today's ``P813``, so the opportunistic refresh
+    # adds no reference-update fragments — but real). Not surfaced in
+    # the SDC Slack summary; counted purely so ``_sdc_writes_total()``
+    # picks up the change.
+    SDC_QUALIFIER_UPDATES = auto()
     # Distinct Commons file pages this SDC run actually wrote to — counted
     # at per-ordinal granularity (one file page = one ordinal in partner
     # mode; one file page per call in the legacy --file/--cat/--list

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -40,6 +40,14 @@ class Result(Enum):
     # cleanup on their synced ordinals — the partial state is real
     # progress, not a failure to be retried wholesale.
     SDC_ITEMS_PARTIALLY_SYNCED = auto()
+    # Distinct Commons file pages this SDC run actually wrote to — counted
+    # at per-ordinal granularity (one file page = one ordinal in partner
+    # mode; one file page per call in the legacy --file/--cat/--list
+    # paths). A page that received both a MediaInfo entity write AND a
+    # follow-up wikitext cleanup edit counts once.  Surfaces the real
+    # batch size to operators, who can't infer it from ITEMS_SYNCED alone
+    # (a 1-file item and a 1,000-file item both count once there).
+    SDC_PAGES_EDITED = auto()
     # Ordinals whose SDC sync raised an unexpected exception
     # (pywikibot APIError, network timeout, deep KeyError, etc.).
     # Per-ordinal granularity so transient failures don't abort the

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -15,7 +15,7 @@ import boto3
 import requests
 
 from ingest_wikimedia.partners import PARTNER_DIR, parse_session_labels, resolve_slug
-from ingest_wikimedia.ssm import REGION, ssm_run
+from ingest_wikimedia.ssm import REGION, fetch_memory_snapshot, ssm_run
 
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
@@ -258,18 +258,44 @@ def get_phase_and_progress(
     return "Unknown", log_mtime
 
 
-def post_to_slack(token: str, rows: list[tuple[str, str]]) -> None:
+def _format_memory_line(snapshot: tuple[int, int] | None) -> str | None:
+    """Format a ``fetch_memory_snapshot`` pair as the Slack readout
+    line, or return ``None`` if no snapshot was obtained.
+
+    Caller-side formatting (rather than baking the string into the
+    shared helper) keeps ``wikimedia_launch`` / ``wikimedia_retry``
+    free to apply their own headroom-threshold semantics on the same
+    raw pair without ferrying a parsed format back through a regex.
+    """
+    if snapshot is None:
+        return None
+    total_mb, available_mb = snapshot
+    used_mb = total_mb - available_mb
+    pct_available = available_mb * 100 // total_mb
+    return f"Memory: {used_mb:,} / {total_mb:,} MB used ({pct_available}% available)"
+
+
+def post_to_slack(
+    token: str,
+    rows: list[tuple[str, str]],
+    memory_line: str | None = None,
+) -> None:
     lines = "\n".join(f"`{session:<32}` {phase}" for session, phase in rows)
+    blocks: list[dict] = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": "Wikimedia Upload Status"},
+        },
+        {"type": "section", "text": {"type": "mrkdwn", "text": lines}},
+    ]
+    if memory_line:
+        blocks.append(
+            {"type": "context", "elements": [{"type": "mrkdwn", "text": memory_line}]}
+        )
     payload = {
         "channel": SLACK_CHANNEL,
         "text": "Wikimedia Upload Status",
-        "blocks": [
-            {
-                "type": "header",
-                "text": {"type": "plain_text", "text": "Wikimedia Upload Status"},
-            },
-            {"type": "section", "text": {"type": "mrkdwn", "text": lines}},
-        ],
+        "blocks": blocks,
     }
     resp = requests.post(
         SLACK_API_URL,
@@ -320,7 +346,11 @@ def main() -> None:
     if not sessions:
         print("No active wikimedia sessions.")
         if notify_if_idle:
-            post_to_slack(token, [("(none)", "No active Wikimedia upload sessions.")])
+            post_to_slack(
+                token,
+                [("(none)", "No active Wikimedia upload sessions.")],
+                memory_line=_format_memory_line(fetch_memory_snapshot(ssm)),
+            )
             print("Posted idle status to Slack.")
         return
 
@@ -452,15 +482,20 @@ def main() -> None:
         # This is a defensive fallback that should never fire.
         return session, "Generating IDs"
 
-    with ThreadPoolExecutor(max_workers=min(len(sessions), 8)) as executor:
+    # Memory snapshot is independent of every per-session fetch — submit it
+    # to the same executor so the SSM round-trip overlaps with the session
+    # phase resolution rather than serializing after it.
+    with ThreadPoolExecutor(max_workers=min(len(sessions) + 1, 8)) as executor:
+        memory_future = executor.submit(fetch_memory_snapshot, ssm)
         futures = {executor.submit(fetch, s): s for s in sessions}
         for future in as_completed(futures):
             session, phase = future.result()
             results[session] = phase
             print(f"{session}: {phase}")
+        memory_line = _format_memory_line(memory_future.result())
 
     rows = [(s, results[s]) for s in sessions if s in results]
-    post_to_slack(token, rows)
+    post_to_slack(token, rows, memory_line=memory_line)
     print("Posted to Slack.")
 
 

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1088,6 +1088,7 @@ def test_safe_process_one_passes_through_on_success(monkeypatch):
     from tools import sdc_sync
 
     fake_tracker = MagicMock()
+    fake_tracker.count.return_value = 0
     monkeypatch.setattr(sdc_sync, "tracker", fake_tracker)
     monkeypatch.setattr(sdc_sync, "process_one", lambda *a: None)
 
@@ -1147,16 +1148,19 @@ def test_safe_process_one_runs_post_sdc_cleanup_when_file_page_supplied(monkeypa
     on the legacy paths."""
     from tools import sdc_sync
 
-    monkeypatch.setattr(sdc_sync, "tracker", MagicMock())
+    fake_tracker = MagicMock()
+    fake_tracker.count.return_value = 0
+    monkeypatch.setattr(sdc_sync, "tracker", fake_tracker)
     monkeypatch.setattr(sdc_sync, "process_one", lambda *a: None)
     monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", True)
 
     cleanup_calls = []
-    monkeypatch.setattr(
-        sdc_sync,
-        "_post_sdc_cleanup_for_legacy_mode",
-        lambda page, dpla_id: cleanup_calls.append((page, dpla_id)),
-    )
+
+    def _record(page, dpla_id):
+        cleanup_calls.append((page, dpla_id))
+        return False
+
+    monkeypatch.setattr(sdc_sync, "_post_sdc_cleanup_for_legacy_mode", _record)
 
     fake_page = MagicMock(name="FilePage")
     sdc_sync._safe_process_one("M1", "dpla-1", file_page=fake_page)
@@ -1170,7 +1174,9 @@ def test_safe_process_one_skips_cleanup_when_no_file_page(monkeypatch):
     ``None`` page handle)."""
     from tools import sdc_sync
 
-    monkeypatch.setattr(sdc_sync, "tracker", MagicMock())
+    fake_tracker = MagicMock()
+    fake_tracker.count.return_value = 0
+    monkeypatch.setattr(sdc_sync, "tracker", fake_tracker)
     monkeypatch.setattr(sdc_sync, "process_one", lambda *a: None)
     monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", True)
 
@@ -1178,7 +1184,7 @@ def test_safe_process_one_skips_cleanup_when_no_file_page(monkeypatch):
     monkeypatch.setattr(
         sdc_sync,
         "_post_sdc_cleanup_for_legacy_mode",
-        lambda *a: called.append(a),
+        lambda *a: called.append(a) or False,
     )
 
     sdc_sync._safe_process_one("M1", "dpla-1")  # no file_page
@@ -1193,7 +1199,9 @@ def test_safe_process_one_skips_cleanup_when_disabled(monkeypatch):
     operator with post-SDC edits."""
     from tools import sdc_sync
 
-    monkeypatch.setattr(sdc_sync, "tracker", MagicMock())
+    fake_tracker = MagicMock()
+    fake_tracker.count.return_value = 0
+    monkeypatch.setattr(sdc_sync, "tracker", fake_tracker)
     monkeypatch.setattr(sdc_sync, "process_one", lambda *a: None)
     monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", False)
 
@@ -1201,12 +1209,120 @@ def test_safe_process_one_skips_cleanup_when_disabled(monkeypatch):
     monkeypatch.setattr(
         sdc_sync,
         "_post_sdc_cleanup_for_legacy_mode",
-        lambda *a: called.append(a),
+        lambda *a: called.append(a) or False,
     )
 
     sdc_sync._safe_process_one("M1", "dpla-1", file_page=MagicMock())
 
     assert called == []
+
+
+def test_safe_process_one_increments_pages_edited_when_sdc_wrote(monkeypatch):
+    """A successful ``process_one`` that committed SDC changes must
+    bump ``SDC_PAGES_EDITED`` once. Detected via the write-counter
+    snapshot delta (claims/refs/removals after > before)."""
+    from tools import sdc_sync
+
+    counts = {
+        Result.SDC_CLAIMS_ADDED: 0,
+        Result.SDC_REFS_ADDED: 0,
+        Result.SDC_REMOVALS: 0,
+    }
+    fake_tracker = MagicMock()
+    fake_tracker.count.side_effect = lambda r: counts.get(r, 0)
+    monkeypatch.setattr(sdc_sync, "tracker", fake_tracker)
+
+    def write_some_claims(*_a):
+        # Simulate process_one's effect: it bumped CLAIMS_ADDED via the
+        # SDC dispatcher.
+        counts[Result.SDC_CLAIMS_ADDED] += 5
+
+    monkeypatch.setattr(sdc_sync, "process_one", write_some_claims)
+    monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", False)
+
+    sdc_sync._safe_process_one("M1", "dpla-1")
+
+    fake_tracker.increment.assert_called_once_with(Result.SDC_PAGES_EDITED)
+
+
+def test_safe_process_one_increments_pages_edited_when_cleanup_wrote(monkeypatch):
+    """Even if SDC made no changes (file already in sync), a wikitext
+    cleanup that actually saved still counts the page as edited.
+    Cleanup-only edits are rare but they're real bytes-on-the-wire."""
+    from tools import sdc_sync
+
+    fake_tracker = MagicMock()
+    fake_tracker.count.return_value = 0  # SDC wrote nothing
+    monkeypatch.setattr(sdc_sync, "tracker", fake_tracker)
+    monkeypatch.setattr(sdc_sync, "process_one", lambda *a: None)
+    monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", True)
+    # Cleanup helper claims it wrote — drives the cleanup_wrote branch.
+    monkeypatch.setattr(sdc_sync, "_post_sdc_cleanup_for_legacy_mode", lambda *_a: True)
+
+    sdc_sync._safe_process_one("M1", "dpla-1", file_page=MagicMock())
+
+    fake_tracker.increment.assert_called_once_with(Result.SDC_PAGES_EDITED)
+
+
+def test_safe_process_one_counts_page_once_when_both_paths_wrote(monkeypatch):
+    """A file that received both an SDC write AND a wikitext cleanup
+    must count as ONE edited page, not two. Otherwise the operator-
+    facing PAGES EDITED total inflates beyond the real file count."""
+    from tools import sdc_sync
+
+    counts = {
+        Result.SDC_CLAIMS_ADDED: 0,
+        Result.SDC_REFS_ADDED: 0,
+        Result.SDC_REMOVALS: 0,
+    }
+    fake_tracker = MagicMock()
+    fake_tracker.count.side_effect = lambda r: counts.get(r, 0)
+    monkeypatch.setattr(sdc_sync, "tracker", fake_tracker)
+    monkeypatch.setattr(
+        sdc_sync,
+        "process_one",
+        lambda *_: counts.__setitem__(
+            Result.SDC_CLAIMS_ADDED, counts[Result.SDC_CLAIMS_ADDED] + 1
+        ),
+    )
+    monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", True)
+    monkeypatch.setattr(sdc_sync, "_post_sdc_cleanup_for_legacy_mode", lambda *_a: True)
+
+    sdc_sync._safe_process_one("M1", "dpla-1", file_page=MagicMock())
+
+    page_increments = [
+        c
+        for c in fake_tracker.increment.call_args_list
+        if c.args == (Result.SDC_PAGES_EDITED,)
+    ]
+    assert len(page_increments) == 1
+
+
+def test_safe_process_one_does_not_increment_pages_edited_when_nothing_wrote(
+    monkeypatch,
+):
+    """The no-op case: process_one ran cleanly but committed no edits
+    (file already in sync), and cleanup didn't either. Nothing got
+    written to Commons → PAGES EDITED must stay flat."""
+    from tools import sdc_sync
+
+    fake_tracker = MagicMock()
+    fake_tracker.count.return_value = 0
+    monkeypatch.setattr(sdc_sync, "tracker", fake_tracker)
+    monkeypatch.setattr(sdc_sync, "process_one", lambda *a: None)
+    monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", True)
+    monkeypatch.setattr(
+        sdc_sync, "_post_sdc_cleanup_for_legacy_mode", lambda *_a: False
+    )
+
+    sdc_sync._safe_process_one("M1", "dpla-1", file_page=MagicMock())
+
+    page_increments = [
+        c
+        for c in fake_tracker.increment.call_args_list
+        if c.args == (Result.SDC_PAGES_EDITED,)
+    ]
+    assert page_increments == []
 
 
 def test_safe_process_one_skips_cleanup_on_missing_entity(monkeypatch):

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -3361,6 +3361,51 @@ def test_submit_per_item_edit_bundles_all_fragments_into_one_post():
     assert payload["claims"] == [new_claim, ref_update, expected_qual_update, removal]
 
 
+def test_submit_per_item_edit_increments_qualifier_counter():
+    """Qualifier-only fragments still represent a real ``wbeditentity``
+    write on a Commons file, so the dispatcher must bump
+    ``SDC_QUALIFIER_UPDATES``. That counter is in ``_SDC_WRITE_COUNTERS``,
+    so ``_sdc_writes_total()`` picks up the change and
+    ``SDC_PAGES_EDITED`` counts the page — the rare case where every
+    DPLA claim on the file is already on today's P813 (so the
+    opportunistic refresh adds no reference fragments) and the only
+    write left in the bundle is the qualifier amend."""
+    from tools import sdc_sync
+
+    qual_update = {"id": "M999$amend", "qualifiers": {"P459": []}}
+
+    fake_tracker = MagicMock()
+    with (
+        patch.object(sdc_sync, "tracker", fake_tracker),
+        patch.object(sdc_sync, "_submit_sdc_write", side_effect=lambda *a, **kw: None),
+    ):
+        sdc_sync._submit_per_item_edit(
+            "M999",
+            "abcdef",
+            summary="qualifier-only edit",
+            qualifier_updates=[qual_update],
+        )
+
+    fake_tracker.increment.assert_called_once_with(Result.SDC_QUALIFIER_UPDATES, 1)
+
+
+def test_sdc_writes_total_includes_qualifier_updates():
+    """The write-delta source used by the partner-mode loop and
+    ``_safe_process_one`` to detect "did this ordinal write anything?"
+    must include qualifier updates — otherwise the rare qualifier-only
+    commit slips past ``SDC_PAGES_EDITED``."""
+    from tools import sdc_sync
+
+    counts = {r: 0 for r in sdc_sync._SDC_WRITE_COUNTERS}
+    fake_tracker = MagicMock()
+    fake_tracker.count.side_effect = lambda r: counts.get(r, 0)
+    with patch.object(sdc_sync, "tracker", fake_tracker):
+        before = sdc_sync._sdc_writes_total()
+        counts[Result.SDC_QUALIFIER_UPDATES] = 3
+        after = sdc_sync._sdc_writes_total()
+    assert after - before == 3
+
+
 def test_p813_refresh_skips_when_no_other_edits():
     """No fragments in any accumulator → no POST, including no P813
     refresh. The refresh only piggybacks on edits we're already making."""

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -480,6 +480,7 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
         tracker_counts={
             Result.SDC_ITEMS_SYNCED: 100,
             Result.SDC_ITEMS_PARTIALLY_SYNCED: 9,
+            Result.SDC_PAGES_EDITED: 1234,
             Result.SDC_CLAIMS_ADDED: 250,
             Result.SDC_REFS_ADDED: 30,
             Result.SDC_REMOVALS: 4,
@@ -494,6 +495,7 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
     stats = captured["stats_lines"]
     assert any(s.startswith("ITEMS SYNCED:") and "100" in s for s in stats)
     assert any(s.startswith("ITEMS PARTIAL:") and "9" in s for s in stats)
+    assert any(s.startswith("PAGES EDITED:") and "1,234" in s for s in stats)
     assert any(s.startswith("CLAIMS ADDED:") and "250" in s for s in stats)
     assert any(s.startswith("REFS ADDED:") and "30" in s for s in stats)
     assert any(s.startswith("REMOVALS:") and "4" in s for s in stats)
@@ -504,6 +506,17 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
     assert any("ORDINAL NO PAGEID:" in s and "6" in s for s in stats)
     assert any("ORDINAL ERRORS:" in s and "7" in s for s in stats)
     assert any("Runtime:" in s and "42s" in s for s in stats)
+
+    # PAGES EDITED belongs in the leading "scope" block (ITEMS SYNCED /
+    # ITEMS PARTIAL / PAGES EDITED) — it's the per-file-page batch size,
+    # paired with the per-item counts. Pin the order so a stray refactor
+    # doesn't bury it next to the SKIPPED footer where operators won't
+    # notice it.
+    def _idx(prefix: str) -> int:
+        return next(i for i, s in enumerate(stats) if s.startswith(prefix))
+
+    assert _idx("ITEMS SYNCED:") < _idx("ITEMS PARTIAL:") < _idx("PAGES EDITED:")
+    assert _idx("PAGES EDITED:") < _idx("CLAIMS ADDED:")
 
 
 def test_notify_sdc_complete_dry_run_adds_suffix():

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -4,7 +4,7 @@ import base64
 import re
 from unittest.mock import MagicMock
 
-from ingest_wikimedia.ssm import ssm_run, stage_and_launch_tmux
+from ingest_wikimedia.ssm import fetch_memory_snapshot, ssm_run, stage_and_launch_tmux
 
 
 def _make_client_returning(stdout: str) -> MagicMock:
@@ -233,3 +233,35 @@ def test_stage_and_launch_tmux_script_filename_is_deterministic_per_session():
     assert path_A1 != path_B, (
         f"different session names must produce different paths: {path_A1} vs {path_B}"
     )
+
+
+def test_fetch_memory_snapshot_parses_free_output():
+    """``free -m | awk 'NR==2{print $2,$7}'`` emits ``"<total> <available>"``;
+    helper returns the parsed ``(total, available)`` pair."""
+    client = _make_client_returning("7700 3200")
+    assert fetch_memory_snapshot(client) == (7700, 3200)
+
+
+def test_fetch_memory_snapshot_returns_none_on_ssm_failure():
+    """An SSM failure must downgrade to ``None`` rather than raise —
+    every caller (status reporter, launch gate, retry gate) needs to
+    be free to apply its own policy when the snapshot is unavailable."""
+    client = MagicMock()
+    client.send_command.return_value = {"Command": {"CommandId": "x"}}
+    client.exceptions.InvocationDoesNotExist = type(
+        "_FakeInvocationDoesNotExist", (Exception,), {}
+    )
+    client.get_command_invocation.return_value = {
+        "Status": "Failed",
+        "StandardErrorContent": "boom",
+    }
+    assert fetch_memory_snapshot(client) is None
+
+
+def test_fetch_memory_snapshot_returns_none_on_malformed_output():
+    """Defensive: any ``free`` output that doesn't yield two positive
+    ints must downgrade to ``None`` (rather than emit a misleading
+    snapshot or raise a ``ZeroDivisionError`` downstream)."""
+    assert fetch_memory_snapshot(_make_client_returning("not numeric")) is None
+    assert fetch_memory_snapshot(_make_client_returning("0 0")) is None
+    assert fetch_memory_snapshot(_make_client_returning("7700")) is None  # single token

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -427,3 +427,78 @@ def test_get_phase_and_progress_returns_none_tuple_when_no_log_exists():
             label="bpl+nonexistent",
         )
     assert result == (None, 0)
+
+
+def test_format_memory_line_formats_pair():
+    """``_format_memory_line`` turns the raw ``(total, available)``
+    pair from ``ingest_wikimedia.ssm.fetch_memory_snapshot`` into the
+    Slack-friendly ``"used / total MB used (pct% available)"`` line.
+    The OOM-watching readout has to be parseable at a glance — pin
+    the exact format so a future thousands-separator or label tweak
+    is noticed."""
+    from scripts.wikimedia_upload_status import _format_memory_line
+
+    # used = total - available = 7700 - 3200 = 4500
+    # pct_available = 3200 * 100 // 7700 = 41
+    assert (
+        _format_memory_line((7700, 3200))
+        == "Memory: 4,500 / 7,700 MB used (41% available)"
+    )
+
+
+def test_format_memory_line_passes_through_none():
+    """When the shared helper couldn't fetch a snapshot it returns
+    ``None``; the formatter has to propagate that so the caller can
+    omit the memory block from the Slack post rather than emit a
+    misleading row."""
+    from scripts.wikimedia_upload_status import _format_memory_line
+
+    assert _format_memory_line(None) is None
+
+
+def test_post_to_slack_includes_memory_line_when_provided():
+    """``post_to_slack`` adds the memory snapshot as a context block at
+    the bottom of the message. Omitted when ``memory_line`` is None
+    (so the message degrades gracefully on snapshot failure)."""
+    from unittest.mock import MagicMock, patch
+
+    from scripts.wikimedia_upload_status import post_to_slack
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"ok": True}
+    fake_resp.raise_for_status.return_value = None
+
+    rows = [("wikimedia-bpl", "Uploading")]
+    with patch(
+        "scripts.wikimedia_upload_status.requests.post", return_value=fake_resp
+    ) as mock_post:
+        post_to_slack(
+            "tok", rows, memory_line="Memory: 4,500 / 7,700 MB used (41% available)"
+        )
+    payload = mock_post.call_args.kwargs["json"]
+    block_texts = [
+        elem["text"]
+        for block in payload["blocks"]
+        if block["type"] == "context"
+        for elem in block["elements"]
+    ]
+    assert any("41% available" in text for text in block_texts)
+
+
+def test_post_to_slack_omits_memory_block_when_none():
+    """No memory line → no context block — the message degrades to just
+    the session phase summary."""
+    from unittest.mock import MagicMock, patch
+
+    from scripts.wikimedia_upload_status import post_to_slack
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"ok": True}
+    fake_resp.raise_for_status.return_value = None
+
+    with patch(
+        "scripts.wikimedia_upload_status.requests.post", return_value=fake_resp
+    ) as mock_post:
+        post_to_slack("tok", [("wikimedia-bpl", "Uploading")], memory_line=None)
+    payload = mock_post.call_args.kwargs["json"]
+    assert not any(b.get("type") == "context" for b in payload["blocks"])

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2050,6 +2050,28 @@ def _build_expected_from_sdc(sdc_payload):
     return expected
 
 
+# Result counters that the SDC dispatcher bumps when ``_submit_per_item_edit``
+# actually POSTs a change. The "did this ordinal write anything?" check
+# in partner mode and ``_safe_process_one`` snapshots the sum of these
+# before vs. after ``process_one``; centralising the tuple here keeps
+# any future SDC write counter from silently slipping past the
+# snapshot delta (and the ``SDC_PAGES_EDITED`` accounting that hangs
+# off it).
+_SDC_WRITE_COUNTERS = (
+    Result.SDC_CLAIMS_ADDED,
+    Result.SDC_REFS_ADDED,
+    Result.SDC_REMOVALS,
+)
+
+
+def _sdc_writes_total() -> int:
+    """Sum of the tracker counters that ``_submit_per_item_edit``
+    increments per write. Used to detect whether a given
+    ``process_one`` call actually committed anything on Commons.
+    """
+    return sum(tracker.count(c) for c in _SDC_WRITE_COUNTERS)
+
+
 def _submit_sdc_write(action, mediaid, dpla_id, **params):
     """Submit an SDC write (wbeditentity or wbremoveclaims) through
     pywikibot's ``simple_request``.
@@ -3288,7 +3310,7 @@ def _post_sdc_cleanup_for_page(
     data_provider: dict,
     *,
     expected_params: dict | None = None,
-) -> None:
+) -> bool:
     """Post-SDC wikitext cleanup for one Commons file page.
 
     Dispatches based on the file's current wikitext shape:
@@ -3319,9 +3341,15 @@ def _post_sdc_cleanup_for_page(
     computes it from ``dpla_metadata_params``. Partner mode passes it
     in so a multi-ordinal item doesn't redundantly recompute per
     ordinal.
+
+    Returns ``True`` when the file page was actually saved (legacy
+    migration rewrote the wikitext, or normalize_page stripped a
+    param); ``False`` when the cleanup was a no-op or skipped.
+    Callers use this to track the per-page edit count for the SDC
+    summary.
     """
     if not file_page.exists():
-        return
+        return False
 
     text = file_page.text or ""
 
@@ -3331,7 +3359,7 @@ def _post_sdc_cleanup_for_page(
         # here would be wasted work — migrate_legacy_file recomputes
         # them internally from item_metadata.
         try:
-            legacy_artwork.migrate_legacy_file(
+            result = legacy_artwork.migrate_legacy_file(
                 file_page=file_page,
                 item_metadata=item_metadata,
                 provider=provider,
@@ -3344,7 +3372,8 @@ def _post_sdc_cleanup_for_page(
                 f" -- cleanup: legacy migration of '{file_page.title()}'"
                 f" for {dpla_id} failed; skipping."
             )
-        return
+            return False
+        return bool(getattr(result, "wikitext_changed", False))
 
     # Strip path. Bail before computing ``expected_params`` when the
     # file has no ``{{DPLA metadata}}`` template either — a hand-written
@@ -3353,7 +3382,7 @@ def _post_sdc_cleanup_for_page(
     # rights URI, builds the hub label, etc.) and would be wasted on
     # a page that ``normalize_page`` is going to no-op anyway.
     if not wikitext_normalize.has_dpla_metadata_template(text):
-        return
+        return False
 
     if expected_params is None:
         try:
@@ -3365,7 +3394,7 @@ def _post_sdc_cleanup_for_page(
                 f" -- cleanup: dpla_metadata_params failed for {dpla_id};"
                 " skipping strip."
             )
-            return
+            return False
 
     # Defensive guard against the upstream null-pageid bug shape and
     # any future regression: ``normalize_page`` strips wikitext params
@@ -3391,7 +3420,7 @@ def _post_sdc_cleanup_for_page(
                 f" -- cleanup: entity fetch failed for {file_page.title()}"
                 f" ({mediaid}); skipping strip out of caution."
             )
-            return
+            return False
         if not _entity_has_dpla_attributed_claims(entity):
             logging.warning(
                 f" -- cleanup: '{file_page.title()}' ({mediaid}) for"
@@ -3399,22 +3428,25 @@ def _post_sdc_cleanup_for_page(
                 " to avoid wiping wikitext params without an SDC"
                 " counterpart (upstream sync likely never fired)."
             )
-            return
+            return False
 
     try:
-        wikitext_normalize.normalize_page(
-            file_page, expected_params, _NORMALIZE_EDIT_SUMMARY
+        return bool(
+            wikitext_normalize.normalize_page(
+                file_page, expected_params, _NORMALIZE_EDIT_SUMMARY
+            )
         )
     except Exception:
         logging.exception(
             f" -- cleanup: normalize_page on '{file_page.title()}' for"
             f" {dpla_id} failed; skipping."
         )
+        return False
 
 
 def _post_sdc_cleanup_for_item(
     s3, partner: str, dpla_id: str, ordinal_items: list[tuple[str, dict]]
-) -> None:
+) -> set[str]:
     """Per-item post-SDC cleanup (partner mode).
 
     Reads ``dpla-map.json`` from S3, resolves provider / data_provider,
@@ -3425,27 +3457,34 @@ def _post_sdc_cleanup_for_item(
     logged but never raised. SDC sync has already committed and counted
     before this runs; a cleanup failure must not roll that back or fail
     the partner batch.
+
+    Returns the set of ``ord_str`` values whose file page was actually
+    rewritten by cleanup (legacy migration or wikitext strip). The
+    partner-mode caller unions this with the set of ordinals whose
+    SDC writes landed to derive a per-page edit count without
+    double-counting pages that had both kinds of edit.
     """
     from ingest_wikimedia import wikimedia
     from ingest_wikimedia.dpla import DPLA
 
+    edited: set[str] = set()
     try:
         item_raw = s3.get_item_metadata(partner, dpla_id)
     except Exception as e:
         logging.warning(f" -- cleanup: S3 read failed for {dpla_id}: {e!r}; skipping.")
-        return
+        return edited
     if not item_raw:
         # dpla-map.json missing — get-ids-es never staged it, or the
         # partner-mode item came from a path that doesn't write one.
         # Nothing to compare against; skip silently.
-        return
+        return edited
     try:
         item_metadata = json.loads(item_raw)
     except json.JSONDecodeError as e:
         logging.warning(
             f" -- cleanup: dpla-map.json parse failed for {dpla_id}: {e}; skipping."
         )
-        return
+        return edited
 
     try:
         provider, data_provider = DPLA.get_provider_and_data_provider(
@@ -3455,7 +3494,7 @@ def _post_sdc_cleanup_for_item(
         logging.warning(
             f" -- cleanup: provider lookup failed for {dpla_id}: {e!r}; skipping."
         )
-        return
+        return edited
 
     try:
         expected_params = wikimedia.dpla_metadata_params(
@@ -3465,7 +3504,7 @@ def _post_sdc_cleanup_for_item(
         logging.warning(
             f" -- cleanup: param compute failed for {dpla_id}: {e!r}; skipping."
         )
-        return
+        return edited
 
     for ord_str, data in ordinal_items:
         title = data.get("title")
@@ -3479,17 +3518,19 @@ def _post_sdc_cleanup_for_item(
                 f" {ord_str} ({title}) of {dpla_id}; skipping."
             )
             continue
-        _post_sdc_cleanup_for_page(
+        if _post_sdc_cleanup_for_page(
             page,
             dpla_id,
             item_metadata,
             provider,
             data_provider,
             expected_params=expected_params,
-        )
+        ):
+            edited.add(ord_str)
+    return edited
 
 
-def _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id: str) -> None:
+def _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id: str) -> bool:
     """Post-SDC cleanup for the ``--file`` / ``--cat`` / ``--list`` paths.
 
     Mirrors :func:`_post_sdc_cleanup_for_item` for single-file modes:
@@ -3501,7 +3542,10 @@ def _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id: str) -> None:
     cache was cleared by an earlier cleanup) the doc is fetched fresh
     from S3 / api.dp.la so the cleanup still runs.
 
-    Best-effort: any failure is logged but doesn't raise.
+    Best-effort: any failure is logged but doesn't raise. Returns
+    ``True`` if cleanup actually rewrote the page, else ``False`` —
+    used by :func:`_safe_process_one` to track per-page edit counts
+    for the SDC summary.
     """
     from ingest_wikimedia.dpla import DPLA
 
@@ -3518,9 +3562,9 @@ def _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id: str) -> None:
             logging.exception(
                 f" -- cleanup: DPLA-doc fetch failed for {dpla_id}; skipping."
             )
-            return
+            return False
     if not doc:
-        return
+        return False
 
     try:
         provider, data_provider = DPLA.get_provider_and_data_provider(doc, hubs)
@@ -3528,9 +3572,9 @@ def _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id: str) -> None:
         logging.warning(
             f" -- cleanup: provider lookup failed for {dpla_id}: {e!r}; skipping."
         )
-        return
+        return False
 
-    _post_sdc_cleanup_for_page(file_page, dpla_id, doc, provider, data_provider)
+    return _post_sdc_cleanup_for_page(file_page, dpla_id, doc, provider, data_provider)
 
 
 def _run_legacy_migration_mode(partner: str, ids_file: str) -> None:
@@ -3875,6 +3919,15 @@ def _run_partner_mode(partner, ids_file):
             # explicit. ``synced_this_item`` derives from the set
             # below; classification is unchanged.
             synced_ord_strs: set[str] = set()
+            # Per-item set of ord_strs whose Commons file page actually
+            # received an edit this run — populated from the SDC-write
+            # snapshot below (claim/ref/removal writes) and unioned with
+            # the set returned by post-SDC cleanup. Drives
+            # ``SDC_PAGES_EDITED``, so operators can read the real batch
+            # size off the Slack summary instead of inferring it from
+            # ``ITEMS SYNCED`` (which collapses 1-file and 1,000-file
+            # items into the same count).
+            pages_edited: set[str] = set()
             # Tracks whether any ordinal hit the per-ordinal exception
             # path (runtime failure) so an item with all-failed ordinals
             # is classified under SDC_ITEMS_SKIPPED_ERROR rather than
@@ -3962,11 +4015,7 @@ def _run_partner_mode(partner, ids_file):
 
                 # Snapshot write counters so we can detect whether this
                 # ordinal's sync actually changed anything on Commons.
-                writes_before = (
-                    tracker.count(Result.SDC_CLAIMS_ADDED)
-                    + tracker.count(Result.SDC_REFS_ADDED)
-                    + tracker.count(Result.SDC_REMOVALS)
-                )
+                writes_before = _sdc_writes_total()
                 # Per-ordinal exception boundary. Without this, any
                 # transient pywikibot APIError (rate limit, maxlag,
                 # transient 503), network timeout, or surprise
@@ -4027,11 +4076,7 @@ def _run_partner_mode(partner, ids_file):
                     tracker.increment(Result.SDC_ORDINALS_SKIPPED_ERROR)
                     had_ordinal_error = True
                     continue
-                writes_after = (
-                    tracker.count(Result.SDC_CLAIMS_ADDED)
-                    + tracker.count(Result.SDC_REFS_ADDED)
-                    + tracker.count(Result.SDC_REMOVALS)
-                )
+                writes_after = _sdc_writes_total()
 
                 # If SDC actually changed for this ordinal, force a
                 # category re-render on the file page via a null edit.
@@ -4043,14 +4088,16 @@ def _run_partner_mode(partner, ids_file):
                 # after the SDC was added. Mirrors the touch pattern in
                 # ingest_wikimedia/categories.py's
                 # touch_files_for_institution().
-                if writes_after > writes_before and title and title != "?":
-                    try:
-                        pywikibot.FilePage(site, title).touch()
-                        logging.info(f" -- Touched '{title}' (category refresh).")
-                    except Exception as e:
-                        logging.warning(
-                            f" -- Failed to touch '{title}' for category refresh: {e!r}"
-                        )
+                if writes_after > writes_before:
+                    pages_edited.add(ord_str)
+                    if title and title != "?":
+                        try:
+                            pywikibot.FilePage(site, title).touch()
+                            logging.info(f" -- Touched '{title}' (category refresh).")
+                        except Exception as e:
+                            logging.warning(
+                                f" -- Failed to touch '{title}' for category refresh: {e!r}"
+                            )
                 synced_ord_strs.add(ord_str)
             # Item-level bucket classification + cleanup dispatch.
             # ``_classify_item_outcome`` returns the bucket; cleanup
@@ -4072,7 +4119,11 @@ def _run_partner_mode(partner, ids_file):
                 synced_items = [
                     (o, d) for o, d in ordinal_items if o in synced_ord_strs
                 ]
-                _post_sdc_cleanup_for_item(s3, partner, dpla_id, synced_items)
+                pages_edited |= _post_sdc_cleanup_for_item(
+                    s3, partner, dpla_id, synced_items
+                )
+            if pages_edited:
+                tracker.increment(Result.SDC_PAGES_EDITED, len(pages_edited))
         completed = True
     except BaseException as exc:
         # The per-ordinal try/except above already swallows every routine
@@ -4148,6 +4199,11 @@ def _safe_process_one(mediaid: str, dpla_id: str, file_page=None) -> None:
     per-institution, per-collection, single-id, ``--file``, ``--cat``,
     ``--list``) ends with the same per-file cleanup.
     """
+    # Snapshot SDC write counters so we can tell whether ``process_one``
+    # actually committed any change for this file. Mirrors the partner-
+    # mode pattern at the per-ordinal level so SDC_PAGES_EDITED is fed
+    # consistently across modes.
+    writes_before = _sdc_writes_total()
     try:
         try:
             process_one(mediaid, dpla_id)
@@ -4165,8 +4221,12 @@ def _safe_process_one(mediaid: str, dpla_id: str, file_page=None) -> None:
             tracker.increment(Result.SDC_ORDINALS_SKIPPED_ERROR)
             return
 
+        sdc_wrote = _sdc_writes_total() > writes_before
+        cleanup_wrote = False
         if _normalize_wikitext_enabled and file_page is not None:
-            _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id)
+            cleanup_wrote = _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id)
+        if sdc_wrote or cleanup_wrote:
+            tracker.increment(Result.SDC_PAGES_EDITED)
     finally:
         # Drop any stash ``parsed()`` left in the cache so a process_one
         # error path (or a cleanup skip when ``file_page`` is None /

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2061,6 +2061,10 @@ _SDC_WRITE_COUNTERS = (
     Result.SDC_CLAIMS_ADDED,
     Result.SDC_REFS_ADDED,
     Result.SDC_REMOVALS,
+    # Qualifier-only edits are real ``wbeditentity`` writes that
+    # otherwise wouldn't bump any of the above. Include here so the
+    # delta-detection feeding ``SDC_PAGES_EDITED`` doesn't miss them.
+    Result.SDC_QUALIFIER_UPDATES,
 )
 
 
@@ -2171,9 +2175,13 @@ def _submit_per_item_edit(
 
     The dispatcher tracker-counts ``new_claims`` under
     ``SDC_CLAIMS_ADDED``, ``reference_updates`` under
-    ``SDC_REFS_ADDED``, and ``removals`` under ``SDC_REMOVALS``.
-    Qualifier-only amends are not separately counted (they ride along
-    on a claim that's already accounted for or on a legacy backfill).
+    ``SDC_REFS_ADDED``, ``removals`` under ``SDC_REMOVALS``, and
+    ``qualifier_updates`` under ``SDC_QUALIFIER_UPDATES``. The
+    qualifier counter is not surfaced in the Slack summary — it
+    exists so the ``SDC_PAGES_EDITED`` write-delta detection picks
+    up the rare qualifier-only commit (every DPLA claim on the file
+    already carries today's ``P813``, so the opportunistic refresh
+    adds no reference fragments).
 
     No-op when every fragment list is empty.
     """
@@ -2217,6 +2225,8 @@ def _submit_per_item_edit(
         tracker.increment(Result.SDC_REFS_ADDED, len(reference_updates))
     if removals:
         tracker.increment(Result.SDC_REMOVALS, len(removals))
+    if qualifier_updates:
+        tracker.increment(Result.SDC_QUALIFIER_UPDATES, len(qualifier_updates))
 
 
 def _build_qualifier_update_fragments(mediaid):


### PR DESCRIPTION
## Summary

Two operator-facing improvements to the Wikimedia Slack notifications, both surfaced by recent sync runs where the existing readouts hid information needed to interpret what was happening.

- **SDC summary now reports `PAGES EDITED`** — distinct Commons file pages this run actually wrote to. Items vary from 1 file to 1,000+ files (e.g. NARA), so `ITEMS SYNCED` alone collapses very different batch sizes into the same number. Counted at per-ordinal granularity with set-based dedup so a page touched by both an SDC write and a wikitext cleanup still counts once. New `SDC_PAGES_EDITED` Result counter, populated in partner mode and `--file`/`--cat`/`--list` legacy paths.
- **`Wikimedia Upload Status` report now ends with a memory snapshot** (used / total MB used, % available). OOM-watching is the operator's main reason for checking this report periodically; previously you had to take a separate SSM hop to learn it. Snapshot is submitted to the existing `ThreadPoolExecutor` so the SSM round-trip overlaps with per-session phase checks rather than serialising after them.

Incidental quality fix: extracted `_sdc_writes_total()` in `tools/sdc_sync.py` so the "did this ordinal write anything?" snapshot delta has one source-of-truth list of SDC write counters — future counters won't silently slip past the new `PAGES_EDITED` accounting. Memory-fetch logic hoisted into shared `ingest_wikimedia.ssm.fetch_memory_snapshot`; the existing inline copies in `wikimedia_launch.py` / `wikimedia_retry.py` can migrate to it later (those callers want headroom-gate semantics, not a formatted string, so the shared helper returns the raw `(total_mb, available_mb)` pair).

## Test plan

- [ ] CI passes (existing 658 tests + 4 new SDC_PAGES_EDITED tests + 4 new memory-snapshot tests = 660 total)
- [ ] Next scheduled `/wikimedia-status` post shows the new `Memory:` line as a context block at the bottom
- [ ] Next SDC completion notice for a partner with multi-file items shows `PAGES EDITED:` strictly greater than `ITEMS SYNCED`
- [ ] Next SDC completion notice for a 1-file-per-item partner shows `PAGES EDITED:` ≈ `ITEMS SYNCED`
- [ ] Idempotent re-run of partner mode shows `PAGES EDITED: 0` when everything is already synced (no MediaInfo write delta, no cleanup save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR enhances the Wikimedia Slack notifications with two operator-focused improvements:

1. **SDC Pages Edited Counter**: The SDC sync completion Slack message now includes a `PAGES EDITED` metric (`Result.SDC_PAGES_EDITED`) alongside existing `ITEMS SYNCED`. It reports the count of distinct Commons file pages actually written during an SDC run using per-ordinal granularity and set-based deduplication to ensure each touched page is counted once even if multiple edits target it.

2. **Memory Snapshot in Status Reports**: The `/wikimedia-status` Slack report now appends a memory snapshot (used/total MB and % available) so operators don’t need to run separate system calls to detect potential out-of-memory conditions. The SSM `free -m` round-trip is moved into a shared `ingest_wikimedia.ssm.fetch_memory_snapshot` helper and scheduled concurrently with existing status work using the existing `ThreadPoolExecutor`.

## Technical Changes

- **SDC tracker updates**:  
  - Added `Result.SDC_PAGES_EDITED` to count distinct edited pages per SDC run.  
  - Added `Result.SDC_QUALIFIER_UPDATES` to ensure qualifier-only `wbeditentity` writes are included in write-delta detection (prevents undercounting in rare cases).
- **SDC refactor/accounting** (`tools/sdc_sync.py`):  
  - Introduced centralized “total SDC writes” tracking via `_sdc_writes_total()` with a single source-of-truth list of SDC write counters (now including qualifier updates).  
  - Refactored post-SDC cleanup paths to return edit outcomes (bool/sets) so `PAGES EDITED` is incremented based on actual page rewrites without double counting.
- **Status refactor**:  
  - Added `fetch_memory_snapshot(client)` in `ingest_wikimedia/ssm.py` to parse `free -m` output and safely return `None` on failures.  
  - Updated `scripts/wikimedia_upload_status.py` to concurrently fetch memory and include it as Slack context.
- **Slack formatting**:  
  - Updated Slack stats line generation to include `PAGES EDITED` (`tests/test_slack.py` verifies ordering and formatting).
- **Test coverage**: Adds/updates unit tests for memory snapshot parsing/formatting and `PAGES EDITED` + qualifier-only write-delta accounting in SDC sync (8 new tests total per the change description).

## Deployment Notes

- **Manual pipeline trigger / ECS redeployment**: No special/manual steps required beyond the normal rollout of these code changes.
- **Environment variables / Secrets Manager keys**: None changed.
- **Database migrations**: None added.
- **Shared infrastructure configuration (CodePipeline/CodeBuild/ECS/IAM)**: None changed.
- **Public-facing API shape / endpoints**: None changed (Slack/internal reporting only).
- **Security implications**: No auth/credential-handling changes; the PR reuses existing SSM access to run `free -m` and parses its output defensively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->