### PR TITLE
uploader: 404 on colliding DPLA ID is the migrate signal, not skip

### DIFF
--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -805,6 +805,138 @@ def test_resolve_hash_drift_case2_tags_when_expected_titles_is_none():
     assert action == "upload_and_tag"
 
 
+def _build_uploader_with_dpla_raising(exc: Exception) -> "object":
+    """Like ``_build_uploader_with_dpla`` but DPLA API raises ``exc`` on
+    every ``get_item_metadata`` call. Used to exercise the "colliding
+    DPLA item couldn't be verified" branches of ``_resolve_hash_drift``.
+    """
+    from tools.uploader import Uploader
+
+    dpla = MagicMock()
+    dpla.get_item_metadata.side_effect = exc
+    return Uploader(
+        tracker=Tracker(),
+        local_fs=MagicMock(),
+        s3_client=MagicMock(),
+        dpla=dpla,
+        site=MagicMock(),
+        category_ensurer=None,
+    )
+
+
+def _make_http_404_error() -> Exception:
+    """Synthesise a ``requests``-shaped HTTPError with response.status_code
+    == 404. Mirrors the shape ``DPLA.get_item_metadata``'s
+    ``response.raise_for_status()`` produces when the DPLA API has dropped
+    the item. Not constructing a real ``requests.HTTPError`` so the test
+    doesn't pull in ``requests`` for a duck-typed check the production
+    code reads via ``getattr``.
+    """
+    err = Exception("404 Client Error: Not Found")
+    err.response = MagicMock()  # type: ignore[attr-defined]
+    err.response.status_code = 404
+    return err
+
+
+def test_resolve_hash_drift_404_on_colliding_id_falls_through_to_migration():
+    """REGRESSION: when the colliding file's DPLA ID returns 404, the
+    bot used to silently fall back to ``upload_only`` — producing a
+    duplicate on Commons beside the orphaned older title. The 404 is
+    in fact the strongest possible signal that the existing file is
+    an orphan from a removed DPLA item; we now legitimately own this
+    content under the new ID and should migrate (move/tag), not
+    duplicate. This is the bug that flooded the Indiana Riley Old
+    Home Society session with duplicates on 2026-06-15."""
+    uploader = _build_uploader_with_dpla_raising(_make_http_404_error())
+    existing_title = "Item - DPLA - bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb (page 2).jpg"
+    intended_title = "Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page 2).jpg"
+    # Case 3 setup: nothing at the intended title → simple move. We
+    # patch _move_to_correct_title so the test doesn't drive a real
+    # pywikibot move; the assertion is just that we don't bail out
+    # to ``upload_only``.
+    intended_page = MagicMock()
+    intended_page.exists.return_value = False
+    with (
+        patch("tools.uploader.get_page", return_value=intended_page),
+        patch.object(uploader, "_move_to_correct_title"),
+    ):
+        action = uploader._resolve_hash_drift(
+            existing_file=_drift_existing_file(existing_title),
+            page_title=intended_title,
+            dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ordinal=2,
+            wiki_markup="",
+        )
+    assert action == "moved", (
+        "404 on the colliding DPLA ID is the rename signal — the orphan "
+        "must be migrated to our new title, not left in place beside a "
+        "duplicate upload."
+    )
+
+
+def test_resolve_hash_drift_non_404_exception_stays_on_upload_only():
+    """Conservative fallback: non-404 exceptions (network timeout, 5xx,
+    JSON parse error, etc.) don't carry the same "old ID is gone"
+    meaning a 404 does. Keep these on the existing ``upload_only``
+    path so a transient DPLA API blip doesn't trigger a destructive
+    move on a file that still has a valid sibling item."""
+
+    class FlakyConnError(Exception):
+        pass
+
+    uploader = _build_uploader_with_dpla_raising(FlakyConnError("connection reset"))
+    existing_title = "Item - DPLA - bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb (page 2).jpg"
+    intended_title = "Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page 2).jpg"
+    # No need to set up intended_page — upload_only returns before get_page.
+    action = uploader._resolve_hash_drift(
+        existing_file=_drift_existing_file(existing_title),
+        page_title=intended_title,
+        dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ordinal=2,
+        wiki_markup="",
+    )
+    assert action == "upload_only"
+
+
+def test_resolve_hash_drift_5xx_response_stays_on_upload_only():
+    """Sister case to the 404 test: a 5xx-shaped HTTPError must NOT
+    take the 404 branch. Pin the exact status check so a refactor that
+    broadens the gate (e.g. to ``status >= 400``) is caught."""
+    err = Exception("503 Service Unavailable")
+    err.response = MagicMock()  # type: ignore[attr-defined]
+    err.response.status_code = 503
+
+    uploader = _build_uploader_with_dpla_raising(err)
+    existing_title = "Item - DPLA - bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb (page 2).jpg"
+    intended_title = "Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page 2).jpg"
+    action = uploader._resolve_hash_drift(
+        existing_file=_drift_existing_file(existing_title),
+        page_title=intended_title,
+        dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ordinal=2,
+        wiki_markup="",
+    )
+    assert action == "upload_only"
+
+
+def test_resolve_hash_drift_valid_cross_item_collision_uploads_only():
+    """Existing positive case (no regression): when the colliding DPLA
+    item IS still valid, the cross-item-collision branch returns
+    ``upload_only`` — our hash gets its own title and we leave the
+    other valid item's file untouched."""
+    uploader = _build_uploader_with_dpla(other_item_exists=True)
+    existing_title = "Item - DPLA - bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb (page 2).jpg"
+    intended_title = "Item - DPLA - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (page 2).jpg"
+    action = uploader._resolve_hash_drift(
+        existing_file=_drift_existing_file(existing_title),
+        page_title=intended_title,
+        dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ordinal=2,
+        wiki_markup="",
+    )
+    assert action == "upload_only"
+
+
 # --------------------------------------------------------------------------
 # select_upload_chunk_size — pin the OOM-prevention contract: files above
 # LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES MUST force chunked upload even when

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -967,12 +967,38 @@ class Uploader:
             try:
                 other_item = self.dpla.get_item_metadata(existing_dpla_id)
             except Exception as ex:
