### PR TITLE
sdc-sync: multiprocessing.Pool dispatch + --workers N flag

### DIFF
--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -115,6 +115,35 @@ class Tracker:
         for value in Result:
             self.data[value] = 0
 
+    def snapshot(self) -> dict["Result", int]:
+        """Return a shallow copy of the counter state, suitable for
+        per-task delta computation across a multiprocessing Pool.
+
+        Pair with :meth:`diff` to compute what changed during a unit of
+        work, and :meth:`merge` on the parent's tracker to absorb the
+        delta returned from a worker process.
+        """
+        return dict(self.data)
+
+    def diff(self, prior: dict["Result", int]) -> dict["Result", int]:
+        """Return ``{key: self.data[key] - prior[key]}`` for every
+        counter, treating missing keys in ``prior`` as zero. Used to
+        capture only the counts a worker added during one task —
+        contrast with returning the full ``self.data`` from a
+        long-lived worker, which would double-count across tasks."""
+        return {key: self.data[key] - prior.get(key, 0) for key in self.data}
+
+    def merge(self, delta: dict["Result", int]) -> None:
+        """Add each counter in ``delta`` into ``self.data``. Used by
+        the parent process to aggregate per-task deltas returned from
+        ``multiprocessing.Pool`` workers. Unknown keys in ``delta``
+        (e.g. an enum added in a future Tracker schema) are silently
+        ignored rather than raising — workers can be slightly newer
+        than the parent during a rolling deploy."""
+        for key, count in delta.items():
+            if key in self.data:
+                self.data[key] += count
+
     def __str__(self) -> str:
         result = "COUNTS:\n"
         for key in self.data:

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -611,7 +611,11 @@ def test_init_partner_worker_binds_mapping_tables_to_module_globals(monkeypatch)
 
     with patch("pywikibot.Site", return_value=fake_site):
         sdc_sync._init_partner_worker(
-            fake_queue, fake_hubs, fake_rights, fake_subject_ids
+            fake_queue,
+            fake_hubs,
+            fake_rights,
+            fake_subject_ids,
+            True,
         )
 
     assert sdc_sync.hubs is fake_hubs
@@ -620,6 +624,35 @@ def test_init_partner_worker_binds_mapping_tables_to_module_globals(monkeypatch)
     # Sanity: the worker should also have set site + logged in (so the
     # initializer hasn't accidentally regressed the existing setup).
     fake_site.login.assert_called_once()
