### PR TITLE
sdc-sync: raise slot budget to 24 / 6 workers + slot-contention visibility

### DIFF
--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -38,12 +38,12 @@ on:
         description: "SDC-sync worker processes per session (parallelism). 1 = single-process."
         required: false
         type: string
-        default: "4"
+        default: "6"
       workers_budget:
         description: "Box-wide cap on concurrent SDC worker slots across all sessions (0 = unlimited)"
         required: false
         type: string
-        default: "16"
+        default: "24"
 
 permissions:
   contents: read

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -414,6 +414,7 @@ def notify_sdc_complete(
     partner_label: str,
     elapsed_seconds: float,
     dry_run: bool = False,
+    workers: int = 1,
 ) -> None:
     """Post the SDC phase's completion summary to #tech-alerts.
 
@@ -423,6 +424,9 @@ def notify_sdc_complete(
     uploading new files; "items synced" is the per-DPLA-ID count, and the
     SKIPPED_* lines surface items the partner-mode loop bailed on because
     their sidecars were missing or malformed.
+
+    ``workers`` turns the aggregate worker-seconds in ``SDC_SLOT_WAIT_SECONDS``
+    into a per-worker average for the SLOT WAIT line.
     """
     token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
     if not token:
@@ -434,6 +438,12 @@ def notify_sdc_complete(
     )
     runtime = _format_runtime(elapsed_seconds)
     dry_run_note = " _(dry run)_" if dry_run else ""
+
+    # Box-wide-slot contention: aggregate worker-seconds waited / workers =
+    # average per worker; expressed as a share of runtime so it reads as
+    # "this session spent ~X% of its time throttled by the budget."
+    avg_wait = tracker.count(Result.SDC_SLOT_WAIT_SECONDS) / max(1, workers)
+    wait_pct = (avg_wait / elapsed_seconds * 100) if elapsed_seconds > 0 else 0
 
     _post_completion_notice(
         token=token,
@@ -452,6 +462,7 @@ def notify_sdc_complete(
             f"ORDINAL MISSING:      {tracker.count(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY):,}",
             f"ORDINAL NO PAGEID:    {tracker.count(Result.SDC_ORDINALS_SKIPPED_MISSING_PAGEID):,}",
             f"ORDINAL ERRORS:       {tracker.count(Result.SDC_ORDINALS_SKIPPED_ERROR):,}",
+            f"SLOT WAIT (avg/wkr):  {_format_runtime(avg_wait)} ({wait_pct:.0f}% of runtime)",
             f"Runtime:              {runtime}",
         ],
     )

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -97,6 +97,9 @@ class Result(Enum):
     LEGACY_SKIPPED_NOT_LEGACY = auto()  # page didn't carry a legacy template
     LEGACY_SKIPPED_ALREADY = auto()  # already migrated (idempotency hit)
     LEGACY_SKIPPED_ERROR = auto()  # raised at runtime, isolated by exc boundary
+    # Aggregate worker-seconds blocked on a box-wide slot (WorkerSlotBudget
+    # contention). Summed across workers; the consumer divides by worker count.
+    SDC_SLOT_WAIT_SECONDS = auto()
 
 
 class Tracker:

--- a/ingest_wikimedia/worker_slots.py
+++ b/ingest_wikimedia/worker_slots.py
@@ -111,6 +111,10 @@ class WorkerSlotBudget:
     def __init__(self, budget: int, slot_dir: str = DEFAULT_SLOT_DIR):
         self.budget = budget
         self.slot_dir = slot_dir
+        # Cumulative seconds this process spent blocked in acquire() waiting
+        # for a free slot. ~0 when the budget isn't contended; grows under
+        # saturation. Callers read it to report slot contention.
+        self.total_wait_seconds = 0.0
         if budget > 0:
             self._ensure_slot_files()
 
@@ -169,7 +173,9 @@ class WorkerSlotBudget:
 
         fd = None
         try:
+            start = time.monotonic()
             fd = self._acquire_slot_fd()
+            self.total_wait_seconds += time.monotonic() - start
             yield
         finally:
             if fd is not None:

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -129,12 +129,12 @@ def main() -> None:
     parser.add_argument("--refresh-only", default="false")
     parser.add_argument("--sdc-only", default="false")
     # Keep in sync with .github/workflows/wikimedia-launch.yml inputs.workers
