### PR TITLE
sdc-sync: dedup legacy {{other date}} inferred claims against DPLA equivalents

### DIFF
--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1238,6 +1238,74 @@ def parse_date_range(date_string: str) -> tuple[int, int] | None:
     return None
 
 
+# Raw ``{{other date|MODIFIER|args...}}`` wikitext. Legacy migration runs
+# before the expand-then-store fix (PR #304) stored this markup verbatim
+# in the P1932 stated-as qualifier instead of its rendered text, so a
+# claim's comparable key never matched the DPLA-sourced equivalent (which
+# carries the *rendered* string, e.g. "circa 1911"). This recogniser
+# converts the markup to the plain display string ``parse_dpla_date``
+# understands so the two dedup.
+_OTHER_DATE_TEMPLATE_RE = re.compile(
+    r"^\{\{\s*other[ _]date\s*\|(.+?)\}\}$", re.IGNORECASE | re.DOTALL
+)
+# Modifiers whose meaning ``parse_dpla_date`` can also represent, mapped
+# to the display-string shape it parses. Anything outside this set
+# (before/after/century/season/…) is intentionally NOT converted: the
+# DPLA side can't represent those either, so they stay as raw-string
+# comparables that only match on byte-identical text — conservative, so
+# an unrecognised modifier can never cause a wrong dedup/removal.
+#
+# These are ``{{other date}}`` *modifier tokens* — a different vocabulary
+# from ``parse_dpla_date``'s display-string decorators (``_DATE_PREFIX``).
+# We normalise every spelling here to the canonical ``"circa "`` prefix
+# before handing off, so this set doesn't need to stay in sync with what
+# ``parse_dpla_date`` strips — it only needs to recognise the template's
+# own circa spellings (incl. bare ``c`` / ``ca`` the template accepts).
+_OTHER_DATE_CIRCA_MODIFIERS = frozenset({"~", "circa", "c", "c.", "ca", "ca."})
+
+
+def parse_other_date_template(value: str) -> str | None:
+    """Convert a raw ``{{other date|...}}`` wikitext value into the plain
+    display string :func:`parse_dpla_date` understands, or ``None`` when
+    the input isn't an ``{{other date}}`` template or uses a modifier
+    DPLA can't represent.
+
+    Handles only the modifiers with an exact ``parse_dpla_date``
+    equivalent:
+
+      * circa family (``~`` / ``circa`` / ``c`` / ``c.`` / ``ca`` /
+        ``ca.``) + a single date  → ``"circa <date>"``
+      * ``?`` (uncertain) + a single date                → ``"<date>?"``
+      * ``s`` / ``decade`` + a year                       → ``"<year>s"``
+
+    Ranges (``{{other date|between|X|Y}}``) are NOT handled here —
+    :func:`parse_date_range` already matches that markup directly.
+
+    Conservative by design: returns ``None`` (caller keeps the raw
+    string, which only matches byte-identical text) rather than guessing
+    at unsupported modifiers, so this can never widen a dedup into a
+    wrong removal.
+    """
+    if not value:
+        return None
+    m = _OTHER_DATE_TEMPLATE_RE.match(value.strip())
+    if not m:
+        return None
+    parts = [p.strip() for p in m.group(1).split("|")]
+    modifier = parts[0].lower() if parts else ""
+    rest = [p for p in parts[1:] if p]
+    if not rest:
+        return None
+    date_arg = rest[0]
+    if modifier in _OTHER_DATE_CIRCA_MODIFIERS:
+        return f"circa {date_arg}"
+    if modifier == "?":
+        return f"{date_arg}?"
+    if modifier in ("s", "decade"):
+        return f"{date_arg}s"
+    return None
+
+
 def _build_date_claim(
     date: str,
     dpla_id: str,

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -1006,3 +1006,82 @@ def test_parse_dpla_date_still_returns_none_for_ranges():
     single year."""
     assert parse_dpla_date("1934 - 1948") is None
     assert parse_dpla_date("between 1934 and 1948") is None
+
+
+# ---------------------------------------------------------------------------
+# parse_other_date_template — convert raw {{other date|MODIFIER|...}} wikitext
+# (legacy inferred-from-Wikitext claims written before the expand-then-store
+# fix) into the display string parse_dpla_date understands, so the reconciler
+# comparable matches the DPLA-sourced equivalent. Conservative: only the
+# modifiers DPLA can represent; None otherwise.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_other_date_template_circa_family():
+    """The reported case (M180313608): every circa-marker spelling maps to
+    'circa <date>', which parse_dpla_date turns into year-precision +
+    approximate — matching the DPLA value-typed time + P1480 circa."""
+    from ingest_wikimedia.sdc import parse_other_date_template
+
+    for raw in (
+        "{{other date|~|1911}}",
+        "{{other date|circa|1911}}",
+        "{{other date|c|1911}}",
+        "{{other date|c.|1911}}",
+        "{{other date|ca|1911}}",
+        "{{other date|ca.|1911}}",
+    ):
+        assert parse_other_date_template(raw) == "circa 1911", raw
+
+
+def test_parse_other_date_template_uncertain_and_decade():
+    from ingest_wikimedia.sdc import parse_other_date_template
+
+    assert parse_other_date_template("{{other date|?|1945}}") == "1945?"
+    assert parse_other_date_template("{{other date|s|1910}}") == "1910s"
+    assert parse_other_date_template("{{other date|decade|1910}}") == "1910s"
+
+
+def test_parse_other_date_template_tolerates_whitespace_and_underscore_alias():
+    from ingest_wikimedia.sdc import parse_other_date_template
+
+    assert parse_other_date_template("{{ other date | ~ | 1911 }}") == "circa 1911"
+    assert parse_other_date_template("{{other_date|~|1911}}") == "circa 1911"
+
+
+def test_parse_other_date_template_preserves_month_precision():
+    """The circa wrapper is stripped to the inner date verbatim, so a
+    YYYY-MM inner value keeps month precision once parse_dpla_date runs."""
+    from ingest_wikimedia.sdc import parse_other_date_template
+
+    assert parse_other_date_template("{{other date|c.|1911-06}}") == "circa 1911-06"
+
+
+def test_parse_other_date_template_returns_none_for_unsupported_modifiers():
+    """between/before/after/century/season have no parse_dpla_date
+    equivalent — return None so the caller keeps the raw string (which
+    only matches byte-identical text). Critical: never widen a dedup into
+    a wrong removal by guessing at a modifier DPLA can't represent.
+    ``between`` is handled separately by parse_date_range, so None here
+    is correct too."""
+    from ingest_wikimedia.sdc import parse_other_date_template
+
+    for raw in (
+        "{{other date|between|1934|1948}}",
+        "{{other date|before|1911}}",
+        "{{other date|after|1911}}",
+        "{{other date|century|19}}",
+        "{{other date|spring|1911}}",
+    ):
+        assert parse_other_date_template(raw) is None, raw
+
+
+def test_parse_other_date_template_returns_none_for_non_template():
+    from ingest_wikimedia.sdc import parse_other_date_template
+
+    assert parse_other_date_template("circa 1911") is None
+    assert parse_other_date_template("1911") is None
+    assert parse_other_date_template("") is None
+    assert parse_other_date_template("{{some other template|x}}") is None
+    # Template present but no date argument → None (nothing to convert).
+    assert parse_other_date_template("{{other date|~}}") is None

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -4561,6 +4561,112 @@ def test_inferred_dupe_cleanup_removes_equivalent_single_date_claim():
     sdc_sync._reset_per_file_accumulators()
 
 
+def test_inferred_dupe_cleanup_removes_legacy_other_date_circa_markup():
+    """Real-world repro (M180313608): a legacy inferred-from-Wikitext
+    claim that predates the expand-then-store fix carries raw
+    ``{{other date|~|1911}}`` markup in P1932, while the DPLA-sourced
+    claim is a value-typed +1911 time with a P1480 circa qualifier.
+    Before the {{other date}} expander these never deduped (one
+    comparable was ``('time', …|circa)``, the other a raw p1932-string).
+    Now the inferred claim is removed."""
+    from tools import sdc_sync
+
+    dpla_claim = {
+        "id": "M180$DPLA",
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P571",
+            "datatype": "time",
+            "datavalue": {
+                "type": "time",
+                "value": {
+                    "time": "+1911-01-01T00:00:00Z",
+                    "precision": 9,
+                    "before": 0,
+                    "after": 0,
+                    "timezone": 0,
+                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
+                },
+            },
+        },
+        # DPLA stamps P459 (heuristic) + P1480 (circa) on the circa date.
+        "qualifiers": {
+            "P459": _dpla_p459(),
+            "P1480": _qual_entity("P1480", "Q5727902"),
+        },
+        "references": [_dpla_reference()],
+    }
+    inferred_claim = _p571_somevalue_with_p1932(
+        "M180$INFERRED",
+        "{{other date|~|1911}}",
+        references=[_inferred_from_wikitext_reference()],
+        p459=False,
+    )
+    entity = {
+        "pageid": 180,
+        "statements": {"P571": [dpla_claim, inferred_claim]},
+    }
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M180")
+    assert sdc_sync.removals == ["M180$INFERRED"]
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_dupe_cleanup_keeps_other_date_markup_when_dpla_date_differs():
+    """Safety: a legacy {{other date|~|1911}} inferred claim must NOT be
+    removed when the DPLA-sourced date is a *different* year — the
+    expander makes equivalent values dedup, not all {{other date}}
+    values vanish."""
+    from tools import sdc_sync
+
+    dpla_claim = {
+        "id": "M180$DPLA",
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P571",
+            "datatype": "time",
+            "datavalue": {
+                "type": "time",
+                "value": {
+                    "time": "+1925-01-01T00:00:00Z",
+                    "precision": 9,
+                    "before": 0,
+                    "after": 0,
+                    "timezone": 0,
+                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
+                },
+            },
+        },
+        "qualifiers": {
+            "P459": _dpla_p459(),
+            "P1480": _qual_entity("P1480", "Q5727902"),
+        },
+        "references": [_dpla_reference()],
+    }
+    inferred_claim = _p571_somevalue_with_p1932(
+        "M180$INFERRED",
+        "{{other date|~|1911}}",
+        references=[_inferred_from_wikitext_reference()],
+        p459=False,
+    )
+    entity = {
+        "pageid": 180,
+        "statements": {"P571": [dpla_claim, inferred_claim]},
+    }
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M180")
+    assert sdc_sync.removals == [], "different year must not dedup"
+    sdc_sync._reset_per_file_accumulators()
+
+
 def test_inferred_dupe_cleanup_skips_property_with_no_dpla_claim():
     """When no DPLA-attributed claim exists on a property, even a
     matching inferred-from-Wikitext claim must stay — there's no

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -20,6 +20,7 @@ from ingest_wikimedia.sdc import (
     parse_date_range,
     parse_dpla_date,
     parse_nara_access_level,
+    parse_other_date_template,
 )
 from ingest_wikimedia import legacy_artwork, wikimedia, wikitext_normalize
 from ingest_wikimedia.slack import notify_phase_start, notify_sdc_complete
@@ -3013,7 +3014,16 @@ def _statement_comparable_value(stmt):
             s = (qv.get("value") or "").strip()
             if not s:
                 continue
-            parsed = parse_dpla_date(s)
+            # Legacy inferred-from-Wikitext claims written before the
+            # expand-then-store fix carry raw ``{{other date|~|1911}}``
+            # markup here instead of its rendered text. Convert the
+            # supported modifiers to the display string parse_dpla_date
+            # understands so they collapse with the DPLA-sourced claim
+            # (which carries the rendered "circa 1911" / value-typed
+            # time). Non-template / unsupported-modifier values pass
+            # through unchanged.
+            parse_input = parse_other_date_template(s) or s
+            parsed = parse_dpla_date(parse_input)
             if parsed and parsed.get("value"):
                 # Same shape (and circa-bit suffix) as
                 # ``_time_claim_comparable`` so a somevalue+P1932="1945"
@@ -3021,16 +3031,13 @@ def _statement_comparable_value(stmt):
                 base = _time_comparable(parsed["value"])
                 key = f"{base}|circa" if parsed.get("approximate") else base
                 return ("time", key, None)
+            # Range parser sees the RAW value — it matches the
+            # ``{{other date|between|X|Y}}`` markup directly.
             rng = parse_date_range(s)
             if rng:
                 return ("date-range", rng[0], rng[1])
             # Literal-string fallback — only matches another P1932
-            # qualifier whose stated-as text is byte-identical. The
-            # inferred-from-Wikitext writer stores the post-expansion
-            # value, but legacy migrations that ran before the
-            # expand-then-store fix may carry raw wikitext here. The
-            # range parser already matches the most common
-            # ``{{other date|between|X|Y}}`` shape directly.
+            # qualifier whose stated-as text is byte-identical.
             return ("p1932-string", s, None)
         return None
 


### PR DESCRIPTION
## Summary

Closes a gap in the #306 inferred-from-Wikitext dedup. The reconciler removes inferred claims whose comparable value matches a DPLA-sourced claim — but **legacy claims written before the expand-then-store fix (#304)** carry raw `{{other date|~|1911}}` markup in their P1932 stated-as qualifier instead of the rendered `circa 1911`. `parse_dpla_date` can't read the markup, so the comparable fell to a raw-string key that never matched the DPLA claim's value-typed-time-plus-circa comparable, and the duplicate survived.

**Repro:** [M180313608](https://commons.wikimedia.org/wiki/File:A_Combined_Souvenir,_History_and_Decennial_Financial_Statement_of_the_Church_of_Our_Lady_of_the_Rosary,_Detroit,_Minnesota_-_DPLA_-_47e72b49fa7f4b17d5322e89dbd6d6de_(page_111).jpg) — DPLA value-typed `+1911` P9 with P1480 circa, vs. inferred `somevalue + P1932="{{other date|~|1911}}"`. Verified the two comparables diverged before this change and match after.

## Fix

New `parse_other_date_template()` in `sdc.py` converts the supported `{{other date}}` modifiers to the display string `parse_dpla_date` understands:
- circa family (`~` / `circa` / `c` / `c.` / `ca` / `ca.`) → `circa <date>`
- `?` → `<date>?`
- `s` / `decade` → `<year>s`

Wired into `_statement_comparable_value`'s somevalue+P1932 branch. **Conservative by design:** returns `None` for unsupported modifiers (`before`/`after`/`century`/`season`/…) and non-template input — those stay byte-identical-only comparables, so an unrecognised form can never widen a dedup into a wrong removal. Ranges (`{{other date|between|X|Y}}`) keep flowing through `parse_date_range`, which already matches that markup.

Offline string-rewrite (no live API): the reconciler comparable runs over many claims with no `site` handle. Distinct from the migration path's `_expand_wikitext_for_date_parse` (live `site.expand_text`), which is correct for *writing* claims; the simplify review confirmed the duplication is justified and correctly scoped.

## Cleaning up existing files

This is the "match the type" fix (vs. a one-time scan). Existing affected files clean up naturally on the next sdc-sync re-run over them — e.g. an `--sdc-only` pass over MDL, which is where most legacy `{{Artwork}}`-migrated dates live.

## Test plan
- [x] `parse_other_date_template` unit tests: circa spellings, `?`, decade, whitespace + `other_date` underscore alias, month-precision passthrough, unsupported-modifier → None, non-template → None
- [x] Reconciler repro tests: M180313608 shape now dedups; a *different-year* DPLA date does NOT dedup (safety)
- [x] Full suite 704 passing (was 696); ruff clean; simplify pass applied
- [ ] EC2: `--sdc-only` re-run over a sample of affected MDL items to confirm the legacy dupes are removed live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a deduplication gap in `sdc-sync`’s handling of legacy inferred date claims derived from Wikitext written before PR `#304`. Those claims stored raw `{{other date|...}}` markup (e.g., `{{other date|~|1911}}`) in the P1932 “stated-as” qualifier; `parse_dpla_date` couldn’t parse that markup, so the tool fell back to raw string comparables that wouldn’t match DPLA-sourced comparable values (notably the value-typed + circa cases), preventing correct deduplication.

## Changes

- **`ingest_wikimedia/sdc.py`**
  - Added `parse_other_date_template(value: str) -> str | None`, which recognizes a restricted set of legacy `{{other date|MODIFIER|date...}}` forms and converts them into display strings that `parse_dpla_date` can parse (e.g., `circa <date>`, `<date>?`, `<year>s`).
  - The implementation is intentionally conservative: it returns `None` for non-template input, missing date arguments, empty inputs, and unsupported modifiers (e.g., `before`, `after`, `century`, `season`), and it leaves range-like forms (e.g., `between`) to existing range handling.

- **`tools/sdc_sync.py`**
  - Updated `_statement_comparable_value` for the inferred-from-wikitext somevalue + **P1932** branch to preprocess the raw stated-as string by calling `parse_other_date_template`.
  - When normalization succeeds, it then parses the normalized string via `parse_dpla_date` to produce the same canonical comparable key used for DPLA value-typed time claims.
  - When normalization returns `None`, the existing logic continues (including using the existing `parse_date_range` path for `{{other date|between|X|Y}}`).

## Testing

- **`tests/test_sdc.py`**: Added unit tests for `parse_other_date_template`, including circa spelling variants, uncertainty marker handling, decade notation, whitespace tolerance, `other_date`/underscore alias support, month-precision passthrough, and verification that unsupported modifiers and non-template inputs return `None`.
- **`tests/test_sdc_sync.py`**: Added regression tests confirming the affected case (M180313608) now deduplicates correctly against the corresponding DPLA equivalent, while different-year DPLA dates do not match.

Full test suite passes (**704 tests**). No pipeline/ECS redeploy, environment variable/secrets changes, database migrations, API/endpoint changes, or security-related changes are included; updated MDL items should self-correct on the next `sdc-sync` run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->