+
+
+def test_init_partner_worker_propagates_normalize_wikitext_flag(monkeypatch):
+    """Regression for the second CodeRabbit finding on #308:
+    ``--no-normalize-wikitext`` flips the parent's
+    ``_normalize_wikitext_enabled`` global, but with spawn start_method
+    workers re-import the module and pick up the default ``True``.
+    The parent must pass the resolved flag via ``initargs`` and the
+    initializer must bind it; otherwise a parent opt-out is silently
+    ignored for every item processed in parallel mode."""
+    from tools import sdc_sync
+
+    fake_queue = MagicMock()
+    fake_site = MagicMock(name="pywikibot_Site")
+
+    # Force the module default to True so we can detect the worker
+    # correctly overrides it down to False via initargs.
+    monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", True, raising=False)
+
+    with patch("pywikibot.Site", return_value=fake_site):
+        sdc_sync._init_partner_worker(fake_queue, {}, {}, {}, False)
+    assert sdc_sync._normalize_wikitext_enabled is False
+
+    # And the opposite — initargs flag True overrides a worker that
+    # happened to start with the global at False.
+    monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", False, raising=False)
+    with patch("pywikibot.Site", return_value=fake_site):
+        sdc_sync._init_partner_worker(fake_queue, {}, {}, {}, True)
+    assert sdc_sync._normalize_wikitext_enabled is True
 
 
 def test_run_partner_mode_dispatches_to_pool_when_workers_above_one(

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -588,6 +588,40 @@ def test_run_partner_mode_uses_inline_loop_when_workers_is_one(tmp_path, monkeyp
     )
 
 
+def test_init_partner_worker_binds_mapping_tables_to_module_globals(monkeypatch):
+    """Regression for CodeRabbit's review of #308: with spawn start_method,
+    worker processes re-import the module fresh. ``hubs`` / ``rights`` /
+    ``subject_ids`` are module-level type annotations (lines 44-46) that
+    only get bound when the parent's ``_initialize()`` runs. Workers
+    skip ``_initialize()``, so without explicit injection the cleanup
+    path (``_post_sdc_cleanup_for_item`` → ``DPLA.get_provider_and_data_provider``)
+    would NameError on every item and silently log + skip cleanup for
+    the whole batch.
+
+    The initializer must accept the parent's already-fetched mapping
+    tables via ``initargs`` and bind them to the worker's module
+    globals before any item processing starts."""
+    from tools import sdc_sync
+
+    fake_queue = MagicMock()
+    fake_site = MagicMock(name="pywikibot_Site")
+    fake_hubs = {"some-hub": {"Wikidata": "Q1"}}
+    fake_rights = {"http://rightsstatements.org/foo": "Q2"}
+    fake_subject_ids = {"subject-name": {"id": ["Q3"]}}
+
+    with patch("pywikibot.Site", return_value=fake_site):
+        sdc_sync._init_partner_worker(
+            fake_queue, fake_hubs, fake_rights, fake_subject_ids
+        )
+
+    assert sdc_sync.hubs is fake_hubs
+    assert sdc_sync.rights is fake_rights
+    assert sdc_sync.subject_ids is fake_subject_ids
+    # Sanity: the worker should also have set site + logged in (so the
+    # initializer hasn't accidentally regressed the existing setup).
+    fake_site.login.assert_called_once()
+
+
 def test_run_partner_mode_dispatches_to_pool_when_workers_above_one(
     tmp_path, monkeypatch
 ):

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -549,6 +549,97 @@ def test_truncate_helper_returns_under_limit_unchanged_and_truncates_long():
     assert sdc_sync._truncate(None) == ""
 
 
+def test_run_partner_mode_uses_inline_loop_when_workers_is_one(tmp_path, monkeypatch):
+    """At the default ``_workers == 1``, partner mode must NOT spin up
+    a multiprocessing Pool — it calls ``_process_one_partner_item``
+    directly in the parent process. Preserves bit-for-bit single-
+    process behaviour and avoids spawn-import overhead for runs that
+    don't ask for parallelism."""
+    from tools import sdc_sync
+
+    ids_file = tmp_path / "ids.txt"
+    ids_file.write_text("abcdef01abcdef01abcdef01abcdef01\n")
+
+    item_calls = []
+    parallel_calls = []
+
+    def fake_process_one_partner_item(s3, partner, dpla_id, idx, total):
+        item_calls.append((partner, dpla_id, idx, total))
+
+    def fake_parallel(partner, dpla_ids, workers):
+        parallel_calls.append((partner, list(dpla_ids), workers))
+
+    monkeypatch.setattr(sdc_sync, "_workers", 1, raising=False)
+    monkeypatch.setattr(
+        sdc_sync, "_process_one_partner_item", fake_process_one_partner_item
+    )
+    monkeypatch.setattr(sdc_sync, "_run_partner_mode_parallel", fake_parallel)
+    with (
+        patch.object(sdc_sync, "setup_logging"),
+        patch.object(sdc_sync, "notify_phase_start"),
+        patch.object(sdc_sync, "notify_sdc_complete"),
+        patch("ingest_wikimedia.s3.S3Client", return_value=MagicMock()),
+    ):
+        sdc_sync._run_partner_mode("nara", str(ids_file))
+
+    assert parallel_calls == [], "Pool path must not run at workers=1"
+    assert item_calls == [("nara", "abcdef01abcdef01abcdef01abcdef01", 1, 1)], (
+        f"expected one inline call to _process_one_partner_item; got {item_calls!r}"
+    )
+
+
+def test_run_partner_mode_dispatches_to_pool_when_workers_above_one(
+    tmp_path, monkeypatch
+):
+    """When ``_workers > 1``, partner mode hands the per-item work
+    off to ``_run_partner_mode_parallel`` and does NOT call
+    ``_process_one_partner_item`` directly. The Pool path owns
+    iteration; the parent's only per-item work is merging deltas."""
+    from tools import sdc_sync
+
+    ids_file = tmp_path / "ids.txt"
+    ids_file.write_text(
+        "aaaa1111aaaa1111aaaa1111aaaa1111\nbbbb2222bbbb2222bbbb2222bbbb2222\n"
+    )
+
+    item_calls = []
+    parallel_calls = []
+
+    def fake_process_one_partner_item(s3, partner, dpla_id, idx, total):
+        item_calls.append((partner, dpla_id, idx, total))
+
+    def fake_parallel(partner, dpla_ids, workers):
+        parallel_calls.append((partner, list(dpla_ids), workers))
+
+    monkeypatch.setattr(sdc_sync, "_workers", 4, raising=False)
+    monkeypatch.setattr(
+        sdc_sync, "_process_one_partner_item", fake_process_one_partner_item
+    )
+    monkeypatch.setattr(sdc_sync, "_run_partner_mode_parallel", fake_parallel)
+    with (
+        patch.object(sdc_sync, "setup_logging"),
+        patch.object(sdc_sync, "notify_phase_start"),
+        patch.object(sdc_sync, "notify_sdc_complete"),
+        patch("ingest_wikimedia.s3.S3Client", return_value=MagicMock()),
+    ):
+        sdc_sync._run_partner_mode("nara", str(ids_file))
+
+    assert item_calls == [], (
+        f"inline _process_one_partner_item must NOT fire under Pool dispatch;"
+        f" got {item_calls!r}"
+    )
+    assert parallel_calls == [
+        (
+            "nara",
+            [
+                "aaaa1111aaaa1111aaaa1111aaaa1111",
+                "bbbb2222bbbb2222bbbb2222bbbb2222",
+            ],
+            4,
+        )
+    ], f"expected one parallel dispatch with 4 workers; got {parallel_calls!r}"
+
+
 def _install_module_globals(
     monkeypatch,
     sdc_sync,

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -26,3 +26,97 @@ def test_str_representation(tracker: Tracker):
     expected_output = "COUNTS:\nFAILED: 2\nSKIPPED: 3\n"
 
     assert str(tracker) == expected_output
+
+
+# ---------------------------------------------------------------------------
+# snapshot / diff / merge — the per-task delta API used by the
+# sdc-sync partner-mode multiprocessing.Pool. Each worker takes a snapshot
+# before processing an item, runs the item (mutating its module-level
+# tracker), and returns the diff to the parent. The parent merges the
+# delta into its own tracker.
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_returns_independent_copy(tracker: Tracker):
+    """Snapshot must be a copy — mutating the tracker afterwards
+    can't change the snapshot's recorded counts."""
+    tracker.increment(Result.DOWNLOADED, 5)
+    snap = tracker.snapshot()
+    tracker.increment(Result.DOWNLOADED, 10)
+    assert snap[Result.DOWNLOADED] == 5
+    assert tracker.count(Result.DOWNLOADED) == 15
+
+
+def test_diff_returns_per_counter_delta(tracker: Tracker):
+    """``diff`` compares the current state against a prior snapshot
+    and returns the per-counter delta. Counters that didn't change
+    appear as 0; this matches the shape the parent's ``merge`` expects."""
+    prior = tracker.snapshot()
+    tracker.increment(Result.SDC_CLAIMS_ADDED, 7)
+    tracker.increment(Result.SDC_REFS_ADDED, 30)
+    delta = tracker.diff(prior)
+    assert delta[Result.SDC_CLAIMS_ADDED] == 7
+    assert delta[Result.SDC_REFS_ADDED] == 30
+    assert delta[Result.DOWNLOADED] == 0
+
+
+def test_diff_handles_decrement_across_reset(tracker: Tracker):
+    """If the tracker was reset between snapshot and diff (e.g. the
+    worker reused its module-level tracker across tasks via reset()),
+    the diff goes negative. This is by design — callers can detect it
+    and decide to log a warning. ``merge`` then just subtracts."""
+    tracker.increment(Result.DOWNLOADED, 5)
+    prior = tracker.snapshot()
+    tracker.reset()
+    delta = tracker.diff(prior)
+    assert delta[Result.DOWNLOADED] == -5
+
+
+def test_merge_aggregates_deltas_from_multiple_workers(tracker: Tracker):
+    """Parent merges per-task deltas from several workers — counts
+    add up across tasks. Mirrors the imap_unordered loop pattern in
+    ``_run_partner_mode_parallel``."""
+    deltas_from_workers = [
+        {Result.SDC_CLAIMS_ADDED: 3, Result.SDC_REFS_ADDED: 12},
+        {Result.SDC_CLAIMS_ADDED: 5, Result.SDC_REFS_ADDED: 18},
+        {Result.SDC_CLAIMS_ADDED: 2, Result.SDC_REMOVALS: 1},
+    ]
+    for delta in deltas_from_workers:
+        tracker.merge(delta)
+    assert tracker.count(Result.SDC_CLAIMS_ADDED) == 10
+    assert tracker.count(Result.SDC_REFS_ADDED) == 30
+    assert tracker.count(Result.SDC_REMOVALS) == 1
+
+
+def test_merge_ignores_unknown_keys(tracker: Tracker):
+    """A worker on a slightly newer Tracker schema may emit a counter
+    the parent doesn't have. Silently ignore — don't raise. Rolling
+    deploys can have brief windows of skew between parent and
+    workers."""
+
+    class _FakeResult:
+        name = "TOTALLY_FAKE_COUNTER"
+
+    fake = _FakeResult()
+    tracker.merge({fake: 999, Result.SDC_CLAIMS_ADDED: 4})
+    assert tracker.count(Result.SDC_CLAIMS_ADDED) == 4
+    # No exception raised — the fake key was silently dropped.
+
+
+def test_snapshot_diff_merge_round_trip(tracker: Tracker):
+    """End-to-end: parent snapshot → worker mutates → diff → parent
+    merges. After the cycle, parent should have exactly the worker's
+    counts even though the worker's tracker started non-empty."""
+    worker = Tracker()
+    worker.increment(Result.DOWNLOADED, 100)  # pre-existing state from prior tasks
+    prior = worker.snapshot()
+    worker.increment(Result.SDC_CLAIMS_ADDED, 2)
+    worker.increment(Result.SDC_REFS_ADDED, 8)
+    delta = worker.diff(prior)
+
+    tracker.merge(delta)
+    assert tracker.count(Result.SDC_CLAIMS_ADDED) == 2
+    assert tracker.count(Result.SDC_REFS_ADDED) == 8
+    # The pre-existing 100 from the worker's earlier task DID NOT
+    # bleed into the parent — diff isolated only this-task's delta.
+    assert tracker.count(Result.DOWNLOADED) == 0

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -4070,7 +4070,13 @@ def _run_partner_mode_parallel(partner, dpla_ids, workers):
         with ctx.Pool(
             processes=workers,
             initializer=_init_partner_worker,
-            initargs=(log_queue,),
+            # Pickle the parent's already-fetched mapping tables across
+            # to each worker so the cleanup path (which calls
+            # ``DPLA.get_provider_and_data_provider`` with ``hubs``)
+            # doesn't NameError under spawn start_method. Sharing one
+            # snapshot also means workers and parent agree on the data
+            # even if ingestion3 updates mid-run.
+            initargs=(log_queue, hubs, rights, subject_ids),
         ) as pool:
             for delta in pool.imap_unordered(_worker_partner_task, tasks):
                 if delta:
@@ -4079,11 +4085,11 @@ def _run_partner_mode_parallel(partner, dpla_ids, workers):
         listener.stop()
 
 
-def _init_partner_worker(log_queue):
+def _init_partner_worker(log_queue, hubs_data, rights_data, subject_ids_data):
     """Per-worker setup for the ``--workers > 1`` partner-mode Pool.
 
     Each multiprocessing worker process re-imports this module (with
-    spawn start_method) and runs this initializer once. Two jobs:
+    spawn start_method) and runs this initializer once. Four jobs:
 
     1. **Fresh pywikibot session per worker.** Each worker gets its
        own ``site``/login pair so HTTP sessions, CSRF tokens, and the
@@ -4091,13 +4097,35 @@ def _init_partner_worker(log_queue):
        the parent's already-opened sockets is a recipe for half-broken
        connections; we always re-login here.)
 
-    2. **Route log records to the parent.** Replace the root logger's
+    2. **Inject the mapping tables the parent already fetched.**
+       ``hubs``, ``rights``, and ``subject_ids`` are bound at parent-
+       process ``_initialize()`` time from ingestion3 + the local
+       ``rights.json``. With spawn start_method the worker re-imports
+       this module fresh — those module globals are declared (lines
+       44-46) but not bound, so first access from the cleanup path
+       (``_post_sdc_cleanup_for_item`` → ``DPLA.get_provider_and_data_provider``
+       at line 3744) would NameError. The parent pickles its already-
+       fetched copies into ``initargs`` and the worker binds them on
+       init, so cleanup works in parallel mode and all workers see
+       identical data (no per-worker re-fetch drift between the parent
+       and ingestion3).
+
+    3. **Route log records to the parent.** Replace the root logger's
        handlers with a single ``QueueHandler`` that pushes records to
        the shared multiprocessing queue. The parent runs a
        ``QueueListener`` that drains records to the per-partner SDC
        log file. Keeps log lines atomic and ordered by completion
        time across workers — much safer than letting N processes
        open the same file descriptor.
+
+    4. **Apply the parent's normalize-wikitext flag.** ``_workers``
+       and ``_normalize_wikitext_enabled`` are also module globals
+       the parent's ``_initialize()`` flips from ``args``; the
+       worker's freshly-imported defaults (workers=1, normalize=True)
+       happen to match production today, but we set
+       ``_normalize_wikitext_enabled`` explicitly here so a future
+       parent invocation with ``--no-normalize-wikitext`` doesn't
+       silently re-enable the strip in workers.
     """
     import logging.handlers
 
@@ -4107,9 +4135,12 @@ def _init_partner_worker(log_queue):
     pywikibot.config.retry_wait = _PYWIKIBOT_RETRY_WAIT
     pywikibot.config.retry_max = _PYWIKIBOT_RETRY_MAX
 
-    global site
+    global site, hubs, rights, subject_ids
     site = pywikibot.Site("commons", "commons")
     site.login()
+    hubs = hubs_data
+    rights = rights_data
+    subject_ids = subject_ids_data
 
     qh = logging.handlers.QueueHandler(log_queue)
     root = logging.getLogger()

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -4076,7 +4076,13 @@ def _run_partner_mode_parallel(partner, dpla_ids, workers):
             # doesn't NameError under spawn start_method. Sharing one
             # snapshot also means workers and parent agree on the data
             # even if ingestion3 updates mid-run.
-            initargs=(log_queue, hubs, rights, subject_ids),
+            initargs=(
+                log_queue,
+                hubs,
+                rights,
+                subject_ids,
+                _normalize_wikitext_enabled,
+            ),
         ) as pool:
             for delta in pool.imap_unordered(_worker_partner_task, tasks):
                 if delta:
@@ -4085,7 +4091,13 @@ def _run_partner_mode_parallel(partner, dpla_ids, workers):
         listener.stop()
 
 
-def _init_partner_worker(log_queue, hubs_data, rights_data, subject_ids_data):
+def _init_partner_worker(
+    log_queue,
+    hubs_data,
+    rights_data,
+    subject_ids_data,
+    normalize_wikitext_enabled,
+):
     """Per-worker setup for the ``--workers > 1`` partner-mode Pool.
 
     Each multiprocessing worker process re-imports this module (with
@@ -4135,12 +4147,13 @@ def _init_partner_worker(log_queue, hubs_data, rights_data, subject_ids_data):
     pywikibot.config.retry_wait = _PYWIKIBOT_RETRY_WAIT
     pywikibot.config.retry_max = _PYWIKIBOT_RETRY_MAX
 
-    global site, hubs, rights, subject_ids
+    global site, hubs, rights, subject_ids, _normalize_wikitext_enabled
     site = pywikibot.Site("commons", "commons")
     site.login()
     hubs = hubs_data
     rights = rights_data
     subject_ids = subject_ids_data
+    _normalize_wikitext_enabled = bool(normalize_wikitext_enabled)
 
     qh = logging.handlers.QueueHandler(log_queue)
     root = logging.getLogger()

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -61,6 +61,13 @@ _legacy_mode_doc_cache: dict[str, dict] = {}
 # wikitext intact.
 _normalize_wikitext_enabled: bool = True
 
+# Number of worker processes for partner-mode SDC sync. Default 1 keeps the
+# pre-PR single-process behaviour; values > 1 enable the multiprocessing
+# Pool dispatch in ``_run_partner_mode``. Set from ``args.workers`` at main()
+# time so tests can monkeypatch the module global directly without needing
+# to construct an argparse Namespace.
+_workers: int = 1
+
 
 def _build_parser() -> argparse.ArgumentParser:
     """Build the argparse parser. Pure — no side effects."""
@@ -157,6 +164,25 @@ def _build_parser() -> argparse.ArgumentParser:
             "(upload → SDC → wikitext cleanup). Pass --no-normalize-wikitext "
             "to disable for diagnostic runs that need the pre-strip wikitext "
             "intact."
+        ),
+    )
+    p.add_argument(
+        "--workers",
+        dest="workers",
+        type=int,
+        default=1,
+        help=(
+            "Number of worker processes for partner-mode SDC sync. "
+            "Default 1 keeps the single-process behaviour unchanged. "
+            "N>1 dispatches per-DPLA-item work to a multiprocessing "
+            "Pool, with each worker holding its own pywikibot session "
+            "and per-task counter deltas merged into the parent's "
+            "Tracker. Wall-clock scales roughly linearly with N up to "
+            "Commons-side parser-pool headroom (~8-16 across all "
+            "concurrent sessions before maxlag starts to bind). Items "
+            "are independent: every ordinal of every item has a "
+            "unique M-id, so workers never write to the same Commons "
+            "MediaInfo entity."
         ),
     )
     return p
@@ -434,7 +460,7 @@ def _initialize() -> None:
     console-script entry point) does no I/O.
     """
     global parser, args, method, dpla_api, site, hubs, rights, subject_ids
-    global _s3_partner, _s3_client, _normalize_wikitext_enabled
+    global _s3_partner, _s3_client, _normalize_wikitext_enabled, _workers
 
     parser = _build_parser()
     args = parser.parse_args()
@@ -491,6 +517,7 @@ def _initialize() -> None:
         _s3_client = S3Client()
 
     _normalize_wikitext_enabled = bool(args.normalize_wikitext)
+    _workers = max(1, int(getattr(args, "workers", 1) or 1))
 
 
 # This is the JSON used for formatting a claim. The P459 -> Q61848113 (determination method) qualifier is hardcoded in for everything DPLA adds. Not all data types have the same format for value, so this is formatted in the function for each property added.
@@ -3998,6 +4025,145 @@ def _migrate_one_dpla_item(s3, partner: str, dpla_id: str) -> None:
             )
 
 
