### PR TITLE
sdc: model content hubs vs service hubs; fix misnamed role constants

### DIFF
--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -68,10 +68,26 @@ Q_PUBLIC_DOMAIN = "Q19652"
 Q_COPYRIGHTED = "Q50423863"
 Q_CC0_PD_SOMEWHERE = "Q88088423"
 Q_PD_MARK_RAW = "Q6938433"
-Q_SMITHSONIAN = "Q518155"
-Q_PUBLISHER = "Q393351"
-Q_AGGREGATOR = "Q108296843"
-Q_CONTRIBUTING_INSTITUTION = "Q108296919"
+# DPLA distinguishes two kinds of hub, which take different SDC partnership
+# shapes (see ``_build_contributed_claims``):
+#   * Content hub — a large institution that IS the data provider (NARA,
+#     Smithsonian, ...). It is itself a repository and sits in P195; its
+#     "data providers" are internal departments, not independent orgs.
+#   * Service hub — an aggregating intermediary; its institutions are
+#     distinct organizations that sit in P195.
+# institutions_v2.json carries no hub-type flag, so content-hub membership
+# is enumerated here.
+Q_NARA = "Q518155"  # National Archives and Records Administration
+Q_SMITHSONIAN = "Q131626"  # Smithsonian Institution
+CONTENT_HUB_QIDS = frozenset({Q_NARA, Q_SMITHSONIAN})
+
+# object-has-role (P3831) qualifier values, named for their actual Wikidata
+# roles. A service hub's hub is an ``aggregator`` (like DPLA itself); its
+# institution is a ``repository``. A content hub is itself a ``repository``;
+# its contributing department is a ``custodial unit``.
+Q_ROLE_AGGREGATOR = "Q393351"
+Q_ROLE_REPOSITORY = "Q108296843"
+Q_ROLE_CONTRIBUTING = "Q108296919"
 Q_NARA_ITEM = "Q11723795"
 Q_NARA_FILE_UNIT = "Q59221146"
 
@@ -893,10 +909,22 @@ def _build_contributed_claims(
 ) -> list[dict]:
     """Build the three-statement P9126 chain (DPLA + hub + institution).
 
-    Each statement gets a P3831 (object of statement) qualifier identifying
-    the role: publisher for DPLA, aggregator for the hub, contributing
-    institution for the institution. The Smithsonian-hub case promotes
-    the hub to fill both hub and institution slots.
+    Each statement gets a P3831 (object has role) qualifier encoding DPLA's
+    two hub models:
+
+      * Content hub (NARA, Smithsonian, ...): the hub IS the providing
+        institution — a ``repository`` that also sits in P195 — and the
+        "institution" is an internal department, tagged as the
+        ``contributing`` (custodial) unit. DPLA is the ``aggregator`` above.
+      * Service hub (everything else): the hub is an aggregating
+        intermediary (``aggregator``, like DPLA) and the institution is a
+        distinct organization (``repository``) that also sits in P195.
+
+    These role/P195 shapes match what is already on Commons; the read side
+    (Module:DPLA) and ``dpla_claims()`` depend on them, so changing them
+    without a coordinated Commons-side rewrite would make every existing
+    P9126 statement look "unexpected" and trigger a remove+re-add on every
+    re-sync.
     """
     out: list[dict] = []
 
@@ -911,20 +939,13 @@ def _build_contributed_claims(
         claim["qualifiers"]["P3831"] = [_qualifier_item_snak("P3831", role_qid)]
         return claim
 
-    # The role qualifiers below intentionally MATCH what sdc-sync.add_contributed
-    # has been writing to Commons. Smithsonian's path distinguishes
-    # aggregator/contributing-institution; the non-Smithsonian path uses
-    # publisher/aggregator for hub/institution respectively. Changing these
-    # values without a coordinated Commons-side rewrite would make every
-    # existing P9126 statement look "unexpected" to dpla_claims() and trigger
-    # a remove+re-add on every re-sync.
-    out.append(_with_role(Q_DPLA, Q_PUBLISHER))
-    if hub == Q_SMITHSONIAN:
-        out.append(_with_role(Q_SMITHSONIAN, Q_AGGREGATOR))
-        out.append(_with_role(institution, Q_CONTRIBUTING_INSTITUTION))
+    out.append(_with_role(Q_DPLA, Q_ROLE_AGGREGATOR))
+    if hub in CONTENT_HUB_QIDS:
+        out.append(_with_role(hub, Q_ROLE_REPOSITORY))
+        out.append(_with_role(institution, Q_ROLE_CONTRIBUTING))
     else:
-        out.append(_with_role(hub, Q_PUBLISHER))
-        out.append(_with_role(institution, Q_AGGREGATOR))
+        out.append(_with_role(hub, Q_ROLE_AGGREGATOR))
+        out.append(_with_role(institution, Q_ROLE_REPOSITORY))
     return out
 
 
@@ -1446,9 +1467,10 @@ def build_claims_for_doc(
             )
         )
 
-    # P195 — collection (one statement; Smithsonian uses hub-as-institution).
+    # P195 — collection (one statement). A content hub is itself the
+    # collection/repository; a service hub's collection is its institution.
     if institution:
