### PR TITLE
wikimedia: exclude the file's own page from inbound-usage check (the real CommonsDelinker over-posting fix)

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -633,26 +633,37 @@ def build_title_drift_move_reason(
 
 def file_has_inbound_usage(site: BaseSite, filename: str) -> bool:
     """Return True if bare-named ``filename`` is used on another wiki
-    (``globalusage``) or a local Commons page (``fileusage``).
+    (``globalusage``) or by *another* local Commons page (``fileusage``).
 
-    Both classes are fetched in one request (capped at one row each). No
-    ``redirects``: we want usage recorded against *this* title, not a
+    The file's OWN description page is excluded from ``fileusage``: a DPLA
+    file page renders ``{{Artwork}}``/``{{Information}}`` with no explicit
+    image param, which auto-displays the page's own image, so the file is
+    listed as a user of itself. That self-reference is not an external
+    relink target — counting it made the gate fire for *every* file,
+    defeating its whole purpose. Because of that guaranteed self-row,
+    ``fileusage`` is fetched with a limit of 2: self plus at most one other
+    user is enough to tell "used by something else" from "only itself".
+
+    No ``redirects``: we want usage recorded against *this* title, not a
     redirect target. Fails open (returns True) on any error so a needed
     relink is never silently dropped.
     """
     api_site = typing.cast(APISite, site)
+    self_title = f"File:{filename}"
     try:
         result = api_site.simple_request(
             action="query",
             prop="globalusage|fileusage",
-            titles=f"File:{filename}",
+            titles=self_title,
             gulimit=1,
-            fulimit=1,
+            fulimit=2,
         ).submit()
         # Parse inside the try too: an unexpected payload shape must fail
         # open (treated as "used"), not raise or fall through to False.
         for page in result.get("query", {}).get("pages", {}).values():
-            if page.get("globalusage") or page.get("fileusage"):
+            if page.get("globalusage"):
+                return True
+            if any(u.get("title") != self_title for u in page.get("fileusage", [])):
                 return True
         return False
     except Exception as e:

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -999,14 +999,49 @@ def test_file_has_inbound_usage_one_combined_request_global_or_local():
     assert set(kwargs["prop"].split("|")) == {"globalusage", "fileusage"}
     assert kwargs["titles"] == "File:F.jpg"
     assert "redirects" not in kwargs
+    # fileusage limit must be >=2: the file's own page always occupies one
+    # row (self-reference), so a limit of 1 could only ever return self and
+    # would mask a genuine second user.
+    assert kwargs["fulimit"] == 2
 
-    # local only
+    # local only (another page embeds it)
     site = _usage_site({"query": {"pages": {"-1": {"fileusage": [{"title": "X"}]}}}})
     assert file_has_inbound_usage(site, "F.jpg") is True
 
     # neither
     site = _usage_site({"query": {"pages": {"-1": {}}}})
     assert file_has_inbound_usage(site, "F.jpg") is False
+
+
+def test_file_has_inbound_usage_ignores_self_reference():
+    """A DPLA file page lists itself in fileusage — {{Artwork}}/{{Information}}
+    with no image param auto-displays the page's own image. That self-row is
+    not an external relink target, so a file used ONLY by itself is unused.
+    (This is what made the CommonsDelinker gate fire for every file.)"""
+    site = _usage_site(
+        {"query": {"pages": {"-1": {"fileusage": [{"title": "File:F.jpg"}]}}}}
+    )
+    assert file_has_inbound_usage(site, "F.jpg") is False
+
+
+def test_file_has_inbound_usage_counts_other_user_alongside_self():
+    """Self-reference plus a genuine external user → used. fulimit=2 ensures
+    the non-self row is fetched even though self occupies one slot."""
+    site = _usage_site(
+        {
+            "query": {
+                "pages": {
+                    "-1": {
+                        "fileusage": [
+                            {"title": "File:F.jpg"},
+                            {"title": "File:Some gallery page.jpg"},
+                        ]
+                    }
+                }
+            }
+        }
+    )
+    assert file_has_inbound_usage(site, "F.jpg") is True
 
 
 def test_file_has_inbound_usage_fails_open_on_error():


### PR DESCRIPTION
## The actual root cause (#312/#314/#316 missed it)

`file_has_inbound_usage` gates CommonsDelinker relink requests on whether a file is used elsewhere. It returned **True for essentially every DPLA file**, so every rename in a re-run posted a `{{universal replace}}` request.

A DPLA file description page renders `{{Artwork}}`/`{{Information}}` **with no explicit image param**, which auto-displays the page's own image — so the file is listed in its **own** `fileusage`. The check `if page.get("fileusage")` counted that self-reference as inbound usage. `fulimit=1` compounded it: the query could only ever return the self-row.

Confirmed on live data — every still-live source page of the in-flight document had `globalusage: []` and `fileusage: [<the file itself>]`:

```
File:History of the Centennial Celebration … (page 50).jpg
  globalusage: []   fileusage: 1 → "File:History of the Centennial Celebration … (page 50).jpg"
```

The earlier move-timing PRs never touched this — they addressed *when* the gate ran. The gate was returning the wrong answer regardless of timing. (Earlier debugging was misled because the titles tested at the time were *redirects*, whose pages don't embed the image, so they read as unused.)

## Fix

- Exclude the subject file's own title from `fileusage` (`any(u["title"] != self_title …)`).
- Raise `fulimit` 1 → 2 so the self-row can't crowd out a genuine second user (self + at most one other is enough to decide "used by something else").
- `globalusage` unchanged (a file can't appear in its own usage on another wiki).

## Verification (live API)

| File | Result |
|---|---|
| `…Centennial…(page 50).jpg` (self-only — was wrongly posting) | **False** ✅ skip |
| `…Centennial…(page 120).jpg` (self-only) | **False** ✅ skip |
| `Fig. 28 - Divieto di transit…1959.svg` (real global usage on it.wikipedia) | **True** ✅ post |

## Tests
- self-only fileusage → unused; self + another user → used; `fulimit` asserted ≥2.
- Full suite: **748 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bug Fix: Correct `file_has_inbound_usage` Gate Function

This PR fixes a critical bug in the `file_has_inbound_usage` function that was causing unnecessary CommonsDelinker relink requests during file renames in re-runs.

### Root Cause
DPLA file description pages render `{{Artwork}}`/`{{Information}}` templates without explicit image parameters, which auto-displays the page's own image. This caused every DPLA file to appear in its own `fileusage` list, and the gate function incorrectly counted this self-reference as evidence of external usage. The original `fulimit=1` parameter compounded the problem by limiting results to only the self-row, making it impossible to detect genuine external usage.

### Solution
The `file_has_inbound_usage` function now:
- Excludes the file's own page title from the `fileusage` check using `any(u.get("title") != self_title ...)`
- Increases `fulimit` from 1 to 2 to allow detection of the self-row plus one genuine external user
- Leaves `globalusage` unchanged (files cannot appear in their own usage on other wikis)
- Expands the docstring to explain why self-references should not trigger relinking

### Changes
- **ingest_wikimedia/wikimedia.py**: Updated `file_has_inbound_usage` implementation and docstring (+18/-7 lines)
- **tests/test_wikimedia.py**: Added two new regression tests and strengthened existing test assertions (+36/-1 lines)

### Verification
- Live API testing confirmed files with only self-referential fileusage now return `False` and are skipped
- Files with genuine external usage still return `True`
- New tests verify self-only fileusage is treated as unused, self plus another user is treated as used, and `fulimit` is enforced at ≥2
- Full test suite: 748 passed; ruff validation clean

### Impact
This fix addresses the root cause that previous PRs (`#312`, `#314`, `#316`) were attempting to address through move timing adjustments, which did not fix the underlying gate function logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->