+def _run_partner_mode_parallel(partner, dpla_ids, workers):
+    """Dispatch partner-mode SDC sync across ``workers`` processes.
+
+    Each worker process runs :func:`_process_one_partner_item` against
+    one DPLA item at a time via ``Pool.imap_unordered``; the parent
+    aggregates per-task counter deltas into the module-level tracker.
+
+    Item-level safety: every ordinal of every item has a unique
+    MediaInfo M-id, so two workers handling different items never
+    write to the same Commons entity. The pywikibot ``Site`` is
+    re-initialized per worker (see :func:`_init_partner_worker`),
+    isolating HTTP sessions and CSRF tokens.
+
+    Logging: workers route records through a ``multiprocessing.Queue``
+    to a ``QueueListener`` thread in the parent, which dispatches them
+    to the per-partner SDC log file the parent already opened.
+
+    Uses ``spawn`` start_method explicitly so workers don't inherit
+    the parent's pywikibot session sockets — fork-then-use of a live
+    session has been a source of half-broken connections in similar
+    bot setups.
+    """
+    import logging.handlers
+    import multiprocessing
+
+    ctx = multiprocessing.get_context("spawn")
+    log_queue = ctx.Manager().Queue(-1)
+
+    # Reuse the file handler(s) the parent's setup_logging already
+    # attached to the root logger — the QueueListener drains worker
+    # records into the same destinations the parent writes to.
+    listener_targets = list(logging.getLogger().handlers)
+    listener = logging.handlers.QueueListener(
+        log_queue, *listener_targets, respect_handler_level=True
+    )
+    listener.start()
+
+    tasks = [
+        (partner, dpla_id, idx, len(dpla_ids))
+        for idx, dpla_id in enumerate(dpla_ids, start=1)
+    ]
+    try:
+        with ctx.Pool(
+            processes=workers,
+            initializer=_init_partner_worker,
+            initargs=(log_queue,),
+        ) as pool:
+            for delta in pool.imap_unordered(_worker_partner_task, tasks):
+                if delta:
+                    tracker.merge(delta)
+    finally:
+        listener.stop()
+
+
+def _init_partner_worker(log_queue):
+    """Per-worker setup for the ``--workers > 1`` partner-mode Pool.
+
+    Each multiprocessing worker process re-imports this module (with
+    spawn start_method) and runs this initializer once. Two jobs:
+
+    1. **Fresh pywikibot session per worker.** Each worker gets its
+       own ``site``/login pair so HTTP sessions, CSRF tokens, and the
+       maxlag-retry config are isolated. (Even with fork, inheriting
+       the parent's already-opened sockets is a recipe for half-broken
+       connections; we always re-login here.)
+
+    2. **Route log records to the parent.** Replace the root logger's
+       handlers with a single ``QueueHandler`` that pushes records to
+       the shared multiprocessing queue. The parent runs a
+       ``QueueListener`` that drains records to the per-partner SDC
+       log file. Keeps log lines atomic and ordered by completion
+       time across workers — much safer than letting N processes
+       open the same file descriptor.
+    """
+    import logging.handlers
+
+    import pywikibot
+
+    pywikibot.config.max_retries = _PYWIKIBOT_MAX_RETRIES
+    pywikibot.config.retry_wait = _PYWIKIBOT_RETRY_WAIT
+    pywikibot.config.retry_max = _PYWIKIBOT_RETRY_MAX
+
+    global site
+    site = pywikibot.Site("commons", "commons")
+    site.login()
+
+    qh = logging.handlers.QueueHandler(log_queue)
+    root = logging.getLogger()
+    root.handlers = [qh]
+    root.setLevel(logging.INFO)
+
+
+def _worker_partner_task(args):
+    """Pool worker entrypoint — snapshot the worker's tracker, run
+    one item end-to-end, return the per-task counter delta.
+
+    Pool workers are reused across many tasks; snapshotting before
+    each task and returning the diff gives the parent only what THIS
+    item contributed, so the merge into the parent's tracker is
+    correct regardless of how many tasks each worker ends up handling.
+
+    Top-level exception boundary mirrors the per-ordinal try/except
+    inside ``_process_one_partner_item``: a routine SDC-write failure
+    is already caught and counted as ``SDC_ORDINALS_SKIPPED_ERROR``
+    in there; reaching this handler means something outside the loop
+    raised. Catch and log so a single bad item doesn't kill the whole
+    pool batch.
+    """
+    partner, dpla_id, idx, total = args
+    prior = tracker.snapshot()
+    try:
+        # Workers create their own S3Client lazily on first use; the
+        # parent's instance can't cross the process boundary cleanly
+        # (boto3 sessions hold sockets / credentials state).
+        s3 = _get_partner_s3_client()
+        _process_one_partner_item(s3, partner, dpla_id, idx, total)
+    except Exception:
+        logging.exception(
+            "Worker task crashed processing %s (idx %s/%s) in partner %s",
+            dpla_id,
+            idx,
+            total,
+            partner,
+        )
+    return tracker.diff(prior)
+
+
+def _get_partner_s3_client():
+    """Lazy per-worker S3Client. Cached on the module-level
+    ``_s3_client`` so subsequent tasks in the same worker reuse the
+    same boto3 session."""
+    global _s3_client
+    if _s3_client is None:
+        from ingest_wikimedia.s3 import S3Client
+
+        _s3_client = S3Client()
+    return _s3_client
+
+
 def _process_one_partner_item(s3, partner, dpla_id, idx, total):
     """Process one DPLA item end-to-end in partner mode — read S3
     sidecars, drive per-ordinal SDC sync against Commons, run the
@@ -4025,8 +4191,7 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
         sdc_raw = s3.get_sdc_json(partner, dpla_id)
     except ClientError as e:
         logging.warning(
-            f" -- S3 error reading sdc.json for {partner}/{dpla_id}:"
-            f" {e!r}; skipping."
+            f" -- S3 error reading sdc.json for {partner}/{dpla_id}: {e!r}; skipping."
         )
         tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
         return
@@ -4057,9 +4222,7 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
     try:
         upload_result = json.loads(upload_raw)
     except json.JSONDecodeError as e:
-        logging.warning(
-            f" -- upload-result.json failed to parse: {e}; skipping."
-        )
+        logging.warning(f" -- upload-result.json failed to parse: {e}; skipping.")
         tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
         return
 
@@ -4188,9 +4351,7 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
         # key raises on the first int() that fails, but Python's
         # sorted() doesn't expose which one — so we re-scan the
         # keys here purely to find the culprit for logging.
-        bad_keys = [
-            repr(k) for k in eligible if not str(k).lstrip("-").isdigit()
-        ]
+        bad_keys = [repr(k) for k in eligible if not str(k).lstrip("-").isdigit()]
         logging.warning(
             f" -- upload-result ordinals malformed for {dpla_id}"
             f" (non-integer key(s): {', '.join(bad_keys) or '<unknown>'});"
@@ -4357,12 +4518,8 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
         )
         and _normalize_wikitext_enabled
     ):
-        synced_items = [
-            (o, d) for o, d in ordinal_items if o in synced_ord_strs
-        ]
-        pages_edited |= _post_sdc_cleanup_for_item(
-            s3, partner, dpla_id, synced_items
-        )
+        synced_items = [(o, d) for o, d in ordinal_items if o in synced_ord_strs]
+        pages_edited |= _post_sdc_cleanup_for_item(s3, partner, dpla_id, synced_items)
     if pages_edited:
         tracker.increment(Result.SDC_PAGES_EDITED, len(pages_edited))
 
@@ -4386,7 +4543,6 @@ def _run_partner_mode(partner, ids_file):
     downloader/uploader pattern) so `wikimedia-upload-status` can detect
     progress; final summary posted via `notify_sdc_complete`.
     """