-        coll_qid = Q_SMITHSONIAN if hub == Q_SMITHSONIAN else institution
+        coll_qid = hub if hub in CONTENT_HUB_QIDS else institution
         claims.append(
             formattedclaim(
                 "P195",

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -1085,3 +1085,69 @@ def test_parse_other_date_template_returns_none_for_non_template():
     assert parse_other_date_template("{{some other template|x}}") is None
     # Template present but no date argument → None (nothing to convert).
     assert parse_other_date_template("{{other date|~}}") is None
+
+
+def _p9126_roles(out):
+    """(mainsnak Q-ID, P3831 role Q-ID) pairs from _build_contributed_claims."""
+
+    def _qid(v):
+        return "Q" + str(v["numeric-id"])
+
+    return [
+        (
+            _qid(c["mainsnak"]["datavalue"]["value"]),
+            _qid(c["qualifiers"]["P3831"][0]["datavalue"]["value"]),
+        )
+        for c in out
+    ]
+
+
+def test_build_contributed_claims_content_hub_shape():
+    """Pins the content-hub P9126 role shape (see _build_contributed_claims
+    for the model). Exact Q-IDs are asserted because they must match what is
+    already on Commons — a value change forces a remove+re-add on re-sync."""
+    import datetime
+
+    from ingest_wikimedia.sdc import (
+        CONTENT_HUB_QIDS,
+        Q_DPLA,
+        Q_NARA,
+        Q_ROLE_AGGREGATOR,
+        Q_ROLE_CONTRIBUTING,
+        Q_ROLE_REPOSITORY,
+        Q_SMITHSONIAN,
+        _build_contributed_claims,
+    )
+
+    assert {Q_NARA, Q_SMITHSONIAN} <= CONTENT_HUB_QIDS
+    date = datetime.date(2026, 6, 16)
+    for hub in (Q_NARA, Q_SMITHSONIAN):
+        roles = _p9126_roles(_build_contributed_claims(hub, "Q999", "abc", date))
+        assert roles == [
+            (Q_DPLA, Q_ROLE_AGGREGATOR),
+            (hub, Q_ROLE_REPOSITORY),
+            ("Q999", Q_ROLE_CONTRIBUTING),
+        ]
+
+
+def test_build_contributed_claims_service_hub_shape():
+    """Service hubs are aggregating intermediaries (aggregator role, like
+    DPLA); their institution is a distinct organization (repository) that
+    also lands in P195."""
+    import datetime
+
+    from ingest_wikimedia.sdc import (
+        Q_DPLA,
+        Q_ROLE_AGGREGATOR,
+        Q_ROLE_REPOSITORY,
+        _build_contributed_claims,
+    )
+
+    roles = _p9126_roles(
+        _build_contributed_claims("Q12345", "Q67890", "abc", datetime.date(2026, 6, 16))
+    )
+    assert roles == [
+        (Q_DPLA, Q_ROLE_AGGREGATOR),
+        ("Q12345", Q_ROLE_AGGREGATOR),
+        ("Q67890", Q_ROLE_REPOSITORY),
+    ]


### PR DESCRIPTION
## Why

The SDC partnership writer (`_build_contributed_claims` in `ingest_wikimedia/sdc.py`) encodes two distinct DPLA hub models, but the constants named them misleadingly:

- **`Q_SMITHSONIAN` actually held NARA's Q-ID (`Q518155`)** — the "Smithsonian branch" was really the NARA branch, keyed on that single hardcoded Q-ID. A real Smithsonian ingest (`Q131626`) would have silently taken the *wrong* (service-hub) path.
- **The P3831 role constants were shifted off their true Wikidata meanings**: `Q_PUBLISHER` held the **aggregator** role (`Q393351`), and `Q_AGGREGATOR` held the **repository** role (`Q108296843`).

## The two models

| | hub role | hub in P195? | institution role |
|---|---|---|---|
| **Content hub** (NARA, Smithsonian, …) | repository | ✅ the hub itself | contributing (internal department) |
| **Service hub** (everything else) | aggregator | ❌ (institution is) | repository (distinct org) |

DPLA is the `aggregator` above both. A content hub *is* the data provider; its "institution" is just an internal department. A service hub is an aggregating intermediary whose institutions are independent organizations.

## No Commons data changes

Read by their **true** role meaning, both branches already write the correct shapes today — so this is a pure naming/structure clarity change. Every Q-ID value is unchanged, verified against the live JFK/NARA SDC. **No re-sync churn.**

## Changes

- `Q_SMITHSONIAN` (`Q518155`) → **`Q_NARA`**; add the real **`Q_SMITHSONIAN = Q131626`**; introduce **`CONTENT_HUB_QIDS = {NARA, Smithsonian}`** and branch on membership instead of a single hardcoded Q-ID, so all content hubs share one path. Smithsonian is `upload:False` today, so this is forward-looking — no existing files change.
- Role constants renamed to true Wikidata roles: **`Q_ROLE_AGGREGATOR`** (`Q393351`), **`Q_ROLE_REPOSITORY`** (`Q108296843`), **`Q_ROLE_CONTRIBUTING`** (`Q108296919`).
- Branch/docstring/comments reworded to the content-hub / service-hub vocabulary.
- New tests pin the content-hub and service-hub P9126 role shapes (exact Q-IDs, since they must match Commons).

`institutions_v2.json` carries no hub-type flag, so content-hub membership is necessarily enumerated in code for now.

## Follow-up (not in this PR)

The Module:DPLA Lua read-side uses the same misnamed role vocabulary and contains a now-stale comment about the "misnamed `Q_SMITHSONIAN` constant." That cleanup rides with the upcoming module promotion, on the Commons side.

## Tests
- `test_build_contributed_claims_content_hub_shape`, `test_build_contributed_claims_service_hub_shape`
- Full suite: **743 passed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

A detailed high-level summary could not be generated for this review. Here is an overview derived from the analyzed file changes:

- **ingest_wikimedia/sdc.py**: ## AI-generated summary of changes
- **tests/test_sdc.py**: ## AI-generated summary of changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->