### PR TITLE
legacy_artwork + sdc-sync: recognise year ranges; clean up duplicate inferred-from-Wikitext claims

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -34,6 +34,8 @@ from urllib.parse import urlencode
 
 import mwparserfromhell
 
+from ingest_wikimedia.sdc import parse_date_range, parse_dpla_date
+
 # DPLA's Commons-bot account names. Revisions authored by these accounts
 # are treated as DPLA-originated for the purpose of provenance
 # classification — any param value they last touched is safe to
@@ -611,6 +613,28 @@ def _expand_wikitext_for_date_parse(raw_date: str, site) -> str:
     return expanded.strip() or raw_date
 
 
+def _iter_dpla_attributed_statements(entity: dict | None, prop: str):
+    """Yield every DPLA-attributed statement on ``prop`` in ``entity``.
+
+    "DPLA-attributed" means the statement carries a
+    ``P459 = Q61848113`` (determination method = heuristic) qualifier —
+    the same signal Module:DPLA's ``dplaStatements`` uses to scope the
+    blue-box render. Both date matchers (structured time and range)
+    walk the same set of DPLA-attributed statements; this generator
+    keeps that contract in one place so a future change to the
+    attribution rule applies to both.
+    """
+    if not entity:
+        return
+    statements = entity.get("statements") or entity.get("claims") or {}
+    for stmt in statements.get(prop, []):
+        for q in (stmt.get("qualifiers") or {}).get(_PID_DPLA_DETERMINATION, []):
+            qv = q.get("datavalue", {}).get("value", {}) or {}
+            if qv.get("id") == _QID_HEURISTIC:
+                yield stmt
+                break
+
+
 def _existing_dpla_date_matches_parsed(
     entity: dict | None, prop: str, parsed: dict
 ) -> bool:
