### PR TITLE
uploader: run the CommonsDelinker usage gate before the move, not after

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -666,7 +666,7 @@ def file_has_inbound_usage(site: BaseSite, filename: str) -> bool:
 
 
 def post_commonsdelinker_request(
-    site: BaseSite, old_filename: str, new_filename: str
+    site: BaseSite, old_filename: str, new_filename: str, check_usage: bool = True
 ) -> None:
     """Append a universal-replace request to CommonsDelinker's filemovers page.
 
@@ -675,7 +675,12 @@ def post_commonsdelinker_request(
     used by other editors on that page.
 
     No-ops when ``old_filename`` has no inbound usage to relink (see
-    ``file_has_inbound_usage``).
+    ``file_has_inbound_usage``). Callers that move-then-relink MUST run that
+    check *before* the move and pass ``check_usage=False`` here: once the
+    file has moved, ``old_filename`` is a redirect and the usage query is
+    unreliable (it can transiently read as "used" right after the move,
+    defeating the gate). The internal check remains the default for any
+    caller that asks about a title that has not just been moved.
 
     Uses the MediaWiki `appendtext` API parameter rather than the naive
     read-modify-write (`page.text = page.text + template; page.save()`).
@@ -698,7 +703,7 @@ def post_commonsdelinker_request(
         primary; conflicting concurrent edits can no longer cause
         spurious rejections.
     """
