### PR TITLE
Isolate per-page SDC cleanup failures; flag sessions waiting on slots

### DIFF
--- a/ingest_wikimedia/worker_slots.py
+++ b/ingest_wikimedia/worker_slots.py
@@ -99,6 +99,12 @@ DEFAULT_SLOT_DIR = "/tmp/sdc-sync-worker-slots"
 # keeps latency low without busy-spinning.
 _POLL_INTERVAL_SECONDS = 0.5
 
+# Stable fragment of the "all slots held" log line. Status tooling greps
+# the sdc-sync log tail for this to tell that a session's workers are
+# blocked on the cap; keep it in the format string below so the two can't
+# drift.
+SLOTS_BUSY_LOG_MARKER = "worker slots busy"
+
 
 class WorkerSlotBudget:
     """A box-wide N-permit semaphore backed by ``fcntl.flock`` slot files.
@@ -211,8 +217,9 @@ class WorkerSlotBudget:
             # concurrency), then poll.
             if not waited_logged:
                 logging.info(
-                    " -- All %d worker slots busy; waiting for capacity.",
+                    " -- All %d %s; waiting for capacity.",
                     self.budget,
+                    SLOTS_BUSY_LOG_MARKER,
                 )
                 waited_logged = True
             time.sleep(_POLL_INTERVAL_SECONDS)

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -17,7 +17,7 @@ import requests
 
 from ingest_wikimedia.partners import PARTNER_DIR, parse_session_labels, resolve_slug
 from ingest_wikimedia.ssm import REGION, fetch_memory_snapshot, ssm_run
-from ingest_wikimedia.worker_slots import DEFAULT_SLOT_DIR
+from ingest_wikimedia.worker_slots import DEFAULT_SLOT_DIR, SLOTS_BUSY_LOG_MARKER
 
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
@@ -184,8 +184,19 @@ def get_phase_and_progress(
 
     # Append a staleness warning to any active (non-complete) phase whose log
     # hasn't been updated in _STALE_SECONDS. Completed phases never get this.
+    # A session is "waiting on slots" when its *last* log line is the box-wide
+    # budget's wait message — i.e. all its workers are currently blocked on the
+    # cap. Keyed on the last line (not anywhere in the tail) so a session that
+    # waited briefly and then resumed isn't flagged.
+    last_log_line = tail.splitlines()[-1] if tail else ""
+    waiting_on_slots = SLOTS_BUSY_LOG_MARKER in last_log_line
+    slot_suffix = " ⏸ waiting on slots" if waiting_on_slots else ""
+
     stale_suffix = ""
-    if counts_marker == 0 and now > 0 and log_mtime > 0:
+    # A blocked session legitimately stops writing to its log while polling,
+    # so don't also flag it as idle/hung — the slot suffix already explains
+    # the silence.
+    if counts_marker == 0 and now > 0 and log_mtime > 0 and not waiting_on_slots:
         idle = now - log_mtime
         if idle > _STALE_SECONDS:
             idle_min = idle // 60
@@ -231,7 +242,7 @@ def get_phase_and_progress(
                 log_mtime,
             )
         return (
-            f"Uploading ({dpla_id_count:,} / {total:,}, ~{pct(dpla_id_count)}%){stale_suffix}",
+            f"Uploading ({dpla_id_count:,} / {total:,}, ~{pct(dpla_id_count)}%){slot_suffix}{stale_suffix}",
             log_mtime,
         )
 
@@ -246,14 +257,14 @@ def get_phase_and_progress(
         # summary surfaces the real synced count via the tracker's
         # SDC_ITEMS_SYNCED line.
         if dpla_id_count == 0:
-            return "SDC syncing (starting...)", log_mtime
+            return f"SDC syncing (starting...){slot_suffix}", log_mtime
         if counts_marker > 0:
             return (
                 f"{_SDC_COMPLETE_PREFIX} ({dpla_id_count:,} items processed)",
                 log_mtime,
             )
         return (
-            f"SDC syncing ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}",
+            f"SDC syncing ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){slot_suffix}{stale_suffix}",
             log_mtime,
         )
 

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -230,9 +230,12 @@ def get_phase_and_progress(
 
     if log_file.endswith("-upload.log"):
         if dpla_id_count == 0:
-            # dpla_id_count == 0 means no items logged yet — uploader just started.
-            # Staleness here would be a false positive from the normal start-up lag.
-            return "Uploading (starting...)", log_mtime
+            # No items logged yet. Distinguish a genuine just-started session
+            # ("starting...") from one parked behind the box-wide cap before
+            # its first item ("queued"). Staleness is suppressed either way —
+            # no progress yet is expected, not a stall.
+            start_state = "queued" if waiting_on_slots else "starting..."
+            return f"Uploading ({start_state}){slot_suffix}", log_mtime
         # Use the COUNTS: terminal marker as the definitive completion signal.
         # dpla_id_count is logged at the start of each item, not after all its
         # files finish, so count arithmetic alone can fire too early.
@@ -257,7 +260,8 @@ def get_phase_and_progress(
         # summary surfaces the real synced count via the tracker's
         # SDC_ITEMS_SYNCED line.
         if dpla_id_count == 0:
-            return f"SDC syncing (starting...){slot_suffix}", log_mtime
+            start_state = "queued" if waiting_on_slots else "starting..."
+            return f"SDC syncing ({start_state}){slot_suffix}", log_mtime
         if counts_marker > 0:
             return (
                 f"{_SDC_COMPLETE_PREFIX} ({dpla_id_count:,} items processed)",
@@ -289,8 +293,12 @@ def _format_memory_line(snapshot: tuple[int, int] | None) -> str | None:
 
 
 def _format_slots_line(ssm) -> str | None:
-    """Report box-wide SDC slot headroom (free count) for the status post,
-    or ``None`` if no budget-enabled session has created the slot dir."""
+    """Report box-wide worker-slot headroom (free count) for the status post,
+    or ``None`` if no budget-enabled session has created the slot dir.
+
+    The cap is shared by every Commons-writing phase — uploader (uploads,
+    renames, template migrations, purges) as well as sdc-sync — so the line
+    is not SDC-specific."""
     try:
         out = ssm_run(
             ssm,
@@ -322,7 +330,7 @@ def _format_slots_line(ssm) -> str | None:
     # smooths a transient all-held/all-free blip into a representative reading.
     held = round(statistics.median(held_samples))
     free = max(0, total - held)
-    return f"SDC slots: ~{free} free of {total} ({held} held)"
+    return f"Worker slots: ~{free} free of {total} ({held} held)"
 
 
 def post_to_slack(

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1666,6 +1666,54 @@ def test_post_sdc_cleanup_for_legacy_mode_reuses_cached_doc(monkeypatch):
     assert "dpla-1" not in sdc_sync._legacy_mode_doc_cache
 
 
+def test_post_sdc_cleanup_for_item_isolates_per_page_failures(monkeypatch, caplog):
+    """A per-page cleanup failure is isolated: the failing page is skipped and
+    its siblings still count. (See _post_sdc_cleanup_for_item for why this must
+    not propagate.)"""
+    import json
+    import logging as _logging
+
+    from ingest_wikimedia import wikimedia
+    from ingest_wikimedia.dpla import DPLA
+    from tools import sdc_sync
+
+    s3 = MagicMock()
+    s3.get_item_metadata.return_value = json.dumps({"id": "d1", "sourceResource": {}})
+    monkeypatch.setattr(sdc_sync, "hubs", {}, raising=False)
+    monkeypatch.setattr(sdc_sync, "site", MagicMock(name="site"), raising=False)
+    monkeypatch.setattr(
+        DPLA,
+        "get_provider_and_data_provider",
+        staticmethod(lambda doc, hubs: ({"name": "p"}, {"name": "d"})),
+    )
+    monkeypatch.setattr(
+        wikimedia, "dpla_metadata_params", lambda *a, **kw: {"title": "x"}
+    )
+    monkeypatch.setattr(
+        sdc_sync.pywikibot, "FilePage", lambda site, title: MagicMock(name=title)
+    )
+
+    calls = []
+
+    def fake_page_cleanup(page, *a, **kw):
+        calls.append(1)
+        if len(calls) == 1:
+            raise TimeoutError("Maximum retries attempted without success.")
+        return True
+
+    monkeypatch.setattr(sdc_sync, "_post_sdc_cleanup_for_page", fake_page_cleanup)
+
+    with caplog.at_level(_logging.ERROR):
+        edited = sdc_sync._post_sdc_cleanup_for_item(
+            s3, "nara", "d1", [("1", {"title": "T1"}), ("2", {"title": "T2"})]
+        )
+
+    # No exception propagated; the failing page is skipped, the sibling counts.
+    assert edited == {"2"}
+    assert len(calls) == 2, "both pages must be attempted despite the first failing"
+    assert any("post-SDC cleanup failed" in r.message for r in caplog.records)
+
+
 # ---------------------------------------------------------------------------
 # _post_sdc_cleanup_for_page — strip-or-migrate dispatcher
 # ---------------------------------------------------------------------------

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -127,6 +127,8 @@ def _fake_ssm_for_phase(
     csv_total: int,
     *,
     mtime: int = 1700000000,
+    now: int | None = None,
+    tail: str = "last log line",
 ):
     """Build a fake `ssm_run` that returns the precheck + counts payload
     `get_phase_and_progress` expects, with the named log file and counts.