-    # / inputs.workers_budget (currently 4 / 16), which the workflow always
+    # / inputs.workers_budget (currently 6 / 24), which the workflow always
     # passes explicitly. These defaults only apply to a bare manual launch —
-    # they let it behave like a workflow launch (4 SDC workers under a
-    # box-wide cap of 16) rather than silently running single-worker, no cap.
-    parser.add_argument("--workers", default="4")
-    parser.add_argument("--workers-budget", default="16")
+    # they let it behave like a workflow launch (6 SDC workers under a
+    # box-wide cap of 24) rather than silently running single-worker, no cap.
+    parser.add_argument("--workers", default="6")
+    parser.add_argument("--workers-budget", default="24")
     args = parser.parse_args()
 
     force = _parse_bool(args.force)

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -175,7 +175,7 @@ def main() -> None:
     # blank) falls back to the conservative default rather than failing
     # the whole launch. --workers must be >= 1; --workers-budget >= 0
     # (0 = unlimited / disabled).
-    sdc_workers = 4
+    sdc_workers = 6
     if args.workers.strip():
         try:
             sdc_workers = int(args.workers)
@@ -186,7 +186,7 @@ def main() -> None:
                 response_url,
                 f"Invalid --workers value: {args.workers!r} (must be an integer >= 1).",
             )
-    sdc_workers_budget = 16
+    sdc_workers_budget = 24
     if args.workers_budget.strip():
         try:
             sdc_workers_budget = int(args.workers_budget)

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -285,6 +285,9 @@ def _format_slots_line(ssm) -> str | None:
             ssm,
             f"D={DEFAULT_SLOT_DIR}; "
             f'if [ ! -d "$D" ]; then echo NODIR; exit 0; fi; '
+            # Without lslocks, grep -c on empty stdin returns 0 and we'd
+            # silently report "all free" — so bail to NODATA instead of lying.
+            f"command -v lslocks >/dev/null 2>&1 || {{ echo NODATA; exit 0; }}; "
             f'echo "TOTAL $(ls "$D" 2>/dev/null | wc -l)"; '
             f"for i in 1 2 3 4; do lslocks 2>/dev/null | grep -c sdc-sync-worker-slots; sleep 1; done",
         )
@@ -296,7 +299,7 @@ def _format_slots_line(ssm) -> str | None:
     held_samples: list[int] = []
     for ln in (out or "").splitlines():
         ln = ln.strip()
-        if ln == "NODIR":
+        if ln in ("NODIR", "NODATA"):
             return None
         if ln.startswith("TOTAL "):
             total = int(ln.split()[1])

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import shlex
+import statistics
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import boto3
@@ -16,6 +17,7 @@ import requests
 
 from ingest_wikimedia.partners import PARTNER_DIR, parse_session_labels, resolve_slug
 from ingest_wikimedia.ssm import REGION, fetch_memory_snapshot, ssm_run
+from ingest_wikimedia.worker_slots import DEFAULT_SLOT_DIR
 
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
@@ -275,10 +277,45 @@ def _format_memory_line(snapshot: tuple[int, int] | None) -> str | None:
     return f"Memory: {used_mb:,} / {total_mb:,} MB used ({pct_available}% available)"
 
 