@@ -618,12 +642,9 @@ def _existing_dpla_date_matches_parsed(
     statement on ``prop`` whose Wikibase time value and circa-flag
     match ``parsed``.
 
-    "DPLA-attributed" means a ``P459 = Q61848113`` (determination
-    method = heuristic) qualifier — the same signal Module:DPLA's
-    ``dplaStatements`` uses to scope the blue-box render. The check
-    deliberately doesn't compare reference shape: the editor-edited
-    legacy value is a different source than DPLA's own sync, but if
-    the *semantic* value and approximate-flag match, there's no
+    The check deliberately doesn't compare reference shape: the editor-
+    edited legacy value is a different source than DPLA's own sync, but
+    if the *semantic* value and approximate-flag match, there's no
     user-contributed information to preserve — the editor's edit was
     just a re-formatting of the DPLA value.
 
@@ -635,23 +656,13 @@ def _existing_dpla_date_matches_parsed(
     same-day with different ``before``/``after`` etc. would represent
     a different uncertainty bound and should not be deduped.
     """
-    if not entity or not parsed or not parsed.get("value"):
+    if not parsed or not parsed.get("value"):
         return False
     parsed_value = parsed["value"]
     if not parsed_value.get("time") or parsed_value.get("precision") is None:
         return False
     parsed_circa = bool(parsed.get("approximate"))
-    statements = entity.get("statements") or entity.get("claims") or {}
-    for stmt in statements.get(prop, []):
-        # DPLA-attributed only.
-        is_dpla = False
-        for q in (stmt.get("qualifiers") or {}).get(_PID_DPLA_DETERMINATION, []):
-            qv = q.get("datavalue", {}).get("value", {}) or {}
-            if qv.get("id") == _QID_HEURISTIC:
-                is_dpla = True
-                break
-        if not is_dpla:
-            continue
+    for stmt in _iter_dpla_attributed_statements(entity, prop):
         ms = stmt.get("mainsnak") or {}
         dv = ms.get("datavalue") or {}
         if dv.get("type") != "time":
@@ -675,6 +686,44 @@ def _existing_dpla_date_matches_parsed(
                 break
         if existing_circa == parsed_circa:
             return True
+    return False
+
+
+def _existing_dpla_date_range_matches(
+    entity: dict | None, prop: str, range_value: tuple[int, int]
+) -> bool:
+    """Mirror of :func:`_existing_dpla_date_matches_parsed` for range-
+    shaped claims. Returns True when ``entity`` already carries a
+    DPLA-attributed statement on ``prop`` whose ``P1932`` stated-as
+    qualifier parses to the same ``(start_year, end_year)`` range.
+
+    ``parse_dpla_date`` returns None for any multi-year range, so a
+    range value can never land as a structured time and the existing
+    parsed-time matcher never fires for it. Without this fallback, the
+    legacy migration emits an inferred-from-Wikitext range claim
+    parallel to the DPLA one — see Group_Portrait_of_"Indians" Mission
+    Grove (M193555788) where ``{{other date|between|1934|1948}}`` was
+    preserved alongside DPLA's ``"1934 - 1948"`` as two P571 statements.
+
+    Match contract: both sides go through
+    :func:`ingest_wikimedia.sdc.parse_date_range` and must produce the
+    same ``(start, end)`` tuple — direction-agnostic, since the helper
+    canonicalises ``(min, max)``.
+    """
+    if not range_value:
+        return False
+    for stmt in _iter_dpla_attributed_statements(entity, prop):
+        # Range claims must be ``somevalue`` mainsnak — a value-typed
+        # time can't represent a multi-year range, so any DPLA range
+        # statement is encoded as somevalue + P1932 stated-as.
+        if (stmt.get("mainsnak") or {}).get("snaktype") != "somevalue":
+            continue
+        for q in (stmt.get("qualifiers") or {}).get("P1932", []):
+            qv = q.get("datavalue") or {}
+            if qv.get("type") != "string":
+                continue
+            if parse_date_range(qv.get("value") or "") == range_value:
+                return True
     return False
 
 
@@ -734,8 +783,6 @@ def materialize_pending_date_claim(
     claim builders so a later phase can add a P813 retrieved-on
     reference snak if useful without changing call sites.
     """
-    from .sdc import parse_dpla_date  # late import to avoid cycle
-
     del today  # currently unused; see docstring
     raw_date = placeholder.get("_phase3a_pending_date_parse")
     prop = placeholder.get("_property")
@@ -757,6 +804,18 @@ def materialize_pending_date_claim(
     # community-imports comparator can never strip cleanly.
     if parsed is not None and _existing_dpla_date_matches_parsed(
         existing_entity, prop, parsed
+    ):
+        return None
+    # Same check for the range case — ``parse_dpla_date`` returns None
+    # for any multi-year range, so the structured-time matcher above
+    # never fires for shapes like ``{{other date|between|1934|1948}}``.
+    # ``parse_date_range`` produces a canonical ``(start, end)`` key
+    # that compares equal across "1934 - 1948", "between 1934 and 1948",
+    # and the raw-wikitext fallback, so the inferred import dedupes
+    # cleanly against a DPLA somevalue+P1932 range claim.
+    range_value = parse_date_range(value_for_parse)
+    if range_value is not None and _existing_dpla_date_range_matches(
+        existing_entity, prop, range_value
     ):
         return None
 

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1178,6 +1178,66 @@ def parse_dpla_date(date_string: str) -> dict | None:
     return None
 
 
+# Year-range patterns. ``parse_dpla_date`` deliberately returns None for any
+# multi-year range, so ranges always land as ``somevalue + P1932`` claims;
+# this helper produces an equivalence key so two range-shaped claims (one
+# from DPLA, one inferred-from-Wikitext) can be recognised as the same
+# statement and the inferred dupe pruned. Requires 3- or 4-digit years on
+# both sides so an ISO-month string like ``"1934-12"`` can't pretend to be
+# a range — single-date parsing handles those.
+_RANGE_DASH = re.compile(r"^(\d{3,4})\s*[-/–—]\s*(\d{3,4})$")
+_RANGE_BETWEEN = re.compile(
+    r"^between\s+(\d{3,4})\s+(?:and|to|-|–|—)\s+(\d{3,4})$",
+    re.IGNORECASE,
+)
+_RANGE_FROM_TO = re.compile(
+    r"^(?:from\s+)?(\d{3,4})\s+(?:to|–|—)\s+(\d{3,4})$",
+    re.IGNORECASE,
+)
+# Raw-wikitext fallback: if ``_expand_wikitext_for_date_parse`` couldn't
+# reach the API or the value was stored before expansion was wired up,
+# the P1932 qualifier carries literal ``{{other date|between|X|Y}}``
+# markup. Match it directly so the reconciler can still dedup.
+_RANGE_OTHER_DATE_BETWEEN = re.compile(
+    r"^\{\{\s*other[ _]date\s*\|\s*between\s*\|\s*(\d{3,4})\s*\|\s*(\d{3,4})\s*\}\}$",
+    re.IGNORECASE,
+)
+
+
+def parse_date_range(date_string: str) -> tuple[int, int] | None:
+    """Parse a year-range string into ``(start_year, end_year)`` with
+    ``start <= end``, or return ``None`` for non-range / unparseable
+    inputs. Used purely for equivalence checks between two range-shaped
+    claims; never used to build structured Wikibase time values.
+
+    Recognised shapes (post wikitext-expansion or raw):
+
+      * ``YYYY - YYYY`` / ``YYYY-YYYY`` / ``YYYY–YYYY`` / ``YYYY/YYYY``
+      * ``between YYYY and YYYY``
+      * ``(from) YYYY to YYYY``
+      * ``{{other date|between|YYYY|YYYY}}`` (raw wikitext fallback)
+
+    Returns ``None`` for single dates, BC dates, prose, or anything else
+    ``parse_dpla_date`` already handles — callers try the single-date
+    parser first and fall back to this helper only on its None result.
+
+    Year 0 returns None, matching ``parse_dpla_date``: proleptic
+    Gregorian has no year 0 and any downstream key built from it would
+    collide with the year-1 form.
+    """
+    if not date_string:
+        return None
+    s = date_string.strip()
+    for rx in (_RANGE_DASH, _RANGE_BETWEEN, _RANGE_FROM_TO, _RANGE_OTHER_DATE_BETWEEN):
+        m = rx.match(s)
+        if m:
+            a, b = int(m[1]), int(m[2])
+            if a == 0 or b == 0:
+                return None
+            return (min(a, b), max(a, b))
+    return None
+
+
 def _build_date_claim(
     date: str,
     dpla_id: str,

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -756,6 +756,135 @@ def test_materialize_pending_date_claim_ignores_non_dpla_attributed_existing():
     assert claim is not None
 
 
+def _dpla_p571_range_statement(p1932_value, *, circa=False):
+    """Build a wbgetentities-shaped DPLA-attributed P571 *range* claim —
+    ``somevalue`` mainsnak with a P1932 stated-as qualifier carrying
+    the range string. Mirrors what
+    :func:`ingest_wikimedia.sdc._build_date_claim` emits when
+    ``parse_dpla_date`` returns None (the universal range path)."""
+    quals = {
+        "P459": [
+            {
+                "snaktype": "value",
+                "property": "P459",
+                "datavalue": {
+                    "type": "wikibase-entityid",
+                    "value": {"id": "Q61848113"},
+                },
+            }
+        ],
+        "P1932": [
+            {
+                "snaktype": "value",
+                "property": "P1932",
+                "datavalue": {"type": "string", "value": p1932_value},
+            }
+        ],
+    }
+    if circa:
+        quals["P1480"] = [
+            {
+                "snaktype": "value",
+                "property": "P1480",
+                "datavalue": {
+                    "type": "wikibase-entityid",
+                    "value": {"id": "Q5727902"},
+                },
+            }
+        ]
+    return {
+        "mainsnak": {
+            "snaktype": "somevalue",
+            "property": "P571",
+            "datatype": "time",
+        },
+        "qualifiers": quals,
+    }
+
+
+def test_materialize_pending_date_claim_skips_when_dpla_already_has_matching_range():
+    """The original bug — ``{{other date|between|1934|1948}}`` expanded
+    to ``between 1934 and 1948`` is semantically identical to DPLA's
+    ``1934 - 1948``. Both produce the same ``(1934, 1948)`` canonical
+    range key via :func:`ingest_wikimedia.sdc.parse_date_range`, so the
+    materialiser must drop the inferred-from-Wikitext import.
+
+    Mirrors M193555788 (Group_Portrait_of_"Indians" Mission Grove)
+    where this dedup failure caused two parallel P571 statements before
+    the range-matcher landed."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "{{other date|between|1934|1948}}",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    site = _FakeSite({"{{other date|between|1934|1948}}": "between 1934 and 1948"})
+    existing = {"statements": {"P571": [_dpla_p571_range_statement("1934 - 1948")]}}
+    claim = materialize_pending_date_claim(
+        placeholder, site=site, existing_entity=existing
+    )
+    assert claim is None
+
+
+def test_materialize_pending_date_claim_skips_range_match_across_format_variants():
+    """Range equivalence is direction- and separator-agnostic. Verify
+    every reasonable cross-pairing of editor-side and DPLA-side
+    formattings dedups, so we don't ship per-format dedup gaps."""
+    site = _FakeSite({})  # no expansion needed; values already in canonical text
+    cross_pairs = [
+        ("1934-1948", "between 1934 and 1948"),
+        ("between 1934 and 1948", "1934 - 1948"),
+        ("1934–1948", "1934/1948"),
+        ("1948 - 1934", "1934 - 1948"),  # reversed order canonicalises
+    ]
+    for editor_value, dpla_value in cross_pairs:
+        placeholder = {
+            "_phase3a_pending_date_parse": editor_value,
+            "_property": "P571",
+            "_permalink": "https://example/permalink",
+        }
+        existing = {"statements": {"P571": [_dpla_p571_range_statement(dpla_value)]}}
+        claim = materialize_pending_date_claim(
+            placeholder, site=site, existing_entity=existing
+        )
+        assert claim is None, (
+            f"editor={editor_value!r} vs dpla={dpla_value!r} should dedup"
+        )
+
+
+def test_materialize_pending_date_claim_imports_when_range_differs():
+    """A range with different endpoints is real community-contributed
+    information — must NOT dedup. The materialiser produces a
+    ``somevalue + P1932`` claim with the editor's range string."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "1950 - 1960",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    existing = {"statements": {"P571": [_dpla_p571_range_statement("1934 - 1948")]}}
+    claim = materialize_pending_date_claim(placeholder, existing_entity=existing)
+    assert claim is not None
+    assert claim["mainsnak"]["snaktype"] == "somevalue"
+    assert claim["qualifiers"]["P1932"][0]["datavalue"]["value"] == "1950 - 1960"
+
+
+def test_materialize_pending_date_claim_range_match_requires_dpla_attribution():
+    """A non-DPLA-attributed (no P459 = Q61848113) existing range claim
+    must NOT trigger the range dedup — same safety bar as the
+    structured-time matcher. Mirror of
+    ``test_materialize_pending_date_claim_ignores_non_dpla_attributed_existing``
+    for the range path."""
+    placeholder = {
+        "_phase3a_pending_date_parse": "1934 - 1948",
+        "_property": "P571",
+        "_permalink": "https://example/permalink",
+    }
+    naked = _dpla_p571_range_statement("1934 - 1948")
+    naked["qualifiers"].pop("P459", None)
+    existing = {"statements": {"P571": [naked]}}
+    claim = materialize_pending_date_claim(placeholder, existing_entity=existing)
+    assert claim is not None
+
+
 def test_materialize_import_claims_forwards_existing_entity_for_dedup():
     """The list-level wrapper has to forward ``existing_entity`` so the
     dedup behaviour applies in the migration pipeline, not only in the

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -893,3 +893,116 @@ def test_next_series_letter_advances_past_z_without_corruption():
     assert seen[27] == "AB"
     # The persisted state matches the last value returned.
     assert letters[("P10358", "en")] == "AB"
+
+
+# ---------------------------------------------------------------------------
+# parse_date_range — year-range equivalence helper used purely for dedup
+# between range-shaped somevalue+P1932 claims. parse_dpla_date deliberately
+# returns None for any range, so this is the only path to recognise two
+# different formattings of the same range as the same fact.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_date_range_dash_variants():
+    """All separator variants between two 4-digit years yield the same
+    (start, end) tuple."""
+    from ingest_wikimedia.sdc import parse_date_range
+
+    assert parse_date_range("1934 - 1948") == (1934, 1948)
+    assert parse_date_range("1934-1948") == (1934, 1948)
+    assert parse_date_range("1934–1948") == (1934, 1948)  # en-dash
+    assert parse_date_range("1934—1948") == (1934, 1948)  # em-dash
+    assert parse_date_range("1934/1948") == (1934, 1948)
+
+
+def test_parse_date_range_between():
+    """``between X and Y`` is the prose form produced by ``{{other date|
+    between|X|Y}}`` after wikitext expansion. Case-insensitive."""
+    from ingest_wikimedia.sdc import parse_date_range
+
+    assert parse_date_range("between 1934 and 1948") == (1934, 1948)
+    assert parse_date_range("Between 1934 and 1948") == (1934, 1948)
+    assert parse_date_range("BETWEEN 1934 AND 1948") == (1934, 1948)
+
+
+def test_parse_date_range_from_to():
+    """``X to Y`` (and ``from X to Y``) covers a less common DPLA shape."""
+    from ingest_wikimedia.sdc import parse_date_range
+
+    assert parse_date_range("1934 to 1948") == (1934, 1948)
+    assert parse_date_range("from 1934 to 1948") == (1934, 1948)
+
+
+def test_parse_date_range_other_date_template_raw_wikitext():
+    """When ``_expand_wikitext_for_date_parse`` couldn't reach the API
+    (or the value was stored before the expand-then-store fix), the
+    P1932 qualifier carries literal ``{{other date|between|X|Y}}``
+    markup. The range parser still recognises it so the reconciler can
+    dedup these legacy-encoded statements without a second API round
+    trip to expand them."""
+    from ingest_wikimedia.sdc import parse_date_range
+
+    assert parse_date_range("{{other date|between|1934|1948}}") == (1934, 1948)
+    # Tolerate optional whitespace and the ``other_date`` underscored
+    # alias MediaWiki accepts for template names.
+    assert parse_date_range("{{ other date | between | 1934 | 1948 }}") == (
+        1934,
+        1948,
+    )
+    assert parse_date_range("{{other_date|between|1934|1948}}") == (1934, 1948)
+
+
+def test_parse_date_range_canonicalises_min_max():
+    """Reversed-order inputs canonicalise to ``(min, max)`` so two
+    range claims that disagree on direction (e.g. ``"1948 - 1934"`` and
+    ``"1934 - 1948"``) still dedup. Wikibase has no semantic for
+    direction on a P1932 qualifier; both encode the same span."""
+    from ingest_wikimedia.sdc import parse_date_range
+
+    assert parse_date_range("1948 - 1934") == (1934, 1948)
+    assert parse_date_range("between 1948 and 1934") == (1934, 1948)
+
+
+def test_parse_date_range_rejects_year_zero():
+    """Year 0 is undefined in proleptic Gregorian — same rule as
+    ``parse_dpla_date``. Refuse to produce a comparable that would
+    collide with a year-1 claim."""
+    from ingest_wikimedia.sdc import parse_date_range
+
+    assert parse_date_range("0 - 1948") is None
+    assert parse_date_range("1934 - 0") is None
+
+
+def test_parse_date_range_rejects_single_year_and_year_month():
+    """Single years and ISO year-month strings must NOT register as
+    ranges — those are the domain of ``parse_dpla_date``. The dash
+    pattern requires 3-4 digits on BOTH sides, which excludes the
+    ``YYYY-MM`` shape (month digits are 1-2)."""
+    from ingest_wikimedia.sdc import parse_date_range
+
+    assert parse_date_range("1945") is None
+    assert parse_date_range("1945-06") is None
+    assert parse_date_range("1945-06-07") is None
+
+
+def test_parse_date_range_rejects_free_prose():
+    """Strings that contain a range-like substring but extra prose
+    around it (e.g. ``"around 1934-1948 era"``) must fall back to
+    ``None``. The regexes are anchored to ``^…$`` so any non-range
+    residue refuses the match — mirrors ``parse_dpla_date``'s
+    conservative-fallback contract."""
+    from ingest_wikimedia.sdc import parse_date_range
+
+    assert parse_date_range("around 1934-1948 era") is None
+    assert parse_date_range("Civil War 1861-1865") is None
+    assert parse_date_range("") is None
+
+
+def test_parse_dpla_date_still_returns_none_for_ranges():
+    """Regression guard — parse_date_range is a *separate* helper, NOT a
+    fallback path inside parse_dpla_date. ``_build_date_claim`` must
+    keep its somevalue-fallback behaviour for ranges so the raw DPLA
+    string is preserved in P1932 instead of being silently coerced to a
+    single year."""
+    assert parse_dpla_date("1934 - 1948") is None
+    assert parse_dpla_date("between 1934 and 1948") is None

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -4129,3 +4129,217 @@ def test_classify_item_outcome_no_progress():
         _classify_item_outcome(synced_this_item=False, had_ordinal_error=False)
         == Result.SDC_ITEMS_SKIPPED_MAPPING
     )
+
+
+# ---------------------------------------------------------------------------
+# _reconcile_inferred_from_wikitext_dupes — idempotency cleanup. Removes
+# inferred-from-Wikitext claims (P887 → Q131783016 reference) whose
+# comparable value equals a DPLA-attributed claim on the same property.
+# Covers the M193555788 (Mission Grove) case where the legacy migrator
+# preserved {{other date|between|1934|1948}} alongside DPLA's
+# "1934 - 1948" because the structured-time matcher couldn't see ranges.
+# ---------------------------------------------------------------------------
+
+
+def _inferred_from_wikitext_reference(
+    permalink="https://commons.wikimedia.org/w/index.php?oldid=1227892018",
+):
+    """Reference snak set the legacy migration importer stamps on
+    every claim it adds: P887 → Q131783016 ("inferred from Wikitext")
+    plus P4656 → permalink. Recognised by the dedup cleanup as "this
+    is one of ours, safe to remove if equivalent to DPLA's"."""
+    return {
+        "snaks": {
+            "P887": _qual_entity("P887", "Q131783016"),
+            "P4656": [
+                {
+                    "snaktype": "value",
+                    "property": "P4656",
+                    "datavalue": {"type": "string", "value": permalink},
+                }
+            ],
+        }
+    }
+
+
+def _p571_somevalue_with_p1932(stmt_id, p1932_value, references=None, p459=True):
+    """Build a P571 somevalue+P1932 statement — the canonical shape for
+    a range-shaped claim, used for both the DPLA-attributed and the
+    inferred-from-Wikitext sides of the dedup test."""
+    quals = {
+        "P1932": _qual_string("P1932", p1932_value),
+    }
+    if p459:
+        quals["P459"] = _dpla_p459()
+    return _stmt(
+        stmt_id=stmt_id,
+        prop="P571",
+        snaktype="somevalue",
+        value=None,
+        qualifiers=quals,
+        references=references or [],
+    )
+
+
+def test_inferred_dupe_cleanup_removes_equivalent_range_claim():
+    """Mission Grove repro — DPLA's P571 somevalue+P1932="1934 - 1948"
+    and an inferred-from-Wikitext P571 somevalue+P1932="{{other date|
+    between|1934|1948}}" should dedup to one claim; the inferred
+    statement gets queued for removal."""
+    from tools import sdc_sync
+
+    dpla_claim = _p571_somevalue_with_p1932(
+        "M999$DPLA",
+        "1934 - 1948",
+        references=[_dpla_reference()],
+    )
+    inferred_claim = _p571_somevalue_with_p1932(
+        "M999$INFERRED",
+        "{{other date|between|1934|1948}}",
+        references=[_inferred_from_wikitext_reference()],
+        p459=False,  # inferred claims don't carry the DPLA-determination qualifier
+    )
+    entity = {
+        "pageid": 999,
+        "statements": {"P571": [dpla_claim, inferred_claim]},
+    }
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M999")
+    assert sdc_sync.removals == ["M999$INFERRED"]
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_dupe_cleanup_preserves_distinct_range_claim():
+    """Inferred range that does NOT match DPLA's range is real
+    community-contributed information — never queue for removal."""
+    from tools import sdc_sync
+
+    dpla_claim = _p571_somevalue_with_p1932(
+        "M999$DPLA",
+        "1934 - 1948",
+        references=[_dpla_reference()],
+    )
+    inferred_claim = _p571_somevalue_with_p1932(
+        "M999$DISTINCT",
+        "1950 - 1960",
+        references=[_inferred_from_wikitext_reference()],
+        p459=False,
+    )
+    entity = {
+        "pageid": 999,
+        "statements": {"P571": [dpla_claim, inferred_claim]},
+    }
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M999")
+    assert sdc_sync.removals == []
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_dupe_cleanup_ignores_foreign_community_claim():
+    """Safety bar: a community claim that happens to encode the same
+    range as DPLA but lacks the P887 → Q131783016 inferred-from-
+    Wikitext fingerprint is third-party content and must NOT be touched.
+    Same string equivalence; only the reference shape distinguishes them."""
+    from tools import sdc_sync
+
+    dpla_claim = _p571_somevalue_with_p1932(
+        "M999$DPLA",
+        "1934 - 1948",
+        references=[_dpla_reference()],
+    )
+    foreign_claim = _p571_somevalue_with_p1932(
+        "M999$FOREIGN",
+        "between 1934 and 1948",
+        references=[_foreign_reference()],
+        p459=False,
+    )
+    entity = {
+        "pageid": 999,
+        "statements": {"P571": [dpla_claim, foreign_claim]},
+    }
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M999")
+    assert sdc_sync.removals == []
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_dupe_cleanup_removes_equivalent_single_date_claim():
+    """Idempotency for non-range claims: if a single-date inferred-
+    from-Wikitext claim parses to the same canonical time as a DPLA
+    value-typed time claim, remove the inferred one. Covers the case
+    where DPLA drifts into emitting the structured time for a value
+    the importer had previously preserved as somevalue+P1932="1945"."""
+    from tools import sdc_sync
+
+    # Hand-built value-typed time statement — _stmt's generic builder
+    # doesn't cover the time mainsnak shape (no other reconciler test
+    # needed it).
+    dpla_claim = {
+        "id": "M999$DPLA",
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P571",
+            "datatype": "time",
+            "datavalue": {
+                "type": "time",
+                "value": {
+                    "time": "+1945-01-01T00:00:00Z",
+                    "precision": 9,
+                    "before": 0,
+                    "after": 0,
+                    "timezone": 0,
+                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
+                },
+            },
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [_dpla_reference()],
+    }
+    inferred_claim = _p571_somevalue_with_p1932(
+        "M999$INFERRED",
+        "1945",
+        references=[_inferred_from_wikitext_reference()],
+        p459=False,
+    )
+    entity = {
+        "pageid": 999,
+        "statements": {"P571": [dpla_claim, inferred_claim]},
+    }
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M999")
+    assert sdc_sync.removals == ["M999$INFERRED"]
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_dupe_cleanup_skips_property_with_no_dpla_claim():
+    """When no DPLA-attributed claim exists on a property, even a
+    matching inferred-from-Wikitext claim must stay — there's no
+    duplication to clean up."""
+    from tools import sdc_sync
+
+    inferred_claim = _p571_somevalue_with_p1932(
+        "M999$ALONE",
+        "1934 - 1948",
+        references=[_inferred_from_wikitext_reference()],
+        p459=False,
+    )
+    entity = {
+        "pageid": 999,
+        "statements": {"P571": [inferred_claim]},
+    }
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M999")
+    assert sdc_sync.removals == []
+    sdc_sync._reset_per_file_accumulators()

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -17,6 +17,7 @@ from pywikibot import pagegenerators
 from ingest_wikimedia.logs import setup_logging
 from ingest_wikimedia.sdc import (
     CHUNKABLE_PROPS,
+    parse_date_range,
     parse_dpla_date,
     parse_nara_access_level,
 )
@@ -2841,9 +2842,14 @@ def _statement_comparable_value(stmt):
     Used by :func:`_reconcile_inferred_from_wikitext_dupes` to decide
     whether an inferred-from-Wikitext claim should be removed because
     an equivalent DPLA-authored statement now covers the same fact.
-    """
-    from ingest_wikimedia.sdc import parse_date_range, parse_dpla_date
 
+    Every non-None return is a 3-tuple ``(shape_tag, primary, secondary)``
+    with ``secondary`` set to ``None`` for shapes that have no second
+    field (string, item, time, range, p1932-string). Uniform arity keeps
+    static analysis happy without changing equivalence semantics —
+    shape_tag still discriminates type so cross-type values can't
+    collide.
+    """
     ms = stmt.get("mainsnak") or {}
     snaktype = ms.get("snaktype")
 
@@ -2853,15 +2859,15 @@ def _statement_comparable_value(stmt):
         v = dv.get("value")
         if dtype == "time":
             try:
-                return ("time", _time_claim_comparable(stmt))
+                return ("time", _time_claim_comparable(stmt), None)
             except (KeyError, TypeError):
                 return None
         if dtype == "string":
-            return ("string", v) if isinstance(v, str) else None
+            return ("string", v, None) if isinstance(v, str) else None
         if dtype == "monolingualtext" and isinstance(v, dict):
             return ("monolingual", v.get("text"), v.get("language"))
         if dtype == "wikibase-entityid" and isinstance(v, dict):
-            return ("item", v.get("id"))
+            return ("item", v.get("id"), None)
         return None
 
     if snaktype == "somevalue":
@@ -2879,7 +2885,7 @@ def _statement_comparable_value(stmt):
                 # collapses with a value-typed time mainsnak.
                 base = _time_comparable(parsed["value"])
                 key = f"{base}|circa" if parsed.get("approximate") else base
-                return ("time", key)
+                return ("time", key, None)
             rng = parse_date_range(s)
             if rng:
                 return ("date-range", rng[0], rng[1])
@@ -2890,7 +2896,7 @@ def _statement_comparable_value(stmt):
             # expand-then-store fix may carry raw wikitext here. The
             # range parser already matches the most common
             # ``{{other date|between|X|Y}}`` shape directly.
-            return ("p1932-string", s)
+            return ("p1932-string", s, None)
         return None
 
     return None

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2507,6 +2507,7 @@ def dpla_claims(
     _reconcile_existing_claims(
         mediaid, dpla_id, expected, protected_props=CHUNKABLE_PROPS
     )
+    _reconcile_inferred_from_wikitext_dupes(mediaid)
 
 
 def _build_expected_from_parsed(
@@ -2819,6 +2820,146 @@ def _reconcile_existing_claims(mediaid, dpla_id, expected, protected_props=froze
                 removals.append(claim[prop]["id"])
             elif claim[prop]["value"] not in expected[prop]:
                 removals.append(claim[prop]["id"])
+
+
+def _statement_comparable_value(stmt):
+    """Comparable key for ``stmt`` that is stable across equivalent
+    encoding shapes — value-typed time vs. somevalue+P1932 stated-as
+    parsing to the same structured date, range-shaped P1932 across the
+    "1934 - 1948" / "between 1934 and 1948" / raw-wikitext variants,
+    and the simple value-typed shapes (string, monolingualtext, item).
+
+    Every return is tagged with a shape discriminator so cross-type
+    values (e.g. a P571 time and a P217 string of digits) can never
+    accidentally compare equal.
+
+    Returns ``None`` for shapes the dedup helper can't reason about
+    (malformed datavalues, novalue snaks, somevalue claims with no
+    P1932 qualifier). Callers treat ``None`` as "skip this statement"
+    rather than as a match.
+
+    Used by :func:`_reconcile_inferred_from_wikitext_dupes` to decide
+    whether an inferred-from-Wikitext claim should be removed because
+    an equivalent DPLA-authored statement now covers the same fact.
+    """
+    from ingest_wikimedia.sdc import parse_date_range, parse_dpla_date
+
+    ms = stmt.get("mainsnak") or {}
+    snaktype = ms.get("snaktype")
+
+    if snaktype == "value":
+        dv = ms.get("datavalue") or {}
+        dtype = dv.get("type")
+        v = dv.get("value")
+        if dtype == "time":
+            try:
+                return ("time", _time_claim_comparable(stmt))
+            except (KeyError, TypeError):
+                return None
+        if dtype == "string":
+            return ("string", v) if isinstance(v, str) else None
+        if dtype == "monolingualtext" and isinstance(v, dict):
+            return ("monolingual", v.get("text"), v.get("language"))
+        if dtype == "wikibase-entityid" and isinstance(v, dict):
+            return ("item", v.get("id"))
+        return None
+
+    if snaktype == "somevalue":
+        for q in (stmt.get("qualifiers") or {}).get("P1932", []):
+            qv = q.get("datavalue") or {}
+            if qv.get("type") != "string":
+                continue
+            s = (qv.get("value") or "").strip()
+            if not s:
+                continue
+            parsed = parse_dpla_date(s)
+            if parsed and parsed.get("value"):
+                # Same shape (and circa-bit suffix) as
+                # ``_time_claim_comparable`` so a somevalue+P1932="1945"
+                # collapses with a value-typed time mainsnak.
+                base = _time_comparable(parsed["value"])
+                key = f"{base}|circa" if parsed.get("approximate") else base
+                return ("time", key)
+            rng = parse_date_range(s)
+            if rng:
+                return ("date-range", rng[0], rng[1])
+            # Literal-string fallback — only matches another P1932
+            # qualifier whose stated-as text is byte-identical. The
+            # inferred-from-Wikitext writer stores the post-expansion
+            # value, but legacy migrations that ran before the
+            # expand-then-store fix may carry raw wikitext here. The
+            # range parser already matches the most common
+            # ``{{other date|between|X|Y}}`` shape directly.
+            return ("p1932-string", s)
+        return None
+
+    return None
+
+
+def _is_inferred_from_wikitext_reference(reference):
+    """Return True iff ``reference`` carries the legacy-migration import
+    fingerprint — a ``P887 = Q131783016`` snak ("based on heuristic =
+    inferred from Wikitext"). The legacy ``{{Artwork}}`` →
+    ``{{DPLA metadata}}`` importer stamps this on every claim it writes,
+    so it's a sufficient marker for "we added this during migration."
+    Parallel of :func:`_is_dpla_reference` for the inferred-import side.
+    """
+    snaks = (reference or {}).get("snaks") or {}
+    for snak in snaks.get("P887") or []:
+        try:
+            if snak["datavalue"]["value"]["id"] == "Q131783016":
+                return True
+        except (KeyError, TypeError):
+            continue
+    return False
+
+
+def _reconcile_inferred_from_wikitext_dupes(mediaid):
+    """Remove inferred-from-Wikitext claims whose comparable value
+    equals a DPLA-attributed claim on the same property.
+
+    Pushes statement IDs onto the module-level ``removals`` accumulator
+    — same channel ``_reconcile_existing_claims`` uses, so the per-file
+    dispatcher flushes both kinds of removal in one wbeditentity.
+
+    Idempotency contract: a file migrated with the legacy
+    ``{{Artwork}}`` importer can carry an inferred-from-Wikitext claim
+    parallel to a DPLA-authored one whenever the migrator couldn't
+    recognise their semantic equivalence (notably for year ranges, see
+    M193555788 with ``{{other date|between|1934|1948}}`` and
+    ``"1934 - 1948"``). On the next sdc-sync re-run, the improved
+    comparable logic — :func:`_statement_comparable_value` plus
+    :func:`ingest_wikimedia.sdc.parse_date_range` — recognises the two
+    statements as the same fact and queues the inferred one for
+    removal. Same rule covers the DPLA-drifts-into-match case (e.g. a
+    later DPLA edit produces a value that happens to equal a
+    previously-preserved community claim): nothing branches on whether
+    the equivalence is new or was always there.
+
+    Safety: only removes statements whose references carry the exact
+    ``P887 → Q131783016`` fingerprint. Third-party community claims
+    that happen to equal a DPLA value are never touched — this routine
+    operates strictly on the import set the migration emitted.
+    """
+    entity = get_entity(mediaid)
+    statements = entity.get("statements") or {}
+    for stmts in statements.values():
+        dpla_comparables = set()
+        inferred_stmts = []
+        for stmt in stmts:
+            refs = stmt.get("references") or []
+            if any(_is_dpla_reference(ref) for ref in refs):
+                comp = _statement_comparable_value(stmt)
+                if comp is not None:
+                    dpla_comparables.add(comp)
+            elif any(_is_inferred_from_wikitext_reference(ref) for ref in refs):
+                inferred_stmts.append(stmt)
+        if not dpla_comparables:
+            continue
+        for stmt in inferred_stmts:
+            comp = _statement_comparable_value(stmt)
+            if comp is not None and comp in dpla_comparables:
+                removals.append(stmt["id"])
 
 
 def _fetch_dpla_doc_from_api(dpla_id, dpla_api):
@@ -3303,6 +3444,7 @@ def process_one_from_sdc(
     _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_number)
     expected = _build_expected_from_sdc(sdc_payload)
     _reconcile_existing_claims(mediaid, dpla_id, expected)
+    _reconcile_inferred_from_wikitext_dupes(mediaid)
     _flush_per_file_edits(mediaid, dpla_id)
 
 


### PR DESCRIPTION
## Summary

Two parallel changes that together restore idempotency for date claims where the editor-provided wikitext and DPLA's display string both encode a year range:

- **`parse_date_range` + range matcher** — `parse_dpla_date` returns `None` for any multi-year range, so the existing structured-time matcher in `legacy_artwork._existing_dpla_date_matches_parsed` never fires for ranges. The migrator emits the import as a duplicate parallel to DPLA's own `somevalue + P1932` claim. New `parse_date_range` canonicalises range strings (dash/slash/en-dash/em-dash separators, `between X and Y`, raw `{{other date|between|X|Y}}` wikitext fallback) to `(start, end)` tuples; `_existing_dpla_date_range_matches` uses that key to dedup at migration time.
- **`_reconcile_inferred_from_wikitext_dupes` cleanup pass** — For files already migrated with the duplicate in SDC, the reconciler walks every property looking for statements with the `P887 → Q131783016` ("inferred from Wikitext") reference fingerprint and removes ones whose comparable value equals a DPLA-attributed claim on the same property. Tagged-tuple comparables prevent cross-type collisions. Safety bar: only claims with the exact reference fingerprint are eligible; third-party community statements are never touched.

The cleanup is symmetric: whether the equivalence was always there (missed at migration time) or DPLA drifted into matching a previously-preserved community value, the same rule applies — making re-runs converge.

Repro file: [M193555788](https://commons.wikimedia.org/wiki/File:Group_Portrait_of_%22Indians%22_Mission_Grove,_Plymouth,_Minnesota_-_DPLA_-_3a04e414ed00330bf0370399c87a6606.jpg) — currently carries two P571 statements (DPLA's `"1934 - 1948"` and the inferred `"{{other date|between|1934|1948}}"`). After this PR, an sdc-sync re-run on the file removes the inferred dupe.

## Test plan

- [x] `pytest -q` (680 passed)
- [x] `ruff check --fix` + `ruff format` on changed files
- [ ] EC2 smoke test on M193555788: re-run sdc-sync and confirm the inferred P571 is removed
- [ ] Follow-up: mirror the range canonicalisation in Module:DPLA so the rendered table dedups equivalent ranges visually (separate change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR introduces coordinated changes to restore idempotency when migrating date claims that encode year ranges in Wikimedia artwork files. The issue occurs when both an editor-provided wikitext value and DPLA’s display string represent the same year range, resulting in duplicate claims.

### Key Changes

**ingest_wikimedia/sdc.py**: Adds a new `parse_date_range(date_string: str) -> tuple[int, int] | None` helper that canonicalizes year-range inputs—including dash/slash/en-dash/em-dash separators, prose forms (`between X and Y`, `X to Y`, optional `from`), and raw `{{other date|between|X|Y}}` wikitext—into normalized `(start_year, end_year)` tuples (with `start <= end`). Returns `None` for non-ranges and for ranges involving year `0`.

**ingest_wikimedia/legacy_artwork.py**: Refactors DPLA duplicate detection and adds explicit Phase 3a deduplication for legacy *date-range* inputs. It introduces `_existing_dpla_date_range_matches` and updates `materialize_pending_date_claim` to compute the range from expanded raw date value and skip materializing the placeholder if an equivalent existing DPLA-attributed range claim is already present.

**tools/sdc_sync.py**: Implements an idempotency cleanup pass, `_reconcile_inferred_from_wikitext_dupes`, that removes duplicate legacy “inferred from Wikitext” statements when a comparable value already exists in a DPLA-attributed statement on the same property. It adds supporting helpers:
- `_statement_comparable_value` for cross-shape comparable-key derivation (shape-tagged to avoid collisions; handles time values and `somevalue+P1932`-based date/range shapes)
- `_is_inferred_from_wikitext_reference` for detecting the migration fingerprint via `P887 → Q131783016`

The cleanup is applied across both legacy migration and partner-mode SDC sync flows.

**Test Coverage**: Adds 456 lines of test coverage across four test files validating:
- range parsing across formatting variants (including wikitext template forms),
- deduplication behavior for legacy range materialization, and
- idempotency of the inferred-from-Wikitext duplicate cleanup.

### Deployment Considerations

**No manual pipeline trigger or ECS redeployment required.** The behavior is integrated into the existing `sdc_sync.py` execution paths (including the legacy migration mode), so it takes effect on the next scheduled/automated run of the sync process.

### Safety & Design

- Deduplication only removes statements that match the exact inferred-from-Wikitext reference fingerprint (`P887→Q131783016`), so community-contributed statements are not modified.
- The rules are symmetric/idempotent: if equivalence was missed initially or later DPLA values drift to match a community value, reruns converge to the same state.

### Testing

680 tests passed with code style checks applied. Includes a reproduction case (M193555788) with duplicate P571 statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->