-    from botocore.exceptions import ClientError
 
     from ingest_wikimedia.s3 import S3Client
 
@@ -4410,11 +4566,24 @@ def _run_partner_mode(partner, ids_file):
     with open(ids_file) as f:
         dpla_ids = [line.strip() for line in f if line.strip()]
 
-    logging.info(f"Partner mode: {partner} — {len(dpla_ids)} items from {ids_file}")
+    workers = _workers
+    logging.info(
+        f"Partner mode: {partner} — {len(dpla_ids)} items from {ids_file}"
+        f" (workers={workers})"
+    )
     completed = False
     try:
-        for local_count, dpla_id in enumerate(dpla_ids, start=1):
-            _process_one_partner_item(s3, partner, dpla_id, local_count, len(dpla_ids))
+        if workers <= 1:
+            # Single-process: identical to pre-PR behaviour. Parent's
+            # module-level tracker is mutated in-place; no Pool, no
+            # logging queue, no delta merge. Keeps the no-parallelism
+            # path bit-for-bit unchanged.
+            for local_count, dpla_id in enumerate(dpla_ids, start=1):
+                _process_one_partner_item(
+                    s3, partner, dpla_id, local_count, len(dpla_ids)
+                )
+        else:
+            _run_partner_mode_parallel(partner, dpla_ids, workers)
         completed = True
     except BaseException as exc:
         # The per-ordinal try/except above already swallows every routine

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -3998,6 +3998,375 @@ def _migrate_one_dpla_item(s3, partner: str, dpla_id: str) -> None:
             )
 
 
