### PR TITLE
sdc-sync: rescue ordinals from Commons by DPLA ID when upload phase can't confirm

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -4343,3 +4343,126 @@ def test_inferred_dupe_cleanup_skips_property_with_no_dpla_claim():
         sdc_sync._reconcile_inferred_from_wikitext_dupes("M999")
     assert sdc_sync.removals == []
     sdc_sync._reset_per_file_accumulators()
+
+
+# ---------------------------------------------------------------------------
+# _find_existing_commons_files_by_dpla_id — Commons-side discovery primitive
+# that decouples SDC eligibility from the upload phase's per-ordinal status.
+# Lets a file already on Commons get its SDC re-synced when the current
+# run's binary path failed (e.g. NARA upstream URLs went stale).
+# ---------------------------------------------------------------------------
+
+
+def _search_hit(pageid: int, title: str) -> dict:
+    """Build a CirrusSearch result hit in the shape Commons returns."""
+    return {"pageid": pageid, "ns": 6, "title": title}
+
+
+def test_find_existing_commons_files_returns_ordinal_map(monkeypatch):
+    """The happy path: search returns N hits, helper parses each
+    title's ``(page N)`` suffix into an ord_str and pairs it with the
+    pageid. Titles are returned without the ``File:`` prefix to match
+    what upload-result.json carries."""
+    from tools import sdc_sync
+
+    dpla_id = "1cac77c12985e6c4a35039031ea49c07"
+    hits = [
+        _search_hit(101521797, f"File:Foo - DPLA - {dpla_id} (page 1).jpg"),
+        _search_hit(101521981, f"File:Foo - DPLA - {dpla_id} (page 19).jpg"),
+        _search_hit(101522004, f"File:Foo - DPLA - {dpla_id} (page 20).jpg"),
+    ]
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value.submit.return_value = {
+        "query": {"search": hits}
+    }
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+
+    found = sdc_sync._find_existing_commons_files_by_dpla_id(dpla_id)
+    assert found == {
+        "1": {"title": f"Foo - DPLA - {dpla_id} (page 1).jpg", "pageid": 101521797},
+        "19": {"title": f"Foo - DPLA - {dpla_id} (page 19).jpg", "pageid": 101521981},
+        "20": {"title": f"Foo - DPLA - {dpla_id} (page 20).jpg", "pageid": 101522004},
+    }
+
+
+def test_find_existing_commons_files_single_file_item(monkeypatch):
+    """Single-file DPLA items don't carry the ``(page N)`` suffix —
+    helper maps them to ord_str ``"1"`` since the uploader's single-
+    ordinal items always serialize as ordinal 1 in upload-result.json."""
+    from tools import sdc_sync
+
+    dpla_id = "deadbeef00000000000000000000beef"
+    hits = [_search_hit(12345, f"File:A single file - DPLA - {dpla_id}.jpg")]
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value.submit.return_value = {
+        "query": {"search": hits}
+    }
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+
+    found = sdc_sync._find_existing_commons_files_by_dpla_id(dpla_id)
+    assert found == {
+        "1": {"title": f"A single file - DPLA - {dpla_id}.jpg", "pageid": 12345}
+    }
+
+
+def test_find_existing_commons_files_returns_empty_on_no_hits(monkeypatch):
+    """File never made it to Commons (or was deleted) — empty result
+    set. Caller's existing skip path runs unchanged."""
+    from tools import sdc_sync
+
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value.submit.return_value = {
+        "query": {"search": []}
+    }
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+
+    assert sdc_sync._find_existing_commons_files_by_dpla_id("a" * 32) == {}
+
+
+def test_find_existing_commons_files_returns_empty_on_api_error(monkeypatch):
+    """Transient Commons API failure during discovery must not abort
+    the partner batch — return ``{}`` and the caller's skip path runs."""
+    from tools import sdc_sync
+
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value.submit.side_effect = RuntimeError("boom")
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+
+    assert sdc_sync._find_existing_commons_files_by_dpla_id("a" * 32) == {}
+
+
+def test_find_existing_commons_files_returns_empty_on_blank_dpla_id(monkeypatch):
+    """Defense-in-depth — never issue an unbounded ``intitle:""``
+    search just because the DPLA ID was empty."""
+    from tools import sdc_sync
+
+    fake_site = MagicMock()
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+
+    assert sdc_sync._find_existing_commons_files_by_dpla_id("") == {}
+    assert sdc_sync._find_existing_commons_files_by_dpla_id(None) == {}  # type: ignore[arg-type]
+    assert fake_site.simple_request.call_count == 0
+
+
+def test_find_existing_commons_files_skips_non_canonical_titles(monkeypatch):
+    """A search hit whose title contains the DPLA ID but doesn't match
+    the canonical ``- DPLA - <id> (page N).<ext>`` pattern (someone
+    uploaded a file with that ID embedded mid-title, or with a non-
+    file extension) is skipped rather than guessing an ordinal."""
+    from tools import sdc_sync
+
+    dpla_id = "1cac77c12985e6c4a35039031ea49c07"
+    hits = [
+        # Canonical — keep.
+        _search_hit(1, f"File:Foo - DPLA - {dpla_id} (page 1).jpg"),
+        # ID is in title but not in the canonical position — skip.
+        _search_hit(2, f"File:Notes on {dpla_id} - other text.txt"),
+    ]
+    fake_site = MagicMock()
+    fake_site.simple_request.return_value.submit.return_value = {
+        "query": {"search": hits}
+    }
+    monkeypatch.setattr(sdc_sync, "site", fake_site, raising=False)
+
+    found = sdc_sync._find_existing_commons_files_by_dpla_id(dpla_id)
+    assert list(found.keys()) == ["1"]

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -323,6 +323,74 @@ def _resolve_pageid_from_title(title: str) -> int | None:
     return None
 
 