+def _format_slots_line(ssm) -> str | None:
+    """Report box-wide SDC slot headroom (free count) for the status post,
+    or ``None`` if no budget-enabled session has created the slot dir."""
+    try:
+        out = ssm_run(
+            ssm,
+            f"D={DEFAULT_SLOT_DIR}; "
+            f'if [ ! -d "$D" ]; then echo NODIR; exit 0; fi; '
+            f'echo "TOTAL $(ls "$D" 2>/dev/null | wc -l)"; '
+            f"for i in 1 2 3 4; do lslocks 2>/dev/null | grep -c sdc-sync-worker-slots; sleep 1; done",
+        )
+    except Exception as e:
+        logging.warning("Could not read slot headroom: %s", e)
+        return None
+    # Parse "TOTAL <n>" followed by the integer held-count samples.
+    total = None
+    held_samples: list[int] = []
+    for ln in (out or "").splitlines():
+        ln = ln.strip()
+        if ln == "NODIR":
+            return None
+        if ln.startswith("TOTAL "):
+            total = int(ln.split()[1])
+        elif ln.isdigit():
+            held_samples.append(int(ln))
+    if not total or not held_samples:
+        return None
+    # Median of the samples: slot ownership churns every few seconds, so this
+    # smooths a transient all-held/all-free blip into a representative reading.
+    held = round(statistics.median(held_samples))
+    free = max(0, total - held)
+    return f"SDC slots: ~{free} free of {total} ({held} held)"
+
+
 def post_to_slack(
     token: str,
     rows: list[tuple[str, str]],
     memory_line: str | None = None,
+    slots_line: str | None = None,
 ) -> None:
     lines = "\n".join(f"`{session:<32}` {phase}" for session, phase in rows)
     blocks: list[dict] = [
@@ -288,9 +325,13 @@ def post_to_slack(
         },
         {"type": "section", "text": {"type": "mrkdwn", "text": lines}},
     ]