-    if not file_has_inbound_usage(site, old_filename):
+    if check_usage and not file_has_inbound_usage(site, old_filename):
         logging.info(
             " -- No inbound usage for [[File:%s]]; skipping CommonsDelinker "
             "request (nothing to relink).",

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1235,6 +1235,57 @@ def test_case1_move_suppresses_commonsdelinker_when_actual_is_sibling():
     assert kwargs.get("post_commonsdelinker") is False
 
 
+def test_move_to_correct_title_checks_usage_before_move_and_skips_when_unused():
+    """The inbound-usage gate must run BEFORE the move: afterward the old
+    title is a redirect and the usage query is unreliable. When the live
+    file has no inbound usage, no CommonsDelinker request is posted."""
+    uploader = _build_uploader_with_dpla()
+    existing = _drift_existing_file("Old Title - DPLA - a (page 1).jpg")
+    intended = _make_intended_page("New Title - DPLA - b (page 1).jpg")
+    order = []
+    existing.move.side_effect = lambda *a, **k: order.append("move")
+
+    def _usage(_site, _name):
+        order.append("usage_check")
+        return False
+
+    with (
+        patch("tools.uploader.file_has_inbound_usage", side_effect=_usage),
+        patch("tools.uploader.post_commonsdelinker_request") as mock_post,
+    ):
+        uploader._move_to_correct_title(existing, intended, "a", "Case 3")
+
+    assert order == ["usage_check", "move"], (
+        "usage must be checked before the move (old title becomes a redirect)"
+    )
+    mock_post.assert_not_called()
+
+
+def test_move_to_correct_title_posts_with_check_usage_false_when_used():
+    """When the live file IS used, the request is posted after the move with
+    check_usage=False — the pre-move decision is authoritative, so the
+    post-move (redirect) re-check is bypassed."""
+    uploader = _build_uploader_with_dpla()
+    existing = _drift_existing_file("Old Title - DPLA - a (page 1).jpg")
+    intended = _make_intended_page("New Title - DPLA - b (page 1).jpg")
+    order = []
+    existing.move.side_effect = lambda *a, **k: order.append("move")
+
+    def _usage(_site, _name):
+        order.append("usage_check")
+        return True
+
+    with (
+        patch("tools.uploader.file_has_inbound_usage", side_effect=_usage),
+        patch("tools.uploader.post_commonsdelinker_request") as mock_post,
+    ):
+        uploader._move_to_correct_title(existing, intended, "a", "Case 3")
+
+    assert order == ["usage_check", "move"]
+    mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs.get("check_usage") is False
+
+
 # ---------------------------------------------------------------------------
 # Granular skip-class counters: NOT_PRESENT vs INELIGIBLE both bump the
 # legacy ``SKIPPED`` aggregate AND a granular counter.

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -1035,6 +1035,20 @@ def test_post_commonsdelinker_request_skips_when_no_usage():
     PageCtor.assert_not_called()
 
 
+def test_post_commonsdelinker_request_check_usage_false_skips_query_and_posts():
+    """``check_usage=False`` posts without querying usage at all. Callers
+    that move-then-relink pass this after running the usage check BEFORE the
+    move, where the old title is still the live file rather than a redirect."""
+    site = MagicMock()
+    with patch("ingest_wikimedia.wikimedia.pywikibot.Page"):
+        post_commonsdelinker_request(
+            site, old_filename="Old.jpg", new_filename="New.jpg", check_usage=False
+        )
+    # No usage query issued, and the request was posted.
+    site.simple_request.assert_not_called()
+    site.editpage.assert_called_once()
+
+
 def test_tag_as_duplicate_uses_prependtext_not_read_modify_write():
     """tag_as_duplicate must use site.editpage(prependtext=...) rather
     than `file_page.text = tag + file_page.text; file_page.save()`.

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -66,6 +66,7 @@ from ingest_wikimedia.wikimedia import (
     ERROR_NOCHANGE,
     ERROR_BACKEND_FAIL,
     get_site,
+    file_has_inbound_usage,
     post_commonsdelinker_request,
 )
 
@@ -790,6 +791,9 @@ class Uploader:
         reason = build_title_drift_move_reason(
             old_filename, new_filename, dpla_id, self.site.user()
         )
+        # Gate before the move, while old_filename is still the live file
+        # (see post_commonsdelinker_request docstring).
+        needs_relink = file_has_inbound_usage(self.site, old_filename)
         logging.info(
             f"Title drift redirect detected — moving "
             f"[[File:{old_filename}]] → [[File:{new_filename}]]"
@@ -800,7 +804,16 @@ class Uploader:
             movetalk=False,
             noredirect=False,  # leave a redirect at the old title
         )
-        post_commonsdelinker_request(self.site, old_filename, new_filename)
+        if needs_relink:
+            post_commonsdelinker_request(
+                self.site, old_filename, new_filename, check_usage=False
+            )
+        else:
+            logging.info(
+                " -- No inbound usage for [[File:%s]]; skipping CommonsDelinker "
+                "request (nothing to relink).",
+                old_filename,
+            )
 
         # Fresh FilePage for the now-real file page at the intended title
         return get_page(self.site, wiki_file_page.title())
@@ -880,6 +893,11 @@ class Uploader:
         reason = build_title_drift_move_reason(
             actual_filename, intended_filename, dpla_id, self.site.user()
         )
+        # Gate before the move, while actual_filename is still the live file
+        # (see post_commonsdelinker_request docstring).
+        needs_relink = post_commonsdelinker and file_has_inbound_usage(
+            self.site, actual_filename
+        )
         logging.info(
             f"Title drift ({case_label}): moving "
             f"[[File:{actual_filename}]] → [[File:{intended_filename}]]"
@@ -890,15 +908,23 @@ class Uploader:
             movetalk=False,
             noredirect=False,
         )
-        if post_commonsdelinker:
-            post_commonsdelinker_request(self.site, actual_filename, intended_filename)
-        else:
+        if needs_relink:
+            post_commonsdelinker_request(
+                self.site, actual_filename, intended_filename, check_usage=False
+            )
+        elif not post_commonsdelinker:
             logging.info(
                 f"Suppressing CommonsDelinker request "
                 f"[[File:{actual_filename}]] → [[File:{intended_filename}]]: "
                 f"actual_filename is one of this item's current asset "
                 f"positions and will be overwritten with different content "
                 f"by a later ordinal in this session."
+            )
+        else:
+            logging.info(
+                " -- No inbound usage for [[File:%s]]; skipping CommonsDelinker "
+                "request (nothing to relink).",
+                actual_filename,
             )
 
         if wiki_markup:


### PR DESCRIPTION
## Problem

#312 added a gate so a CommonsDelinker relink request is only posted when the file being renamed actually has inbound usage. The gate logic is correct, but it lives *inside* `post_commonsdelinker_request`, which both title-drift call sites in `tools/uploader.py` invoke **after** `existing_file.move(...)`.

The move uses `noredirect=False`, so the old title becomes a **redirect** the instant the move completes. Querying `globalusage`/`fileusage` of that fresh redirect is unreliable — right after the move it can transiently read as "used" (replication/index lag), which defeats the no-usage gate. Once state settles, the same query reads clean.

**Symptom:** a re-run of a partner set (where every rename was a Case-3 hash-drift orphan migration) posted a `{{universal replace}}` request to [User:CommonsDelinker/commands/filemovers](https://commons.wikimedia.org/wiki/User:CommonsDelinker/commands/filemovers) for nearly every file, even though none had any inbound usage. The run log confirmed the gate fired only once across 136 moves.

## Fix

Run the gate **before** the move, while the old title is still the live file:

- `_move_to_correct_title` and the redirect-relic mover now compute `needs_relink = file_has_inbound_usage(...)` *before* `move()`, then post only if usage was found.
- `post_commonsdelinker_request` gains `check_usage: bool = True`. The move-then-relink callers pass `check_usage=False` (their pre-move decision is authoritative; re-querying the now-redirect title would be the same unreliable read). The internal gate stays the default for any caller asking about a title that hasn't just been moved.

No change to the gate's own logic — only *when* it runs.

## Tests

- `test_move_to_correct_title_checks_usage_before_move_and_skips_when_unused` — asserts the usage check runs **before** the move, and no request is posted when the live file is unused.
- `test_move_to_correct_title_posts_with_check_usage_false_when_used` — used file → posted after the move with `check_usage=False`.
- `test_post_commonsdelinker_request_check_usage_false_skips_query_and_posts` — `check_usage=False` issues no usage query and posts.
- Existing #312 gate tests unchanged. Full suite: **746 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a timing issue with the CommonsDelinker usage gate that was defeating the gate's purpose in determining whether a file should be relinked after a move.

## Problem

The usage check was executing *after* the file move via `existing_file.move()`. Since the move uses `noredirect=False`, the old title immediately becomes a redirect. Querying the usage of this fresh redirect produces unreliable results due to replication and index lag—it can transiently report the file as "used" right after the move. The observed symptom was CommonsDelinker requests being posted for nearly every file despite none having actual inbound usage.

## Solution

The usage check now runs *before* the file move, while the old title is still the live file.

**Key changes:**
- `post_commonsdelinker_request()` now accepts an optional `check_usage: bool = True` parameter to control whether inbound-usage probing is performed
- Updated docstring clarifies that callers performing a move-then-relink sequence should call `file_has_inbound_usage()` before the move and then call `post_commonsdelinker_request(..., check_usage=False)` to avoid unreliable usage results against the redirect
- In `_move_to_correct_title()` and `_resolve_redirect_move()`, the usage check is now called before `move()`, and the CommonsDelinker request is only posted if usage is detected
- Call sites that move-then-relink pass `check_usage=False` since their pre-move decision is authoritative

## Test Coverage

Added three new unit tests verifying:
1. `_move_to_correct_title` checks inbound usage *before* performing the move and skips posting a CommonsDelinker request when unused
2. When usage is true, CommonsDelinker posting occurs after the move with `check_usage=False`
3. When `post_commonsdelinker_request(..., check_usage=False)` is used, no usage query is issued but the edit request still succeeds

**Test results:** 746 passed, ruff clean.

## Deployment Notes

No infrastructure changes required—no database migrations, environment variable changes, shared infrastructure configuration changes, or public API modifications. No manual pipeline trigger or ECS redeployment needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->