+def _process_one_partner_item(s3, partner, dpla_id, idx, total):
+    """Process one DPLA item end-to-end in partner mode — read S3
+    sidecars, drive per-ordinal SDC sync against Commons, run the
+    post-SDC cleanup.
+
+    Extracted from :func:`_run_partner_mode`'s for-loop body so the
+    body can be dispatched to worker processes by a
+    ``multiprocessing.Pool`` when ``--workers > 1``. Uses module-
+    level state (``tracker``, ``site``, accumulators,
+    ``_entity_cache``) — at workers=1 these are the parent's; under
+    a Pool each worker process has its own copy. Returns ``None`` on
+    every path; failures are tracked via the module-level Tracker,
+    not raised.
+    """
+    from botocore.exceptions import ClientError
+
+    # Item-start marker — `wikimedia_upload_status._sdc_progress`
+    # greps for this to surface SDC progress.
+    logging.info(f"DPLA ID: {dpla_id} ({idx}/{total})")
+
+    # S3Client.get_item_file returns None on 404/NoSuchKey but
+    # re-raises any other ClientError. Catch those per-item so one
+    # transient S3 failure doesn't abort the whole partner batch.
+    try:
+        sdc_raw = s3.get_sdc_json(partner, dpla_id)
+    except ClientError as e:
+        logging.warning(
+            f" -- S3 error reading sdc.json for {partner}/{dpla_id}:"
+            f" {e!r}; skipping."
+        )
+        tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
+        return
+    if sdc_raw is None:
+        logging.info(" -- No sdc.json on S3; skipping.")
+        tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
+        return
+    try:
+        sdc_payload = json.loads(sdc_raw)
+    except json.JSONDecodeError as e:
+        logging.warning(f" -- sdc.json failed to parse: {e}; skipping.")
+        tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
+        return
+
+    try:
+        upload_raw = s3.get_upload_result(partner, dpla_id)
+    except ClientError as e:
+        logging.warning(
+            f" -- S3 error reading upload-result.json for {partner}/{dpla_id}:"
+            f" {e!r}; skipping."
+        )
+        tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
+        return
+    if upload_raw is None:
+        logging.info(" -- No upload-result.json on S3; skipping.")
+        tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
+        return
+    try:
+        upload_result = json.loads(upload_raw)
+    except json.JSONDecodeError as e:
+        logging.warning(
+            f" -- upload-result.json failed to parse: {e}; skipping."
+        )
+        tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
+        return
+
+    # file-list.txt maps ordinal-1 (zero-indexed) → download URL.
+    # Used to populate the per-ordinal P2699 qualifier on the
+    # P7482 (described at) claim — every file gets one, but the
+    # URL differs per ordinal so it can't live in the per-item
+    # sdc.json. A missing or empty file-list.txt is non-fatal:
+    # P2699 simply isn't materialized for those ordinals (the
+    # rest of the SDC pass still runs).
+    try:
+        file_list = s3.get_file_list(partner, dpla_id)
+    except ClientError as e:
+        logging.warning(
+            f" -- S3 error reading file-list.txt for {partner}/{dpla_id}: {e!r};"
+            " continuing without P2699 qualifiers."
+        )
+        file_list = []
+
+    ordinals = upload_result.get("ordinals", {})
+    # Guard the type of `ordinals` before iteration — if the JSON
+    # sidecar is corrupt or its schema drifts (null, list, scalar),
+    # `ordinals.items()` would raise out of the whole loop and abort
+    # the partner batch. Same handling as any other mapping error.
+    if not isinstance(ordinals, dict):
+        logging.warning(
+            f" -- upload-result.json has non-mapping `ordinals` for {dpla_id}; skipping."
+        )
+        tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
+        return
+    eligible: dict[str, dict] = {}
+    unresolved_ords: list[str] = []
+    for ord_str, data in ordinals.items():
+        if not isinstance(data, dict):
+            continue
+        if data.get("status") in ("UPLOADED", "SKIPPED"):
+            eligible[ord_str] = data
+        else:
+            # NOT_PRESENT / INELIGIBLE / FAILED — the upload phase
+            # couldn't confirm this ordinal in *this* run, but the
+            # file may exist on Commons from a prior run. Defer to
+            # the post-loop Commons discovery pass below.
+            unresolved_ords.append(ord_str)
+
+    # Data-side phases (SDC sync, template migration) operate on
+    # the Commons file, which is independent of whether the
+    # current run successfully refreshed the S3 binary. When the
+    # upload phase left ordinals as NOT_PRESENT/INELIGIBLE/
+    # FAILED, search Commons by DPLA-ID for any existing files
+    # and graft them onto ``eligible``. Lets a transient binary-
+    # side failure (broken upstream URL, S3 hiccup) NOT block
+    # data-side maintenance of files that are already on Commons.
+    #
+    # Lazy: the search only fires if at least one ordinal needs
+    # rescuing — healthy items where everything UPLOADED/SKIPPED
+    # this run pay zero extra API cost.
+    if unresolved_ords:
+        discovered = _find_existing_commons_files_by_dpla_id(dpla_id)
+        rescued = 0
+        for ord_str in unresolved_ords:
+            found = discovered.get(ord_str)
+            if not found:
+                continue
+            # Preserve the original status string for traceability
+            # (Slack summaries / logs can still distinguish "this
+            # run didn't upload" from "this run uploaded fresh"),
+            # but inject the discovered title+pageid so the
+            # per-ordinal sync path treats the file as syncable.
+            eligible[ord_str] = {
+                **ordinals[ord_str],
+                "title": found["title"],
+                "pageid": found["pageid"],
+                "discovered_via_dpla_id": True,
+            }
+            rescued += 1
+        if rescued:
+            logging.info(
+                f" -- Recovered {rescued} ordinal(s) via Commons "
+                f"intitle:{dpla_id} discovery (upload phase reported "
+                "non-eligible status but file exists on Commons)."
+            )
+
+    if not eligible:
+        logging.info(" -- No SDC-eligible ordinals; skipping.")
+        tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
+        return
+
+    # Per-ordinal sync tracking. ``synced_ord_strs`` records
+    # which ordinals' ``process_one_from_sdc`` returned without
+    # raising — i.e. the ordinals the cleanup pass *should*
+    # touch. Filtering on this set when calling
+    # ``_post_sdc_cleanup_for_item`` keeps cleanup from
+    # running against ordinals that were skipped earlier in
+    # this same item (null pageid, missing-entity skip, etc.) —
+    # the defensive entity-guard inside ``_post_sdc_cleanup_for_page``
+    # would refuse the strip anyway, but routing past it
+    # avoids the wasted entity fetch and keeps the contract
+    # explicit. ``synced_this_item`` derives from the set
+    # below; classification is unchanged.
+    synced_ord_strs: set[str] = set()
+    # Per-item set of ord_strs whose Commons file page actually
+    # received an edit this run — populated from the SDC-write
+    # snapshot below (claim/ref/removal writes) and unioned with
+    # the set returned by post-SDC cleanup. Drives
+    # ``SDC_PAGES_EDITED``, so operators can read the real batch
+    # size off the Slack summary instead of inferring it from
+    # ``ITEMS SYNCED`` (which collapses 1-file and 1,000-file
+    # items into the same count).
+    pages_edited: set[str] = set()
+    # Tracks whether any ordinal hit the per-ordinal exception
+    # path (runtime failure) so an item with all-failed ordinals
+    # is classified under SDC_ITEMS_SKIPPED_ERROR rather than
+    # SDC_ITEMS_SKIPPED_MAPPING — they mean different things and
+    # operators read the Slack summary to distinguish bad data
+    # from bad network/API.
+    had_ordinal_error = False
+    # int(ord_str) on a malformed ordinal key (e.g. "abc" instead
+    # of "3") would otherwise raise out of the whole loop and
+    # abort the partner batch. Skip the item, log, and account
+    # for it as a mapping skip — same handling as malformed JSON.
+    try:
+        ordinal_items = sorted(eligible.items(), key=lambda kv: int(kv[0]))
+    except (TypeError, ValueError):
+        # Surface the offending key so operators can trace the
+        # data-quality issue back to upload-result.json. The sort
+        # key raises on the first int() that fails, but Python's
+        # sorted() doesn't expose which one — so we re-scan the
+        # keys here purely to find the culprit for logging.
+        bad_keys = [
+            repr(k) for k in eligible if not str(k).lstrip("-").isdigit()
+        ]
+        logging.warning(
+            f" -- upload-result ordinals malformed for {dpla_id}"
+            f" (non-integer key(s): {', '.join(bad_keys) or '<unknown>'});"
+            " skipping."
+        )
+        tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
+        return
+
+    # Compute per-ordinal P304 (page-number) values for any
+    # multi-file extension group. Single-file groups (one JPG,
+    # one PDF, etc.) are absent from the map — `page_numbers.get(
+    # ord_str)` returns None for them and process_one_from_sdc
+    # skips the qualifier. JPGs and PDFs are numbered as
+    # independent series per the user-confirmed rule.
+    page_numbers = _compute_page_numbers(ordinal_items)
+
+    for ord_str, data in ordinal_items:
+        pageid = data.get("pageid")
+        title = data.get("title", "?")
+        # `if not pageid` rather than `is None` — a recorded
+        # pageid of 0 is just as malformed as a missing one
+        # (no Commons MediaInfo entity has ID `M0`) and would
+        # otherwise propagate downstream as a confusing
+        # pywikibot APIError on the bogus mediaid. The
+        # uploader has historically written ``pageid: 0`` (and
+        # since 2026-06 ``pageid: null``) for successful new
+        # uploads when pywikibot's FilePage cache wasn't
+        # invalidated post-upload.
+        #
+        # When ``title`` is present (which it almost always is —
+        # the uploader writes both fields), fall back to a
+        # Commons API lookup keyed on the title to recover the
+        # real pageid. Lets a re-run of ``sdc-sync`` self-heal
+        # past the upstream sidecar defect instead of silently
+        # repeating the same skip. ``_resolve_pageid_from_title``
+        # returns ``None`` on any failure (page deleted, API
+        # error) — in that case the original skip path runs.
+        if not pageid and title and title != "?":
+            resolved = _resolve_pageid_from_title(title)
+            if resolved:
+                logging.info(
+                    f" -- Ordinal {ord_str}: upload-result pageid"
+                    f" was {data.get('pageid')!r}; resolved to"
+                    f" {resolved} via Commons title lookup."
+                )
+                pageid = resolved
+        if not pageid:
+            logging.warning(
+                f" -- Ordinal {ord_str}: missing/zero pageid"
+                f" ({data.get('pageid')!r}) for '{title}' and"
+                " title→pageid fallback failed; skipping."
+            )
+            tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_PAGEID)
+            # Treat as an ordinal error for item-level bucket
+            # classification — an item where every ordinal had
+            # null pageid should not silently fall into the
+            # MAPPING bucket; it's a real failure that needs
+            # the upstream uploader fix.
+            had_ordinal_error = True
+            continue
+        mediaid = f"M{pageid}"
+        logging.info(f" -- Ordinal {ord_str}: {mediaid} ({title})")
+
+        # Snapshot write counters so we can detect whether this
+        # ordinal's sync actually changed anything on Commons.
+        writes_before = _sdc_writes_total()
+        # Per-ordinal exception boundary. Without this, any
+        # transient pywikibot APIError (rate limit, maxlag,
+        # transient 503), network timeout, or surprise
+        # KeyError/AssertionError deep in the property-builder
+        # propagates up through both nested loops and aborts
+        # the entire partner batch — losing thousands of items'
+        # worth of work because of one bad page. Other failure
+        # modes in this function (S3 ClientError, JSON parse,
+        # malformed ordinals) already skip-and-continue; this
+        # makes the actual SDC write follow the same pattern.
+        # `logging.exception` writes the full traceback into
+        # the SDC log file so notify_pipeline_fail's
+        # `_summarize_log` can surface it in Slack.
+        # Look up this ordinal's download URL from file-list.txt
+        # (zero-indexed; ord_str is "1"-indexed). Used to stamp the
+        # per-ordinal P2699 qualifier on the P7482 statement.
+        # Explicit range guard — Python's negative indexing would
+        # silently grab the LAST entry for ord_str == "0", planting
+        # the wrong URL on a real Commons claim via wbsetqualifier.
+        try:
+            ord_num = int(ord_str)
+        except ValueError:
+            download_url = None
+        else:
+            if 1 <= ord_num <= len(file_list):
+                download_url = file_list[ord_num - 1] or None
+            else:
+                download_url = None
+        try:
+            process_one_from_sdc(
+                mediaid,
+                dpla_id,
+                sdc_payload,
+                download_url=download_url,
+                page_number=page_numbers.get(ord_str),
+            )
+        except _MissingEntityError:
+            # Commons says the MediaInfo entity at this M-id doesn't
+            # exist. Almost always means the file page was deleted
+            # (often by a Commons curator as a duplicate) between
+            # upload and SDC sync, OR this is an SDC-only run for a
+            # file that wasn't uploaded through our pipeline in this
+            # run. Either way it's outside the SDC phase's remit —
+            # not an error, just a clean skip. Tracked separately
+            # from real errors so operators can tell them apart.
+            logging.info(
+                f" -- Ordinal {ord_str} ({mediaid}) for {dpla_id}:"
+                " Commons MediaInfo entity does not exist; skipping"
+                " ordinal (not an error)."
+            )
+            tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY)
+            continue
+        except Exception:
+            logging.exception(
+                f" -- Ordinal {ord_str} ({mediaid}) for {dpla_id}:"
+                " SDC sync failed; skipping ordinal."
+            )
+            tracker.increment(Result.SDC_ORDINALS_SKIPPED_ERROR)
+            had_ordinal_error = True
+            continue
+        writes_after = _sdc_writes_total()
+
+        # If SDC actually changed for this ordinal, force a
+        # category re-render on the file page via a null edit.
+        # MediaWiki caches categories at render time; SDC writes
+        # don't propagate to the page's category list until the
+        # wikitext is re-evaluated. Without this the maintenance
+        # categories like "Digital Public Library of America
+        # files missing required SDC statements" cling on long
+        # after the SDC was added. Mirrors the touch pattern in
+        # ingest_wikimedia/categories.py's
+        # touch_files_for_institution().
+        if writes_after > writes_before:
+            pages_edited.add(ord_str)
+            if title and title != "?":
+                try:
+                    pywikibot.FilePage(site, title).touch()
+                    logging.info(f" -- Touched '{title}' (category refresh).")
+                except Exception as e:
+                    logging.warning(
+                        f" -- Failed to touch '{title}' for category refresh: {e!r}"
+                    )
+        synced_ord_strs.add(ord_str)
+    # Item-level bucket classification + cleanup dispatch.
+    # ``_classify_item_outcome`` returns the bucket; cleanup
+    # runs for any progress-made outcome (full or partial),
+    # against ONLY the ordinals that synced — partial-sync
+    # items must not retry cleanup on the ordinals that
+    # were skipped earlier in this loop (null pageid,
+    # missing entity, etc.).
+    outcome = _classify_item_outcome(bool(synced_ord_strs), had_ordinal_error)
+    tracker.increment(outcome)
+    if (
+        outcome
+        in (
+            Result.SDC_ITEMS_SYNCED,
+            Result.SDC_ITEMS_PARTIALLY_SYNCED,
+        )
+        and _normalize_wikitext_enabled
+    ):
+        synced_items = [
+            (o, d) for o, d in ordinal_items if o in synced_ord_strs
+        ]
+        pages_edited |= _post_sdc_cleanup_for_item(
+            s3, partner, dpla_id, synced_items
+        )
+    if pages_edited:
+        tracker.increment(Result.SDC_PAGES_EDITED, len(pages_edited))
+
+
 def _run_partner_mode(partner, ids_file):
     """Drive the SDC phase from precomputed S3 sidecars for a whole partner.
 
@@ -4045,357 +4414,7 @@ def _run_partner_mode(partner, ids_file):
     completed = False
     try:
         for local_count, dpla_id in enumerate(dpla_ids, start=1):
-            # Item-start marker — `wikimedia_upload_status._sdc_progress`
-            # greps for this to surface SDC progress.
-            logging.info(f"DPLA ID: {dpla_id} ({local_count}/{len(dpla_ids)})")
-
-            # S3Client.get_item_file returns None on 404/NoSuchKey but
-            # re-raises any other ClientError. Catch those per-item so one
-            # transient S3 failure doesn't abort the whole partner batch.
-            try:
-                sdc_raw = s3.get_sdc_json(partner, dpla_id)
-            except ClientError as e:
-                logging.warning(
-                    f" -- S3 error reading sdc.json for {partner}/{dpla_id}:"
-                    f" {e!r}; skipping."
-                )
-                tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
-                continue
-            if sdc_raw is None:
-                logging.info(" -- No sdc.json on S3; skipping.")
-                tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
-                continue
-            try:
-                sdc_payload = json.loads(sdc_raw)
-            except json.JSONDecodeError as e:
-                logging.warning(f" -- sdc.json failed to parse: {e}; skipping.")
-                tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
-                continue
-
-            try:
-                upload_raw = s3.get_upload_result(partner, dpla_id)
-            except ClientError as e:
-                logging.warning(
-                    f" -- S3 error reading upload-result.json for {partner}/{dpla_id}:"
-                    f" {e!r}; skipping."
-                )
-                tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
-                continue
-            if upload_raw is None:
-                logging.info(" -- No upload-result.json on S3; skipping.")
-                tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
-                continue
-            try:
-                upload_result = json.loads(upload_raw)
-            except json.JSONDecodeError as e:
-                logging.warning(
-                    f" -- upload-result.json failed to parse: {e}; skipping."
-                )
-                tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
-                continue
-
-            # file-list.txt maps ordinal-1 (zero-indexed) → download URL.
-            # Used to populate the per-ordinal P2699 qualifier on the
-            # P7482 (described at) claim — every file gets one, but the
-            # URL differs per ordinal so it can't live in the per-item
-            # sdc.json. A missing or empty file-list.txt is non-fatal:
-            # P2699 simply isn't materialized for those ordinals (the
-            # rest of the SDC pass still runs).
-            try:
-                file_list = s3.get_file_list(partner, dpla_id)
-            except ClientError as e:
-                logging.warning(
-                    f" -- S3 error reading file-list.txt for {partner}/{dpla_id}: {e!r};"
-                    " continuing without P2699 qualifiers."
-                )
-                file_list = []
-
-            ordinals = upload_result.get("ordinals", {})
-            # Guard the type of `ordinals` before iteration — if the JSON
-            # sidecar is corrupt or its schema drifts (null, list, scalar),
-            # `ordinals.items()` would raise out of the whole loop and abort
-            # the partner batch. Same handling as any other mapping error.
-            if not isinstance(ordinals, dict):
-                logging.warning(
-                    f" -- upload-result.json has non-mapping `ordinals` for {dpla_id}; skipping."
-                )
-                tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
-                continue
-            eligible: dict[str, dict] = {}
-            unresolved_ords: list[str] = []
-            for ord_str, data in ordinals.items():
-                if not isinstance(data, dict):
-                    continue
-                if data.get("status") in ("UPLOADED", "SKIPPED"):
-                    eligible[ord_str] = data
-                else:
-                    # NOT_PRESENT / INELIGIBLE / FAILED — the upload phase
-                    # couldn't confirm this ordinal in *this* run, but the
-                    # file may exist on Commons from a prior run. Defer to
-                    # the post-loop Commons discovery pass below.
-                    unresolved_ords.append(ord_str)
-
-            # Data-side phases (SDC sync, template migration) operate on
-            # the Commons file, which is independent of whether the
-            # current run successfully refreshed the S3 binary. When the
-            # upload phase left ordinals as NOT_PRESENT/INELIGIBLE/
-            # FAILED, search Commons by DPLA-ID for any existing files
-            # and graft them onto ``eligible``. Lets a transient binary-
-            # side failure (broken upstream URL, S3 hiccup) NOT block
-            # data-side maintenance of files that are already on Commons.
-            #
-            # Lazy: the search only fires if at least one ordinal needs
-            # rescuing — healthy items where everything UPLOADED/SKIPPED
-            # this run pay zero extra API cost.
-            if unresolved_ords:
-                discovered = _find_existing_commons_files_by_dpla_id(dpla_id)
-                rescued = 0
-                for ord_str in unresolved_ords:
-                    found = discovered.get(ord_str)
-                    if not found:
-                        continue
-                    # Preserve the original status string for traceability
-                    # (Slack summaries / logs can still distinguish "this
-                    # run didn't upload" from "this run uploaded fresh"),
-                    # but inject the discovered title+pageid so the
-                    # per-ordinal sync path treats the file as syncable.
-                    eligible[ord_str] = {
-                        **ordinals[ord_str],
-                        "title": found["title"],
-                        "pageid": found["pageid"],
-                        "discovered_via_dpla_id": True,
-                    }
-                    rescued += 1
-                if rescued:
-                    logging.info(
-                        f" -- Recovered {rescued} ordinal(s) via Commons "
-                        f"intitle:{dpla_id} discovery (upload phase reported "
-                        "non-eligible status but file exists on Commons)."
-                    )
-
-            if not eligible:
-                logging.info(" -- No SDC-eligible ordinals; skipping.")
-                tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
-                continue
-
-            # Per-ordinal sync tracking. ``synced_ord_strs`` records
-            # which ordinals' ``process_one_from_sdc`` returned without
-            # raising — i.e. the ordinals the cleanup pass *should*
-            # touch. Filtering on this set when calling
-            # ``_post_sdc_cleanup_for_item`` keeps cleanup from
-            # running against ordinals that were skipped earlier in
-            # this same item (null pageid, missing-entity skip, etc.) —
-            # the defensive entity-guard inside ``_post_sdc_cleanup_for_page``
-            # would refuse the strip anyway, but routing past it
-            # avoids the wasted entity fetch and keeps the contract
-            # explicit. ``synced_this_item`` derives from the set
-            # below; classification is unchanged.
-            synced_ord_strs: set[str] = set()
-            # Per-item set of ord_strs whose Commons file page actually
-            # received an edit this run — populated from the SDC-write
-            # snapshot below (claim/ref/removal writes) and unioned with
-            # the set returned by post-SDC cleanup. Drives
-            # ``SDC_PAGES_EDITED``, so operators can read the real batch
-            # size off the Slack summary instead of inferring it from
-            # ``ITEMS SYNCED`` (which collapses 1-file and 1,000-file
-            # items into the same count).
-            pages_edited: set[str] = set()
-            # Tracks whether any ordinal hit the per-ordinal exception
-            # path (runtime failure) so an item with all-failed ordinals
-            # is classified under SDC_ITEMS_SKIPPED_ERROR rather than
-            # SDC_ITEMS_SKIPPED_MAPPING — they mean different things and
-            # operators read the Slack summary to distinguish bad data
-            # from bad network/API.
-            had_ordinal_error = False
-            # int(ord_str) on a malformed ordinal key (e.g. "abc" instead
-            # of "3") would otherwise raise out of the whole loop and
-            # abort the partner batch. Skip the item, log, and account
-            # for it as a mapping skip — same handling as malformed JSON.
-            try:
-                ordinal_items = sorted(eligible.items(), key=lambda kv: int(kv[0]))
-            except (TypeError, ValueError):
-                # Surface the offending key so operators can trace the
-                # data-quality issue back to upload-result.json. The sort
-                # key raises on the first int() that fails, but Python's
-                # sorted() doesn't expose which one — so we re-scan the
-                # keys here purely to find the culprit for logging.
-                bad_keys = [
-                    repr(k) for k in eligible if not str(k).lstrip("-").isdigit()
-                ]
-                logging.warning(
-                    f" -- upload-result ordinals malformed for {dpla_id}"
-                    f" (non-integer key(s): {', '.join(bad_keys) or '<unknown>'});"
-                    " skipping."
-                )
-                tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
-                continue
-
-            # Compute per-ordinal P304 (page-number) values for any
-            # multi-file extension group. Single-file groups (one JPG,
-            # one PDF, etc.) are absent from the map — `page_numbers.get(
-            # ord_str)` returns None for them and process_one_from_sdc
-            # skips the qualifier. JPGs and PDFs are numbered as
-            # independent series per the user-confirmed rule.
-            page_numbers = _compute_page_numbers(ordinal_items)
-
-            for ord_str, data in ordinal_items:
-                pageid = data.get("pageid")
-                title = data.get("title", "?")
-                # `if not pageid` rather than `is None` — a recorded
-                # pageid of 0 is just as malformed as a missing one
-                # (no Commons MediaInfo entity has ID `M0`) and would
-                # otherwise propagate downstream as a confusing
-                # pywikibot APIError on the bogus mediaid. The
-                # uploader has historically written ``pageid: 0`` (and
-                # since 2026-06 ``pageid: null``) for successful new
-                # uploads when pywikibot's FilePage cache wasn't
-                # invalidated post-upload.
-                #
-                # When ``title`` is present (which it almost always is —
-                # the uploader writes both fields), fall back to a
-                # Commons API lookup keyed on the title to recover the
-                # real pageid. Lets a re-run of ``sdc-sync`` self-heal
-                # past the upstream sidecar defect instead of silently
-                # repeating the same skip. ``_resolve_pageid_from_title``
-                # returns ``None`` on any failure (page deleted, API
-                # error) — in that case the original skip path runs.
-                if not pageid and title and title != "?":
-                    resolved = _resolve_pageid_from_title(title)
-                    if resolved:
-                        logging.info(
-                            f" -- Ordinal {ord_str}: upload-result pageid"
-                            f" was {data.get('pageid')!r}; resolved to"
-                            f" {resolved} via Commons title lookup."
-                        )
-                        pageid = resolved
-                if not pageid:
-                    logging.warning(
-                        f" -- Ordinal {ord_str}: missing/zero pageid"
-                        f" ({data.get('pageid')!r}) for '{title}' and"
-                        " title→pageid fallback failed; skipping."
-                    )
-                    tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_PAGEID)
-                    # Treat as an ordinal error for item-level bucket
-                    # classification — an item where every ordinal had
-                    # null pageid should not silently fall into the
-                    # MAPPING bucket; it's a real failure that needs
-                    # the upstream uploader fix.
-                    had_ordinal_error = True
-                    continue
-                mediaid = f"M{pageid}"
-                logging.info(f" -- Ordinal {ord_str}: {mediaid} ({title})")
-
-                # Snapshot write counters so we can detect whether this
-                # ordinal's sync actually changed anything on Commons.
-                writes_before = _sdc_writes_total()
-                # Per-ordinal exception boundary. Without this, any
-                # transient pywikibot APIError (rate limit, maxlag,
-                # transient 503), network timeout, or surprise
-                # KeyError/AssertionError deep in the property-builder
-                # propagates up through both nested loops and aborts
-                # the entire partner batch — losing thousands of items'
-                # worth of work because of one bad page. Other failure
-                # modes in this function (S3 ClientError, JSON parse,
-                # malformed ordinals) already skip-and-continue; this
-                # makes the actual SDC write follow the same pattern.
-                # `logging.exception` writes the full traceback into
-                # the SDC log file so notify_pipeline_fail's
-                # `_summarize_log` can surface it in Slack.
-                # Look up this ordinal's download URL from file-list.txt
-                # (zero-indexed; ord_str is "1"-indexed). Used to stamp the
-                # per-ordinal P2699 qualifier on the P7482 statement.
-                # Explicit range guard — Python's negative indexing would
-                # silently grab the LAST entry for ord_str == "0", planting
-                # the wrong URL on a real Commons claim via wbsetqualifier.
-                try:
-                    ord_num = int(ord_str)
-                except ValueError:
-                    download_url = None
-                else:
-                    if 1 <= ord_num <= len(file_list):
-                        download_url = file_list[ord_num - 1] or None
-                    else:
-                        download_url = None
-                try:
-                    process_one_from_sdc(
-                        mediaid,
-                        dpla_id,
-                        sdc_payload,
-                        download_url=download_url,
-                        page_number=page_numbers.get(ord_str),
-                    )
-                except _MissingEntityError:
-                    # Commons says the MediaInfo entity at this M-id doesn't
-                    # exist. Almost always means the file page was deleted
-                    # (often by a Commons curator as a duplicate) between
-                    # upload and SDC sync, OR this is an SDC-only run for a
-                    # file that wasn't uploaded through our pipeline in this
-                    # run. Either way it's outside the SDC phase's remit —
-                    # not an error, just a clean skip. Tracked separately
-                    # from real errors so operators can tell them apart.
-                    logging.info(
-                        f" -- Ordinal {ord_str} ({mediaid}) for {dpla_id}:"
-                        " Commons MediaInfo entity does not exist; skipping"
-                        " ordinal (not an error)."
-                    )
-                    tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY)
-                    continue
-                except Exception:
-                    logging.exception(
-                        f" -- Ordinal {ord_str} ({mediaid}) for {dpla_id}:"
-                        " SDC sync failed; skipping ordinal."
-                    )
-                    tracker.increment(Result.SDC_ORDINALS_SKIPPED_ERROR)
-                    had_ordinal_error = True
-                    continue
-                writes_after = _sdc_writes_total()
-
-                # If SDC actually changed for this ordinal, force a
-                # category re-render on the file page via a null edit.
-                # MediaWiki caches categories at render time; SDC writes
-                # don't propagate to the page's category list until the
-                # wikitext is re-evaluated. Without this the maintenance
-                # categories like "Digital Public Library of America
-                # files missing required SDC statements" cling on long
-                # after the SDC was added. Mirrors the touch pattern in
-                # ingest_wikimedia/categories.py's
-                # touch_files_for_institution().
-                if writes_after > writes_before:
-                    pages_edited.add(ord_str)
-                    if title and title != "?":
-                        try:
-                            pywikibot.FilePage(site, title).touch()
-                            logging.info(f" -- Touched '{title}' (category refresh).")
-                        except Exception as e:
-                            logging.warning(
-                                f" -- Failed to touch '{title}' for category refresh: {e!r}"
-                            )
-                synced_ord_strs.add(ord_str)
-            # Item-level bucket classification + cleanup dispatch.
-            # ``_classify_item_outcome`` returns the bucket; cleanup
-            # runs for any progress-made outcome (full or partial),
-            # against ONLY the ordinals that synced — partial-sync
-            # items must not retry cleanup on the ordinals that
-            # were skipped earlier in this loop (null pageid,
-            # missing entity, etc.).
-            outcome = _classify_item_outcome(bool(synced_ord_strs), had_ordinal_error)
-            tracker.increment(outcome)
-            if (
-                outcome
-                in (
-                    Result.SDC_ITEMS_SYNCED,
-                    Result.SDC_ITEMS_PARTIALLY_SYNCED,
-                )
-                and _normalize_wikitext_enabled
-            ):
-                synced_items = [
-                    (o, d) for o, d in ordinal_items if o in synced_ord_strs
-                ]
-                pages_edited |= _post_sdc_cleanup_for_item(
-                    s3, partner, dpla_id, synced_items
-                )
-            if pages_edited:
-                tracker.increment(Result.SDC_PAGES_EDITED, len(pages_edited))
+            _process_one_partner_item(s3, partner, dpla_id, local_count, len(dpla_ids))
         completed = True
     except BaseException as exc:
         # The per-ordinal try/except above already swallows every routine


### PR DESCRIPTION
## Summary

Adds per-session parallelism to partner-mode SDC sync. Default `--workers 1` preserves the pre-PR single-process behaviour bit-for-bit. `--workers N > 1` dispatches per-DPLA-item work to a `multiprocessing.Pool` (spawn start_method) with N worker processes.

LBJ-class partner runs (~4k items, 51h serial today) finish in roughly `51/N` hours at the maxlag-headroom ceiling of ~N=8 — about 6-7h.

## Commits

1. **`dd19468` — Extract per-item body of `_run_partner_mode`** into `_process_one_partner_item(s3, partner, dpla_id, idx, total)`. Pure refactor, no behaviour change. Sets up the seam for the Pool integration.
2. **`cee554a` — Pool dispatch + `--workers` flag.** Workers each get a fresh pywikibot session, lazy S3Client, and route log records to the parent's per-partner log file via `QueueHandler`/`QueueListener`. Per-task counter deltas (Tracker `snapshot`/`diff`/`merge` API, new) accumulate into the parent's tracker.
3. **`d6e56cf` — Pass `hubs` / `rights` / `subject_ids` via initargs** (CR finding). Spawn workers re-import the module and would NameError on the cleanup path's reference to `hubs` without explicit injection.
4. **`7ecdf37` — Pass `--no-normalize-wikitext` via initargs** (CR finding). Same class of issue as #3 — the parent's CLI opt-out wasn't propagating to workers.

## EC2 smoke test (2026-06-15)

Ran `--workers 4` on a 30-item NARA test CSV from `/home/ec2-user/ingest-wikimedia-parallelism/` (separate checkout to avoid disturbing the 6 production sessions still on main). Items included one 1,500-ordinal multi-volume military personnel file, so it ran for ~20 min before I killed it (kept the smoke scoped).

What the run verified:
- ✅ **Workers spawn**: 7 Python processes total (1 parent + 4 workers + 2 multiprocessing helpers), counted via `ps -ef | grep ingest-wikimedia-parallelism`.
- ✅ **Parallelism is real**: log shows ordinals from different DPLA items interleaved by completion (e.g. `(page 330)` of one item, `(page 371)` of another, all within the same second).
- ✅ **Log file via QueueListener works**: `./logs/20260615-020041-nara-sdc.log` grew to 3,099 lines across 2,831 ordinals processed, no interleaved-mid-line corruption.
- ✅ **No errors / tracebacks**: zero matches for `Traceback|Exception|ERROR` across the entire log.
- ✅ **Per-worker pacing healthy**: ~4 sec per ordinal per worker (visible from `Ordinal N` → `Touched N` cadence in the log).
- ✅ **`hubs` injection works**: the `_post_sdc_cleanup_for_item` touches (which depend on `DPLA.get_provider_and_data_provider(item_metadata, hubs)`) fired correctly for every synced ordinal.
- ⚠️ **Not verified end-to-end**: the terminal `COUNTS:` block and `notify_sdc_complete` Slack message — the run was killed before completion to keep the smoke scoped. Both code paths are exercised by the existing workers=1 path (which is unit-tested in this PR) and unit tests cover the `Tracker.merge` aggregation logic.

## Constraints / follow-ups

- **Concurrent-session budget**: at the existing 6-session steady state, default `--workers 1` is safe. Operators can flip higher per-session when other sessions aren't running. A follow-up PR will add a cross-session shared budget (fcntl slot-file semaphore at ~16 total) so concurrent sessions cooperatively share Commons capacity without operator math.
- **Test plan checklist**:
  - [x] Tracker delta API (`snapshot`/`diff`/`merge`): 6 unit tests
  - [x] Partner-mode dispatch: 2 tests covering `workers=1` inline vs. `workers>1` Pool dispatch
  - [x] Worker initializer binds `hubs`/`rights`/`subject_ids`/`_normalize_wikitext_enabled` correctly: 2 tests
  - [x] Full suite: 696 passing (was 686), ruff clean
  - [x] EC2 smoke at `--workers 4` (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)