+def _find_existing_commons_files_by_dpla_id(dpla_id: str) -> dict[str, dict]:
+    """Find every Commons file whose title carries ``dpla_id`` and map
+    each by its ordinal-from-filename.
+
+    Returns ``{ord_str: {"title": <title-without-File:>, "pageid": <int>}}``.
+    Empty dict on any failure mode — caller's existing skip path runs.
+
+    Uses CirrusSearch ``intitle:<dpla_id>`` which exact-matches the
+    32-hex DPLA ID anywhere in the title. The DPLA ID is unique enough
+    that the result set is bounded by the item's file count
+    (typically 1, occasionally 20–30 for multi-page archival items).
+    Within-item ordinal collisions are impossible — Commons titles
+    must be unique, and the bot produces deterministic (page N)
+    suffixes per ordinal.
+
+    Used by the SDC eligibility-discovery fallback: when the
+    uploader couldn't confirm an ordinal (NOT_PRESENT / INELIGIBLE /
+    FAILED) but a Commons file with that DPLA ID and ordinal already
+    exists from a prior successful run, sync SDC against the existing
+    file rather than skipping the data-side work because of a transient
+    binary-side failure.
+    """
+    if not dpla_id:
+        return {}
+    try:
+        result = site.simple_request(
+            action="query",
+            list="search",
+            srnamespace=6,
+            srsearch=f'intitle:"{dpla_id}"',
+            # 50 hits comfortably exceeds the largest multi-file items
+            # in DPLA's corpus (P.D. records / microfilm reels run
+            # 20–30 pages). Bumping further has no cost when the actual
+            # hit count is small.
+            srlimit=50,
+            srprop="",
+        ).submit()
+    except Exception:
+        return {}
+    out: dict[str, dict] = {}
+    for hit in result.get("query", {}).get("search", []) or []:
+        if not isinstance(hit, dict):
+            continue
+        title = hit.get("title")
+        pageid = hit.get("pageid")
+        if not isinstance(title, str) or not isinstance(pageid, int) or pageid <= 0:
+            continue
+        # ``upload-result.json`` records titles without the ``File:``
+        # prefix; mirror that here so downstream lookups (which
+        # re-prepend ``File:`` themselves) work uniformly.
+        bare_title = title[5:] if title.lower().startswith("file:") else title
+        # The intitle search can surface files where the DPLA ID
+        # appears outside the canonical `- DPLA - <id> [(page N)].<ext>`
+        # tail (e.g. a hand-named file that happened to mention the
+        # ID in its title). Confirm via the shared extractor that
+        # this hit's title actually carries the DPLA-tail anchor we
+        # produce; skip otherwise rather than guess the ordinal.
+        if extract_dpla_id_from_commons_title(bare_title) != dpla_id:
+            continue
+        ordinal = wikimedia.extract_page_ordinal_from_commons_title(bare_title)
+        # Single-file items have no `(page N)` suffix — the uploader
+        # serialises them as ordinal "1" in upload-result.json, so
+        # mirror that here.
+        ord_str = str(ordinal) if ordinal is not None else "1"
+        out[ord_str] = {"title": bare_title, "pageid": pageid}
+    return out
+
+
 def _truncate(text: str | None, limit: int = 500) -> str:
     """Return ``text`` shortened to ``limit`` chars with an ellipsis suffix.
 
@@ -4053,12 +4121,58 @@ def _run_partner_mode(partner, ids_file):
                 )
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
                 continue
-            eligible = {
-                ord_str: data
-                for ord_str, data in ordinals.items()
-                if isinstance(data, dict)
-                and data.get("status") in ("UPLOADED", "SKIPPED")
-            }
+            eligible: dict[str, dict] = {}
+            unresolved_ords: list[str] = []
+            for ord_str, data in ordinals.items():
+                if not isinstance(data, dict):
+                    continue
+                if data.get("status") in ("UPLOADED", "SKIPPED"):
+                    eligible[ord_str] = data
+                else:
+                    # NOT_PRESENT / INELIGIBLE / FAILED — the upload phase
+                    # couldn't confirm this ordinal in *this* run, but the
+                    # file may exist on Commons from a prior run. Defer to
+                    # the post-loop Commons discovery pass below.
+                    unresolved_ords.append(ord_str)
+
+            # Data-side phases (SDC sync, template migration) operate on
+            # the Commons file, which is independent of whether the
+            # current run successfully refreshed the S3 binary. When the
+            # upload phase left ordinals as NOT_PRESENT/INELIGIBLE/
+            # FAILED, search Commons by DPLA-ID for any existing files
+            # and graft them onto ``eligible``. Lets a transient binary-
+            # side failure (broken upstream URL, S3 hiccup) NOT block
+            # data-side maintenance of files that are already on Commons.
+            #
+            # Lazy: the search only fires if at least one ordinal needs
+            # rescuing — healthy items where everything UPLOADED/SKIPPED
+            # this run pay zero extra API cost.
+            if unresolved_ords:
+                discovered = _find_existing_commons_files_by_dpla_id(dpla_id)
+                rescued = 0
+                for ord_str in unresolved_ords:
+                    found = discovered.get(ord_str)
+                    if not found:
+                        continue
+                    # Preserve the original status string for traceability
+                    # (Slack summaries / logs can still distinguish "this
+                    # run didn't upload" from "this run uploaded fresh"),
+                    # but inject the discovered title+pageid so the
+                    # per-ordinal sync path treats the file as syncable.
+                    eligible[ord_str] = {
+                        **ordinals[ord_str],
+                        "title": found["title"],
+                        "pageid": found["pageid"],
+                        "discovered_via_dpla_id": True,
+                    }
+                    rescued += 1
+                if rescued:
+                    logging.info(
+                        f" -- Recovered {rescued} ordinal(s) via Commons "
+                        f"intitle:{dpla_id} discovery (upload phase reported "
+                        "non-eligible status but file exists on Commons)."
+                    )
+
             if not eligible:
                 logging.info(" -- No SDC-eligible ordinals; skipping.")
                 tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)


### PR DESCRIPTION
## Summary

Data-side phases (SDC sync, template migration) operate on the Commons file, not on the current run's S3 binary. Today they're gated on the uploader's per-ordinal status — UPLOADED/SKIPPED only — so a transient binary-side failure (broken upstream URL, S3 gap, content-type drift) blocks SDC sync of files that already exist on Commons from a prior successful run.

This PR adds a Commons-side discovery fallback in the SDC phase: when the upload phase couldn't confirm an ordinal (NOT_PRESENT / INELIGIBLE / FAILED), the SDC phase searches Commons via CirrusSearch `intitle:<dpla_id>` and parses each canonical `… - DPLA - <id> (page N).<ext>` filename to recover the ordinal → MediaInfo-id mapping. Rescued ordinals get `title` + `pageid` injected into the eligibility set so the existing per-ordinal sync code path treats them as syncable.

## Repro this fixes

DPLA ID `1cac77c12985e6c4a35039031ea49c07` (NARA M269 Mississippi cavalry microfilm). NARA's OpaAPI now returns HTML for all 21 of its image URLs. The 21 files are already on Commons from a prior successful run. Before this PR, `/wikimedia-upload <id>` reported `No SDC-eligible ordinals; skipping.` because every ordinal status was `NOT_PRESENT`. After this PR, the same invocation finds the 21 files via Commons discovery and runs SDC sync against them.

## What this does NOT solve

Files from withdrawn institutions (NCDHC and similar — ~500K files from ~100 institutions whose hub is no longer in the pipeline) never enter the CSV in the first place, so the eligibility filter never sees them. That needs a separate Commons-driven maintenance pipeline; this PR is the narrower in-flight-ingest decoupling.

## Design notes

- **Lazy**: discovery only fires when at least one ordinal needs rescuing. Healthy items where everything UPLOADED/SKIPPED this run pay zero extra Commons API cost.
- **Reuse**: `extract_dpla_id_from_commons_title` and `extract_page_ordinal_from_commons_title` already exist in `ingest_wikimedia/wikimedia.py`. The new helper calls them rather than re-encoding the canonical filename pattern.
- **Safety bar**: a search hit whose title contains the DPLA ID but doesn't match the canonical `- DPLA - <id> [(page N)].<ext>` tail is skipped (someone hand-named a file with the ID embedded elsewhere). Avoids guessing ordinals.
- **Observability**: rescued ordinals carry `discovered_via_dpla_id: True` so future Slack/log summaries can distinguish them from natively-uploaded ones.

## Test plan

- [x] 6 new unit tests for `_find_existing_commons_files_by_dpla_id` covering: happy path (multi-page), single-file item, no hits, API error, empty DPLA ID, non-canonical title skip
- [x] Full test suite (686 passing, was 680)
- [x] ruff check + format
- [ ] EC2 smoke test: re-run `/wikimedia-upload 1cac77c12985e6c4a35039031ea49c07` and confirm SDC phase now processes the 21 ordinals

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds a Commons-side discovery fallback to the SDC (Shared Data Collections) sync phase. When the upload phase cannot confirm an ordinal's status due to transient binary-side failures (broken upstream URLs, S3 gaps, content-type drift), the sync phase can now search Commons via CirrusSearch to recover pre-existing files and continue the synchronization pipeline.

## Changes

**New helper function** (`tools/sdc_sync.py`):
- `_find_existing_commons_files_by_dpla_id(dpla_id)`: Queries Commons CirrusSearch using `intitle:<dpla_id>` to discover pre-existing files, validates hits against the canonical Commons filename pattern (`… - DPLA - <id> (page N).<ext>`), and returns an ordinal-to-MediaInfo-id mapping. Gracefully returns an empty dict on failures or invalid inputs.

**Updated SDC partner-mode logic** (`tools/sdc_sync.py`):
- Modified `_run_partner_mode` to detect ordinals marked `NOT_PRESENT`/`INELIGIBLE`/`FAILED` in the upload result.
- When such unresolved ordinals exist, invokes the new Commons discovery helper.
- Rescued ordinals are injected into the eligibility set with a `discovered_via_dpla_id` marker for observability.
- Only runs when needed (zero API cost on healthy items where all ordinals uploaded or were skipped).

**Test coverage** (`tests/test_sdc_sync.py`):
- Added 6 new unit tests validating the discovery function across multiple scenarios: multi-page canonical titles, single-file items, empty results, API errors, blank/None DPLA IDs, and non-canonical title filtering.

## Operational Notes

- **No manual pipeline trigger or redeployment required**: Changes are to the SDC sync tool only and take effect on next deployment.
- **No environment variables, AWS Secrets Manager keys, or infrastructure configuration changes**.
- **No database migrations**.
- **No changes to public-facing APIs**.
- **Security consideration**: Introduces a new external data input (CirrusSearch queries to Wikimedia Commons) to recover file mappings; these queries are read-only and use a standard search API available to all clients.

## Concrete Impact

Addresses cases like DPLA ID `1cac77c12985e6c4a35039031ea49c07` (NARA M269 Mississippi cavalry microfilm with 21 files), where NARA's API returns HTML for all image URLs, marking every ordinal as `NOT_PRESENT` despite the files existing on Commons from a prior successful run. The PR explicitly notes that the broader problem of withdrawn-institution orphaned files (~500K files) is out of scope and requires a separate Commons-driven maintenance pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->