-    if memory_line:
+    context_bits = [b for b in (slots_line, memory_line) if b]
+    if context_bits:
         blocks.append(
-            {"type": "context", "elements": [{"type": "mrkdwn", "text": memory_line}]}
+            {
+                "type": "context",
+                "elements": [{"type": "mrkdwn", "text": "   •   ".join(context_bits)}],
+            }
         )
     payload = {
         "channel": SLACK_CHANNEL,
@@ -485,17 +526,19 @@ def main() -> None:
     # Memory snapshot is independent of every per-session fetch — submit it
     # to the same executor so the SSM round-trip overlaps with the session
     # phase resolution rather than serializing after it.
-    with ThreadPoolExecutor(max_workers=min(len(sessions) + 1, 8)) as executor:
+    with ThreadPoolExecutor(max_workers=min(len(sessions) + 2, 8)) as executor:
         memory_future = executor.submit(fetch_memory_snapshot, ssm)
+        slots_future = executor.submit(_format_slots_line, ssm)
         futures = {executor.submit(fetch, s): s for s in sessions}
         for future in as_completed(futures):
             session, phase = future.result()
             results[session] = phase
             print(f"{session}: {phase}")
         memory_line = _format_memory_line(memory_future.result())
+        slots_line = slots_future.result()
 
     rows = [(s, results[s]) for s in sessions if s in results]
-    post_to_slack(token, rows, memory_line=memory_line)
+    post_to_slack(token, rows, memory_line=memory_line, slots_line=slots_line)
     print("Posted to Slack.")
 
 

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -607,6 +607,7 @@ def test_run_partner_mode_acquires_one_slot_per_item_when_workers_is_one(
     class _SpyBudget:
         def __init__(self, budget):
             self.budget = budget
+            self.total_wait_seconds = 0.0
 
         @contextlib.contextmanager
         def acquire(self):

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -519,6 +519,31 @@ def test_notify_sdc_complete_stats_reflect_tracker_counts():
     assert _idx("PAGES EDITED:") < _idx("CLAIMS ADDED:")
 
 
+def test_notify_sdc_complete_reports_slot_wait_contention():
+    """SLOT WAIT shows the per-worker average (aggregate worker-seconds ÷
+    workers) as a share of runtime — a stable whole-run contention figure,
+    not a point-in-time slot-count snapshot."""
+    tracker = MagicMock(spec=Tracker)
+    # 240 worker-seconds aggregate ÷ 4 workers = 60s avg/worker; over a
+    # 300s runtime that's 20%.
+    counts = {Result.SDC_SLOT_WAIT_SECONDS: 240}
+    tracker.count.side_effect = lambda r: counts.get(r, 0)
+    captured: dict = {}
+    with (
+        patch.dict(os.environ, {"DPLA_SLACK_BOT_TOKEN": "x"}, clear=True),
+        patch("ingest_wikimedia.slack._post_completion_notice") as mock_post,
+    ):
+        mock_post.side_effect = lambda **kwargs: captured.update(kwargs)
+        notify_sdc_complete(
+            tracker=tracker,
+            partner_label="nara",
+            elapsed_seconds=300.0,
+            workers=4,
+        )
+    line = next(s for s in captured["stats_lines"] if s.startswith("SLOT WAIT"))
+    assert "20%" in line
+
+
 def test_notify_sdc_complete_dry_run_adds_suffix():
     """`dry_run=True` appends the same italicized note as upload-complete."""
     tracker = MagicMock(spec=Tracker)

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -526,3 +526,14 @@ def test_format_slots_line_none_when_no_slot_dir():
 
     with patch("scripts.wikimedia_upload_status.ssm_run", return_value="NODIR\n"):
         assert _format_slots_line(object()) is None
+
+
+def test_format_slots_line_none_when_lslocks_absent():
+    """lslocks missing → NODATA → no line (rather than a misleading "all
+    free" from grep -c on empty stdin)."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import _format_slots_line
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", return_value="NODATA\n"):
+        assert _format_slots_line(object()) is None

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -502,3 +502,27 @@ def test_post_to_slack_omits_memory_block_when_none():
         post_to_slack("tok", [("wikimedia-bpl", "Uploading")], memory_line=None)
     payload = mock_post.call_args.kwargs["json"]
     assert not any(b.get("type") == "context" for b in payload["blocks"])
+
+
+def test_format_slots_line_reports_free_headroom():
+    """Median of the held-count samples → free = total − held; reports the
+    stable headroom count, not who holds what."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import _format_slots_line
+
+    # TOTAL 24, held samples [16,14,17,15] → median 15.5 → 16 held → 8 free.
+    out = "TOTAL 24\n16\n14\n17\n15\n"
+    with patch("scripts.wikimedia_upload_status.ssm_run", return_value=out):
+        line = _format_slots_line(object())
+    assert line == "SDC slots: ~8 free of 24 (16 held)"
+
+
+def test_format_slots_line_none_when_no_slot_dir():
+    """No slot dir (no budget-enabled session has run) → no line."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import _format_slots_line
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", return_value="NODIR\n"):
+        assert _format_slots_line(object()) is None

--- a/tests/test_worker_slots.py
+++ b/tests/test_worker_slots.py
@@ -197,3 +197,37 @@ def test_acquire_releases_on_exception_in_block(tmp_path):
         pass
     # Slot must be free despite the exception.
     assert not _slot_is_held(str(tmp_path), 0)
+
+
+def test_total_wait_seconds_zero_when_uncontended(tmp_path):
+    """An acquire that finds a free slot on the first scan adds ~0 to the
+    cumulative wait counter, so an uncontended session reports no
+    contention."""
+    budget = WorkerSlotBudget(budget=2, slot_dir=str(tmp_path))
+    with budget.acquire():
+        pass
+    assert budget.total_wait_seconds < 0.5
+
+
+def test_total_wait_seconds_accumulates_when_blocked(tmp_path):
+    """When the only slot is held by a foreign session, acquire() blocks
+    and the blocked time is added to total_wait_seconds once it proceeds."""
+    budget = WorkerSlotBudget(budget=1, slot_dir=str(tmp_path))
+    proceeded = threading.Event()
+
+    def worker():
+        with budget.acquire():
+            proceeded.set()
+
+    stack = contextlib.ExitStack()
+    stack.enter_context(_foreign_flock(str(tmp_path), 0))
+    t = threading.Thread(target=worker)
+    t.start()
+    try:
+        # Hold the only slot long enough that the worker must poll-wait.
+        assert not proceeded.wait(timeout=0.8)
+    finally:
+        stack.close()  # release so the worker can proceed
+    assert proceeded.wait(timeout=3)
+    t.join(timeout=1)
+    assert budget.total_wait_seconds > 0.3

--- a/tests/test_worker_slots.py
+++ b/tests/test_worker_slots.py
@@ -230,4 +230,5 @@ def test_total_wait_seconds_accumulates_when_blocked(tmp_path):
         stack.close()  # release so the worker can proceed
     assert proceeded.wait(timeout=3)
     t.join(timeout=1)
+    assert not t.is_alive(), "worker thread should exit after slot release"
     assert budget.total_wait_seconds > 0.3

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -4237,6 +4237,7 @@ def _worker_partner_task(args):
     """
     partner, dpla_id, idx, total = args
     prior = tracker.snapshot()
+    wait_before = _worker_slot_budget.total_wait_seconds
     try:
         # Workers create their own S3Client lazily on first use; the
         # parent's instance can't cross the process boundary cleanly
@@ -4265,6 +4266,12 @@ def _worker_partner_task(args):
         # (e.g. an acquire()/setup fault); otherwise they drop silently from
         # the tally while the per-ordinal handler owns the routine failures.
         tracker.increment(Result.SDC_ITEMS_SKIPPED_ERROR)
+    # Fold this task's slot-wait into the tracker so the parent aggregates
+    # contention across all workers (worker-seconds). Whole seconds only —
+    # sub-second waits (uncontended acquires) round to 0 and don't clutter.
+    wait_delta = round(_worker_slot_budget.total_wait_seconds - wait_before)
+    if wait_delta:
+        tracker.increment(Result.SDC_SLOT_WAIT_SECONDS, wait_delta)
     return tracker.diff(prior)
 
 
@@ -4701,6 +4708,10 @@ def _run_partner_mode(partner, ids_file):
                     _process_one_partner_item(
                         s3, partner, dpla_id, local_count, len(dpla_ids)
                     )
+            # One process, so its accumulated wait IS the session total.
+            slot_wait = round(slot_budget.total_wait_seconds)
+            if slot_wait:
+                tracker.increment(Result.SDC_SLOT_WAIT_SECONDS, slot_wait)
         else:
             _run_partner_mode_parallel(partner, dpla_ids, workers)
         completed = True
@@ -4744,6 +4755,7 @@ def _run_partner_mode(partner, ids_file):
                 tracker=tracker,
                 partner_label=partner,
                 elapsed_seconds=elapsed,
+                workers=workers,
             )
         else:
             logging.warning(

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -4267,9 +4267,11 @@ def _worker_partner_task(args):
         # the tally while the per-ordinal handler owns the routine failures.
         tracker.increment(Result.SDC_ITEMS_SKIPPED_ERROR)
     # Fold this task's slot-wait into the tracker so the parent aggregates
-    # contention across all workers (worker-seconds). Whole seconds only —
-    # sub-second waits (uncontended acquires) round to 0 and don't clutter.
-    wait_delta = round(_worker_slot_budget.total_wait_seconds - wait_before)
+    # contention across all workers (worker-seconds). Diff the *floored*
+    # cumulative wait rather than rounding the per-task delta: whole-second
+    # boundary crossings telescope to int(total), so sustained sub-second
+    # waits aren't each rounded away to 0.
+    wait_delta = int(_worker_slot_budget.total_wait_seconds) - int(wait_before)
     if wait_delta:
         tracker.increment(Result.SDC_SLOT_WAIT_SECONDS, wait_delta)
     return tracker.diff(prior)
@@ -4709,7 +4711,7 @@ def _run_partner_mode(partner, ids_file):
                         s3, partner, dpla_id, local_count, len(dpla_ids)
                     )
             # One process, so its accumulated wait IS the session total.
-            slot_wait = round(slot_budget.total_wait_seconds)
+            slot_wait = int(slot_budget.total_wait_seconds)
             if slot_wait:
                 tracker.increment(Result.SDC_SLOT_WAIT_SECONDS, slot_wait)
         else:


### PR DESCRIPTION
## Why

First time the box-wide slot budget saturated (8 concurrent sessions), the data said we had room: **~7–8× sdc-sync throughput** vs the old single-process code (e.g. ronald-reagan 229→1,581 pages/hr; military-personnel ~395→3,214), **zero maxlag** (Commons replag 0.8 s, no pauses across ~107k writes), and an **idle box** (load 0.04, 3 GB free). The 16-cap was a sound conservative start that's proven its value; the evidence supports a measured bump.

## Changes

- **Defaults raised** (kept in sync across `scripts/wikimedia_launch.py` argparse and `.github/workflows/wikimedia-launch.yml` inputs): `--workers-budget` 16 → **24**, `--workers` 4 → **6**. 6 lets a low-contention session use more of the 24-slot cap while keeping the **resident worker-process count** — the real memory constraint on the 2-vCPU / 7.6 GB box — bounded (8 was OOM-risky).
- **Per-run contention metric.** `WorkerSlotBudget` accumulates `total_wait_seconds`; sdc-sync folds it into a new `SDC_SLOT_WAIT_SECONDS` tracker counter (worker-seconds, aggregated through the existing snapshot/diff/merge — the same path every other counter uses), surfaced in the SDC completion Slack summary as a **per-worker-average share of runtime**. A stable whole-run figure, not a misleading point-in-time snapshot.
- **Live headroom.** `wikimedia_upload_status` (powers both the on-demand `/wikimedia-status` and the scheduled summary — same script) now reports **free-slot count**, sampled and median'd over ~4 s to smooth the per-second churn in slot ownership, and overlapped inside the existing `ThreadPoolExecutor` so it adds no status-post latency.

## Tests

`WorkerSlotBudget` wait accumulation (uncontended ≈ 0; blocked accrues); slack SLOT WAIT line math; `_format_slots_line` headroom parse + NODIR → None; existing slot/launch/sdc tests updated for the new defaults and contention wiring. Full suite: 737 passed; ruff clean; simplify pass applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR increases SDC worker parallelism defaults and adds visibility into worker-slot contention and live slot headroom. The slot budget is raised from **16→24** concurrent slots and the default worker count from **4→6**, motivated by production throughput gains (~7–8×) while maintaining **zero maxlag** and no observed pauses. It also improves reporting so contention can be quantified and monitored over time.

## Deployment Impact

**No ECS redeployment required.** The updated defaults and reporting take effect on the **next** wikimedia launch/status run after the updated code is deployed/executed (manual bare launches pick up the updated script defaults; workflow runs pass the updated inputs explicitly).

## Changes

### SDC parallelism defaults (workflow + launch script)
- Updated workflow inputs in `.github/workflows/wikimedia-launch.yml`:
  - `workers`: **"4" → "6"**
  - `workers_budget`: **"16" → "24"**
- Updated corresponding CLI defaults/fallbacks in `scripts/wikimedia_launch.py`:
  - `--workers` default **"6"**
  - `--workers-budget` default **"24"**
- Fix: ensured blank/unset workflow inputs don’t silently downgrade to old **4/16** defaults.

### Contention visibility metric
- Added `Result.SDC_SLOT_WAIT_SECONDS` in `ingest_wikimedia/tracker.py` for aggregate “worker-seconds blocked by slot-budget contention”.
- Extended `WorkerSlotBudget` in `ingest_wikimedia/worker_slots.py` to track `total_wait_seconds` while blocked in `acquire()`.
- Instrumentation in `tools/sdc_sync.py`:
  - Measures per-worker slot wait and increments `SDC_SLOT_WAIT_SECONDS` using an **integer diff** of floored cumulative wait before/after processing (fixing prior undercount from per-task rounding).
  - Passes `workers=workers` into the completion Slack notifier.

### Slack completion + status enhancements
- Updated `notify_sdc_complete` in `ingest_wikimedia/slack.py` to accept `workers: int` and report:
  - **`SLOT WAIT (avg/wkr)`** derived from `SDC_SLOT_WAIT_SECONDS` as a per-worker average and expressed as a % of elapsed runtime.
- Updated `scripts/wikimedia_upload_status.py` to include live SDC slot headroom in Slack context:
  - Samples held-slot counts and uses a **median filter** (smoothed over a few seconds).
  - Adds a robust guard in `_format_slots_line` to return `None` when `lslocks` isn’t available (avoids false “all free” reporting).
  - Extends `post_to_slack(..., slots_line=...)` and computes slot/memory lines concurrently.

### Test updates
- Added/updated coverage for:
  - `WorkerSlotBudget.total_wait_seconds`
  - contention % formatting in Slack completion
  - slot headroom line generation and `NODIR`/`NODATA` cases
- Fix: updated spy helpers to match the production object shape for `total_wait_seconds`.
- Added an assertion that worker threads terminate after timed joins (preventing stuck-thread false positives).
- **737 tests passed; ruff validation clean.**

## Manual triggers / API / infra / security checks
- **No database migrations**.
- **No environment variables or Secrets Manager keys added/removed/renamed** (existing AWS/Slack secrets are reused).
- **No shared infrastructure configuration changes** beyond the workflow input defaults.
- **No public API response shape changes or endpoint additions/removals**.
- **No security/auth changes**; Slack output and SSM-based slot/status checks use the existing auth/credential flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->