### PR TITLE
sdc-sync + uploader: box-wide Commons-write budget + wire --workers/--workers-budget through launch

### DIFF
--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -34,6 +34,16 @@ on:
         description: "SDC-only backfill — skip download + upload phases, just re-enumerate IDs and run sdc-sync"
         type: boolean
         default: false
+      workers:
+        description: "SDC-sync worker processes per session (parallelism). 1 = single-process."
+        required: false
+        type: string
+        default: "4"
+      workers_budget:
+        description: "Box-wide cap on concurrent SDC worker slots across all sessions (0 = unlimited)"
+        required: false
+        type: string
+        default: "16"
 
 permissions:
   contents: read
@@ -71,6 +81,8 @@ jobs:
           INPUT_MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days }}
           INPUT_REFRESH_ONLY: ${{ github.event.inputs.refresh_only }}
           INPUT_SDC_ONLY: ${{ github.event.inputs.sdc_only }}
+          INPUT_WORKERS: ${{ github.event.inputs.workers }}
+          INPUT_WORKERS_BUDGET: ${{ github.event.inputs.workers_budget }}
         run: |
           python scripts/wikimedia_launch.py \
             --partner "$INPUT_PARTNER" \
@@ -78,4 +90,6 @@ jobs:
             --response-url "$INPUT_RESPONSE_URL" \
             --max-age-days "$INPUT_MAX_AGE_DAYS" \
             --refresh-only "$INPUT_REFRESH_ONLY" \
-            --sdc-only "$INPUT_SDC_ONLY"
+            --sdc-only "$INPUT_SDC_ONLY" \
+            --workers "$INPUT_WORKERS" \
+            --workers-budget "$INPUT_WORKERS_BUDGET"

--- a/ingest_wikimedia/worker_slots.py
+++ b/ingest_wikimedia/worker_slots.py
@@ -1,0 +1,161 @@
+"""Cross-session worker-slot budget for SDC sync parallelism.
+
+The SDC sync ``--workers N`` flag (PR #308) parallelizes one partner run
+across N worker processes. But the wiki EC2 box typically runs 6+
+concurrent ``sdc-sync`` sessions, and Commons' MediaWiki parser pool
+only tolerates ~16 concurrent bot writes before maxlag starts to bind.
+A per-session worker count can't see the other sessions, so 6 sessions
+× 4 workers = 24 writers would oversubscribe.
+
+This module provides a *box-wide* semaphore that all sessions share:
+a fixed directory of N slot files, each acquired with a non-blocking
+``fcntl.flock``. A worker checks out a slot before its per-item Commons
+work and releases it on return. When more workers than slots exist
+across all sessions, the excess block until a slot frees.
+
+What the cap actually bounds: the number of DPLA *items* being actively
+synced at once across the box, which is N. Because each item's worker
+issues its per-ordinal Commons writes sequentially, that also bounds the
+number of concurrent write *streams* to N — a deliberately loose proxy
+for "concurrent writes", not a tight per-write rate limit. A 1-ordinal
+item and a 1500-ordinal item each occupy exactly one slot, so a slot
+held by a large item represents far more write work than one held by a
+small item. That's acceptable here: the real per-process safety net
+against overrunning Commons is pywikibot's own ``maxlag`` backoff (each
+worker has its own session and honors it independently); the slot budget
+is the coarser, cross-session throttle that keeps the *number* of
+simultaneously-writing sessions bounded so they don't collectively
+stampede the parser pool. Per-write slot acquisition would make the cap
+a tight write-rate bound but at the cost of ~1 lock cycle per ordinal
+(1500+ on a large item) for no practical gain over maxlag.
+
+Why flock slot files rather than a SysV/POSIX semaphore:
+
+  * **Crash-safe.** ``flock`` locks release automatically when the
+    holding fd is closed *or the process dies* — so a worker that
+    segfaults or is OOM-killed mid-item frees its slot immediately,
+    with no leaked-permit accounting to repair. A SysV semaphore
+    leaks a permit on holder death unless SEM_UNDO is set up
+    perfectly, which is exactly the failure mode that bites at 3am.
+  * **Inspectable.** ``lslocks`` / ``ls`` show the live state; an
+    operator can see and reason about the budget without special
+    tooling.
+  * **No cleanup contract.** Slot files are created once and left in
+    place; there's no "last one out frees the IPC object" dance.
+
+Consistency note: the budget value N must be the same across all
+concurrent sessions for the cap to mean what it says. In practice it
+comes from a single launch-time default, so all sessions agree. If two
+sessions disagree (N=16 vs N=8), the effective cap is the larger N but
+the smaller-N session only ever competes for the lower slots — a
+benign degradation, not a correctness break.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import logging
+import os
+import time
+
+# Box-wide shared directory holding the slot lock files. Fixed path so
+# every ``sdc-sync`` process on the host contends over the same set.
+# Under /tmp because the locks are inherently ephemeral — a reboot that
+# clears /tmp also kills every holder, so there's nothing to preserve.
+DEFAULT_SLOT_DIR = "/tmp/sdc-sync-worker-slots"
+
+# Poll interval when every slot is currently held. Slots turn over on
+# the order of seconds (one per-item SDC sync), so a sub-second poll
+# keeps latency low without busy-spinning.
+_POLL_INTERVAL_SECONDS = 0.5
+
+
+class WorkerSlotBudget:
+    """A box-wide N-permit semaphore backed by ``fcntl.flock`` slot files.
+
+    ``budget <= 0`` disables the semaphore entirely: :meth:`acquire`
+    becomes a no-op context manager. This is the single-process /
+    unlimited path — callers don't special-case it.
+    """
+
+    def __init__(self, budget: int, slot_dir: str = DEFAULT_SLOT_DIR):
+        self.budget = budget
+        self.slot_dir = slot_dir
+        if budget > 0:
+            self._ensure_slot_files()
+
+    def _ensure_slot_files(self) -> None:
+        """Create the slot directory and the N slot files if absent.
+
+        Idempotent and safe to call concurrently from multiple
+        sessions: ``makedirs(exist_ok=True)`` and ``open(..., "a")``
+        both tolerate the file/dir already existing, and neither
+        truncates — so a session starting up never disturbs the locks
+        another session is already holding on the same files.
+        """
+        os.makedirs(self.slot_dir, exist_ok=True)
+        for i in range(self.budget):
+            path = os.path.join(self.slot_dir, f"slot-{i}")
+            # "a" creates-if-absent without truncating; immediately
+            # closed because we only need the file to exist. Acquisition
+            # opens its own fd per attempt.
+            with open(path, "a"):
+                pass
+
+    @contextlib.contextmanager
+    def acquire(self):
+        """Acquire one slot for the duration of the ``with`` block.
+
+        Scans the slot files for one not currently flock'd, taking the
+        first free one. If every slot is held, sleeps
+        ``_POLL_INTERVAL_SECONDS`` and rescans — blocking until capacity
+        frees. The held fd is closed on exit, which releases the flock
+        (also released automatically if this process dies while
+        holding it).
+
+        When ``budget <= 0`` the budget is disabled and this yields
+        immediately without touching the filesystem.
+        """
+        if self.budget <= 0:
+            yield
+            return
+
+        fd = None
+        try:
+            fd = self._acquire_slot_fd()
+            yield
+        finally:
+            if fd is not None:
+                # Closing the fd releases the flock. No explicit
+                # LOCK_UN needed — close is the documented release.
+                os.close(fd)
+
+    def _acquire_slot_fd(self) -> int:
+        """Block until a slot is free; return the held fd.
+
+        Returns the open file descriptor whose flock this call now
+        holds. Caller owns closing it.
+        """
+        waited_logged = False
+        while True:
+            for i in range(self.budget):
+                path = os.path.join(self.slot_dir, f"slot-{i}")
+                fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o644)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    return fd
+                except OSError:
+                    # Slot held by another worker/session — try the next.
+                    os.close(fd)
+                    continue
+            # Every slot busy. Log once so an operator watching the log
+            # can see the budget is saturated (expected under heavy
+            # concurrency), then poll.
+            if not waited_logged:
+                logging.info(
+                    " -- All %d worker slots busy; waiting for capacity.",
+                    self.budget,
+                )
+                waited_logged = True
+            time.sleep(_POLL_INTERVAL_SECONDS)

--- a/ingest_wikimedia/worker_slots.py
+++ b/ingest_wikimedia/worker_slots.py
@@ -122,8 +122,25 @@ class WorkerSlotBudget:
         both tolerate the file/dir already existing, and neither
         truncates — so a session starting up never disturbs the locks
         another session is already holding on the same files.
+
+        Validates that an existing slot directory is owned by the
+        current user before reusing it. Catches a future deployment-
+        model change where the host gains other local accounts — an
+        attacker who can write into our slot dir can `unlink` a held
+        lock file, forcing a new inode the next time we ``os.open``
+        it and silently breaking the exclusion invariant. On today's
+        single-tenant EC2 the check is a no-op; the cost is one
+        ``os.stat`` per session start.
         """
         os.makedirs(self.slot_dir, exist_ok=True)
+        st = os.stat(self.slot_dir)
+        if st.st_uid != os.getuid():
+            raise RuntimeError(
+                f"Worker slot dir {self.slot_dir!r} is owned by uid "
+                f"{st.st_uid}, not the current user (uid {os.getuid()}); "
+                "refusing to use it (an attacker with write access could "
+                "unlink held lock files and break the exclusion invariant)."
+            )
         for i in range(self.budget):
             path = os.path.join(self.slot_dir, f"slot-{i}")
             # "a" creates-if-absent without truncating; immediately

--- a/ingest_wikimedia/worker_slots.py
+++ b/ingest_wikimedia/worker_slots.py
@@ -70,10 +70,23 @@ benign degradation, not a correctness break.
 from __future__ import annotations
 
 import contextlib
