### PR TITLE
legacy_artwork: fix AttributeError on string creator in canonical compare

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -346,20 +346,16 @@ def plan_migration(
 def _canonical_value_for_key(canonical_params: dict, key: str) -> str:
     """Pull the comparable canonical value for a key.
 
-    Scalar keys (title/description/date/permission) live at the top
-    level. The creator key is special: ``dpla_metadata_params`` emits
-    creator inside the ``{{InFi|Creator|...}}`` sub-template shape, so
-    the comparable canonical value is the second positional. Source,
-    institution, etc. are sub-template valued and not handled in
+    title/description/date/permission/creator are all scalar strings in
+    ``dpla_metadata_params``'s output — creator included (it comes from
+    ``extract_strings``, not an ``{{InFi|Creator|...}}`` sub-template dict).
+    Source, institution, etc. are sub-template valued and not handled in
     Phase 3a's scalar mapping — return empty so the equality check
-    correctly classifies them as "different" and they fall through
-    to community-import or dpla-originated based on provenance only.
+    classifies them as "different" and they fall through to community-import
+    or dpla-originated based on provenance only.
     """
-    if key in ("title", "description", "date", "permission"):
+    if key in ("title", "description", "date", "permission", "creator"):
         return str(canonical_params.get(key, ""))
-    if key == "creator":
-        creator = canonical_params.get("creator", {})
-        return str(creator.get("params", {}).get("2", ""))
     return ""
 
 

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -274,10 +274,9 @@ def _canonical_params(**overrides) -> dict:
         "description": "A description",
         "date": "1900",
         "permission": "{{Cc-zero}}",
-        "creator": {
-            "name": "InFi",
-            "params": {"1": "Creator", "2": "A Creator", "id": "fileinfotpl_aut"},
-        },
+        # creator is a plain string in dpla_metadata_params (extract_strings),
+        # NOT an {{InFi|Creator|...}} dict — see _canonical_value_for_key.
+        "creator": "A Creator",
         "source": {"name": "DPLA", "params": {}},
         "institution": {"name": "Institution", "params": {}},
         "languages": frozenset({"en"}),
@@ -341,6 +340,35 @@ def test_plan_migration_skips_community_value_that_matches_canonical():
     assert plan is not None
     assert plan.community_imports == {}
     assert plan.dpla_originated_params["title"] == "A Title"
+
+
+def test_plan_migration_imports_creator_param_that_differs_from_canonical():
+    """Regression: canonical 'creator' is a plain string (extract_strings),
+    not an {{InFi|Creator|...}} dict. A file whose Artwork template carries
+    a community creator that differs from canonical must be imported — and
+    must not raise ``AttributeError: 'str' object has no attribute 'get'``
+    (the old _canonical_value_for_key called .get() on the string)."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|creator=A Creator}}"),
+        (2, "Editor1", "{{Artwork|creator=Someone Else}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert plan.community_imports == {"creator": "Someone Else"}
+    assert "creator" not in plan.dpla_originated_params
+
+
+def test_plan_migration_skips_creator_param_matching_canonical():
+    """A community editor restating DPLA's creator verbatim is redundant —
+    canonical creator (a string) compares equal, so no import."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|creator=A Creator}}"),
+        (2, "Editor1", "{{Artwork|creator=A Creator}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert plan.community_imports == {}
+    assert plan.dpla_originated_params.get("creator") == "A Creator"
 
 
 def test_plan_migration_records_source_permalink():


### PR DESCRIPTION
## Problem

`_canonical_value_for_key` (used by `plan_migration` to compare a file's Artwork-template params against canonical DPLA values) had a `creator` branch:

```python
creator = canonical_params.get("creator", {})
return str(creator.get("params", {}).get("2", ""))
```

It assumed `creator` was an `{{InFi|Creator|...}}` sub-template dict. But `dpla_metadata_params` returns `creator` as a **plain string** (via `extract_strings`, `-> str`). So `.get()` on a string raised:

```
AttributeError: 'str' object has no attribute 'get'
```

for any file whose Artwork template carried a `creator` param. It surfaced as worker-task crashes in the legacy-migration cleanup path — e.g. 3 such crashes in the `nara+ronald-reagan-library` SDC run (`legacy_artwork.py:362` ← `plan_migration` ← `migrate_legacy_file`).

It went unnoticed because the **test fixture encoded the same wrong (dict) shape**, and no test fed a `creator` param through `plan_migration` — so the fixture agreed with the bug instead of catching it.

## Fix

`creator` is a scalar string like title/description/date/permission — fold it into that branch:

```python
if key in ("title", "description", "date", "permission", "creator"):
    return str(canonical_params.get(key, ""))
return ""
```

- Corrected the `_canonical_params` test fixture to the real string shape.
- Added two regression tests feeding a `creator` Artwork param through `plan_migration` (differs-from-canonical → imported; matches → skipped). Both raised `AttributeError` under the old code.

## Notes

This is a code bug, independent of the transient `TimeoutError`s in the same run (those are the post-SDC-cleanup timeouts that #314 now absorbs).

Full suite: **748 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes an `AttributeError` in the `_canonical_value_for_key` function within `legacy_artwork.py` that was causing worker-task crashes during legacy migration operations. The function incorrectly assumed `creator` was a dictionary representation of an `InFi` template, but `dpla_metadata_params` returns it as a plain string, causing `'str' object has no attribute 'get'` errors.

## Changes

**ingest_wikimedia/legacy_artwork.py**
- Refactored `_canonical_value_for_key` to treat `title`, `description`, `date`, `permission`, and `creator` as scalar string fields
- Simplified equality checking by consolidating these five fields into a single conditional branch that returns `str(canonical_params.get(key, ""))` for all of them
- This aligns the implementation with how these parameters are actually returned from `dpla_metadata_params`

**tests/test_legacy_artwork.py**
- Corrected the test canonical-params fixture to represent `creator` as a plain string instead of an `InFi`-shaped dictionary
- Added regression test `test_plan_migration_imports_creator_param_that_differs_from_canonical()` to verify creator handling when community editor's value differs from canonical
- Added regression test `test_plan_migration_skips_creator_param_matching_canonical()` to verify creator handling when values match
- Both new tests would have triggered the original `AttributeError` with the buggy code

## Impact

- Prevents worker-task crashes in the legacy-migration cleanup path (3 documented crashes occurred during `nara+ronald-reagan-library` SDC run)
- No changes to public APIs, infrastructure, environment variables, or database
- Test coverage: 748 tests passing, ruff validation clean

<!-- end of auto-generated comment: release notes by coderabbit.ai -->