-                logging.warning(
-                    f"Hash drift for {dpla_id} {ordinal}: failed to verify "
-                    f"colliding DPLA item {existing_dpla_id}: {ex}; "
-                    f"falling back to upload_only."
-                )
-                return "upload_only"
+                # A 404 from the DPLA API for the colliding file's DPLA ID
+                # is the strongest possible signal that the existing
+                # Commons file is an orphan: that ID no longer resolves to
+                # any item, so the previous bot upload's DPLA-side anchor
+                # is gone. Treat it exactly like ``other_item is None`` —
+                # fall through to the Case 1/2/3 migration so we move the
+                # orphan to the new ID's title (or upload-and-tag it),
+                # rather than silently creating a duplicate alongside it.
+                #
+                # Distinguishing 404 from other exceptions matters because
+                # the catch-all path is reached by network timeouts, 5xx
+                # responses, JSON parse errors, etc. — none of which carry
+                # the same definitive "the old ID is gone" meaning. Those
+                # stay on the conservative ``upload_only`` fallback so a
+                # transient API blip doesn't trigger a destructive move on
+                # a file that still has a valid sibling item.
+                status = getattr(getattr(ex, "response", None), "status_code", None)
+                if status == 404:
+                    logging.info(
+                        f"Hash drift for {dpla_id} {ordinal}: colliding "
+                        f"DPLA item {existing_dpla_id} no longer exists "
+                        f"(404); treating [[File:{actual_filename}]] as "
+                        f"an orphan and migrating."
+                    )
+                    other_item = None
+                else:
+                    logging.warning(
+                        f"Hash drift for {dpla_id} {ordinal}: failed to verify "
+                        f"colliding DPLA item {existing_dpla_id}: {ex}; "
+                        f"falling back to upload_only."
+                    )
+                    return "upload_only"
             if other_item:
                 logging.info(
                     f"Hash drift for {dpla_id} {ordinal}: "


### PR DESCRIPTION
## Summary

Fixes a latent bug in `_resolve_hash_drift` that was producing silent duplicates on Commons whenever a hub re-harvested items with new DPLA IDs and the old IDs were dropped from the DPLA API.

**Root cause:** When the uploader finds a hash collision against an existing Commons file whose name carries a *different* DPLA ID, it asks the DPLA API whether that colliding ID is still a live item. The intent: if the old ID is gone, treat the existing file as an orphan and migrate it (move or upload-and-tag); if the old ID is still live, leave the other file alone and upload our hash to its own title. The catch-all `except Exception` in that lookup conflated **definitive 404 (item gone)** with **transient API failures (timeout/5xx/parse error)** and routed both to `upload_only` — silently producing a duplicate beside the orphan.

**Fix:** distinguish a 404 (fall through to the Case 1/2/3 migration path — exactly the behavior we want when the old ID has been removed) from other exceptions (keep the conservative `upload_only` fallback so a transient blip can't trigger a destructive move).

**Why now / not a regression:** The behavior has been there since [#194 (May 2026)](https://github.com/dpla/ingest-wikimedia/pull/194). It just started firing en masse because Indiana re-harvested institutions with new DPLA IDs while the old IDs were dropped from the DPLA index — every collision in the Riley Old Home Society session hit the 404 path. Observed concrete instance: [File:Letter from Riley to his sister, Elva Eitel - DPLA - e34aba3a103424a60774d79f3762619d (page 2).jpg](https://commons.wikimedia.org/wiki/File:Letter_from_Riley_to_his_sister,_Elva_Eitel_-_DPLA_-_e34aba3a103424a60774d79f3762619d_(page_2).jpg) uploaded as a duplicate of the existing 2023 upload [8c61a9e566718f471a8ec9666fc31f45](https://commons.wikimedia.org/wiki/File:Letter_from_Riley_to_his_sister,_Elva_Eitel_-_DPLA_-_8c61a9e566718f471a8ec9666fc31f45_(page_2).jpg).

## Test plan

- [ ] CI passes (4 new tests: 404 → migration; non-404 exception → upload_only; 5xx → upload_only pinned; valid cross-item → upload_only no regression; 716 existing tests still green)
- [ ] After merge, watch the next Riley/Indiana session log for `colliding DPLA item ... no longer exists (404); treating ... as an orphan and migrating.` instead of `failed to verify colliding DPLA item ... falling back to upload_only.`
- [ ] Separate task: tag/delete the duplicates already created in the 2026-06-15 Riley session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Fixes a latent bug in `_resolve_hash_drift` that has been causing silent duplicate file uploads on Wikimedia Commons. The function previously conflated definitive 404 responses (indicating an old DPLA ID no longer exists) with transient API failures (timeouts, 5xx errors), routing all exceptions to the conservative `upload_only` path and preventing orphaned files from being properly migrated.

## Problem
When a hash collision is detected against an existing Commons file, `_resolve_hash_drift` queries the DPLA API to verify whether the old DPLA ID associated with that file still exists. A 404 indicates the colliding item has been removed and should trigger file migration (move or upload-and-tag). However, the previous catch-all `except Exception` block treated all failures identically, causing transient API hiccups and parsing errors to be handled the same as definitive 404 responses. This resulted in silent duplicate uploads beside orphaned files rather than proper migration.

The bug lay dormant since May 2026 (PR `#194`) but recently surfaced at scale during re-harvesting of Indiana institutions with new DPLA IDs, where colliding items produced duplicates instead of proper orphan migration.

## Solution
Modified `_resolve_hash_drift` to distinguish 404 responses from other exceptions:
- **404 response**: Logs that the colliding DPLA item no longer exists, sets `other_item = None`, and allows the migration path to proceed
- **Non-404 exceptions**: Logs a warning and falls back to the conservative `upload_only` behavior, avoiding destructive moves on files with potentially valid siblings

This prevents transient API failures from triggering unintended file operations while allowing legitimate orphan migration when items have definitively been removed.

## Changes
- **tools/uploader.py** (+32 lines): Enhanced exception handling in `_resolve_hash_drift` to check `response.status_code == 404` and route accordingly
- **tests/test_uploader.py** (+132 lines): Added comprehensive regression test coverage including:
  - 404 collision path leading to migration
  - Non-404 exception handling (conservative upload_only fallback)
  - 5xx HTTPError behavior verification
  - Valid cross-item collision regression prevention

<!-- end of auto-generated comment: release notes by coderabbit.ai -->