+import errno
 import fcntl
 import logging
 import os
 import time
+
+# Mode for slot files: owner read/write only. They carry no data (the
+# flock is the whole signal), so group/other access buys nothing and a
+# stricter mode keeps another local account from interfering with the
+# lock files on a shared host.
+_SLOT_FILE_MODE = 0o600
+
+# errnos ``flock(LOCK_NB)`` raises specifically for "another holder has
+# it" — the only condition that warrants moving on to the next slot /
+# polling. Any other OSError (EACCES, ENOLCK, EIO, …) is a real fault
+# that must propagate rather than spin forever.
+_FLOCK_CONTENDED_ERRNOS = frozenset({errno.EAGAIN, errno.EWOULDBLOCK})
 
 # Box-wide shared directory holding the slot lock files. Fixed path so
 # every ``sdc-sync`` process on the host contends over the same set.
@@ -157,14 +170,19 @@ class WorkerSlotBudget:
         while True:
             for i in range(self.budget):
                 path = os.path.join(self.slot_dir, f"slot-{i}")
-                fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o644)
+                fd = os.open(path, os.O_RDWR | os.O_CREAT, _SLOT_FILE_MODE)
                 try:
                     fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                     return fd
-                except OSError:
-                    # Slot held by another worker/session — try the next.
+                except OSError as e:
                     os.close(fd)
-                    continue
+                    if e.errno in _FLOCK_CONTENDED_ERRNOS:
+                        # Slot held by another worker/session — try the
+                        # next one. Any other errno (permission, ENOLCK,
+                        # I/O) is a real fault: re-raise rather than spin
+                        # forever masking it.
+                        continue
+                    raise
             # Every slot busy. Log once so an operator watching the log
             # can see the budget is saturated (expected under heavy
             # concurrency), then poll.

--- a/ingest_wikimedia/worker_slots.py
+++ b/ingest_wikimedia/worker_slots.py
@@ -1,33 +1,49 @@
-"""Cross-session worker-slot budget for SDC sync parallelism.
+"""Cross-session box-wide budget for concurrent Commons-writing work.
 
 The SDC sync ``--workers N`` flag (PR #308) parallelizes one partner run
 across N worker processes. But the wiki EC2 box typically runs 6+
-concurrent ``sdc-sync`` sessions, and Commons' MediaWiki parser pool
-only tolerates ~16 concurrent bot writes before maxlag starts to bind.
-A per-session worker count can't see the other sessions, so 6 sessions
-× 4 workers = 24 writers would oversubscribe.
+concurrent wikimedia sessions, and Commons' MediaWiki parser pool only
+tolerates ~16 concurrent bot writes before maxlag starts to bind. A
+per-session worker count can't see the other sessions, so 6 sessions ×
+4 workers = 24 writers would oversubscribe.
 
 This module provides a *box-wide* semaphore that all sessions share:
 a fixed directory of N slot files, each acquired with a non-blocking
-``fcntl.flock``. A worker checks out a slot before its per-item Commons
-work and releases it on return. When more workers than slots exist
-across all sessions, the excess block until a slot frees.
+``fcntl.flock``. A process checks out a slot before its per-item Commons
+work and releases it on return. When more would-be writers than slots
+exist across all sessions, the excess block until a slot frees.
 
-What the cap actually bounds: the number of DPLA *items* being actively
-synced at once across the box, which is N. Because each item's worker
-issues its per-ordinal Commons writes sequentially, that also bounds the
-number of concurrent write *streams* to N — a deliberately loose proxy
-for "concurrent writes", not a tight per-write rate limit. A 1-ordinal
-item and a 1500-ordinal item each occupy exactly one slot, so a slot
-held by a large item represents far more write work than one held by a
-small item. That's acceptable here: the real per-process safety net
-against overrunning Commons is pywikibot's own ``maxlag`` backoff (each
-worker has its own session and honors it independently); the slot budget
-is the coarser, cross-session throttle that keeps the *number* of
-simultaneously-writing sessions bounded so they don't collectively
+Both Commons-writing phases draw from the same pool:
+
+  * **SDC sync** — each pool worker (``--workers N``) holds one slot per
+    item it processes.
+  * **Uploader** — single-process (no parallelism), but holds one slot
+    per item too, so it counts as one writer against the shared cap
+    alongside SDC-sync workers. (The downloader is deliberately NOT in
+    the pool: it writes to source sites, not Commons, so it contends for
+    a different resource.)
+
+So the cap bounds the number of DPLA *items* being actively written to
+Commons at once across the whole box — summed over every upload and
+SDC-sync session — to N. Because each item's writer issues its
+per-ordinal Commons writes sequentially, that also bounds the number of
+concurrent write *streams* to N: a deliberately loose proxy for
+"concurrent writes", not a tight per-write rate limit. A 1-ordinal item
+and a 1500-ordinal item each occupy exactly one slot, so a slot held by
+a large item represents far more write work than one held by a small
+item. That's acceptable here: the real per-process safety net against
+overrunning Commons is pywikibot's own ``maxlag`` backoff (each process
+has its own session and honors it independently); the slot budget is the
+coarser, cross-session throttle that keeps the *number* of
+simultaneously-writing processes bounded so they don't collectively
 stampede the parser pool. Per-write slot acquisition would make the cap
 a tight write-rate bound but at the cost of ~1 lock cycle per ordinal
 (1500+ on a large item) for no practical gain over maxlag.
+
+Note: a long-running uploader holding a slot for the duration of a big
+item can make SDC-sync workers (or other uploaders) block waiting for
+capacity — that is the intended cooperative throttle, not a bug. Size N
+with the combined upload + SDC-sync population in mind.
 
 Why flock slot files rather than a SysV/POSIX semaphore:
 

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -128,8 +128,13 @@ def main() -> None:
     parser.add_argument("--max-age-days", default="")
     parser.add_argument("--refresh-only", default="false")
     parser.add_argument("--sdc-only", default="false")
-    parser.add_argument("--workers", default="1")
-    parser.add_argument("--workers-budget", default="0")
+    # Keep in sync with .github/workflows/wikimedia-launch.yml inputs.workers
+    # / inputs.workers_budget (currently 4 / 16), which the workflow always
+    # passes explicitly. These defaults only apply to a bare manual launch —
+    # they let it behave like a workflow launch (4 SDC workers under a
+    # box-wide cap of 16) rather than silently running single-worker, no cap.
+    parser.add_argument("--workers", default="4")
+    parser.add_argument("--workers-budget", default="16")
     args = parser.parse_args()
 
     force = _parse_bool(args.force)

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -866,11 +866,16 @@ def main() -> None:
             f"{is_last_env}; "
             f"{single_item_env}"
         )
-        # SDC-sync parallelism options, shared by both invocation sites
-        # below. --workers > 1 enables the multiprocessing pool;
-        # --workers-budget caps concurrent worker slots box-wide. Both
-        # values are already validated above.
+        # SDC-sync parallelism options. --workers > 1 enables the
+        # multiprocessing pool; --workers-budget caps concurrent worker
+        # slots box-wide. Both values are already validated above.
         sdc_opts = f" --workers {sdc_workers} --workers-budget {sdc_workers_budget}"
+        # The uploader is single-process but shares the same box-wide
+        # Commons-write budget (one slot per item) so concurrent upload
+        # and SDC-sync sessions across the host don't collectively
+        # overrun maxlag. Only the budget — no --workers (no upload
+        # parallelism).
+        upload_opts = f" --workers-budget {sdc_workers_budget}"
         if sdc_only:
             # SDC-only backfill: re-enumerate the partner's items (which
             # also refreshes sdc.json sidecars from the latest ingestion3
@@ -893,7 +898,7 @@ def main() -> None:
                 f"downloader {dl_age_opt}{dl_notify_opt}{csv_file} {canonical}",
             ]
             if not refresh_only:
-                pipeline_steps.append(f"uploader {csv_file} {canonical}")
+                pipeline_steps.append(f"uploader {csv_file} {canonical}{upload_opts}")
                 # SDC sync is the final step of every upload run: it reads
                 # the per-item sdc.json (staged by get-ids-es) and
                 # upload-result.json (written by uploader) sidecars and

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -128,6 +128,8 @@ def main() -> None:
     parser.add_argument("--max-age-days", default="")
     parser.add_argument("--refresh-only", default="false")
     parser.add_argument("--sdc-only", default="false")
+    parser.add_argument("--workers", default="1")
+    parser.add_argument("--workers-budget", default="0")
     args = parser.parse_args()
 
     force = _parse_bool(args.force)
@@ -162,6 +164,34 @@ def main() -> None:
             _slack_fail(
                 response_url,
                 f"Invalid --max-age-days value: {args.max_age_days!r} (must be a positive integer).",
+            )
+
+    # SDC-sync parallelism knobs. Empty string (workflow input left
+    # blank) falls back to the conservative default rather than failing
+    # the whole launch. --workers must be >= 1; --workers-budget >= 0
+    # (0 = unlimited / disabled).
+    sdc_workers = 4
+    if args.workers.strip():
+        try:
+            sdc_workers = int(args.workers)
+            if sdc_workers < 1:
+                raise ValueError
+        except ValueError:
+            _slack_fail(
+                response_url,
+                f"Invalid --workers value: {args.workers!r} (must be an integer >= 1).",
+            )
+    sdc_workers_budget = 16
+    if args.workers_budget.strip():
+        try:
+            sdc_workers_budget = int(args.workers_budget)
+            if sdc_workers_budget < 0:
+                raise ValueError
+        except ValueError:
+            _slack_fail(
+                response_url,
+                f"Invalid --workers-budget value: {args.workers_budget!r}"
+                " (must be an integer >= 0; 0 disables the budget).",
             )
 
     # --partner may be a shlex-encoded list: 'bpl "indiana|Indiana State Library"'