@@ -145,13 +147,15 @@ def _fake_ssm_for_phase(
     call_count = [0]
     sep = "__WM_SEP__"
 
+    now_val = mtime if now is None else now
+
     def fake_ssm_run(_client, _command, **_kwargs):
         call_count[0] += 1
         if call_count[0] == 1:
             return f"{mtime}\n{log_filename}\n"
-        # now and mtime both come from the same `mtime` parameter so the
-        # staleness suffix never fires (now == mtime → idle == 0).
-        body = f"{mtime}\n{mtime}\n{sep}\nlast log line\n{sep}\n"
+        # Default now == mtime so the staleness suffix never fires (idle == 0);
+        # callers pass an explicit later ``now`` to exercise staleness.
+        body = f"{now_val}\n{mtime}\n{sep}\n{tail}\n{sep}\n"
         body += "\n".join(str(n) for n in awk_counts) + "\n"
         body += f"{csv_total}\n"
         return body
@@ -275,6 +279,32 @@ def test_get_phase_and_progress_reports_sdc_syncing_in_progress():
     # mtime is the second tuple element — present so callers can compare
     # across labels (see test_main_picks_latest_active_label_by_mtime).
     assert log_mtime > 0
+
+
+def test_get_phase_and_progress_flags_waiting_on_slots():
+    """When the sdc-log tail's last line is the slot-budget wait message,
+    the phase is annotated 'waiting on slots' — and the idle/stale warning
+    is suppressed (a blocked session legitimately stops writing its log)."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_phase(
+        log_filename="20260616-000000-nara+x-sdc.log",
+        awk_counts=[100, 0, 0, 0],
+        csv_total=200,
+        mtime=1700000000,
+        now=1700000000
+        + 3600,  # 1h since last log write — would be "idle" if not waiting
+        tail=" -- All 16 worker slots busy; waiting for capacity.",
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _ = get_phase_and_progress(
+            client=None, session="wikimedia-nara+x", hub="nara", label="nara+x"
+        )
+    assert phase.startswith("SDC syncing")
+    assert "waiting on slots" in phase
+    assert "idle" not in phase, "stale/idle warning must be suppressed while waiting"
 
 
 def test_get_phase_and_progress_reports_sdc_complete():

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -353,6 +353,29 @@ def test_get_phase_and_progress_reports_sdc_starting_with_no_items():
     assert phase == "SDC syncing (starting...)"
 
 
+def test_get_phase_and_progress_reports_sdc_queued_when_waiting():
+    """An -sdc.log with no items logged yet whose tail is the slot-budget
+    wait message is "queued" (parked behind the cap), not "starting..."."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_phase(
+        log_filename="20260525-200000-minnesota-sdc.log",
+        awk_counts=[0, 0, 0, 0],
+        csv_total=10,
+        tail=" -- All 16 worker slots busy; waiting for capacity.",
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-minnesota",
+            hub="minnesota",
+            label="minnesota",
+        )
+    assert phase == "SDC syncing (queued) ⏸ waiting on slots"
+
+
 def test_main_picks_latest_active_label_by_mtime_when_earlier_label_aborted():
     """Regression: when a multi-target session has an EARLIER label whose
     phase ended without a COUNTS terminal marker (e.g. an SDC sync that
@@ -545,7 +568,7 @@ def test_format_slots_line_reports_free_headroom():
     out = "TOTAL 24\n16\n14\n17\n15\n"
     with patch("scripts.wikimedia_upload_status.ssm_run", return_value=out):
         line = _format_slots_line(object())
-    assert line == "SDC slots: ~8 free of 24 (16 held)"
+    assert line == "Worker slots: ~8 free of 24 (16 held)"
 
 
 def test_format_slots_line_none_when_no_slot_dir():

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -3818,14 +3818,30 @@ def _post_sdc_cleanup_for_item(
                 f" {ord_str} ({title}) of {dpla_id}; skipping."
             )
             continue
-        if _post_sdc_cleanup_for_page(
-            page,
-            dpla_id,
-            item_metadata,
-            provider,
-            data_provider,
-            expected_params=expected_params,
-        ):
+        # Best-effort, per page: the post-SDC cleanup (wikitext strip /
+        # legacy migration) loads the page text, which can hit a transient
+        # Commons API timeout under concurrency. The item's SDC has already
+        # synced and been counted by the time we get here, so a cleanup
+        # failure must NOT escape to the worker-task boundary — that would
+        # mis-count the item as SDC_ITEMS_SKIPPED_ERROR (double-counting an
+        # already-synced item) and skip the PAGES_EDITED tally for its other
+        # pages. Skip this page; it re-cleans idempotently on a later run.
+        try:
+            saved = _post_sdc_cleanup_for_page(
+                page,
+                dpla_id,
+                item_metadata,
+                provider,
+                data_provider,
+                expected_params=expected_params,
+            )
+        except Exception:
+            logging.exception(
+                f" -- cleanup: post-SDC cleanup failed for ordinal {ord_str}"
+                f" ({title}) of {dpla_id}; skipping (SDC already synced)."
+            )
+            continue
+        if saved:
             edited.add(ord_str)
     return edited
 


### PR DESCRIPTION
## Why

Prompted by the `nara+...records-of-the-us-fish-and-wildlife-service` SDC summary: **11,435 items synced, but only 3,679 pages edited, 44 SKIPPED(error)**. Two issues surfaced.

## 1. Cleanup-crash double-count (`tools/sdc_sync.py`)

The items-vs-pages gap itself is expected (most items are no-ops at SDC-sync time). But the 44 errors were not benign: in `_post_sdc_cleanup_for_item`, the per-ordinal `_post_sdc_cleanup_for_page` call can raise on a **transient Commons API timeout** (e.g. loading `file_page.text`). The item's SDC has *already* synced and been counted (`SDC_ITEMS_SYNCED`) by that point, so letting the exception propagate to the worker-task boundary's broad `except` re-counted the same item as `SDC_ITEMS_SKIPPED_ERROR` — **inflating both the synced and skipped tallies and undercounting `SDC_PAGES_EDITED`** for the item's already-cleaned siblings.

Fix: wrap the per-page cleanup call best-effort (log + skip that page; it re-cleans idempotently on the next run), mirroring the adjacent `FilePage`-construction guard. The item is no longer mis-classified as a crash.

## 2. Status visibility for blocked sessions (`scripts/wikimedia_upload_status.py`)

With the new box-wide worker-slot budget, an on-demand status check gave no signal about which sessions were actively writing vs. queued behind the cap. `get_phase_and_progress` now appends **`⏸ waiting on slots`** to a session's phase when its *last* log line is the `WorkerSlotBudget` wait message — i.e. all its workers are currently blocked. While waiting, the idle/stale warning is suppressed (a blocked worker legitimately stops writing, so the old heuristic would false-positive "hung").

The wait-message marker is promoted to `worker_slots.SLOTS_BUSY_LOG_MARKER`, shared by the logger that emits it and the status grep that detects it, so the two can't drift.

## Tests
- `test_post_sdc_cleanup_for_item_isolates_per_page_failures` — a per-page cleanup failure is logged and skipped; siblings still count; exception does not escape.
- `test_get_phase_and_progress_flags_waiting_on_slots` — the slot suffix appears and the idle warning is suppressed when the log tail is the wait message.
- Full suite: **740 passed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR addresses two issues discovered during large SDC (Structured Data Commons) sync analysis.

### Issue 1: Double-count bug in per-page post-SDC cleanup exception handling
**Problem:** In `tools/sdc_sync.py`, when per-page post-SDC cleanup for an item fails (e.g., transient Commons API timeout while loading `file_page.text`), the exception could escape and cause the item to be misclassified and counted twice—once as `SDC_ITEMS_SYNCED` (before cleanup) and again as `SDC_ITEMS_SKIPPED_ERROR` (at the worker-task boundary). This inflated error tallies and could undercount successfully cleaned/edited pages.

**Solution:** `_post_sdc_cleanup_for_item` now wraps the per-page cleanup call in best-effort error handling: failures are logged with ordinal/title/DPLA context and the code `continue`s to sibling pages without propagating the exception. Cleanup failures are therefore isolated to the affected page, and re-cleaning can proceed idempotently on a subsequent run.

### Issue 2: Session status visibility for worker-slot backpressure
**Problem:** With a box-wide worker-slot capacity budget, `scripts/wikimedia_upload_status.py` previously didn’t clearly distinguish sessions actively writing versus queued behind capacity limits.

**Solution:**
- Added a stable shared marker constant `SLOTS_BUSY_LOG_MARKER` in `ingest_wikimedia/worker_slots.py` and updated the “all slots busy” log message to use it (preventing drift from a hardcoded substring).
- Updated `get_phase_and_progress` in `scripts/wikimedia_upload_status.py` to detect slot-waiting by checking the session’s last log line for `SLOTS_BUSY_LOG_MARKER`, appending `⏸ waiting on slots` to the phase when applicable.
- During slot-waiting, suppressed the usual idle/stale warning (since blocked workers may legitimately stop writing).
- Improved queue-state messaging so slot-waiting sessions report “queued” (instead of “starting...”) when no items have been logged yet; SDC-related phases similarly show `SDC syncing (queued)` and include `⏸ waiting on slots` suffixes as appropriate.
- Generalized displayed slot terminology from “SDC slots” to “Worker slots” in the slot headroom/status line.

### Tests
- Added `test_post_sdc_cleanup_for_item_isolates_per_page_failures` to verify per-page cleanup failures don’t propagate, sibling cleanup still runs, only successfully edited ordinals are returned, and an error log is emitted.
- Added upload-status tests:
  - `test_get_phase_and_progress_flags_waiting_on_slots`
  - `test_get_phase_and_progress_reports_sdc_queued_when_waiting`
- Enhanced `_fake_ssm_for_phase` to allow controlled `now` timestamps and mocked log `tail` text for the slot-wait detection scenarios.
- Test suite result: **740 passed** with **no ruff style issues**.

## Operational / compatibility notes
- No manual pipeline trigger or ECS redeployment required.
- No environment variables, AWS Secrets Manager keys, database migrations, shared infrastructure configuration (CodePipeline/CodeBuild/ECS/IAM), or public API/endpoint shape changes.
- No security/credential handling changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->