### PR TITLE
uploader: gate CommonsDelinker relink requests on actual file usage

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -649,6 +649,12 @@ def file_has_inbound_usage(site: BaseSite, filename: str) -> bool:
             gulimit=1,
             fulimit=1,
         ).submit()
+        # Parse inside the try too: an unexpected payload shape must fail
+        # open (treated as "used"), not raise or fall through to False.
+        for page in result.get("query", {}).get("pages", {}).values():
+            if page.get("globalusage") or page.get("fileusage"):
+                return True
+        return False
     except Exception as e:
         logging.warning(
             "Could not check usage for [[File:%s]] (%s); "
@@ -657,10 +663,6 @@ def file_has_inbound_usage(site: BaseSite, filename: str) -> bool:
             e,
         )
         return True
-    for page in result.get("query", {}).get("pages", {}).values():
-        if page.get("globalusage") or page.get("fileusage"):
-            return True
-    return False
 
 
 def post_commonsdelinker_request(

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -631,6 +631,38 @@ def build_title_drift_move_reason(
     return candidates[-1]
 
 
+def file_has_inbound_usage(site: BaseSite, filename: str) -> bool:
+    """Return True if bare-named ``filename`` is used on another wiki
+    (``globalusage``) or a local Commons page (``fileusage``).
+
+    Both classes are fetched in one request (capped at one row each). No
+    ``redirects``: we want usage recorded against *this* title, not a
+    redirect target. Fails open (returns True) on any error so a needed
+    relink is never silently dropped.
+    """
+    api_site = typing.cast(APISite, site)
+    try:
+        result = api_site.simple_request(
+            action="query",
+            prop="globalusage|fileusage",
+            titles=f"File:{filename}",
+            gulimit=1,
+            fulimit=1,
+        ).submit()
+    except Exception as e:
+        logging.warning(
+            "Could not check usage for [[File:%s]] (%s); "
+            "assuming used and posting CommonsDelinker request.",
+            filename,
+            e,
+        )
+        return True
+    for page in result.get("query", {}).get("pages", {}).values():
+        if page.get("globalusage") or page.get("fileusage"):
+            return True
+    return False
+
+
 def post_commonsdelinker_request(
     site: BaseSite, old_filename: str, new_filename: str
 ) -> None:
@@ -639,6 +671,9 @@ def post_commonsdelinker_request(
     Both filenames should be bare (without the 'File:' namespace prefix).
     Each call makes one edit, matching the one-request-per-edit convention
     used by other editors on that page.
+
+    No-ops when ``old_filename`` has no inbound usage to relink (see
+    ``file_has_inbound_usage``).
 
     Uses the MediaWiki `appendtext` API parameter rather than the naive
     read-modify-write (`page.text = page.text + template; page.save()`).
@@ -661,6 +696,13 @@ def post_commonsdelinker_request(
         primary; conflicting concurrent edits can no longer cause
         spurious rejections.
     """
+    if not file_has_inbound_usage(site, old_filename):
+        logging.info(
+            " -- No inbound usage for [[File:%s]]; skipping CommonsDelinker "
+            "request (nothing to relink).",
+            old_filename,
+        )
+        return
     page = pywikibot.Page(site, COMMONSDELINKER_PAGE)
     template = (
         f"{{{{universal replace"

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -16,6 +16,7 @@ from ingest_wikimedia.wikimedia import (
     extract_page_ordinal_from_commons_title,
     extract_strings,
     extract_strings_dict,
+    file_has_inbound_usage,
     is_same_item_redirect_relic,
     merge_preserved_wikitext,
     post_commonsdelinker_request,
@@ -929,7 +930,10 @@ def test_post_commonsdelinker_request_uses_appendtext_not_read_modify_write():
     `appendtext` is server-side atomic: no read, no basetimestamp, no
     race. This test pins both halves of that contract.
     """
-    site = MagicMock()
+    # Old.jpg has inbound usage, so the usage gate lets the post through.
+    site = _usage_site(
+        {"query": {"pages": {"-1": {"globalusage": [{"title": "w:en:Example"}]}}}}
+    )
     # If anything tries to read page.text the test fails loudly: that
     # would mean we slipped back into the naive form.
     page_text_accessed = MagicMock(
@@ -967,6 +971,60 @@ def test_post_commonsdelinker_request_uses_appendtext_not_read_modify_write():
     assert "|New.jpg" in kwargs["appendtext"]
     # page.save must not be called — that path re-introduces the read.
     page.save.assert_not_called()
+
+
+def _usage_site(submit_return=None, submit_exc=None):
+    """A mock site whose simple_request(...).submit() returns the given
+    query result (or raises). Used to drive the usage gate."""
+    site = MagicMock()
+    sub = site.simple_request.return_value.submit
+    if submit_exc is not None:
+        sub.side_effect = submit_exc
+    else:
+        sub.return_value = submit_return
+    return site
+
+
+def test_file_has_inbound_usage_one_combined_request_global_or_local():
+    """Global and local usage are fetched in a SINGLE request
+    (prop=globalusage|fileusage); usage in either class counts as used,
+    and neither counts as unused. ``redirects`` must not be set."""
+    # global only
+    site = _usage_site({"query": {"pages": {"-1": {"globalusage": [{"x": 1}]}}}})
+    assert file_has_inbound_usage(site, "F.jpg") is True
+    # exactly one API request, with the combined prop and no redirect-following
+    assert site.simple_request.call_count == 1
+    _, kwargs = site.simple_request.call_args
+    assert kwargs["action"] == "query"
+    assert set(kwargs["prop"].split("|")) == {"globalusage", "fileusage"}
+    assert kwargs["titles"] == "File:F.jpg"
+    assert "redirects" not in kwargs
+
+    # local only
+    site = _usage_site({"query": {"pages": {"-1": {"fileusage": [{"title": "X"}]}}}})
+    assert file_has_inbound_usage(site, "F.jpg") is True
+
+    # neither
+    site = _usage_site({"query": {"pages": {"-1": {}}}})
+    assert file_has_inbound_usage(site, "F.jpg") is False
+
+
+def test_file_has_inbound_usage_fails_open_on_error():
+    """A query error must fail OPEN (return True) so a needed relink is
+    never silently dropped on a transient API failure."""
+    site = _usage_site(submit_exc=RuntimeError("api down"))
+    assert file_has_inbound_usage(site, "F.jpg") is True
+
+
+def test_post_commonsdelinker_request_skips_when_no_usage():
+    """No inbound usage → no filemovers edit (nothing to relink)."""
+    site = _usage_site({"query": {"pages": {"-1": {}}}})
+    with patch("ingest_wikimedia.wikimedia.pywikibot.Page") as PageCtor:
+        post_commonsdelinker_request(
+            site, old_filename="Old.jpg", new_filename="New.jpg"
+        )
+    site.editpage.assert_not_called()
+    PageCtor.assert_not_called()
 
 
 def test_tag_as_duplicate_uses_prependtext_not_read_modify_write():

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -1016,6 +1016,14 @@ def test_file_has_inbound_usage_fails_open_on_error():
     assert file_has_inbound_usage(site, "F.jpg") is True
 
 
+def test_file_has_inbound_usage_fails_open_on_malformed_payload():
+    """An unexpected payload shape (parse error) must also fail OPEN, not
+    raise or fall through to False — the parse runs inside the try."""
+    # `pages` as a list rather than the expected dict → .values() raises.
+    site = _usage_site({"query": {"pages": ["unexpected"]}})
+    assert file_has_inbound_usage(site, "F.jpg") is True
+
+
 def test_post_commonsdelinker_request_skips_when_no_usage():
     """No inbound usage → no filemovers edit (nothing to relink)."""
     site = _usage_site({"query": {"pages": {"-1": {}}}})


### PR DESCRIPTION
## Problem

Every title-drift rename posts a `{{universal replace}}` to `User:CommonsDelinker/commands/filemovers` unconditionally — even when the file has zero usage anywhere, so there is nothing to relink. A reviewer flagged this on a zero-usage NARA `.mp3` (empty `Special:GlobalUsage`). At our move volume this hands CommonsDelinker a large volume of nothing-to-do requests.

## Fix

- New `file_has_inbound_usage(site, filename)` — checks **global** (other wikis) **and** local Commons usage in a **single** combined API request (`prop=globalusage|fileusage`, one row each, so local usage adds no extra round-trip). Fails **open** (returns `True`) on API/parse error so a genuinely needed relink is never silently dropped.
- `post_commonsdelinker_request` now early-returns when the old title has no inbound usage. The gate lives in the post function — a **single chokepoint** that covers all title-drift call sites (`_resolve_redirect_move`, `_move_to_correct_title`) automatically.
- The post runs *after* the move (old title is now a redirect); we deliberately **don't** follow redirects in the query, because remote/local pages still reference the old name — that's exactly what needs relinking.

## Tests

`file_has_inbound_usage`: one combined request (asserts `prop`, `titles`, no `redirects`), global-only / local-only / neither, fail-open on error. `post_commonsdelinker_request`: skips the filemovers edit when usage is empty. Existing append-text test updated to drive the gate. Full suite: 731 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR optimizes CommonsDelinker integration by gating relink requests on whether the old filename is actually referenced (globally on other wikis or locally on Commons). This prevents large volumes of unnecessary “universal replace” requests for zero-usage files.

### Changes

**`ingest_wikimedia/wikimedia.py`:**
- Added `file_has_inbound_usage(site: BaseSite, filename: str) -> bool`, which makes a single combined MediaWiki API request (`prop=globalusage|fileusage` for `File:<filename>`, without following redirects) and returns whether the old file has any inbound usage.
- Implemented “fail open” behavior: on API errors or malformed/unexpected payloads, it returns `True` (and logs a warning) to avoid suppressing needed relinks.
- Updated `post_commonsdelinker_request(site, old_filename, new_filename)` to early-return (log informationally and skip) when `file_has_inbound_usage(site, old_filename)` is false, creating a single chokepoint that covers all title-drift relink call sites.

**`tests/test_wikimedia.py`:**
- Added `_usage_site(...)` helper to mock `site.simple_request(...).submit()` results for the usage gate.
- Added tests covering:
  - combined API request structure and global-only/local-only/neither usage scenarios
  - fail-open behavior on API errors
  - fail-open behavior on malformed payloads
  - skipping CommonsDelinker posting when no usage is found (verifies no `site.editpage` call and no `pywikibot.Page` construction)
- Updated an existing test to use `_usage_site(...)` so the usage gate permits the post.

### Impact Assessment

- **No pipeline trigger or ECS redeployment changes required**: next standard deployment should pick up the logic change.
- **No environment variables or AWS Secrets Manager keys added/removed/renamed.**
- **No database migrations.**
- **No shared infrastructure configuration changes** (CodePipeline/CodeBuild/ECS/IAM) .
- **No public API response shape changes** and no new endpoints.
- **Security implications: minimal/none** beyond additional reads from existing Wikimedia/MediaWiki usage data; no auth/credential changes or new external data sources.
- **Test suite status**: 731 tests passing with clean ruff output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->