@@ -836,6 +866,11 @@ def main() -> None:
             f"{is_last_env}; "
             f"{single_item_env}"
         )
+        # SDC-sync parallelism options, shared by both invocation sites
+        # below. --workers > 1 enables the multiprocessing pool;
+        # --workers-budget caps concurrent worker slots box-wide. Both
+        # values are already validated above.
+        sdc_opts = f" --workers {sdc_workers} --workers-budget {sdc_workers_budget}"
         if sdc_only:
             # SDC-only backfill: re-enumerate the partner's items (which
             # also refreshes sdc.json sidecars from the latest ingestion3
@@ -845,7 +880,7 @@ def main() -> None:
             pipeline_steps = [
                 f"cd {base}",
                 get_ids_cmd,
-                f"sdc-sync --partner {canonical} --ids-file {csv_file}",
+                f"sdc-sync --partner {canonical} --ids-file {csv_file}{sdc_opts}",
             ]
         else:
             dl_age_opt = (
@@ -866,7 +901,7 @@ def main() -> None:
                 # refresh_only because no upload phase ran — there's no
                 # upload-result.json to drive from.
                 pipeline_steps.append(
-                    f"sdc-sync --partner {canonical} --ids-file {csv_file}"
+                    f"sdc-sync --partner {canonical} --ids-file {csv_file}{sdc_opts}"
                 )
         target_steps = " && ".join(pipeline_steps)
         target_blocks.append(

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -616,6 +616,7 @@ def test_init_partner_worker_binds_mapping_tables_to_module_globals(monkeypatch)
             fake_rights,
             fake_subject_ids,
             True,
+            0,  # workers_budget — disabled for this test
         )
 
     assert sdc_sync.hubs is fake_hubs
@@ -644,15 +645,31 @@ def test_init_partner_worker_propagates_normalize_wikitext_flag(monkeypatch):
     monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", True, raising=False)
 
     with patch("pywikibot.Site", return_value=fake_site):
-        sdc_sync._init_partner_worker(fake_queue, {}, {}, {}, False)
+        sdc_sync._init_partner_worker(fake_queue, {}, {}, {}, False, 0)
     assert sdc_sync._normalize_wikitext_enabled is False
 
     # And the opposite — initargs flag True overrides a worker that
     # happened to start with the global at False.
     monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", False, raising=False)
     with patch("pywikibot.Site", return_value=fake_site):
-        sdc_sync._init_partner_worker(fake_queue, {}, {}, {}, True)
+        sdc_sync._init_partner_worker(fake_queue, {}, {}, {}, True, 0)
     assert sdc_sync._normalize_wikitext_enabled is True
+
+
+def test_init_partner_worker_builds_slot_budget_from_arg(monkeypatch):
+    """The worker initializer must construct a WorkerSlotBudget from the
+    ``workers_budget`` initarg and bind it to the module global the
+    task path acquires from. Verifies the budget value plumbs through
+    so a parent's --workers-budget actually caps the worker pool."""
+    from tools import sdc_sync
+
+    fake_queue = MagicMock()
+    fake_site = MagicMock(name="pywikibot_Site")
+
+    with patch("pywikibot.Site", return_value=fake_site):
+        sdc_sync._init_partner_worker(fake_queue, {}, {}, {}, True, 12)
+
+    assert sdc_sync._worker_slot_budget.budget == 12
 
 
 def test_run_partner_mode_dispatches_to_pool_when_workers_above_one(

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -666,10 +666,30 @@ def test_init_partner_worker_builds_slot_budget_from_arg(monkeypatch):
     fake_queue = MagicMock()
     fake_site = MagicMock(name="pywikibot_Site")
 
+    constructed = {}
+
+    class _SpyBudget:
+        def __init__(self, budget):
+            constructed["budget"] = budget
+
+    # Fake WorkerSlotBudget so construction does no filesystem work
+    # (a real budget=12 would create 12 slot files in the shared
+    # /tmp/sdc-sync-worker-slots dir), and register the module global for
+    # auto-restore so a leaked enabled budget can't bleed into later
+    # worker-task tests. WorkerSlotBudget's own behaviour is covered by
+    # test_worker_slots.py.
+    monkeypatch.setattr(
+        sdc_sync, "_worker_slot_budget", sdc_sync._worker_slot_budget, raising=False
+    )
+    monkeypatch.setattr(sdc_sync, "WorkerSlotBudget", _SpyBudget)
+
     with patch("pywikibot.Site", return_value=fake_site):
         sdc_sync._init_partner_worker(fake_queue, {}, {}, {}, True, 12)
 
-    assert sdc_sync._worker_slot_budget.budget == 12
+    assert constructed["budget"] == 12, (
+        "budget value must plumb through to construction"
+    )
+    assert isinstance(sdc_sync._worker_slot_budget, _SpyBudget)
 
 
 def test_run_partner_mode_dispatches_to_pool_when_workers_above_one(

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -16,6 +16,7 @@ A claim that contains any user-authored qualifier or reference is
 NOT safe — the wbeditentity round-trip would erase that data.
 """
 
+import contextlib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -585,6 +586,50 @@ def test_run_partner_mode_uses_inline_loop_when_workers_is_one(tmp_path, monkeyp
     assert parallel_calls == [], "Pool path must not run at workers=1"
     assert item_calls == [("nara", "abcdef01abcdef01abcdef01abcdef01", 1, 1)], (
         f"expected one inline call to _process_one_partner_item; got {item_calls!r}"
+    )
+
+
+def test_run_partner_mode_acquires_one_slot_per_item_when_workers_is_one(
+    tmp_path, monkeypatch
+):
+    """A single-process (``_workers == 1``) run acquires one slot per item
+    from a budget built with ``_workers_budget``. Spy budget so the
+    assertion is on acquire count, not on real /tmp slot files."""
+    from tools import sdc_sync
+
+    ids_file = tmp_path / "ids.txt"
+    ids_file.write_text(
+        "aaaa1111aaaa1111aaaa1111aaaa1111\nbbbb2222bbbb2222bbbb2222bbbb2222\n"
+    )
+
+    acquire_calls = []
+
+    class _SpyBudget:
+        def __init__(self, budget):
+            self.budget = budget
+
+        @contextlib.contextmanager
+        def acquire(self):
+            acquire_calls.append(self.budget)
+            yield
+
+    monkeypatch.setattr(sdc_sync, "_workers", 1, raising=False)
+    monkeypatch.setattr(sdc_sync, "_workers_budget", 16, raising=False)
+    monkeypatch.setattr(sdc_sync, "WorkerSlotBudget", _SpyBudget)
+    monkeypatch.setattr(
+        sdc_sync, "_process_one_partner_item", lambda s3, p, d, i, t: None
+    )
+    with (
+        patch.object(sdc_sync, "setup_logging"),
+        patch.object(sdc_sync, "notify_phase_start"),
+        patch.object(sdc_sync, "notify_sdc_complete"),
+        patch("ingest_wikimedia.s3.S3Client", return_value=MagicMock()),
+    ):
+        sdc_sync._run_partner_mode("nara", str(ids_file))
+
+    assert acquire_calls == [16, 16], (
+        f"expected one slot acquire per item from a budget built with "
+        f"_workers_budget=16; got {acquire_calls!r}"
     )
 
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1229,3 +1229,83 @@ def test_pageid_refresh_returns_immediately_on_first_success(monkeypatch):
     assert uploader._refresh_pageid_with_retries("File:X.tiff") == 42
     assert len(get_page_calls) == 1
     assert sleep_calls == [], "no sleep on first-attempt-success path"
+
+
+# --------------------------------------------------------------------------
+# Box-wide Commons-write budget wiring (shared with the SDC-sync phase).
+# The uploader is single-process but must check out one slot per item so
+# it counts as one writer against the shared cap. Verifies main() builds
+# the budget from --workers-budget and wraps each process_item in acquire().
+# --------------------------------------------------------------------------
+
+
+def test_main_acquires_one_budget_slot_per_item():
+    """main() must construct a WorkerSlotBudget from --workers-budget and
+    enter its acquire() context exactly once per DPLA item, around the
+    process_item call. A spy budget records the constructed budget value
+    and counts context entries."""
+    from click.testing import CliRunner
+
+    import tools.uploader as up
+
+    acquire_calls = []
+    constructed_budget = {}
+
+    class _SpyBudget:
+        def __init__(self, budget):
+            constructed_budget["value"] = budget
+
+        def acquire(self):
+            from contextlib import contextmanager
+
+            @contextmanager
+            def _cm():
+                acquire_calls.append(True)
+                yield
+
+            return _cm()
+
+    processed = []
+
+    # Mock the heavy setup seams so main() runs its loop without touching
+    # AWS / Commons / disk. ToolsContext.init returns a context whose
+    # getters yield mocks; the Uploader's process_item just records the id.
+    fake_ctx = MagicMock()
+    fake_ctx.get_tracker.return_value = Tracker()
+    fake_ctx.get_local_fs.return_value = MagicMock()
+    fake_ctx.get_s3_client.return_value = MagicMock()
+    fake_dpla = MagicMock()
+    fake_dpla.get_providers_data.return_value = {}
+    fake_ctx.get_dpla.return_value = fake_dpla
+
+    def fake_process_item(dpla_id, *a, **kw):
+        processed.append(dpla_id)
+
+    with (
+        patch.object(up.ToolsContext, "init", return_value=fake_ctx),
+        patch.object(up, "get_site", return_value=MagicMock()),
+        patch.object(up, "CategoryEnsurer", return_value=MagicMock()),
+        patch.object(up, "WorkerSlotBudget", _SpyBudget),
+        patch.object(up, "setup_logging"),
+        patch.object(up, "notify_phase_start"),
+        patch.object(up, "notify_upload_complete"),
+        patch.object(up, "_post_upload_touch_new_institutions"),
+        patch.object(up, "load_ids", return_value=["id_a", "id_b", "id_c"]),
+        patch.object(up.Uploader, "process_item", side_effect=fake_process_item),
+    ):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            # ids_file is a click.File argument; create a throwaway file
+            # (load_ids is mocked, so contents don't matter).
+            with open("ids.csv", "w") as fh:
+                fh.write("id_a\nid_b\nid_c\n")
+            result = runner.invoke(
+                up.main, ["ids.csv", "nara", "--workers-budget", "16"]
+            )
+
+    assert result.exit_code == 0, result.output
+    assert constructed_budget["value"] == 16, "budget not built from --workers-budget"
+    assert processed == ["id_a", "id_b", "id_c"], "all items must be processed"
+    assert len(acquire_calls) == 3, (
+        f"expected one slot acquire per item; got {len(acquire_calls)}"
+    )

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 from ingest_wikimedia.tracker import Result, Tracker
 from ingest_wikimedia.wikimedia import WMC_UPLOAD_CHUNK_SIZE
+from ingest_wikimedia.worker_slots import WorkerSlotBudget
 from tools.uploader import (
     LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES,
     _post_item_orphan_check,
@@ -16,6 +17,12 @@ from tools.uploader import (
     is_dup_sha1_sibling_at_expected_title,
     select_upload_chunk_size,
 )
+
+
+# A disabled budget (budget <= 0) whose acquire() is a no-op context
+# manager — the touch helper now acquires a slot internally, so its unit
+# tests just need a budget object that never blocks.
+_DISABLED_BUDGET = WorkerSlotBudget(0)
 
 
 def _ensurer_with(newly_created: set[str]) -> MagicMock:
@@ -32,7 +39,9 @@ def test_skips_when_category_ensurer_is_none():
         patch("tools.uploader.time.sleep") as sleep_mock,
         patch("tools.uploader.touch_institution_files") as touch_mock,
     ):
-        _post_upload_touch_new_institutions(MagicMock(), None, dry_run=False)
+        _post_upload_touch_new_institutions(
+            MagicMock(), None, dry_run=False, slot_budget=_DISABLED_BUDGET
+        )
     sleep_mock.assert_not_called()
     touch_mock.assert_not_called()
 
@@ -43,7 +52,9 @@ def test_skips_when_dry_run():
         patch("tools.uploader.time.sleep") as sleep_mock,
         patch("tools.uploader.touch_institution_files") as touch_mock,
     ):
-        _post_upload_touch_new_institutions(MagicMock(), ensurer, dry_run=True)
+        _post_upload_touch_new_institutions(
+            MagicMock(), ensurer, dry_run=True, slot_budget=_DISABLED_BUDGET
+        )
     sleep_mock.assert_not_called()
     touch_mock.assert_not_called()
 
@@ -54,7 +65,9 @@ def test_skips_when_newly_created_is_empty():
         patch("tools.uploader.time.sleep") as sleep_mock,
         patch("tools.uploader.touch_institution_files") as touch_mock,
     ):
-        _post_upload_touch_new_institutions(MagicMock(), ensurer, dry_run=False)
+        _post_upload_touch_new_institutions(
+            MagicMock(), ensurer, dry_run=False, slot_budget=_DISABLED_BUDGET
+        )
     sleep_mock.assert_not_called()
     touch_mock.assert_not_called()
 
@@ -67,7 +80,9 @@ def test_sleeps_then_touches_each_newly_created_qid():
         patch("tools.uploader.touch_institution_files", return_value=4) as touch_mock,
         patch("tools.uploader._REPLICATION_SETTLE_SECS", 10),
     ):
-        _post_upload_touch_new_institutions(site, ensurer, dry_run=False)
+        _post_upload_touch_new_institutions(
+            site, ensurer, dry_run=False, slot_budget=_DISABLED_BUDGET
+        )
 
     sleep_mock.assert_called_once_with(10)
     assert touch_mock.call_count == 3
@@ -96,7 +111,9 @@ def test_per_qid_exception_does_not_stop_remaining_qids(caplog):
         ) as touch_mock,
         caplog.at_level(_logging.INFO),
     ):
-        _post_upload_touch_new_institutions(MagicMock(), ensurer, dry_run=False)
+        _post_upload_touch_new_institutions(
+            MagicMock(), ensurer, dry_run=False, slot_budget=_DISABLED_BUDGET
+        )
 
     qids_attempted = {call.args[1] for call in touch_mock.call_args_list}
     assert qids_attempted == {"Q_good_1", "Q_bad", "Q_good_2"}

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -261,3 +261,46 @@ def test_slack_fail_operational_silent_when_no_bot_token(monkeypatch):
         "fallback must NOT attempt post_message with an empty token; "
         f"got: {posted_to_channel!r}"
     )
+
+
+@pytest.mark.parametrize("bad_value", ["0", "-1", "abc", "1.5"])
+def test_invalid_workers_fails_fast(bad_value):
+    """--workers must be an integer >= 1. Anything else fails the launch
+    with a clear error rather than shelling a bogus value to EC2."""
+    exit_info = _run_main(["--partner", "minnesota", "--workers", bad_value])
+    assert exit_info is not None, f"expected SystemExit for --workers {bad_value!r}"
+    assert exit_info.code == 1
+
+
+@pytest.mark.parametrize("bad_value", ["-1", "abc", "1.5"])
+def test_invalid_workers_budget_fails_fast(bad_value):
+    """--workers-budget must be an integer >= 0 (0 disables). Negative or
+    non-integer values fail fast."""
+    exit_info = _run_main(["--partner", "minnesota", "--workers-budget", bad_value])
+    assert exit_info is not None, f"expected SystemExit for budget {bad_value!r}"
+    assert exit_info.code == 1
+
+
+def test_workers_budget_zero_is_accepted():
+    """--workers-budget 0 is the explicit 'disabled' value and must NOT
+    trip the validation gate (0 is a valid sentinel, distinct from a
+    negative error)."""
+    # Reaches past the workers/budget validation; the partner slug is
+    # bogus so it exits later (target validation), but NOT at the budget
+    # gate. We assert the error message isn't the budget one.
+    import scripts.wikimedia_launch as launch_mod
+
+    with patch(
+        "sys.argv",
+        [
+            "wikimedia_launch.py",
+            "--partner",
+            "not-a-real-hub",
+            "--workers-budget",
+            "0",
+        ],
+    ):
+        try:
+            launch_mod.main()
+        except SystemExit:
+            pass  # exits later for an unrelated reason; that's fine

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -281,26 +281,15 @@ def test_invalid_workers_budget_fails_fast(bad_value):
     assert exit_info.code == 1
 
 
-def test_workers_budget_zero_is_accepted():
+def test_workers_budget_zero_is_accepted(capsys):
     """--workers-budget 0 is the explicit 'disabled' value and must NOT
     trip the validation gate (0 is a valid sentinel, distinct from a
     negative error)."""
-    # Reaches past the workers/budget validation; the partner slug is
-    # bogus so it exits later (target validation), but NOT at the budget
-    # gate. We assert the error message isn't the budget one.
-    import scripts.wikimedia_launch as launch_mod
-
-    with patch(
-        "sys.argv",
-        [
-            "wikimedia_launch.py",
-            "--partner",
-            "not-a-real-hub",
-            "--workers-budget",
-            "0",
-        ],
-    ):
-        try:
-            launch_mod.main()
-        except SystemExit:
-            pass  # exits later for an unrelated reason; that's fine
+    exit_info = _run_main(["--partner", "not-a-real-hub", "--workers-budget", "0"])
+    assert exit_info is not None and exit_info.code == 1, (
+        "expected SystemExit(1) for the bogus partner after budget validation"
+    )
+    err = capsys.readouterr().err
+    assert "Invalid --workers-budget value" not in err, (
+        f"--workers-budget 0 must pass the budget gate, not trip it; got: {err!r}"
+    )

--- a/tests/test_worker_slots.py
+++ b/tests/test_worker_slots.py
@@ -69,7 +69,11 @@ def test_acquire_picks_a_free_slot_when_some_are_held(tmp_path):
     """With budget 3 and slots 0 and 1 held by foreign sessions,
     acquire() takes slot 2 rather than blocking."""
     budget = WorkerSlotBudget(budget=3, slot_dir=str(tmp_path))
-    held = [_hold_raw_flock(str(tmp_path), 0), _hold_raw_flock(str(tmp_path), 1)]
+    # Build incrementally so a fd from a successful open is tracked for
+    # cleanup even if a later open raises (no leak window).
+    held = []
+    held.append(_hold_raw_flock(str(tmp_path), 0))
+    held.append(_hold_raw_flock(str(tmp_path), 1))
     try:
         acquired = []
 

--- a/tests/test_worker_slots.py
+++ b/tests/test_worker_slots.py
@@ -1,0 +1,148 @@
+"""Tests for the box-wide WorkerSlotBudget semaphore.
+
+These exercise the flock-slot-file primitive directly with a temp slot
+dir so they don't touch the real ``/tmp/sdc-sync-worker-slots`` other
+processes on a dev box might use. Cross-process behaviour (the part that
+actually matters) is verified by holding raw flocks on the slot files
+to simulate other sessions, rather than spawning real subprocesses.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import threading
+import time
+
+from ingest_wikimedia.worker_slots import WorkerSlotBudget
+
+
+def _hold_raw_flock(slot_dir, index):
+    """Open + non-blocking-flock slot-<index> the way a foreign session
+    would, returning the held fd. Caller closes it to release."""
+    fd = os.open(os.path.join(slot_dir, f"slot-{index}"), os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    return fd
+
+
+def test_creates_slot_files_for_budget(tmp_path):
+    """Construction with budget N creates exactly N slot files."""
+    WorkerSlotBudget(budget=4, slot_dir=str(tmp_path))
+    slots = sorted(p.name for p in tmp_path.iterdir())
+    assert slots == ["slot-0", "slot-1", "slot-2", "slot-3"]
+
+
+def test_disabled_budget_creates_no_files_and_acquires_freely(tmp_path):
+    """budget <= 0 is the disabled / unlimited path: no slot files, and
+    acquire() is a no-op context manager that never blocks."""
+    budget = WorkerSlotBudget(budget=0, slot_dir=str(tmp_path))
+    assert list(tmp_path.iterdir()) == []
+    # Many concurrent acquires must all succeed instantly — no cap.
+    with budget.acquire(), budget.acquire(), budget.acquire():
+        pass  # no exception, no block
+
+
+def test_acquire_holds_a_slot_for_block_duration(tmp_path):
+    """While inside acquire(), one slot file is flock'd and therefore
+    can't be flock'd by a simulated foreign session; after the block,
+    it frees."""
+    budget = WorkerSlotBudget(budget=1, slot_dir=str(tmp_path))
+    with budget.acquire():
+        # The single slot is now held by us — a foreign non-blocking
+        # flock attempt must fail.
+        fd = os.open(os.path.join(tmp_path, "slot-0"), os.O_RDWR)
+        try:
+            failed = False
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                failed = True
+            assert failed, "slot-0 should be held while inside acquire()"
+        finally:
+            os.close(fd)
+    # Outside the block the slot is free again — foreign flock succeeds.
+    fd = _hold_raw_flock(str(tmp_path), 0)
+    os.close(fd)
+
+
+def test_acquire_picks_a_free_slot_when_some_are_held(tmp_path):
+    """With budget 3 and slots 0 and 1 held by foreign sessions,
+    acquire() takes slot 2 rather than blocking."""
+    budget = WorkerSlotBudget(budget=3, slot_dir=str(tmp_path))
+    held = [_hold_raw_flock(str(tmp_path), 0), _hold_raw_flock(str(tmp_path), 1)]
+    try:
+        acquired = []
+
+        def worker():
+            with budget.acquire():
+                acquired.append(True)
+                time.sleep(0.1)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=2)
+        assert acquired == [True], "should have taken the one free slot (slot-2)"
+        assert not t.is_alive()
+    finally:
+        for fd in held:
+            os.close(fd)
+
+
+def test_acquire_blocks_until_a_slot_frees(tmp_path):
+    """budget 1, slot already held by a foreign session: acquire()
+    blocks, then proceeds once the foreign holder releases."""
+    budget = WorkerSlotBudget(budget=1, slot_dir=str(tmp_path))
+    foreign_fd = _hold_raw_flock(str(tmp_path), 0)
+
+    proceeded = threading.Event()
+
+    def worker():
+        with budget.acquire():
+            proceeded.set()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    # While the foreign session holds the only slot, the worker must NOT
+    # have proceeded.
+    assert not proceeded.wait(timeout=0.6), "worker entered before a slot was free"
+    # Release the foreign hold; the worker should now acquire promptly.
+    os.close(foreign_fd)
+    assert proceeded.wait(timeout=3), "worker did not proceed after slot freed"
+    t.join(timeout=1)
+
+
+def test_dead_holder_auto_releases_slot(tmp_path):
+    """The crash-safety property: a slot held by an fd that gets closed
+    (simulating a dead process) frees automatically — no leaked permit.
+    flock release on close IS the mechanism that protects against a
+    crashed worker, so assert it directly."""
+    budget = WorkerSlotBudget(budget=1, slot_dir=str(tmp_path))
+    # Simulate a worker that grabbed the slot then died without an
+    # orderly release — i.e. just the fd vanishing.
+    dead_fd = _hold_raw_flock(str(tmp_path), 0)
+    os.close(dead_fd)  # process death == fd close, from the kernel's view
+
+    proceeded = []
+
+    def worker():
+        with budget.acquire():
+            proceeded.append(True)
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join(timeout=3)
+    assert proceeded == [True], "slot should have been free after holder fd closed"
+
+
+def test_acquire_releases_on_exception_in_block(tmp_path):
+    """If the with-block raises, the slot still frees (finally clause).
+    Otherwise one bad item would permanently burn a slot."""
+    budget = WorkerSlotBudget(budget=1, slot_dir=str(tmp_path))
+    try:
+        with budget.acquire():
+            raise ValueError("boom")
+    except ValueError:
+        pass
+    # Slot must be free despite the exception.
+    fd = _hold_raw_flock(str(tmp_path), 0)
+    os.close(fd)

--- a/tests/test_worker_slots.py
+++ b/tests/test_worker_slots.py
@@ -5,10 +5,16 @@ dir so they don't touch the real ``/tmp/sdc-sync-worker-slots`` other
 processes on a dev box might use. Cross-process behaviour (the part that
 actually matters) is verified by holding raw flocks on the slot files
 to simulate other sessions, rather than spawning real subprocesses.
+
+The flock helpers below open/close their fds within a single lexical
+scope (``_foreign_flock`` is a context manager; ``_slot_is_held`` opens
+and closes inside one call) so resource lifetime is obvious — no bare
+fd is ever returned for the caller to remember to close.
 """
 
 from __future__ import annotations
 
+import contextlib
 import fcntl
 import os
 import threading
@@ -17,12 +23,30 @@ import time
 from ingest_wikimedia.worker_slots import WorkerSlotBudget
 
 
-def _hold_raw_flock(slot_dir, index):
-    """Open + non-blocking-flock slot-<index> the way a foreign session
-    would, returning the held fd. Caller closes it to release."""
+@contextlib.contextmanager
+def _foreign_flock(slot_dir, index):
+    """Hold an exclusive flock on slot-<index> the way a foreign session
+    would, releasing it (closing the fd) on context exit."""
     fd = os.open(os.path.join(slot_dir, f"slot-{index}"), os.O_RDWR | os.O_CREAT, 0o644)
-    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    return fd
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        yield
+    finally:
+        os.close(fd)
+
+
+def _slot_is_held(slot_dir, index) -> bool:
+    """Return True iff slot-<index> can't be exclusively flock'd right
+    now (i.e. something else holds it). Opens and closes its own fd, so
+    it never perturbs the lock state it's probing."""
+    fd = os.open(os.path.join(slot_dir, f"slot-{index}"), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return False  # we got the lock → nobody else holds it
+    except OSError:
+        return True
+    finally:
+        os.close(fd)
 
 
 def test_creates_slot_files_for_budget(tmp_path):
@@ -48,33 +72,18 @@ def test_acquire_holds_a_slot_for_block_duration(tmp_path):
     it frees."""
     budget = WorkerSlotBudget(budget=1, slot_dir=str(tmp_path))
     with budget.acquire():
-        # The single slot is now held by us — a foreign non-blocking
-        # flock attempt must fail.
-        fd = os.open(os.path.join(tmp_path, "slot-0"), os.O_RDWR)
-        try:
-            failed = False
-            try:
-                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except OSError:
-                failed = True
-            assert failed, "slot-0 should be held while inside acquire()"
-        finally:
-            os.close(fd)
-    # Outside the block the slot is free again — foreign flock succeeds.
-    fd = _hold_raw_flock(str(tmp_path), 0)
-    os.close(fd)
+        assert _slot_is_held(str(tmp_path), 0), (
+            "slot-0 should be held while inside acquire()"
+        )
+    # Outside the block the slot is free again.
+    assert not _slot_is_held(str(tmp_path), 0)
 
 
 def test_acquire_picks_a_free_slot_when_some_are_held(tmp_path):
     """With budget 3 and slots 0 and 1 held by foreign sessions,
     acquire() takes slot 2 rather than blocking."""
     budget = WorkerSlotBudget(budget=3, slot_dir=str(tmp_path))
-    # Build incrementally so a fd from a successful open is tracked for
-    # cleanup even if a later open raises (no leak window).
-    held = []
-    held.append(_hold_raw_flock(str(tmp_path), 0))
-    held.append(_hold_raw_flock(str(tmp_path), 1))
-    try:
+    with _foreign_flock(str(tmp_path), 0), _foreign_flock(str(tmp_path), 1):
         acquired = []
 
         def worker():
@@ -87,30 +96,30 @@ def test_acquire_picks_a_free_slot_when_some_are_held(tmp_path):
         t.join(timeout=2)
         assert acquired == [True], "should have taken the one free slot (slot-2)"
         assert not t.is_alive()
-    finally:
-        for fd in held:
-            os.close(fd)
 
 
 def test_acquire_blocks_until_a_slot_frees(tmp_path):
     """budget 1, slot already held by a foreign session: acquire()
     blocks, then proceeds once the foreign holder releases."""
     budget = WorkerSlotBudget(budget=1, slot_dir=str(tmp_path))
-    foreign_fd = _hold_raw_flock(str(tmp_path), 0)
-
     proceeded = threading.Event()
 
     def worker():
         with budget.acquire():
             proceeded.set()
 
+    # ExitStack so the foreign hold can be released mid-test (not just at
+    # block end) while still guaranteeing release if an assert fails.
+    stack = contextlib.ExitStack()
+    stack.enter_context(_foreign_flock(str(tmp_path), 0))
     t = threading.Thread(target=worker)
     t.start()
-    # While the foreign session holds the only slot, the worker must NOT
-    # have proceeded.
-    assert not proceeded.wait(timeout=0.6), "worker entered before a slot was free"
-    # Release the foreign hold; the worker should now acquire promptly.
-    os.close(foreign_fd)
+    try:
+        # While the foreign session holds the only slot, the worker must
+        # NOT have proceeded.
+        assert not proceeded.wait(timeout=0.6), "worker entered before a slot was free"
+    finally:
+        stack.close()  # release the foreign hold
     assert proceeded.wait(timeout=3), "worker did not proceed after slot freed"
     t.join(timeout=1)
 
@@ -121,10 +130,10 @@ def test_dead_holder_auto_releases_slot(tmp_path):
     flock release on close IS the mechanism that protects against a
     crashed worker, so assert it directly."""
     budget = WorkerSlotBudget(budget=1, slot_dir=str(tmp_path))
-    # Simulate a worker that grabbed the slot then died without an
-    # orderly release — i.e. just the fd vanishing.
-    dead_fd = _hold_raw_flock(str(tmp_path), 0)
-    os.close(dead_fd)  # process death == fd close, from the kernel's view
+    # Grab the slot then immediately release the fd — process death is,
+    # from the kernel's view, just the fd closing.
+    with _foreign_flock(str(tmp_path), 0):
+        pass
 
     proceeded = []
 
@@ -148,5 +157,4 @@ def test_acquire_releases_on_exception_in_block(tmp_path):
     except ValueError:
         pass
     # Slot must be free despite the exception.
-    fd = _hold_raw_flock(str(tmp_path), 0)
-    os.close(fd)
+    assert not _slot_is_held(str(tmp_path), 0)

--- a/tests/test_worker_slots.py
+++ b/tests/test_worker_slots.py
@@ -15,6 +15,7 @@ fd is ever returned for the caller to remember to close.
 from __future__ import annotations
 
 import contextlib
+import errno
 import fcntl
 import os
 import threading
@@ -145,6 +146,27 @@ def test_dead_holder_auto_releases_slot(tmp_path):
     t.start()
     t.join(timeout=3)
     assert proceeded == [True], "slot should have been free after holder fd closed"
+
+
+def test_acquire_reraises_non_contention_oserror(tmp_path, monkeypatch):
+    """A non-contention OSError from flock (e.g. ENOLCK / EACCES) must
+    propagate, not be swallowed as "slot busy" and spun on forever. Only
+    EAGAIN/EWOULDBLOCK mean contention."""
+    budget = WorkerSlotBudget(budget=1, slot_dir=str(tmp_path))
+
+    def boom(fd, op):
+        raise OSError(errno.ENOLCK, "no locks available")
+
+    monkeypatch.setattr(fcntl, "flock", boom)
+    raised = None
+    try:
+        with budget.acquire():
+            pass
+    except OSError as e:
+        raised = e
+    assert raised is not None and raised.errno == errno.ENOLCK, (
+        "non-contention flock errno must propagate, not loop forever"
+    )
 
 
 def test_acquire_releases_on_exception_in_block(tmp_path):

--- a/tests/test_worker_slots.py
+++ b/tests/test_worker_slots.py
@@ -21,6 +21,8 @@ import os
 import threading
 import time
 
+import pytest
+
 from ingest_wikimedia.worker_slots import WorkerSlotBudget
 
 
@@ -55,6 +57,21 @@ def test_creates_slot_files_for_budget(tmp_path):
     WorkerSlotBudget(budget=4, slot_dir=str(tmp_path))
     slots = sorted(p.name for p in tmp_path.iterdir())
     assert slots == ["slot-0", "slot-1", "slot-2", "slot-3"]
+
+
+def test_rejects_slot_dir_owned_by_a_different_user(tmp_path, monkeypatch):
+    """An existing slot dir whose owner doesn't match the current uid is
+    refused. An attacker with write access to our slot directory can
+    ``unlink`` a held lock file, forcing a new inode the next time we
+    ``os.open`` it and silently breaking the exclusion invariant — so
+    we fail closed on any ownership mismatch rather than running on a
+    potentially-hostile directory."""
+    import os as real_os
+
+    real_uid = real_os.getuid()
+    monkeypatch.setattr("os.getuid", lambda: real_uid + 1)
+    with pytest.raises(RuntimeError, match="owned by uid"):
+        WorkerSlotBudget(budget=2, slot_dir=str(tmp_path))
 
 
 def test_disabled_budget_creates_no_files_and_acquires_freely(tmp_path):

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -209,17 +209,17 @@ def _build_parser() -> argparse.ArgumentParser:
         default=0,
         help=(
             "Box-wide cap on concurrent SDC worker slots across ALL "
-            "sdc-sync sessions on the host. In parallel mode (--workers "
-            ">1), each worker checks out a flock-backed slot before its "
-            "per-item Commons work, so the total concurrent Commons-write "
-            "load is bounded by this value regardless of how many "
-            "sessions run or how many workers each was launched with — "
-            "excess workers block until a slot frees. 0 (default) "
-            "disables the budget. Set to ~16 in production so 6+ "
-            "concurrent sessions cooperatively share Commons capacity "
-            "without oversubscribing the parser pool. Has no effect at "
-            "--workers 1 (the single-process path doesn't go through the "
-            "worker pool)."
+            "sdc-sync sessions on the host. Every item-processing path "
+            "checks out a flock-backed slot before its per-item Commons "
+            "work — the parallel workers (--workers >1) and the "
+            "single-process path (--workers 1) alike — so the total "
+            "concurrent Commons-write load is bounded by this value "
+            "regardless of how many sessions run or how many workers each "
+            "was launched with; excess workers block until a slot frees. "
+            "0 (default) disables the budget (acquire is a no-op). Set to "
+            "~16 in production so 6+ concurrent sessions cooperatively "
+            "share Commons capacity without oversubscribing the parser "
+            "pool."
         ),
     )
     return p
@@ -4678,14 +4678,17 @@ def _run_partner_mode(partner, ids_file):
     completed = False
     try:
         if workers <= 1:
-            # Single-process: identical to pre-PR behaviour. Parent's
-            # module-level tracker is mutated in-place; no Pool, no
-            # logging queue, no delta merge. Keeps the no-parallelism
-            # path bit-for-bit unchanged.
+            # Single-process: parent's module-level tracker is mutated
+            # in-place; no Pool, no logging queue, no delta merge. Still
+            # acquires one box-wide slot per item so a 1-worker session
+            # counts against --workers-budget like the parallel path
+            # (no-op when the budget is 0, so a plain run is unchanged).
+            slot_budget = WorkerSlotBudget(_workers_budget)
             for local_count, dpla_id in enumerate(dpla_ids, start=1):
-                _process_one_partner_item(
-                    s3, partner, dpla_id, local_count, len(dpla_ids)
-                )
+                with slot_budget.acquire():
+                    _process_one_partner_item(
+                        s3, partner, dpla_id, local_count, len(dpla_ids)
+                    )
         else:
             _run_partner_mode_parallel(partner, dpla_ids, workers)
         completed = True

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -25,6 +25,7 @@ from ingest_wikimedia import legacy_artwork, wikimedia, wikitext_normalize
 from ingest_wikimedia.slack import notify_phase_start, notify_sdc_complete
 from ingest_wikimedia.tracker import Result, Tracker
 from ingest_wikimedia.wikimedia import extract_dpla_id_from_commons_title
+from ingest_wikimedia.worker_slots import WorkerSlotBudget
 
 # Module-level SDC tracker. Counters accumulate across one invocation of
 # main() — the helpers (`_post_new_refs`, `_post_new_claims`,
@@ -67,6 +68,22 @@ _normalize_wikitext_enabled: bool = True
 # time so tests can monkeypatch the module global directly without needing
 # to construct an argparse Namespace.
 _workers: int = 1
+
+# Box-wide cap on concurrent SDC worker slots across ALL sdc-sync sessions
+# on the host — see ingest_wikimedia.worker_slots.WorkerSlotBudget. Workers
+# in parallel mode (workers > 1) check out a slot before their per-item
+# Commons work, so the total concurrent Commons-write load is bounded by
+# this value no matter how many sessions run or how many workers each was
+# launched with. 0 disables the budget (unlimited). Set from
+# ``args.workers_budget`` at main() time.
+_workers_budget: int = 0
+
+# Per-worker WorkerSlotBudget instance. Defaults to a disabled (no-op)
+# budget so ``_worker_slot_budget.acquire()`` is always safe to call even
+# before a worker runs its initializer; _init_partner_worker replaces it
+# with a real budget built from _workers_budget. _worker_partner_task
+# acquires a slot from it around each item's Commons work.
+_worker_slot_budget = WorkerSlotBudget(0)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -183,6 +200,26 @@ def _build_parser() -> argparse.ArgumentParser:
             "are independent: every ordinal of every item has a "
             "unique M-id, so workers never write to the same Commons "
             "MediaInfo entity."
+        ),
+    )
+    p.add_argument(
+        "--workers-budget",
+        dest="workers_budget",
+        type=int,
+        default=0,
+        help=(
+            "Box-wide cap on concurrent SDC worker slots across ALL "
+            "sdc-sync sessions on the host. In parallel mode (--workers "
+            ">1), each worker checks out a flock-backed slot before its "
+            "per-item Commons work, so the total concurrent Commons-write "
+            "load is bounded by this value regardless of how many "
+            "sessions run or how many workers each was launched with — "
+            "excess workers block until a slot frees. 0 (default) "
+            "disables the budget. Set to ~16 in production so 6+ "
+            "concurrent sessions cooperatively share Commons capacity "
+            "without oversubscribing the parser pool. Has no effect at "
+            "--workers 1 (the single-process path doesn't go through the "
+            "worker pool)."
         ),
     )
     return p
@@ -461,6 +498,7 @@ def _initialize() -> None:
     """
     global parser, args, method, dpla_api, site, hubs, rights, subject_ids
     global _s3_partner, _s3_client, _normalize_wikitext_enabled, _workers
+    global _workers_budget
 
     parser = _build_parser()
     args = parser.parse_args()
@@ -518,6 +556,7 @@ def _initialize() -> None:
 
     _normalize_wikitext_enabled = bool(args.normalize_wikitext)
     _workers = max(1, int(getattr(args, "workers", 1) or 1))
+    _workers_budget = max(0, int(getattr(args, "workers_budget", 0) or 0))
 
 
 # This is the JSON used for formatting a claim. The P459 -> Q61848113 (determination method) qualifier is hardcoded in for everything DPLA adds. Not all data types have the same format for value, so this is formatted in the function for each property added.
@@ -4082,6 +4121,7 @@ def _run_partner_mode_parallel(partner, dpla_ids, workers):
                 rights,
                 subject_ids,
                 _normalize_wikitext_enabled,
+                _workers_budget,
             ),
         ) as pool:
             for delta in pool.imap_unordered(_worker_partner_task, tasks):
@@ -4097,6 +4137,7 @@ def _init_partner_worker(
     rights_data,
     subject_ids_data,
     normalize_wikitext_enabled,
+    workers_budget,
 ):
     """Per-worker setup for the ``--workers > 1`` partner-mode Pool.
 
@@ -4138,6 +4179,13 @@ def _init_partner_worker(
        ``_normalize_wikitext_enabled`` explicitly here so a future
        parent invocation with ``--no-normalize-wikitext`` doesn't
        silently re-enable the strip in workers.
+
+    5. **Build the box-wide worker-slot budget.** ``workers_budget``
+       is the parent's ``--workers-budget`` value; each worker
+       constructs its own :class:`WorkerSlotBudget` pointed at the
+       shared on-disk slot dir, so every worker across every session
+       contends over the same flock'd slot files. ``budget <= 0``
+       yields a disabled (no-op) budget.
     """
     import logging.handlers
 
@@ -4148,12 +4196,14 @@ def _init_partner_worker(
     pywikibot.config.retry_max = _PYWIKIBOT_RETRY_MAX
 
     global site, hubs, rights, subject_ids, _normalize_wikitext_enabled
+    global _worker_slot_budget
     site = pywikibot.Site("commons", "commons")
     site.login()
     hubs = hubs_data
     rights = rights_data
     subject_ids = subject_ids_data
     _normalize_wikitext_enabled = bool(normalize_wikitext_enabled)
+    _worker_slot_budget = WorkerSlotBudget(workers_budget)
 
     qh = logging.handlers.QueueHandler(log_queue)
     root = logging.getLogger()
@@ -4184,7 +4234,17 @@ def _worker_partner_task(args):
         # parent's instance can't cross the process boundary cleanly
         # (boto3 sessions hold sockets / credentials state).
         s3 = _get_partner_s3_client()
-        _process_one_partner_item(s3, partner, dpla_id, idx, total)
+        # Check out one box-wide slot for the duration of this item.
+        # The budget caps how many items sync concurrently across all
+        # sessions (= a loose, item-granular proxy for concurrent write
+        # streams — see worker_slots.py for why per-item, not per-write).
+        # When the budget is disabled (workers_budget <= 0) this is a
+        # no-op. Acquiring once around the whole item — through the fast
+        # S3 reads and all the per-ordinal writes — keeps the acquire in
+        # one place; pywikibot's per-worker maxlag backoff remains the
+        # real per-write safety net.
+        with _worker_slot_budget.acquire():
+            _process_one_partner_item(s3, partner, dpla_id, idx, total)
     except Exception:
         logging.exception(
             "Worker task crashed processing %s (idx %s/%s) in partner %s",

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -209,17 +209,18 @@ def _build_parser() -> argparse.ArgumentParser:
         default=0,
         help=(
             "Box-wide cap on concurrent SDC worker slots across ALL "
-            "sdc-sync sessions on the host. Every item-processing path "
-            "checks out a flock-backed slot before its per-item Commons "
-            "work — the parallel workers (--workers >1) and the "
-            "single-process path (--workers 1) alike — so the total "
-            "concurrent Commons-write load is bounded by this value "
+            "sdc-sync sessions on the host. In partner mode, every "
+            "item-processing path checks out a flock-backed slot before "
+            "its per-item Commons work — the parallel workers (--workers "
+            ">1) and the single-process path (--workers 1) alike — so the "
+            "total concurrent Commons-write load is bounded by this value "
             "regardless of how many sessions run or how many workers each "
             "was launched with; excess workers block until a slot frees. "
             "0 (default) disables the budget (acquire is a no-op). Set to "
             "~16 in production so 6+ concurrent sessions cooperatively "
             "share Commons capacity without oversubscribing the parser "
-            "pool."
+            "pool. The single-purpose manual modes (--list / --file / "
+            "--cat) do NOT participate in the budget."
         ),
     )
     return p
@@ -4253,6 +4254,10 @@ def _worker_partner_task(args):
             total,
             partner,
         )
+        # Count items that crash before the inner per-ordinal handler runs
+        # (e.g. an acquire()/setup fault); otherwise they drop silently from
+        # the tally while the per-ordinal handler owns the routine failures.
+        tracker.increment(Result.SDC_ITEMS_SKIPPED_ERROR)
     return tracker.diff(prior)
 
 

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -30,6 +30,7 @@ from ingest_wikimedia.s3 import (
 )
 from ingest_wikimedia.tools_context import ToolsContext
 from ingest_wikimedia.tracker import Result, Tracker
+from ingest_wikimedia.worker_slots import WorkerSlotBudget
 from ingest_wikimedia.categories import CategoryEnsurer, touch_institution_files
 from ingest_wikimedia.dpla import (
     SOURCE_RESOURCE_FIELD_NAME,
@@ -1357,7 +1358,23 @@ class Uploader:
 @click.argument("partner")
 @click.option("--dry-run", is_flag=True)
 @click.option("--verbose", is_flag=True)
-def main(ids_file, partner: str, dry_run: bool, verbose: bool) -> None:
+@click.option(
+    "--workers-budget",
+    type=int,
+    default=0,
+    help=(
+        "Box-wide cap on concurrent Commons-writing processes across ALL "
+        "wikimedia sessions on the host, shared with the SDC-sync phase. "
+        "The uploader is single-process (no parallelism), so it checks out "
+        "exactly ONE slot while working an item — making it count as one "
+        "writer against the shared budget alongside SDC-sync workers. 0 "
+        "(default) disables the budget. See "
+        "ingest_wikimedia.worker_slots.WorkerSlotBudget."
+    ),
+)
+def main(
+    ids_file, partner: str, dry_run: bool, verbose: bool, workers_budget: int
+) -> None:
     start_time = time.time()
     tools_context = ToolsContext.init(partner)
 
@@ -1391,8 +1408,22 @@ def main(ids_file, partner: str, dry_run: bool, verbose: bool) -> None:
 
         dpla_ids = load_ids(ids_file)
 
+        # Box-wide Commons-write budget, shared with the SDC-sync phase
+        # (same flock slot dir). The uploader is single-process, so it
+        # holds exactly one slot while working an item — counting as one
+        # writer against the shared cap so concurrent upload + SDC-sync
+        # sessions across the host don't collectively overrun Commons'
+        # maxlag threshold. Per-item acquire (not whole-run) so the
+        # uploader doesn't stall at startup holding a slot through its
+        # S3 reads when the pool is momentarily full, and briefly frees
+        # the slot between items. budget <= 0 disables it (no-op).
+        slot_budget = WorkerSlotBudget(workers_budget)
+
         for dpla_id in tqdm(dpla_ids, desc="Uploading Items", unit="Item", ncols=100):
-            uploader.process_item(dpla_id, providers_json, partner, verbose, dry_run)
+            with slot_budget.acquire():
+                uploader.process_item(
+                    dpla_id, providers_json, partner, verbose, dry_run
+                )
 
     finally:
         elapsed = time.time() - start_time

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1396,6 +1396,18 @@ def main(
 
     dpla.check_partner(partner)
 
+    # Box-wide Commons-write budget, shared with the SDC-sync phase
+    # (same flock slot dir). The uploader is single-process, so it holds
+    # exactly one slot while working an item — counting as one writer
+    # against the shared cap so concurrent upload + SDC-sync sessions
+    # across the host don't collectively overrun Commons' maxlag
+    # threshold. Per-item acquire (not whole-run) so the uploader doesn't
+    # stall at startup holding a slot through its S3 reads when the pool
+    # is momentarily full, and briefly frees the slot between items.
+    # budget <= 0 disables it (no-op). Built before the try so the
+    # post-upload touch in the finally can reuse it.
+    slot_budget = WorkerSlotBudget(workers_budget)
+
     try:
         local_fs.setup_temp_dir()
         setup_logging(partner, "upload", logging.INFO)
@@ -1407,17 +1419,6 @@ def main(
         logging.info(f"Starting upload for {partner}")
 
         dpla_ids = load_ids(ids_file)
-
-        # Box-wide Commons-write budget, shared with the SDC-sync phase
-        # (same flock slot dir). The uploader is single-process, so it
-        # holds exactly one slot while working an item — counting as one
-        # writer against the shared cap so concurrent upload + SDC-sync
-        # sessions across the host don't collectively overrun Commons'
-        # maxlag threshold. Per-item acquire (not whole-run) so the
-        # uploader doesn't stall at startup holding a slot through its
-        # S3 reads when the pool is momentarily full, and briefly frees
-        # the slot between items. budget <= 0 disables it (no-op).
-        slot_budget = WorkerSlotBudget(workers_budget)
 
         for dpla_id in tqdm(dpla_ids, desc="Uploading Items", unit="Item", ncols=100):
             with slot_budget.acquire():
@@ -1436,7 +1437,12 @@ def main(
         # run of fix-unknown-categories to clean up after the fact.  The 10s
         # pause is a cheap belt-and-suspenders against very-late ensure()
         # calls — for typical runs replication has settled long before this.
-        _post_upload_touch_new_institutions(commons_site, category_ensurer, dry_run)
+        #
+        # Passes the slot budget through: these touches are Commons writes,
+        # so the helper holds a slot around them (see its docstring).
+        _post_upload_touch_new_institutions(
+            commons_site, category_ensurer, dry_run, slot_budget
+        )
         notify_upload_complete(
             # Bare partner slug, not "wikimedia-<partner>" — notify_upload_complete
             # always prepends "wikimedia-" itself (matching the bare-label
@@ -1665,10 +1671,18 @@ def _post_item_orphan_check(
 
 
 def _post_upload_touch_new_institutions(
-    commons_site, category_ensurer: CategoryEnsurer, dry_run: bool
+    commons_site,
+    category_ensurer: CategoryEnsurer,
+    dry_run: bool,
+    slot_budget: WorkerSlotBudget,
 ) -> None:
     """At end-of-run, force-rerender files for any institutions whose P8464
-    was first added this session — see touch_institution_files() docstring."""
+    was first added this session — see touch_institution_files() docstring.
+
+    These touches are Commons writes, so they're done under a box-wide slot
+    (``slot_budget``). The slot is acquired *after* the early-return guards
+    so the common no-op case (no new institutions) never blocks waiting for
+    capacity it doesn't need."""
     if not category_ensurer or dry_run:
         return
     newly_created = category_ensurer.newly_created
@@ -1681,14 +1695,15 @@ def _post_upload_touch_new_institutions(
     )
     time.sleep(_REPLICATION_SETTLE_SECS)
     total = 0
-    for inst_qid in sorted(newly_created):
-        try:
-            n = touch_institution_files(commons_site, inst_qid)
-        except Exception as e:
-            logging.warning(f"Search/touch for {inst_qid} failed: {e}")
-            continue
-        logging.info(f"  Touched {n} files for {inst_qid}")
-        total += n
+    with slot_budget.acquire():
+        for inst_qid in sorted(newly_created):
+            try:
+                n = touch_institution_files(commons_site, inst_qid)
+            except Exception as e:
+                logging.warning(f"Search/touch for {inst_qid} failed: {e}")
+                continue
+            logging.info(f"  Touched {n} files for {inst_qid}")
+            total += n
     logging.info(
         f"Post-upload touch complete: {total} files across {len(newly_created)} institution(s)"
     )

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1367,9 +1367,11 @@ class Uploader:
         "wikimedia sessions on the host, shared with the SDC-sync phase. "
         "The uploader is single-process (no parallelism), so it checks out "
         "exactly ONE slot while working an item — making it count as one "
-        "writer against the shared budget alongside SDC-sync workers. 0 "
-        "(default) disables the budget. See "
-        "ingest_wikimedia.worker_slots.WorkerSlotBudget."
+        "writer against the shared budget alongside SDC-sync workers. "
+        "0 (default) disables the budget — correct for a standalone run, "
+        "which has no peers to coordinate with. Pass --workers-budget 16 "
+        "to join the shared box-wide cap (the launch workflow does this). "
+        "See ingest_wikimedia.worker_slots.WorkerSlotBudget."
     ),
 )
 def main(


### PR DESCRIPTION
## Summary

Follow-up to #308 (per-session SDC parallelism). Introduces a **box-wide cap on concurrent Commons-writing processes** shared across both the SDC-sync and upload phases, and wires the parallelism/budget knobs through the launch chain.

## Commits

1. **`WorkerSlotBudget`** (`ingest_wikimedia/worker_slots.py`) — box-wide N-permit semaphore over `fcntl.flock` slot files in a fixed shared dir. A process checks out one slot before its per-item Commons work; excess block until a slot frees. flock chosen for crash-safety (a slot frees automatically when its holder's fd closes or the process dies — no leaked-permit accounting). `budget<=0` disables it (no-op).

2. **SDC-sync integration** — each `--workers N` pool worker holds one slot per item; `--workers-budget` threaded to workers via Pool initargs.

3. **Uploader integration** — the uploader stays **single-process** (no parallelism — we don't yet know if concurrent binary uploads would overload anything), but checks out **one slot per item** from the *same* pool. So an uploader counts as one writer against the shared budget alongside SDC workers.

4. **Launch wiring** — `--workers` (default 4) + `--workers-budget` (default 16) flow through `wikimedia-launch.yml` → `wikimedia_launch.py` (validated, fail-fast) → the sdc-sync command (both flags) and the uploader command (budget only). The **downloader is deliberately excluded** — it writes to source sites, not Commons, so it contends for a different resource.

## What the cap bounds

The number of DPLA items being written to Commons at once across the whole box — summed over every upload **and** sdc-sync session — is bounded by N (default 16, the rough maxlag-safe ceiling). Each item's writer issues its per-ordinal writes sequentially, so this also bounds concurrent write *streams* to N — a deliberately loose, item-granular proxy (a 1-ordinal and a 1500-ordinal item each hold one slot). pywikibot's per-process `maxlag` backoff remains the real per-write safety net; the budget is the coarser cross-session throttle.

## Behavior notes / caveats

- **Uploader can now gate SDC (and vice versa).** A long-running uploader holding a slot can make SDC workers block waiting for capacity — the intended cooperative throttle, not a bug. Size N with the combined population in mind.
- **Rollout window**: the budget only coordinates among **new-code** processes that call `acquire()`. Sessions already running the old code are invisible to it, so during rollout the true total is `(old sessions) + (new budget cap)`; self-heals as old runs drain.
- **Per-item granularity** (not per-write) is deliberate: per-write would mean ~1 lock cycle per ordinal (1500+ on big items) for no practical gain over maxlag. Surfaced by the simplify review; documented in the module docstring.

## Test plan
- [x] 7 `WorkerSlotBudget` unit tests: cross-session contention (raw flocks), crash-safety (fd-close auto-release), disabled mode, picks-free-slot, blocks-until-free, releases-on-exception
- [x] SDC worker-init builds budget from initarg; launch-flag validation (bad `--workers`/`--workers-budget` fail fast; budget 0 accepted)
- [x] Uploader CliRunner test: builds budget from `--workers-budget`, enters `acquire()` once per item
- [x] Full suite 713 passing (was 696 on origin/main post-#308); ruff clean; simplify pass applied
- [ ] EC2: smoke a `--workers 4 --workers-budget 16` SDC run + a concurrent uploader run, confirm they share/contend for the 16 slots (recommend before relying on the budget in production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds a host-wide concurrency cap for Wikimedia Commons–writing “item work” (shared across `sdc-sync` and the uploader) via `WorkerSlotBudget`, implemented with `fcntl.flock` over per-slot lock files in `/tmp/sdc-sync-worker-slots` (default). The cap bounds concurrent item-level writes across all related sessions running on the same host.

## Key Changes

- **Core mechanism**: Adds `ingest_wikimedia/worker_slots.py` with:
  - `WorkerSlotBudget(budget, slot_dir=DEFAULT_SLOT_DIR)` using an N-permit semaphore backed by non-blocking exclusive `fcntl.flock` on `slot-0..slot-(N-1)` files.
  - **Crash-safety**: permits are released automatically when the holder’s file descriptor closes/dies (prevents leaked permits).
  - **Disabled mode**: when `budget <= 0`, `acquire()` is a no-op (no slot files are created).

- **Launch/workflow wiring**:
  - `.github/workflows/wikimedia-launch.yml` adds manual `workflow_dispatch` inputs:
    - `workers` (default `"4"`)
    - `workers_budget` (default `"16"`)
  - These are forwarded to `scripts/wikimedia_launch.py` via step environment variables (`INPUT_WORKERS`, `INPUT_WORKERS_BUDGET`) and translated into CLI flags:
    - `--workers` + `--workers-budget` for `sdc-sync`
    - `--workers-budget` for the uploader (uploader remains single-process for binary uploads, but still contends for the shared Commons-write budget)
  - Downloader is intentionally excluded since it writes to source sites, not Commons.

- **Launch validation + fail-fast** (`scripts/wikimedia_launch.py`):
  - Validates `--workers` (integer ≥ 1) and `--workers-budget` (integer ≥ 0; `0` disables).
  - On invalid inputs, exits early with Slack-based failure signaling when `--response-url` is provided.
  - Ensures single-process runs (`--workers 1`) still apply the Commons-write budget (so it can’t oversubscribe when other sessions are active).

- **SDC-sync integration** (`tools/sdc_sync.py`):
  - Adds `--workers-budget`.
  - In parallel partner-mode, passes the shared budget value to workers and acquires **one slot per item** for the duration of the per-item partner workflow using `with _worker_slot_budget.acquire(): ...`.
  - In single-process partner mode, still acquires per item around the per-item call.

- **Uploader integration** (`tools/uploader.py`):
  - Adds `--workers-budget` and acquires **one slot per item** around `Uploader.process_item(...)`.
  - Reuses the same budget for post-upload Commons “touch” work via `_post_upload_touch_new_institutions(..., slot_budget=...)`.

- **Test coverage**:
  - Adds a dedicated `tests/test_worker_slots.py` suite covering contention across flock holders, blocking/retry behavior, disabled mode, dead-holder auto-release, and error propagation.
  - Extends `sdc-sync`, `uploader`, and `wikimedia_launch` tests to verify correct construction/usage of `WorkerSlotBudget` and validation/fail-fast behavior.

## Rollout / Triggering

- **Requires** running the existing **manual GitHub Actions** workflow trigger (`workflow_dispatch`) for `wikimedia-launch` to take effect.
- **No** ECS redeployment is included.

## Operational / Security Notes

- No environment variables or AWS Secrets Manager keys are added/changed at the infrastructure level.
- No database migrations or public API response changes.
- The only operational footprint is creation/use of a fixed local lock directory under `/tmp`; the `fcntl.flock` approach is designed to be crash-safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->