### PR TITLE
docs: sync doc set with code merged since the 2026-06-10 pass (#293–#318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ Pre-commit hooks use [ruff](https://docs.astral.sh/ruff/) for linting and format
 ```text
 get-ids-es <partner> [--institution NAME ...] [--collection NAME] [--single-id ID]
 downloader <ids.csv> <partner> [--max-age-days N] [--notify-complete] [--overwrite] [--dry-run] [--verbose]
-uploader   <ids.csv> <partner> [--dry-run] [--verbose]
-sdc-sync   --partner <partner> [--ids-file PATH]
+uploader   <ids.csv> <partner> [--workers-budget N] [--dry-run] [--verbose]
+sdc-sync   --partner <partner> [--ids-file PATH] [--workers N] [--workers-budget N] [--migrate-legacy] [--no-normalize-wikitext]
 sdc-sync   --file "File:Title.jpg" [--file ...] | --cat <Category> | --lists <dir>
 ```
 
 Pass `--help` to any command for full option details. In practice nothing here is invoked by hand — runs are launched via Slack and orchestrated by `scripts/wikimedia_launch.py`. See [docs/architecture.md](docs/architecture.md) for the dispatch chain.
+
+`sdc-sync`'s concurrency flags default to single-process, no-budget when run standalone (`--workers 1`, `--workers-budget 0`); the launcher and retry workflows pass `--workers 6 --workers-budget 24` so concurrent sessions cooperatively share the box-wide Commons-write cap. The uploader is single-process and likewise defaults to `--workers-budget 0` standalone, joining the shared budget only when the launcher sets it. `--migrate-legacy` runs the legacy `{{Artwork}}` → `{{DPLA metadata}}` migration instead of an SDC sync; `--no-normalize-wikitext` disables the default post-SDC strip of redundant `{{DPLA metadata}}` template params.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,16 +13,17 @@ Projects and improvements needed for this project
 
 ## Downloads
 
-- [ ] Implement parsing of IIIF v3 manifests
+- [x] Implement parsing of IIIF v3 manifests
+  - Done in `ingest_wikimedia/iiif.py`: `get_iiif_urls` dispatches on the manifest `@context` to `iiif_v3_urls` (v3) or `iiif_v2_urls` (v2).
 - [ ] Paralleize downloads
   - Paralleize around DPLA records (10 threads for 10 records).
   - For multi-page records the images are processed sequenctially. This might make aborting an entire record when one image fails.
   - *Needs further investigation*.
+  - **Note**: the downloader is still single-process — only the SDC-sync phase has been parallelized (see Metadata Sync below). This item remains open.
 
-- [ ] Implement filter to skip an entire DPLA record if the record id exists in some kind of 'banned object list'.
-
+- [x] Implement filter to skip an entire DPLA record if the record id exists in some kind of 'banned object list'.
+  - Done: `ingest_wikimedia/banlist.py` (`Banlist`) reads `dpla-id-banlist.txt`; `tools/get_ids_es.py` calls `is_banned()` to drop banned IDs at ID-generation time (and pre-checks single-ID launches before the ES round-trip).
   - This is necessary to prevent our bot from getting banned when a page is deleted for copyright reasons and we automatiicaly re-attempt to upload it on the next cycle.
-  - Likely implementation is a filter applied to data read in at Download step (similar to `--filter-filter`)
 
 ## Uploads
 
@@ -38,19 +39,25 @@ Projects and improvements needed for this project
 
 A much larger unscropped set of work that is folded into the Wikimedia Workflow document
 
+- [x] SDC-sync parallelism + box-wide worker-slot budget
+  - SDC sync runs across N worker processes (`sdc-sync --workers N`, default 6 from the launcher/workflow).
+  - A box-wide flock-backed slot budget (`--workers-budget N`, default 24) caps concurrent Commons writers across all sessions so they don't oversubscribe Commons' parser pool. See `ingest_wikimedia/worker_slots.py` and [operations → Worker-slot budget](docs/operations.md#worker-slot-budget).
+
 ## September 19th notes
+
+> **Largely superseded.** The "updating existing asset" and "duplicate check" matrices below described hash-drift / duplicate handling that has since shipped: the downloader re-fetches on hash change, and the SDC-sync phase reconciles Commons against the precomputed `sdc.json` (and migrates legacy wikitext). Kept here for historical context; not an active work item.
 
 - Dominic has deleted all the duplicates
 - There are a number of items which may have misnumbered pages.
 - Domiic to writ
 
-Functionality for updating existing asset
+Functionality for updating existing asset *(superseded — implemented as hash-drift handling + SDC sync)*
 
 - Check hash on download; if different overwrite image in s3
 - Upload asset will check if hash on s3 is different from hash in wiki
 - overwirte if different
 
-Duplicate check
+Duplicate check *(superseded)*
 case 1: hash and filename match; no op
 case 2: hash exists DPLA filename does not exist; move file to new page
 case 3: hash exists, file name disagreement between Wiki and DPLA

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,8 +38,9 @@ AWS SSM  →  EC2  (i-033eff6c8c168f999, "wiki downloads")
     │  Per target, sequentially:
     │    1. get-ids-es <partner> > <partner>.csv
     │    2. downloader <partner>.csv <partner>
-    │    3. uploader   <partner>.csv <partner>
-    │    4. sdc-sync   --partner <partner> --ids-file <partner>.csv
+    │    3. uploader   <partner>.csv <partner> --workers-budget 24
+    │    4. sdc-sync   --partner <partner> --ids-file <partner>.csv \
+    │                    --workers 6 --workers-budget 24
     ▼
 S3 (s3://dpla-wikimedia/)        Wikimedia Commons
     sidecars + media bytes       file pages + MediaInfo SDC
@@ -142,6 +143,34 @@ Session conflict rules:
 
 GitHub Actions concurrency keys layer over the SSM-level conflict detection. The Lambda passes `concurrency_key = sha256(shlex.join(targets))[:16]`; two identical dispatches collapse to the same group and queue. Different targets get different keys and run in parallel inside the workflow (the EC2-side conflict check is what serialises them if needed).
 
+### Intra-host write throttle (`WorkerSlotBudget`)
+
+The session-conflict rules above keep *distinct targets* from clobbering each other, but they don't bound how hard the box collectively hammers Commons. That's a separate, finer-grained layer.
+
+Two phases write to Commons: the **uploader** (single-process) and **sdc-sync** (parallelised across a spawn-start `multiprocessing.Pool` via `--workers N`). Each sdc-sync worker — and the uploader — does per-DPLA-*item* work, and Commons' MediaWiki parser pool only tolerates a limited number of concurrent bot writes before maxlag starts to bind. Per-session worker counts can't see each other, so 6 sessions × 6 workers would oversubscribe.
+
+`ingest_wikimedia/worker_slots.py` provides `WorkerSlotBudget`: a box-wide N-permit semaphore backed by `N` `fcntl`-flock slot files under `/tmp/sdc-sync-worker-slots` (`--workers-budget N`). Every writer — each sdc-sync Pool worker *and* the single-process uploader — checks out exactly one slot per item before its per-item Commons work and releases it on return, so **all upload and sdc-sync sessions on the host contend over the same cap**. The downloader is deliberately not in the pool (it writes to source sites, not Commons). `budget <= 0` disables the semaphore (acquire is a no-op); `flock` makes it crash-safe (a dead holder's slot frees automatically when its fd closes).
+
+```text
+  --workers-budget 24  →  /tmp/sdc-sync-worker-slots/{slot-0 … slot-23}
+                                  ▲  ▲  ▲          ▲   ▲
+   ┌───────────────────────┐     │  │  │          │   │   (24 flock'd slot files,
+   │ sdc-sync session A     │     │  │  │          │   │    box-wide, shared)
+   │  Pool(--workers 6)     │─────┘  │  │          │   │
+   │   w1 w2 w3 w4 w5 w6     │────────┘  │          │   │
+   └───────────────────────┘  (1 slot/item)        │   │
+   ┌───────────────────────┐                       │   │
+   │ sdc-sync session B …   │───────────────────────┘   │
+   └───────────────────────┘  (its 6 workers …)         │
+   ┌───────────────────────┐                            │
+   │ uploader (any session) │────────────────────────────┘
+   └───────────────────────┘  (single process, 1 slot/item)
+```
+
+**Invariant: the budget value must be identical across every concurrent session.** It is the cap's whole meaning — if two sessions disagree (24 vs 12), the effective cap degrades to the larger value while the smaller-budget session only ever competes for the lower slots. In practice the value comes from one launch-time default (see below), so all sessions agree.
+
+`tools/sdc_sync.py` itself defaults to `--workers 1 --workers-budget 0` (the single-process, no-cap path, so a hand-run sdc-sync behaves exactly as before). The production values **6 / 24** come from `scripts/wikimedia_launch.py` and the `workers` / `workers_budget` inputs on `wikimedia-launch.yml`: the launcher appends `--workers 6 --workers-budget 24` to the sdc-sync step and `--workers-budget 24` to the uploader step. The cap therefore belongs to the launch path, not to the tool's own defaults.
+
 ## Failure semantics
 
 Inside a target block, steps are chained with `&&` — any step failing aborts that target's remaining steps and triggers the `||` failure handler. The handler runs `notify_pipeline_fail()` from `ingest_wikimedia.slack`, which reads `WIKIMEDIA_LAST_EXIT` and posts a #tech-alerts message including:
@@ -175,7 +204,9 @@ The downloader and uploader also handle per-item failures internally; they only 
 | SSM client | `ingest_wikimedia/ssm.py` | `ssm_run`, `stage_and_launch_tmux` |
 | Slack helpers | `ingest_wikimedia/slack.py` | All `notify_*` functions, `notify_pipeline_fail`, log summariser |
 | Tracker | `ingest_wikimedia/tracker.py` | Per-phase counter set, used in completion messages |
-| SDC builders | `ingest_wikimedia/sdc.py` | `build_claims_for_doc`, P1545 chunking, rights mapping, NARA XML parsing |
+| SDC builders | `ingest_wikimedia/sdc.py` | `build_claims_for_doc`, P1545 chunking, rights mapping, NARA XML parsing, content-hub/service-hub partnership model (P195 + P3831 roles, `CONTENT_HUB_QIDS`) |
+| Legacy migration | `ingest_wikimedia/legacy_artwork.py` | `{{Artwork}}`→`{{DPLA metadata}}` migration: provenance walk, community-value import as SDC, wikitext rewrite |
+| Worker-slot budget | `ingest_wikimedia/worker_slots.py` | Box-wide `flock`-backed concurrent-Commons-write cap shared across all upload + sdc-sync sessions |
 | Wikimedia helpers | `ingest_wikimedia/wikimedia.py` | Title generation, hash-drift handling, CommonsDelinker post |
 | Banlist | `ingest_wikimedia/banlist.py` + `dpla-id-banlist.txt` | Per-DPLA-ID skip list |
 

--- a/docs/maintenance-tools.md
+++ b/docs/maintenance-tools.md
@@ -13,6 +13,7 @@ These tools sit alongside the four pipeline phases but are not part of the Slack
 | [`nuke`](#nuke) | Hard-delete S3 contents for a list of DPLA IDs |
 | [`get-ids-retry`](#get-ids-retry) | Parse logs to build per-hub retry CSVs |
 | [`fix-unknown-categories`](#fix-unknown-categories) | Backfill maintenance categories after partner registry changes |
+| [`sdc-sync --migrate-legacy`](#sdc-sync---migrate-legacy) | One-time migration of legacy `{{Artwork}}` files to `{{DPLA metadata}}` |
 
 ---
 
@@ -201,6 +202,35 @@ Source: `tools/fix_unknown_categories.py`.
 Walks Commons looking for files in `Category:Media contributed by the Digital Public Library of America with unknown partner` or `... with unknown institution` — files where the Lua module couldn't resolve a hub or institution category from SDC. For each, attempts to re-resolve against current `institutions_v2.json` mappings and writes the corrected categories back via wikitext edit.
 
 Used after a major `institutions_v2.json` change (new hub added, institution moved between hubs, partner names normalised) to clean up the maintenance categories that accumulated under the old mappings.
+
+---
+
+## `sdc-sync --migrate-legacy`
+
+Source: `tools/sdc_sync.py` (`_run_legacy_migration_mode`).
+
+A one-time bulk migration mode of the same `sdc-sync` entrypoint that runs Phase 4. Instead of running an SDC sync, `--migrate-legacy` walks the partner's files and migrates any still wrapped in the legacy `{{Artwork}}` (or `{{Information}}` / `{{Photograph}}`) template to `{{DPLA metadata}}`. For each file it:
+
+1. Walks the file's revision history to separate DPLA-bot values (overwrite-safe) from community contributions.
+2. Imports the community values as SDC statements, referenced with `P887`→`Q131783016` (inferred from) + `P4656` (imported-from permalink).
+3. Rewrites the wikitext from the legacy wrapper to `{{DPLA metadata}}`.
+
+```bash
+sdc-sync --partner <partner> --migrate-legacy
+```
+
+**In-pipeline vs. explicit mode.** The same legacy migration — *plus* the redundant-param strip — also runs automatically as the wikitext-cleanup step of **every** partner-mode SDC sync (i.e. on every Phase 4 ordinal; see [operations](operations.md#phase-4-sdc-sync-sdc-sync)). The dispatch is per-file: legacy-wrapped files get migrated, `{{DPLA metadata}}` files get stripped, anything else is skipped. `--migrate-legacy` is the explicit one-time mode that does *only* the migration walk across a whole partner, for clearing a backlog of legacy files in one pass rather than waiting for each to be touched by a regular sync.
+
+### `--workers` / `--workers-budget`
+
+`sdc-sync` accepts two parallelism flags, normally set by the launcher / workflow (defaults `6` / `24`) but settable by hand for a manual partner sync:
+
+- `--workers N` — number of worker processes for partner-mode SDC sync. Argparse default is **`1`** (single-process, standalone-safe); the launcher and workflow pass **`6`**. `N>1` dispatches per-DPLA-item work to a multiprocessing pool, each worker holding its own pywikibot session. Items are independent (every ordinal has a unique M-id), so workers never write to the same MediaInfo entity.
+- `--workers-budget N` — box-wide cap on concurrent Commons-writing slots shared across **all** sdc-sync sessions on the host (and the uploader). Argparse default is **`0`** (unlimited / budget disabled); the launcher and workflow pass **`24`** (production runs `~16`+ to keep 6+ concurrent sessions from oversubscribing Commons' parser pool). The single-purpose manual modes (`--list` / `--file` / `--cat`) do not participate in the budget. See [Worker-slot budget](operations.md#worker-slot-budget) for the slot mechanics and ops inspection.
+
+### `--no-normalize-wikitext`
+
+The post-SDC wikitext cleanup (legacy migration + redundant-param strip) is **on by default** on every partner sync. Pass `--no-normalize-wikitext` to disable the strip for diagnostic runs that need the pre-cleanup wikitext left intact.
 
 ---
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -469,7 +469,7 @@ Key log lines:
 | `Skipping <id>: Already exists on commons.` | File already on Commons, skipping |
 | `COUNTS:` followed by `UPLOADED: N`, `SKIPPED: N`, `FAILED: N`, `BYTES: N` | Phase complete |
 | `Bad provider.` | Data provider not configured for upload |
-| `All N worker slots busy; waiting for capacity.` | SDC/upload worker blocked on the box-wide [worker-slot budget](#worker-slot-budget) — expected under heavy concurrency |
+| ` -- All N worker slots busy; waiting for capacity.` | SDC/upload worker blocked on the box-wide [worker-slot budget](#worker-slot-budget) — expected under heavy concurrency |
 
 ### Slack notifications
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -253,8 +253,17 @@ uploader <partner>.csv <partner>
 Reads each item's precomputed `sdc.json` and `upload-result.json` from S3, and for every ordinal whose upload status is `UPLOADED` or `SKIPPED`, posts MediaInfo statements (and references) to the corresponding Commons file via the wbeditentity API. Idempotent — re-syncing a fully-synced item produces zero writes.
 
 ```bash
-sdc-sync --partner <partner> --ids-file <partner>.csv
+sdc-sync --partner <partner> --ids-file <partner>.csv --workers 6 --workers-budget 24
 ```
+
+`--workers N` runs the partner sync across N worker processes (the launcher and workflow default to `6`); `--workers-budget N` caps concurrent Commons writers box-wide across all sessions (default `24`). See [Worker-slot budget](#worker-slot-budget) below.
+
+**Wikitext cleanup runs in this phase too.** After posting SDC for an ordinal, sdc-sync also reconciles the file's wikitext:
+
+- Files still on a legacy `{{Artwork}}` / `{{Information}}` / `{{Photograph}}` wrapper are auto-migrated to `{{DPLA metadata}}` — walking each file's revision history to separate DPLA-bot values (overwrite-safe) from community contributions (preserved as SDC with `P887→Q131783016` + `P4656` permalink references), then rewriting the wikitext.
+- Files already on `{{DPLA metadata}}` have template params that are now redundant with SDC stripped out.
+
+This cleanup is on by default; pass `--no-normalize-wikitext` to leave the pre-strip wikitext intact for diagnostic runs. (A separate explicit one-time mode, `sdc-sync --migrate-legacy`, runs the legacy migration *instead of* a normal sync — see [maintenance tools](maintenance-tools.md).)
 
 All phases are idempotent — re-running is safe and picks up where it left off.
 
@@ -309,6 +318,8 @@ Inputs:
 - `max_age_days` (optional integer): for `refresh_only` runs, re-download files older than N days in S3 (default: 365)
 - `refresh_only` (boolean, default `false`): run `get-ids-es → downloader` only — skip the upload and SDC phases (see "Alternate run modes" above)
 - `sdc_only` (boolean, default `false`): run `get-ids-es → sdc-sync` only — skip the download and upload phases (see "Alternate run modes" above). Mutually exclusive with `refresh_only`.
+- `workers` (string, default `"6"`): number of SDC-sync worker processes per session. `1` runs single-process; higher values parallelize the partner sync across that many processes. Passed through to `sdc-sync --workers`.
+- `workers_budget` (string, default `"24"`): box-wide cap on concurrent Commons-writing slots shared across all sessions on EC2 (`0` = unlimited). Passed through to `sdc-sync --workers-budget` and the uploader's `--workers-budget`. See [Worker-slot budget](#worker-slot-budget). Both inputs are blank-safe — an empty value falls back to the launcher default (`6` / `24`).
 
 Steps:
 1. Installs `boto3` and `requests`
@@ -410,6 +421,35 @@ aws ssm send-command \
 
 Or trigger `/wikimedia-status` from Slack.
 
+### Worker-slot budget
+
+SDC-sync parallelism (`--workers N`) and the uploader share a single **box-wide** budget of concurrent Commons writers, so the 6+ sessions that typically run at once don't collectively overrun Commons' parser pool (which binds on maxlag past ~16 concurrent bot writes). The budget is a set of flock-backed slot files — one permit each — under:
+
+```text
+/tmp/sdc-sync-worker-slots/slot-0 … slot-N
+```
+
+Each SDC worker (and the single-process uploader) checks out one slot per item it writes and releases it on return; slots auto-release if the holding process dies (the flock drops on `close`/exit). The downloader does **not** participate — it writes to source sites, not Commons.
+
+Inspect live holders:
+
+```bash
+# Who currently holds a slot
+lslocks | grep sdc-sync-worker-slots
+# Or just see the slot files
+ls /tmp/sdc-sync-worker-slots/
+```
+
+**Budget-consistency invariant**: the budget value (`24` in production) must be identical across all concurrent sessions for the cap to mean what it says. In practice every session inherits it from the same launch-time default, so they agree. If two sessions disagree (e.g. 24 vs 8), the effective cap is the *larger* N — a benign degradation, not a correctness break.
+
+**Detecting a session blocked on the cap**: when every slot is held, a worker logs a line containing `worker slots busy` before it polls for capacity. Grep the sdc-sync log tail for that marker to tell that a session is waiting on the budget rather than stuck:
+
+```bash
+tail -200 /home/ec2-user/ingest-wikimedia/<partner>/logs/<latest>-sdc.log | grep "worker slots busy"
+```
+
+A reboot that clears `/tmp` is safe — it also kills every slot holder, so there's nothing to preserve.
+
 ### Log files
 
 Logs are written to `/home/ec2-user/ingest-wikimedia/<partner>/logs/` with names like:
@@ -429,6 +469,7 @@ Key log lines:
 | `Skipping <id>: Already exists on commons.` | File already on Commons, skipping |
 | `COUNTS:` followed by `UPLOADED: N`, `SKIPPED: N`, `FAILED: N`, `BYTES: N` | Phase complete |
 | `Bad provider.` | Data provider not configured for upload |
+| `All N worker slots busy; waiting for capacity.` | SDC/upload worker blocked on the box-wide [worker-slot budget](#worker-slot-budget) — expected under heavy concurrency |
 
 ### Slack notifications
 

--- a/docs/pipeline-phases.md
+++ b/docs/pipeline-phases.md
@@ -124,22 +124,33 @@ Source: `tools/uploader.py`. The most complex phase.
 
 Source: `tools/sdc_sync.py`. See [sdc-sync.md](sdc-sync.md) for the full SDC deep dive. This section covers the phase's role in the pipeline.
 
-**Inputs.** Partner mode: `--partner <partner> [--ids-file PATH]`. Legacy mode: `--file "File:Title.jpg"` (repeatable) or `--cat <Category>` or `--lists <dir>` (Slack runs never use the legacy mode).
+**Inputs.** Partner mode: `--partner <partner> [--ids-file PATH]`, plus:
+
+- `--workers N` (default 1) — number of worker processes for partner-mode sync. `N > 1` dispatches per-DPLA-item work to a spawn-start `multiprocessing.Pool`, each worker holding its own pywikibot session; `N = 1` keeps the single-process path. Production launches pass `6`.
+- `--workers-budget N` (default 0) — box-wide cap on concurrent Commons-writing items across **all** sdc-sync and uploader sessions on the host (see [architecture.md § Intra-host write throttle](architecture.md#intra-host-write-throttle-workerslotbudget)). `0` disables it; production launches pass `24`. Must be identical across concurrent sessions.
+- `--migrate-legacy` — swaps SDC sync for the standalone legacy-Artwork migration mode (see below).
+- `--normalize-wikitext` / `--no-normalize-wikitext` (default on) — controls the post-SDC wikitext-cleanup strip.
+
+Legacy mode: `--file "File:Title.jpg"` (repeatable) or `--cat <Category>` or `--lists <dir>` (Slack runs never use the legacy mode; these single-purpose manual modes do not participate in the worker-slot budget).
 
 **What it does (partner mode).**
 
 1. Reads the IDs CSV.
-2. For each item: reads `sdc.json`, `upload-result.json`, and `file-list.txt` from S3. Items missing any of these sidecars are skipped (counter `SDC_ITEMS_SKIPPED_NO_SIDECAR`).
-3. Filters to ordinals whose `upload-result.json` status is `UPLOADED` or `SKIPPED`. Computes per-ordinal P304 page numbers via `_compute_page_numbers()` for multi-file extension groups (e.g. items with both jpg and pdf get separate page-number sequences per extension).
-4. For each eligible ordinal: looks up its `download_url` from `file-list.txt` by 1-based index, derives `mediaid = M<pageid>` from `upload-result.json`, then calls `process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url, page_number)`.
-5. Inside `process_one_from_sdc`: walks the staged `sdc.json` claims, runs the `check()` matcher against current Commons-side state, accumulates new claims / qualifier amends / reference updates / removals into per-file lists, then **flushes everything as one `wbeditentity` revision** via `_flush_per_file_edits()`. The previous design (multiple separate `wbsetclaim` / `wbsetqualifier` / `wbremoveclaims` POSTs per file) could leak orphaned stale statements if an intermediate call failed; the consolidated dispatcher is all-or-nothing per file.
+2. **Dispatch.** When `--workers 1` (the default), the parent walks items in-process. When `--workers > 1`, items are dispatched one-per-task to a `multiprocessing.Pool` via `imap_unordered`; each worker re-logs into Commons, processes one item end-to-end, and returns its per-task counter delta, which the parent merges into the shared `Tracker`. Every ordinal of every item has a unique M-id, so workers never write to the same MediaInfo entity. **Either path** acquires one box-wide `WorkerSlotBudget` slot around each item (a no-op when `--workers-budget` is 0), so a 1-worker session still counts against the cap exactly like a parallel one; time spent blocked on a slot accrues into `SDC_SLOT_WAIT_SECONDS`.
+3. Per item (`_process_one_partner_item`): reads `sdc.json`, `upload-result.json`, and `file-list.txt` from S3. Items missing the `sdc.json` / `upload-result.json` sidecars are skipped (counter `SDC_ITEMS_SKIPPED_NO_SIDECAR`); a missing `file-list.txt` is non-fatal (P2699 qualifiers are simply not materialized).
+4. Filters to ordinals whose `upload-result.json` status is `UPLOADED` or `SKIPPED`. Computes per-ordinal P304 page numbers via `_compute_page_numbers()` for multi-file extension groups (e.g. items with both jpg and pdf get separate page-number sequences per extension).
+5. For each eligible ordinal: looks up its `download_url` from `file-list.txt` by 1-based index, derives `mediaid = M<pageid>` from `upload-result.json`, then calls `process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url, page_number)`.
+6. Inside `process_one_from_sdc`: walks the staged `sdc.json` claims, runs the `check()` matcher against current Commons-side state, accumulates new claims / qualifier amends / reference updates / removals into per-file lists, then **flushes everything as one `wbeditentity` revision** via `_flush_per_file_edits()`. The previous design (multiple separate `wbsetclaim` / `wbsetqualifier` / `wbremoveclaims` POSTs per file) could leak orphaned stale statements if an intermediate call failed; the consolidated dispatcher is all-or-nothing per file.
+7. **Post-SDC wikitext cleanup** (on by default; `--no-normalize-wikitext` disables). For each synced file, dispatches on the page's current wikitext shape: a `{{DPLA metadata}}` page gets its now-redundant params stripped (`wikitext_normalize.normalize_page`); a legacy `{{Artwork}}` / `{{Information}}` / `{{Photograph}}` page is run through the same migration as `--migrate-legacy` (see below). This strip is the documented end of the per-file lifecycle (upload → SDC → wikitext cleanup).
 
 **Per-ordinal qualifiers materialised at write time** (not baked into `sdc.json`, because they vary per ordinal):
 
 - P304 (page number) qualifier on P760, only when the ordinal is part of a multi-file extension group.
 - P2699 (URL) qualifier on P7482, with the per-ordinal direct download URL from `file-list.txt`.
 
-**Counters tracked.** `SDC_ITEMS_SYNCED`, `SDC_CLAIMS_ADDED`, `SDC_REFS_ADDED`, `SDC_REMOVALS`, `SDC_ITEMS_SKIPPED_NO_SIDECAR`, `SDC_ITEMS_SKIPPED_MAPPING`, `SDC_ORDINALS_SKIPPED_ERROR`, `SDC_ORDINALS_SKIPPED_MISSING_ENTITY`, `SDC_ITEMS_SKIPPED_ERROR`. The error / mapping / missing-entity split is deliberate — operators need to distinguish bad-data items from bad-network items from upload-never-happened items.
+**Legacy-Artwork migration mode (`--migrate-legacy`).** Instead of running SDC sync, `sdc-sync --partner <partner> --migrate-legacy` walks the same partner IDs CSV and migrates each item's Commons files from the legacy `{{Artwork}}` form to `{{DPLA metadata}}`. For each file it walks the revision history to distinguish DPLA-bot-authored values (overwrite-safe with canonical data) from community contributions, preserves the community values by importing them as SDC statements with the `P887 → Q131783016` ("inferred from Wikitext") + `P4656` (Wikimedia import URL permalink) reference shape, then rewrites the wikitext. The exact same migration also runs automatically inside the post-SDC cleanup pass whenever a normal sync encounters a file still in the legacy form, so the standalone mode is just a way to drive it for a whole partner without re-syncing. `ingest_wikimedia/legacy_artwork.py` holds the logic; counters land in the `LEGACY_*` set.
+
+**Counters tracked.** Sync counters: `SDC_ITEMS_SYNCED` (item fully synced — every eligible ordinal succeeded), `SDC_ITEMS_PARTIALLY_SYNCED` (at least one ordinal synced *and* at least one sibling ordinal errored — broken out so dashboards keying on "items fully done" don't count mixed results as healthy), `SDC_CLAIMS_ADDED`, `SDC_REFS_ADDED`, `SDC_REMOVALS`, `SDC_QUALIFIER_UPDATES`, `SDC_PAGES_EDITED` (distinct Commons file pages actually written), `SDC_ITEMS_SKIPPED_NO_SIDECAR`, `SDC_ITEMS_SKIPPED_MAPPING`, `SDC_ITEMS_SKIPPED_ERROR`, `SDC_ORDINALS_SKIPPED_ERROR`, `SDC_ORDINALS_SKIPPED_MISSING_ENTITY`, `SDC_ORDINALS_SKIPPED_MISSING_PAGEID` (uploader recorded a null/zero pageid and the title→pageid fallback couldn't resolve it either), and `SDC_SLOT_WAIT_SECONDS` (aggregate worker-seconds blocked on a `WorkerSlotBudget` slot, summed across workers). The error / mapping / missing-entity split is deliberate — operators need to distinguish bad-data items from bad-network items from upload-never-happened items. Migration mode adds the `LEGACY_*` set (`LEGACY_MIGRATED`, `LEGACY_IMPORTS_POSTED`, `LEGACY_SKIPPED_NOT_LEGACY`, `LEGACY_SKIPPED_ALREADY`, `LEGACY_SKIPPED_ERROR`).
 
 ---
 
@@ -178,7 +189,7 @@ logging.info("\n" + str(tracker))
 notify_*_complete(tracker, partner_label, elapsed, dry_run)
 ```
 
-The SDC phase resets the tracker at the start of `_run_partner_mode` so per-partner counts don't accumulate across invocations in the same process.
+The SDC phase resets the tracker at the start of `_run_partner_mode` so per-partner counts don't accumulate across invocations in the same process. Its completion call differs from the other phases': `notify_sdc_complete(tracker=, partner_label=, elapsed_seconds=, workers=)` passes the sync's worker count rather than `dry_run`, so the Slack summary can report the average per-worker slot wait (`SDC_SLOT_WAIT_SECONDS / workers`).
 
 ## Phase-start notifications
 

--- a/docs/sdc-sync.md
+++ b/docs/sdc-sync.md
@@ -2,18 +2,23 @@
 
 The `sdc-sync` phase reconciles each DPLA-uploaded Commons file's MediaInfo structured data against the per-item `sdc.json` envelope staged by `get-ids-es`. It is the only phase that talks to Commons' Wikibase API directly.
 
-This document covers the *internals* — every property the bot writes, the atomic dispatcher design, idempotency, chunked claims, and known Wikibase API gotchas. For the phase's role in the pipeline, see [pipeline-phases.md](pipeline-phases.md#4-sdc-sync--sdc-sync).
+This document covers the *internals* — the worker model and box-wide write budget, every property the bot writes, the atomic dispatcher design, idempotency, chunked claims, legacy `{{Artwork}}` migration, the post-SDC wikitext cleanup, and known Wikibase API gotchas. For the phase's role in the pipeline, see [pipeline-phases.md](pipeline-phases.md#4-sdc-sync--sdc-sync).
 
 ## Table of contents
 
 1. [Entry points](#entry-points)
-2. [The atomic dispatcher](#the-atomic-dispatcher)
-3. [What the bot writes (per property)](#what-the-bot-writes-per-property)
-4. [The canonical reference triple](#the-canonical-reference-triple)
-5. [Idempotency: `check()`](#idempotency-check)
-6. [Chunked claims](#chunked-claims)
-7. [The P813 refresh](#the-p813-refresh)
-8. [Wikibase API gotchas](#wikibase-api-gotchas)
+2. [Parallelism & worker model](#parallelism--worker-model)
+3. [Box-wide worker-slot budget](#box-wide-worker-slot-budget)
+4. [Eligibility, ordinal rescue & pageid self-heal](#eligibility-ordinal-rescue--pageid-self-heal)
+5. [The atomic dispatcher](#the-atomic-dispatcher)
+6. [What the bot writes (per property)](#what-the-bot-writes-per-property)
+7. [The canonical reference triple](#the-canonical-reference-triple)
+8. [Idempotency: `check()`](#idempotency-check)
+9. [Chunked claims](#chunked-claims)
+10. [The P813 refresh](#the-p813-refresh)
+11. [Legacy `{{Artwork}}` migration](#legacy-artwork-migration)
+12. [Post-SDC wikitext normalization (strip)](#post-sdc-wikitext-normalization-strip)
+13. [Wikibase API gotchas](#wikibase-api-gotchas)
 
 ---
 
@@ -22,18 +27,67 @@ This document covers the *internals* — every property the bot writes, the atom
 ```python
 # Partner mode (Slack-launched runs)
 sdc-sync --partner <partner> [--ids-file <path>]
+         [--workers N] [--workers-budget N]
+         [--normalize-wikitext | --no-normalize-wikitext]
 
-# Legacy modes (operator runs, not used in pipeline)
+# Legacy {{Artwork}} → {{DPLA metadata}} migration (partner-scoped sub-command)
+sdc-sync --partner <partner> --migrate-legacy [--ids-file <path>]
+
+# Manual modes (operator runs, not used in pipeline)
 sdc-sync --file "File:Title.jpg" [--file "File:Other.jpg" ...]
 sdc-sync --cat <Commons-category> [--recurse] [--limit N]
 sdc-sync --lists <directory-of-txt-files>
 ```
 
-**Partner mode** drives off the S3 sidecars only (no `api.dp.la` calls). It iterates the IDs CSV, reads `sdc.json` + `upload-result.json` + `file-list.txt` per item, picks `UPLOADED` / `SKIPPED` ordinals from `upload-result.json`, and calls `process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url, page_number)` per ordinal.
+`_build_parser()` (`tools/sdc_sync.py`) defines every flag. The defaults that matter:
 
-**Legacy mode** builds claims at runtime via `parsed()`, fetching the source document either from S3 (`--from-s3 <partner>`) or from `api.dp.la` directly (one retry on network failure). Calls `process_one(mediaid, dpla_id)`. `--file` is repeatable (pass once per title); `--lists` reads every `.txt` file in a directory as a list of titles. Slack-launched runs never go through this path; it remains supported for one-off operator runs.
+| Flag | argparse default | Production value | Set by |
+|---|---|---|---|
+| `--workers` | `1` | `6` | launcher, not sdc-sync |
+| `--workers-budget` | `0` (disabled) | `24` | launcher, not sdc-sync |
+| `--normalize-wikitext` / `--no-normalize-wikitext` | on (`default=True`, `BooleanOptionalAction`) | on | — |
+| `--migrate-legacy` | `False` | `False` | — |
 
-Both paths converge on the per-file accumulators + atomic `wbeditentity` dispatcher.
+The production `6` / `24` figures come from the launcher `scripts/wikimedia_launch.py` (`--workers default="6"`, `--workers-budget default="24"`) and `.github/workflows/wikimedia-launch.yml`, which always pass them explicitly — **not** from sdc-sync's own defaults. Run `sdc-sync --partner <p>` by hand and you get single-worker, no slot budget.
+
+**Partner mode** drives off the S3 sidecars only (no `api.dp.la` calls). It iterates the IDs CSV, reads `sdc.json` + `upload-result.json` + `file-list.txt` per item, picks `UPLOADED` / `SKIPPED` ordinals from `upload-result.json`, and calls `process_one_from_sdc(mediaid, dpla_id, sdc_payload, download_url, page_number)` per ordinal. (Ordinals the uploader left in a non-eligible state are still rescued — see [Eligibility, ordinal rescue & pageid self-heal](#eligibility-ordinal-rescue--pageid-self-heal).)
+
+**Manual modes** (`--file` / `--cat` / `--lists`) build claims at runtime via `parsed()`, fetching the source document either from S3 (`--from-s3 <partner>`) or from `api.dp.la` directly (one retry on network failure). Calls `process_one(mediaid, dpla_id)`. `--file` is repeatable (pass once per title); `--lists` reads every `.txt` file in a directory as a list of titles. Slack-launched runs don't use these modes; they remain supported for one-off operator runs.
+
+**Note — the post-SDC cleanup runs on *every* mode.** Whether the file arrived via partner mode or a manual `--file`/`--cat`/`--lists` run, the per-file lifecycle ends the same way: after SDC sync the dispatcher runs the wikitext-cleanup pass (`_post_sdc_cleanup_for_page`), which strips redundant `{{DPLA metadata}}` params and, on any file still carrying a legacy `{{Artwork}}` template, auto-migrates it. So a manual rerun is *not* a pure SDC-only path the way it once was — see [Post-SDC wikitext normalization](#post-sdc-wikitext-normalization-strip) and [Legacy `{{Artwork}}` migration](#legacy-artwork-migration).
+
+All paths converge on the per-file accumulators + atomic `wbeditentity` dispatcher.
+
+## Parallelism & worker model
+
+Partner mode fans out per-DPLA-item work across a `multiprocessing.Pool` sized by `--workers N`. `_run_partner_mode_parallel(partner, dpla_ids, workers)` builds the pool with an explicit **spawn** context (`multiprocessing.get_context("spawn")`) so workers don't inherit the parent's pywikibot sockets, then dispatches via `pool.imap_unordered(_worker_partner_task, tasks)`. `--workers 1` keeps the original single-process path unchanged.
+
+The unit of parallelism is the DPLA item, never the M-id: every ordinal of every item has a unique MediaInfo entity, so no two workers ever write the same Commons entity.
+
+- **Per-worker pywikibot login.** `_init_partner_worker(...)` runs once per worker as the Pool `initializer`: it builds a fresh `pywikibot.Site("commons", "commons")` and calls `site.login()`, so each worker holds its own authenticated session. It also receives the parent's `hubs` / `rights` / `subject-ids` data and the `--no-normalize-wikitext` / `--workers-budget` settings so workers behave identically to the parent.
+- **Per-task tracker deltas.** Each task (`_worker_partner_task`) snapshots the worker's `Tracker` before the item (`tracker.snapshot()`), processes the item, and returns the diff; the parent merges every delta back with `tracker.merge(delta)`. Counters therefore aggregate correctly across workers without shared mutable state.
+- **Log aggregation.** Workers route their `logging` records through a `QueueHandler` into a `Manager().Queue`; the parent runs a `logging.handlers.QueueListener` against its real handlers, so all worker output interleaves into one log stream.
+
+Wall-clock scales roughly linearly with `N` up to Commons-side parser-pool headroom — which is exactly what the slot budget below exists to bound.
+
+## Box-wide worker-slot budget
+
+`WorkerSlotBudget` (`ingest_wikimedia/worker_slots.py`) caps concurrent Commons-write load **across every `sdc-sync` and `uploader` process on the host**, not just within one run. It is a set of `N` `fcntl`-flock lock files at `/tmp/sdc-sync-worker-slots/slot-0` … `slot-N-1` (`DEFAULT_SLOT_DIR = "/tmp/sdc-sync-worker-slots"`), where `N` is `--workers-budget`. To start its per-item Commons work a process must `flock` an exclusive lock on one slot file; if all `N` are held it blocks until one frees.
+
+- **Every item checks out a slot — even at `--workers 1`.** Both the parallel path (around each `_process_one_partner_item` call) and the single-process partner loop wrap the per-item work in `with slot_budget.acquire():`. The uploader (`tools/uploader.py`) builds a `WorkerSlotBudget(workers_budget)` and acquires a slot per item too, so **upload sessions and sdc-sync sessions across the whole box cooperatively share the same cap** — the budget protects the MediaWiki parser pool / `maxlag` regardless of how many runs are live or how many workers each launched with.
+- **The budget value must be identical across concurrent sessions.** Slots are positional lock files; two sessions launched with different `--workers-budget` would disagree on how many slots exist. Production pins it at `24` for all sessions.
+- **`budget <= 0` disables it** — `acquire()` becomes a no-op `contextmanager` (the manual `--file`/`--cat`/`--lists` modes never acquire a slot at all, independent of the budget value).
+- **Crash-safe.** `flock` locks release automatically when the holding fd is closed *or the process dies*, so a killed worker never strands a slot — no reaper or cleanup pass is needed.
+- **Wait time is measured.** Time spent blocked on a slot is accumulated into the `SDC_SLOT_WAIT_SECONDS` tracker counter and surfaced in the Slack summary, so oversubscription shows up as visible queueing.
+
+## Eligibility, ordinal rescue & pageid self-heal
+
+Whether an ordinal gets an SDC sync is **decoupled from the upload-result status of *this* run.** The uploader writes `UPLOADED` / `SKIPPED` for ordinals it confirmed, but also `NOT_PRESENT` / `INELIGIBLE` / `FAILED` for ordinals it couldn't confirm (broken upstream URL, S3 hiccup, etc.). Those last three don't block data-side maintenance:
+
+- **Commons discovery rescue.** Any ordinal left non-eligible is deferred to a post-loop pass that calls `_find_existing_commons_files_by_dpla_id(dpla_id)` — a CirrusSearch `intitle:` query scoped to namespace 6 (`File:`). If a matching Commons file already exists from a prior run, its title + pageid are grafted onto the eligible set (tagged `discovered_via_dpla_id`) and synced normally. The search is lazy: it only fires when at least one ordinal needs rescuing, so healthy items pay zero extra API cost.
+- **Pageid self-heal.** `_resolve_pageid_from_title(...)` repairs sidecars whose recorded pageid is null or `0` by resolving it from the file title, so a malformed `upload-result.json` doesn't strand an otherwise-syncable ordinal.
+
+Ordinals that can't be salvaged are counted distinctly: `SDC_ORDINALS_SKIPPED_ERROR`, `SDC_ORDINALS_SKIPPED_MISSING_ENTITY` (Commons returned `no-such-entity` for the M-id), and `SDC_ORDINALS_SKIPPED_MISSING_PAGEID`. Item-level outcomes split full from partial progress: `_classify_item_outcome` returns `SDC_ITEMS_PARTIALLY_SYNCED` when an item has at least one synced ordinal *and* at least one errored sibling, so a dashboard keying on `SDC_ITEMS_SYNCED` doesn't read mixed-result items as fully healthy.
 
 ## The atomic dispatcher
 
@@ -132,6 +186,8 @@ Every DPLA-authored statement also carries a `P459 = Q61848113` (determination m
 
 **Time comparison** uses `_time_claim_comparable` and the canonical `time|precision[|circa]` comparable string from `_extract_comparable_value` — so a `2026-06-01` precision-day claim matches an existing `2026-06-01` precision-day claim regardless of which property they're on.
 
+**The `time` branch and the somevalue → value-typed migration.** The `time` kind handles `P571` when `parse_dpla_date` produced a value-typed date, mirroring the `item`/`string`/`somevalue` branches above. Crucially, a Commons statement carrying the *old* `somevalue + P1932` date shape does **not** match the new value-typed time claim, so `check()` returns "add" for the value-typed claim — and on the same reconcile cycle the stale `somevalue` statement is queued for removal by `_reconcile_existing_claims` (its `P1932` verbatim string is no longer in `expected` once the `sdc.json` carries the value-typed equivalent). One pass migrates the file from the old shape to the new without ever leaving the date duplicated. A malformed Commons time datavalue (missing `time`/`precision`) is treated as non-matching so the bad statement is replaced rather than crashing the ordinal.
+
 ## Chunked claims
 
 Wikibase enforces a 1500-character cap on `string` and `monolingualtext` values. DPLA descriptions and titles often exceed this. The bot splits long values into per-chunk statements, each carrying a `P1545` (series ordinal) qualifier to preserve ordering.
@@ -165,6 +221,42 @@ When the dispatcher is making *any* other edit on a file, it also refreshes `P81
 **Conditional.** `_build_p813_refresh_fragments` is only invoked when the per-file dispatcher already has other edits to make (`has_any_other_edit`). Files where nothing else changed do *not* generate spurious revisions just to bump P813.
 
 **Cosmetic note on diffs.** When `P813` changes, Wikibase's diff renderer shows the entire reference (URL, publisher, retrieved date) twice — once removed, once added — because reference identity is content-hash, not a stable ID. The data is correct; the diff is just noisy. Switching to `wbsetreference` for in-place reference updates is theoretically possible but would break the atomic-bundle property (separate API calls per refreshed reference) without changing the visual diff in any documented way.
+
+## Legacy `{{Artwork}}` migration
+
+Some early DPLA uploads used the `{{Artwork}}` template instead of `{{DPLA metadata}}`. `ingest_wikimedia/legacy_artwork.py` migrates them. It reaches files two ways:
+
+- **As a standalone sub-command.** `--migrate-legacy` (with `--partner`) runs `_run_legacy_migration_mode` instead of an SDC sync — it walks the partner's IDs CSV and migrates every legacy file.
+- **Opportunistically, on every mode.** The post-SDC cleanup dispatcher (`_post_sdc_cleanup_for_page`) inspects each file's wikitext after sync; if `legacy_artwork.find_legacy_template(text)` finds a `{{Artwork}}` invocation still present, it auto-migrates that file inline. So legacy files surface and convert during ordinary partner runs, not only under `--migrate-legacy`.
+
+**Preserving community edits.** A naive overwrite would clobber translations and corrections made by Commons editors after the original DPLA upload. The migrator walks the file's revision history (`fetch_revision_snapshots` → `trace_param_provenance` → `classify_param_provenance`) to label each `{{Artwork}}` parameter value as **DPLA-bot-authored** (members of `DPLA_BOT_ACCOUNTS`, overwrite-safe) or **community-contributed**. Community values that differ from the canonical DPLA value are not discarded — they're preserved as SDC import statements carrying a distinct reference shape:
+
+```
+P887 (based on heuristic) → Q131783016 (inferred from Wikitext)
+P4656 (Wikimedia import URL) → <revision permalink>
+```
+
+so the provenance of the editor's contribution survives on the entity.
+
+**Write order is load-bearing.** The SDC import is POSTed **first**, the wikitext rewrite **second**. If the process dies between them, the file stays in legacy `{{Artwork}}` form (it'll be retried) — the reverse order would irrecoverably lose the community values before they were captured in SDC.
+
+**Idempotency.** `entity_was_already_migrated` returns true when any mapped property already carries the legacy-import reference signature (`P887 → Q131783016`), so a re-run is a cheap no-op rather than a double migration.
+
+**Counters** (in `ingest_wikimedia/tracker.py`): `LEGACY_MIGRATED`, `LEGACY_IMPORTS_POSTED`, `LEGACY_SKIPPED_NOT_LEGACY`, `LEGACY_SKIPPED_ALREADY`, `LEGACY_SKIPPED_ERROR`.
+
+## Post-SDC wikitext normalization (strip)
+
+`ingest_wikimedia/wikitext_normalize.py` is the final step of the per-file lifecycle: **upload → SDC → wikitext cleanup.** It is **on by default** (`--normalize-wikitext` / `--no-normalize-wikitext`, a `BooleanOptionalAction`) and runs on every trigger mode via `_post_sdc_cleanup_for_page`.
+
+Once the SDC the bot just wrote makes a `{{DPLA metadata}}` template param redundant, the template param is pure duplication on the file page. `normalize(wikitext, expected_params)` strips each scalar param (`title`, `description`, `date`, `creator`, `hub`, `institution`, `url`, `dpla_id`, `local_id`, `permission`) whose verbatim value matches the canonical DPLA value. It is conservative on every edge case — missing template, multiple templates, an unrecognised wrapping template, a param it can't compare — all leave that param untouched, because the cost of an un-stripped match is just a redundant param the next pass catches, while the cost of a wrong strip is data loss.
+
+**Safety guard against stripping the wrong file.** Before stripping anything, the dispatcher confirms the entity actually carries DPLA-attributed SDC via `_entity_has_dpla_attributed_claims` (a statement with the `P459 = Q61848113` qualifier — the same "this is OUR claim" marker described above). If the entity has no DPLA-attributed claims, the strip is refused: there's nothing the wikitext would be redundant *with*.
+
+**Per-item language unwrapping.** For non-English items, an editor may have wrapped the canonical value in a single-language template (e.g. `{{es|<canonical Spanish title>}}`). `_value_matches` unwraps such a `{{<code>|...}}` wrapper before comparing — but **only** if `<code>` is in the per-item allowlist of safe-to-unwrap codes. That allowlist (`_extract_unwrap_languages` in `ingest_wikimedia/wikimedia.py`) always seeds `en` and adds any ISO-639-1 codes derived from the record's `sourceResource.language`. So `{{es|…}}` is unwrapped (and the param stripped) on a Spanish-declared item, but on an English item `{{es|A Title}}` survives even if the inner text byte-matches the canonical English — there the `es` tag is editor-contributed translation metadata, not a redundant wrapper. `{{LangSwitch|…}}` and other non-language-wrapper templates are always treated as a mismatch and preserved.
+
+> Note: this unwrapping affects **comparison only**. The SDC monolingualtext claims the bot writes (`P1476`, `P10358`, …) are still hardcoded `language="en"` — see `_build_monolingual_claim` in `ingest_wikimedia/sdc.py`. Don't infer that the written claim language tracks the source language.
+
+**`{{other date}}` expansion + year-range dedup.** On re-sync, `_reconcile_inferred_from_wikitext_dupes(mediaid)` (called from `process_one_from_sdc`) removes inferred-from-Wikitext date claims that have become redundant with a DPLA-attributed date claim. The comparison expands `{{other date}}` invocations (`parse_other_date_template`) and treats year-range equivalence (`parse_date_range`, both in `sdc.py`) as a match — so an inferred date claim whose comparable value equals a DPLA-attributed claim is pruned even when the two were written in different syntaxes.
 
 ## Wikibase API gotchas
 

--- a/docs/slack-guide.md
+++ b/docs/slack-guide.md
@@ -190,15 +190,44 @@ If your kill argument matches zero active sessions, the response says so but no 
 /wikimedia-status
 ```
 
-Posts to #tech-alerts with each active session and its current phase + progress:
+Posts to #tech-alerts a **Wikimedia Upload Status** header block, one row per active session (the session name in a fixed-width backtick column, followed by its current phase + progress), and a trailing context line summarising box-wide worker-slot and memory headroom:
 
 ```text
-🟢 Active Wikimedia upload sessions
-• wikimedia-bpl — Uploading (3,214 / 11,503, ~28%)
-• wikimedia-indiana+indiana-state-library — SDC syncing (812 / 4,002, ~20%)
+Wikimedia Upload Status
+
+`wikimedia-bpl                    ` Uploading (3,214 / 11,503, ~28%)
+`wikimedia-indiana+indiana-state-l` [indiana+indiana-state-library] SDC syncing (812 / 4,002, ~20%) ⏸ waiting on slots
+`wikimedia-pa+free-library-of-phila` Uploading (queued)
+
+Worker slots: ~4 free of 16 (12 held)   •   Memory: 21,480 / 31,008 MB used (30% available)
 ```
 
-The status workflow runs automatically every 6 hours and posts only when something is active. The Slack-triggered version always posts (so an empty result confirms "nothing's running" rather than looking like the command silently failed).
+Phase annotations you may see on a row:
+
+- **`⏸ waiting on slots`** — every one of that session's workers is currently blocked on the box-wide worker-slot cap (`--workers-budget`). The session is healthy, just throttled while it waits for a slot to free.
+- **`(queued)`** — the session is parked behind the cap and hasn't logged its first item yet (vs. `starting...`, which means it's launching but not budget-blocked).
+- **`⚠ idle Nm`** — the session's log hasn't been written to in over 30 minutes and it isn't slot-blocked, so it may be hung.
+
+The trailing context line:
+
+- **Worker slots** — box-wide free/held slot count (the median of four `lslocks` samples). This cap is shared by both the uploader and sdc-sync, so it reflects total Commons-writing concurrency across every session, not SDC alone. Omitted if no budget-enabled session has set up the slot directory.
+- **Memory** — used / total MB on the EC2 box, with percent available.
+
+The status workflow runs automatically every 6 hours and the Slack-triggered version (`/wikimedia-status`) runs on demand. **Both always post**, even when nothing is running — an idle run posts `No active Wikimedia upload sessions.` along with the memory line, so an empty result confirms "nothing's running" rather than looking like the command silently failed.
+
+### Reading the SDC completion summary
+
+When the SDC phase finishes, #tech-alerts gets a **Wikimedia SDC Complete** message with a block of counts. Most are self-explanatory, but a few are easy to misread:
+
+- **ITEMS SYNCED** — DPLA items where every eligible ordinal posted successfully.
+- **ITEMS PARTIAL** — items where at least one ordinal synced *and* at least one sibling ordinal errored. These are not counted under ITEMS SYNCED, so a healthy-looking run can still have partials worth checking.
+- **PAGES EDITED** — the number of distinct Commons file pages actually written. This is the real batch size: a one-file item and a thousand-file item both count as a single synced item, so PAGES EDITED is the figure you can't infer from ITEMS SYNCED.
+- **CLAIMS ADDED / REFS ADDED / REMOVALS** — statements added, references added, and statements removed across all pages.
+- **SKIPPED (no sidecar) / (mapping) / (error)** — items the partner-mode loop bailed on before writing anything, by reason: no `sdc.json` staged, a mapping problem, or a runtime error.
+- **ORDINAL MISSING** — ordinals whose Commons MediaInfo entity no longer exists (`no-such-entity`, usually a file deleted as a duplicate). Not a failure — the rest of the item's ordinals still count.
+- **ORDINAL NO PAGEID** — the uploader sidecar had a null pageid and the title→pageid fallback also failed, so that ordinal couldn't be located.
+- **ORDINAL ERRORS** — per-ordinal runtime exceptions, isolated so one bad ordinal doesn't sink its siblings.
+- **SLOT WAIT (avg/wkr)** — average time each worker spent blocked on the box-wide slot budget, shown as `Nm (X% of runtime)`. A high percentage means the session was throttled by the cap for much of its run.
 
 ---
 

--- a/docs/slack-guide.md
+++ b/docs/slack-guide.md
@@ -196,7 +196,7 @@ Posts to #tech-alerts a **Wikimedia Upload Status** header block, one row per ac
 Wikimedia Upload Status
 
 `wikimedia-bpl                    ` Uploading (3,214 / 11,503, ~28%)
-`wikimedia-indiana+indiana-state-l` [indiana+indiana-state-library] SDC syncing (812 / 4,002, ~20%) ⏸ waiting on slots
+`wikimedia-indiana+indiana-state-l` SDC syncing (812 / 4,002, ~20%) ⏸ waiting on slots
 `wikimedia-pa+free-library-of-phila` Uploading (queued)
 
 Worker slots: ~4 free of 16 (12 held)   •   Memory: 21,480 / 31,008 MB used (30% available)

--- a/docs/special-cases.md
+++ b/docs/special-cases.md
@@ -9,6 +9,9 @@ The uploader carries the bulk of the pipeline's "what if Commons-side state does
 5. [CommonsDelinker integration](#commonsdelinker-integration)
 6. [Orphan tagging](#orphan-tagging)
 7. [Wikimedia error codes](#wikimedia-error-codes)
+8. [Content hubs vs. service hubs](#content-hubs-vs-service-hubs)
+9. [Per-ordinal status and pageid rescue](#per-ordinal-status-and-pageid-rescue)
+10. [Limitations](#limitations)
 
 ## Title generation
 
@@ -74,9 +77,13 @@ else:
 
 ### Case 0 — Cross-item collision
 
-The existing title encodes a different DPLA ID (extracted via the regex `- DPLA - ([0-9a-f]{32})`), AND that other DPLA item is still valid in `api.dp.la`. Both files coexist; we upload to our intended title without touching the existing file.
+The existing title encodes a *different* DPLA ID (extracted via `extract_dpla_id_from_commons_title`, regex `- DPLA - ([0-9a-f]{32})`). Whether we leave the existing file alone or migrate it hinges on whether that other DPLA ID still resolves:
 
-Return: `"upload_only"`.
+- **Other item still valid in `api.dp.la`** — two genuinely distinct items happen to share a hash. Both files coexist; we upload to our intended title without touching the existing file. Return `"upload_only"`.
+- **404 on the colliding DPLA ID** — the strongest possible signal that the existing Commons file is an orphan: its DPLA-side anchor is gone. We treat the 404 exactly like `other_item is None` and **fall through to Case 1/2/3 migration** (move or upload-and-tag), rather than silently creating a duplicate alongside the orphan.
+- **Any *other* error (network timeout, 5xx, JSON parse failure)** — none of these mean "the old ID is gone," so we stay on the conservative `"upload_only"` fallback. A transient API blip must not trigger a destructive move on a file that may still have a valid sibling item.
+
+The 404-vs-other distinction is read off `ex.response.status_code`.
 
 ### Case 1 — Intended title is a redirect to the existing file
 
@@ -125,20 +132,26 @@ Used otherwise. Replaces the redirect text with fresh wikitext, optionally mergi
 
 `User:CommonsDelinker/commands/filemovers` on Commons is a community-operated bot's instruction queue. The pipeline appends `{{universal replace|<old>|<new>|reason=...}}` lines to it; CommonsDelinker reads the page out-of-band, rewrites every link to `[[File:<old>]]` on every Wikimedia wiki to point at `[[File:<new>]]`, and deletes the obsolete redirect.
 
-**One function, one API.** `post_commonsdelinker_request(site, old_filename, new_filename)` in `ingest_wikimedia/wikimedia.py` is the only call site. It uses MediaWiki's `appendtext` API parameter (not read-modify-write) for two reasons:
+**One function, one API.** `post_commonsdelinker_request(site, old_filename, new_filename, check_usage=True)` in `ingest_wikimedia/wikimedia.py` is the only call site. It uses MediaWiki's `appendtext` API parameter (not read-modify-write) for two reasons:
 
 1. The page is currently ~230 KB and growing. Loading it via `page.text` then re-saving the whole thing would burn ~500 KB per request — contributed to a recent OOM episode.
 2. `page.text` reads from a replica that can lag the primary by seconds; under burst load (a hub move-storm can post hundreds of requests in a minute) read-modify-write produced self-inflicted `editconflict` rejections. `appendtext` is server-side concatenation against the primary, no GET, atomic.
 
+**Gated on actual inbound usage.** The function posts a request only if the old title actually has links to relink. `file_has_inbound_usage(site, filename)` queries `globalusage|fileusage` for the title and returns `True` if the file is used on another wiki or by *another* local Commons page. It **excludes the file's own description page** from `fileusage`: a DPLA file page renders `{{Artwork}}`/`{{Information}}` with no explicit image parameter, so MediaWiki auto-displays the page's own image and lists the file as a user of itself. Counting that self-reference made the gate fire for every file, defeating its purpose — hence the `fulimit=2` (self plus at most one other is enough to distinguish "used by something else" from "only itself") and the explicit `title != self_title` filter. The check **fails open** (returns `True`) on any error, so a needed relink is never silently dropped.
+
+**The check runs *before* the move.** All three call sites verify usage while the old title is still the live file, then pass `check_usage=False` to `post_commonsdelinker_request`. Once a file has moved, the old title is a redirect and the usage query is unreliable — it can transiently read as "used" right after the move, defeating the gate. The internal `check_usage=True` default remains for any caller asking about a title that has *not* just been moved.
+
 **Reason string.** The default is `"[[COM:FR|File renamed]]: [[COM:FR#FR4|Criterion 4]] (harmonize the names of a set of images)"` — Commons' File Renaming policy criterion 4 (harmonising a set of related files). `build_title_drift_move_reason` iteratively shortens the reason string until it fits MediaWiki's 500-byte `CommentStore::COMMENT_CHARACTER_LIMIT` once username + filenames + the 36-byte fixed prefix overhead is accounted for.
 
-**Three call sites in `tools/uploader.py`:**
+**Three call sites in `tools/uploader.py`:** each computes `needs_relink = file_has_inbound_usage(...)` *before* the move, then posts (with `check_usage=False`) only if true.
 
-| Call site | When | Notes |
+| Call site | When | Posts a delinker request when… |
 |---|---|---|
-| `_resolve_redirect_move` | After moving a redirect target to the intended title | Always posts a delinker request |
-| `_move_to_correct_title` (Case 3) | After moving a file from a wrong title to the intended title | Posts unless the old title is a sibling slot |
-| `_move_to_correct_title` (Case 1) | After moving a file when the intended title was a redirect to it | Same suppression rule |
+| `_resolve_redirect_move` | After moving a redirect target to the intended title | The old title has inbound usage |
+| `_move_to_correct_title` (Case 3) | After moving a file from a wrong title to the intended title | The old title has inbound usage AND is not a suppressed sibling slot |
+| `_move_to_correct_title` (Case 1) | After moving a file when the intended title was a redirect to it | Same: inbound usage AND not a sibling slot |
+
+In other words: a delinker request is posted only if the old title has inbound usage and is not a suppressed sibling slot, and the usage check always runs before the move. A sibling slot is suppressed (`post_commonsdelinker=False`) because a later ordinal in the same session will overwrite the redirect at that title with different content, making any link-rewrite request invalid.
 
 The Case-2 path does NOT post a delinker request — there, `_tag_drift_duplicate` flags the old file for human review instead.
 
@@ -167,7 +180,7 @@ ERROR_BACKEND_FAIL  = "backend-fail-internal"
 
 `IGNORE_WIKIMEDIA_WARNINGS` (passed to pywikibot's `ignore_warnings=` argument) suppresses cosmetic warnings:
 
-- `bad-prefix`, `duplicate-archive`, `duplicate-version`, `empty-file`, `exists`, `exists-normalized`, `was-deleted`, `large-file`, etc.
+- `bad-prefix`, `badfilename`, `duplicate-archive`, `duplicate-version`, `empty-file`, `exists`, `exists-normalized`, `filetype-unwanted-type`, `page-exists`, `was-deleted`.
 
 But deliberately does NOT include `duplicate` or `no-change` — those still hard-fail because they indicate state we need to react to (different from a cosmetic "this filename is a bit weird" warning).
 
@@ -188,3 +201,54 @@ When `site.upload(...)` returns falsy (pywikibot returns `None` when the file ex
 - `fileexists-shared-forbidden`
 
 These all mean "transient or correctable" — re-running the upload usually succeeds. The retry CSV merges download-retry and upload-retry into one combined CSV per hub so a single uploader invocation handles both.
+
+## Content hubs vs. service hubs
+
+DPLA distinguishes two kinds of hub, and `ingest_wikimedia/sdc.py` encodes the partnership chain (the three-statement P9126 "operator" chain, each statement carrying a P3831 *object has role* qualifier) differently for each. The split is enumerated in code because `institutions_v2.json` carries no hub-type flag:
+
+```python
+Q_NARA = "Q518155"          # National Archives and Records Administration
+Q_SMITHSONIAN = "Q131626"   # Smithsonian Institution
+CONTENT_HUB_QIDS = frozenset({Q_NARA, Q_SMITHSONIAN})
+```
+
+The role-qualifier values (named for their actual Wikidata roles — renamed from the earlier misnamed `Q_SMITHSONIAN`/`Q_PUBLISHER`/`Q_AGGREGATOR`):
+
+```python
+Q_ROLE_AGGREGATOR   = "Q393351"      # aggregator (DPLA, and any service hub)
+Q_ROLE_REPOSITORY   = "Q108296843"   # repository
+Q_ROLE_CONTRIBUTING = "Q108296919"   # contributing / custodial unit
+```
+
+DPLA itself is always the top `aggregator` in P9126. The hub and institution roles then differ:
+
+| | Hub role | Institution role | Sits in P195 (collection) |
+|---|---|---|---|
+| **Content hub** (NARA, Smithsonian) | `repository` (`Q_ROLE_REPOSITORY`) | `contributing` (`Q_ROLE_CONTRIBUTING`) | The **hub** |
+| **Service hub** (everything else) | `aggregator` (`Q_ROLE_AGGREGATOR`, like DPLA) | `repository` (`Q_ROLE_REPOSITORY`) | The **institution** |
+
+A content hub *is* the providing institution — a `repository` that sits in P195 — and its "data providers" are internal departments, tagged as the `contributing` (custodial) unit. A service hub is an aggregating intermediary whose institutions are distinct organizations that each sit in P195.
+
+These role/P195 shapes match what is already on Commons; the read side (`Module:DPLA`) and `dpla_claims()` depend on them, so changing them without a coordinated Commons-side rewrite would make every existing P9126 statement look "unexpected" and trigger a remove+re-add on every re-sync.
+
+## Per-ordinal status and pageid rescue
+
+SDC eligibility is **decoupled from upload-result status**. The uploader writes a per-item `<partner>/<dpla_id>/upload-result.json` sidecar keyed by ordinal, with one `ORDINAL_*` status per ordinal:
+
+```python
+ORDINAL_UPLOADED     # file just uploaded (or drift-moved into place)
+ORDINAL_SKIPPED      # existing Commons file matches our SHA1
+ORDINAL_NOT_PRESENT  # no S3 asset to upload (downloader gap)
+ORDINAL_INELIGIBLE   # S3 asset present but uploader chose not to upload
+ORDINAL_FAILED       # upload attempted, raised, did not land
+```
+
+UPLOADED and SKIPPED ordinals carry a `title` and `pageid` and are eligible for `wbsetclaims`; NOT_PRESENT / INELIGIBLE / FAILED have no canonical Commons page to attach structured data to.
+
+**Pageid resolution and the fail-closed contract.** Commons can accept a large (chunked) upload and return without a real `.pageid` (or return `0`) while indexing lags. `_refresh_pageid_with_retries(page_title)` (in `tools/uploader.py`) re-fetches the page with bounded backoff to ride out that lag. If the budget is exhausted without a real id, it returns `None` and the sidecar records `pageid: null` rather than a malformed `0`. That `pageid: null` is a deliberate **fail-closed contract**: `sdc-sync`'s `if not pageid` guard feeds the title→pageid fallback, which recovers the real pageid on the next run.
+
+**Rescue by DPLA ID.** When the uploader couldn't confirm an ordinal (NOT_PRESENT / INELIGIBLE / FAILED) but a Commons file with that DPLA ID and ordinal already exists from a prior successful run, `_find_existing_commons_files_by_dpla_id(dpla_id)` (in `tools/sdc_sync.py`) rescues the ordinal → `{title, pageid}` mapping. It uses CirrusSearch `intitle:"<dpla_id>"` (the 32-hex ID is unique enough that the result set is bounded by the item's file count) and lets SDC sync against the existing file rather than skipping the data-side work because of a transient binary-side failure. It returns an empty dict on any failure mode, in which case the caller's existing skip path runs.
+
+## Limitations
+
+**Duplicate detection is SHA1-only.** `find_file_by_hash` queries Commons' `allimages?sha1=...`, so the entire decision tree above keys on exact byte-for-byte hash matches. It does **not** catch visually-identical re-encodes: a different encoding of the same image produces different bytes → a different SHA1 → no match, so the uploader treats it as net-new (or uploads a new version over the existing title). This is known and accepted behavior, not a bug.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,47 +1,47 @@
 # Templates and the Lua Module
 
-How the pipeline uses Commons templates to display item metadata — and how the planned transition from the legacy `{{Artwork}}`-based wikitext to the SDC-backed `{{DPLA metadata}}` will work.
+How the pipeline uses Commons templates to display item metadata — and how the transition from the legacy `{{Artwork}}`-based wikitext to the SDC-backed `{{DPLA metadata}}` works.
 
 This document is the *pipeline's* view of the templates. For the user-facing template documentation (what editors see and how they augment it), see the [Template:DPLA metadata/doc](https://commons.wikimedia.org/wiki/Template:DPLA_metadata/doc) page on Commons.
 
-## Current state: `{{DPLA metadata}}` with explicit params at upload, then SDC
+## Current state: flat-param `{{DPLA metadata}}` at upload, then SDC, then strip
 
-As of [PR #291](https://github.com/dpla/ingest-wikimedia/pull/291), the uploader writes a fully-rendered `{{DPLA metadata}}` block as the file page's wikitext at upload time. After SDC sync lands the same metadata as MediaInfo statements, the explicit params and the SDC carry the same values; the file page renders both side-by-side (yellow-box from params + blue-box from SDC) until the planned cleanup pass strips the now-redundant params (see [Planned transition](#planned-transition) below).
+The uploader writes a fully-rendered `{{DPLA metadata}}` block as the file page's wikitext at upload time. After SDC sync lands the same metadata as MediaInfo statements, the explicit params and the SDC carry the same values; the file page renders both side-by-side (yellow box from params + blue box from SDC). A post-SDC cleanup pass then strips the now-redundant params — this pass is implemented and on by default (see [Per-file lifecycle](#per-file-lifecycle) below), not a future plan.
 
 ### Upload-time wikitext
 
-`get_wiki_text(dpla_id, item_metadata, provider, data_provider)` in `ingest_wikimedia/wikimedia.py` composes the file-page wikitext. The current template literal:
+`get_wiki_text(dpla_id, item_metadata, provider, data_provider)` in `ingest_wikimedia/wikimedia.py` composes the file-page wikitext. The shape is **flat**: every param is a top-level scalar — there are no `{{InFi}}` / `{{DPLA}}` / `{{Institution}}` sub-templates inside the block. The template literal:
 
 ```wikitext
 == {{int:filedesc}} ==
-{{ DPLA metadata
-   | Other fields 1 = {{ InFi | Creator | <creator> | id=fileinfotpl_aut }}
-   | title       = <title>
-   | description = <description>
-   | date        = <date_string>
-   | permission  = {{<permissions-template>}}
-   | source      = {{ DPLA
-                       | <data-provider>
-                       | hub      = <provider>
-                       | url      = <isShownAt>
-                       | dpla_id  = <dpla_id>
-                       | local_id = <local_id>
-                   }}
-   | Institution = {{ Institution | wikidata = <data-provider-qid> }}
+
+{{DPLA metadata
+| creator = <creator>
+| title = <title>
+| description = <description>
+| date = <date_string>
+| permission = {{<permissions-template>}}
+| hub = <provider-qid>
+| institution = <data-provider-qid>
+| url = <isShownAt>
+| dpla_id = <dpla_id>
+| local_id = <local_id>
 }}
 ```
 
 Notable wiring:
 
-- The wrapper template is `{{DPLA metadata}}` (the DPLA-owned template backed by `Module:DPLA`), not `{{Artwork}}`. PR #291 swapped just the wrapper name; the inner parameter set is the same one the prior `{{Artwork}}`-based uploader had been emitting.
-- The `| Other fields 1` row is included only when a creator is present. It uses the same `{{InFi|Creator|…}}` idiom Artwork had, which the DPLA template renders compatibly. Once SDC sync lands the value as a creator statement, the cleanup pass would replace this row with a top-level `|creator=` param (yellow-box-compatible) before stripping it entirely.
-- `| source = {{DPLA|...}}` is the DPLA-specific source sub-template. `Template:DPLA` on Commons renders DPLA's catalog link, hub attribution, and local identifier inside the source slot. This `Template:DPLA` is distinct from `Module:DPLA` (the Lua module backing `{{DPLA metadata}}`); the sub-template stays for legacy pages even after the SDC sync lands the same data as `P7482` / `P760` / `P9126` claims.
-- `| permission = {{<permissions-template>}}` resolves to one of `NKC`, `NoC-US`, `PD-US`, `cc-zero`, or a CC-by/by-sa code per `license_to_markup_code()` (mapping is in `ingest_wikimedia/wikimedia.py`).
-- `| Institution = {{Institution|wikidata=...}}` uses Commons' standard `{{Institution}}` template for the institution row.
+- The wrapper template is `{{DPLA metadata}}` (the DPLA-owned template backed by `Module:DPLA`), not `{{Artwork}}`.
+- **The values are computed by `dpla_metadata_params(dpla_id, item_metadata, provider, data_provider)`, the single source of truth feeding both the writer (`get_wiki_text`) and the post-SDC comparator (`wikitext_normalize`).** Both sides derive their expectations from this one helper, so the value the uploader emits and the value the strip pass tests against can never drift.
+- **Why flat.** The previous nested sub-templates (`{{DPLA|...}}` in `source`, `{{Institution|...}}`, `{{InFi|Creator|…}}` in `Other fields 1`) emitted wikitext-table markup that, when it landed inside `Module:DPLA`'s HTML `<td>`, produced a table-syntax-in-cell rendering bug. Collapsing to flat scalars — which the module's yellow box reads directly via the same parametric helpers that drive the blue box — eliminates that bug.
+- The `| creator` row is **suppressed entirely** when DPLA has no creator string, to avoid a blank `creator =` row. The template also accepts `author` and `artist` as aliases for `creator` (editor familiarity with `{{Information}}` / `{{Artwork}}` conventions); `creator` is preferred for the [archival-records sense the SAA assigns to it](https://dictionary.archivists.org/entry/creator.html), which matches DPLA's source collections better than "Author."
+- `| permission` resolves to one of `NKC`, `NoC-US`, `PD-US`, `cc-zero`, or a CC-by/by-sa code per `license_to_markup_code()` (mapping is in `ingest_wikimedia/wikimedia.py`), wrapped as `{{...}}`. When the rights URI is unmapped, the param renders **empty** (`| permission =`) rather than a malformed `{{}}` invocation.
+- `| hub` and `| institution` are Wikidata Q-IDs (provider and data-provider respectively). The institution Q-ID doubles as the Institution-row driver: `Module:DPLA` expands `{{Institution|wikidata=<inst>}}` on its side, so no `{{Institution}}` sub-template appears in the wikitext.
+- `| url` / `| dpla_id` / `| local_id` carry DPLA's catalog link, the DPLA item id, and the contributor's local identifier as plain strings. The DPLA-specific source rendering (catalog link, hub attribution, local identifier) is done by `Module:DPLA` from these scalars, not by a `{{DPLA|...}}` sub-template in the wikitext. (`Template:DPLA`, the source sub-template, is distinct from `Module:DPLA`; it still appears on un-migrated legacy pages — see below.)
 
-### Files uploaded before PR #291
+### Files uploaded in the legacy `{{Artwork}}` form
 
-Pages already on Commons keep their `{{Artwork}}` blocks until they're individually edited. There's no backfill pass yet; `Module:DPLA` happily renders an `{{Artwork}}`-wikitext file's SDC the same way it renders a `{{DPLA metadata}}`-wikitext file's, so the visible difference is only in the wikitext-tab view, not the rendered file description.
+Older pages on Commons carry `{{Artwork}}` blocks (or the older nested-`{{DPLA metadata}}` sub-template form). `Module:DPLA` renders an `{{Artwork}}`-wikitext file's SDC the same way it renders a flat-`{{DPLA metadata}}` file's, so the visible difference is only in the wikitext-tab view, not the rendered file description. The legacy `{{Artwork}}` → `{{DPLA metadata}}` migration is implemented and runs from the post-SDC cleanup dispatcher (see [Legacy migration](#legacy-artwork--dpla-metadata-migration-implemented) below).
 
 ### Post-upload rendering: `{{DPLA metadata}}` + `Module:DPLA`
 
@@ -69,48 +69,47 @@ The module's existence is acknowledged in a handful of code comments inside the 
 
 The pipeline does NOT directly invoke the module, render it client-side, or test it. Module:DPLA lives on Commons and is maintained as a Wikimedia-side artefact; this repo's responsibility is to write SDC the module can render correctly. See [this test file on Commons](https://commons.wikimedia.org/wiki/File:Plate_49_of_King%27s_1933_aerial_coverage_of_Denver,_Colorado_-_DPLA_-_4c3f5ad9bfac4097b95c9f8deb8e1a21.jpg) for a live render.
 
-## Planned transition
+## The per-file lifecycle and the strip/migrate pass
 
-The roadmap is to ship `{{DPLA metadata}}` as the *primary* format the pipeline writes at upload time, replacing the `{{Artwork}}`-based wikitext block. Two reasons:
-
-1. **Single source of truth.** Today the metadata is duplicated — once as wikitext templated by the uploader, once as SDC reconciled by the sync phase. Switching the primary display to `{{DPLA metadata}}` means the SDC IS the metadata, full stop. The file-page wikitext becomes a bare `{{DPLA metadata}}` invocation that picks everything up from SDC.
-2. **Live updates.** When `Module:DPLA` reads SDC, every file gets the current rendering of the current data — no need to re-edit thousands of wikitext blobs to push out a display change.
+The goal is for SDC to *be* the metadata: once a file's display is entirely SDC-driven, any future DPLA sync that updates the source data flows through to the rendered page automatically via `Module:DPLA`, with no wikitext re-edit needed across thousands of files. Two forces make this work — wikitext params are needed at upload (the [upload API](https://www.mediawiki.org/wiki/API:Upload) can't attach SDC in the same request, and Commons won't tolerate a file landing with no readable description even briefly), but stale params left behind would *override* SDC on display and mask future corrections, so they have to be stripped once the SDC counterpart exists.
 
 ### Per-file lifecycle
 
 Three edits per file, in order:
 
-1. **Upload — *done* (PR #291).** The uploader writes `{{DPLA metadata}}` with explicit wikitext parameters: `title`, `description`, `date`, `permission`, `source` (as a `{{DPLA|...}}` sub-template carrying catalog link, hub attribution, local identifier), `Institution`, plus a `{{InFi|Creator|…}}` row in `Other fields 1` when a creator is known. Wikitext params are necessary at this step because MediaWiki's [upload API](https://www.mediawiki.org/wiki/API:Upload) doesn't allow SDC statements to be attached in the same request, and Commons will not tolerate a file landing with no readable description even briefly. The Lua module renders these params in the yellow box on a fresh upload (with no SDC populated yet).
-2. **SDC sync — *done* (existing phase).** A subsequent edit posts the same metadata as MediaInfo statements via `wbeditentity`. After this edit, the wikitext params and the SDC contain the same values — the displayed page now has the SDC-driven blue box *and* the param-driven yellow box, both rendering identical content.
-3. **Cleanup edit — *planned*.** A one-time follow-up edit will strip the now-redundant wikitext params, leaving a bare `{{DPLA metadata}}` invocation plus the licensing template. From this point on the file's display is entirely SDC-driven, and any future DPLA sync that updates the source data flows through to the rendered page automatically — no wikitext re-edit needed.
+1. **Upload.** The uploader writes flat-param `{{DPLA metadata}}` (the shape above). The module renders these params in the yellow box on a fresh upload, before any SDC is populated.
+2. **SDC sync.** A subsequent edit posts the same metadata as MediaInfo statements via `wbeditentity`. After this edit, the wikitext params and the SDC contain the same values — the displayed page now has the SDC-driven blue box *and* the param-driven yellow box, both rendering identical content.
+3. **Post-SDC cleanup.** A follow-up edit strips the now-redundant wikitext params, leaving (when every param strips) a bare single-line `{{DPLA metadata}}` invocation plus the licensing template. From this point on the file's display is entirely SDC-driven. The licensing template stays in the wikitext because Commons' file-curation conventions require the license to remain visible there (not just in SDC) for human review.
 
-Step 3 matters because explicit wikitext params *override* SDC on display (see [`Template:DPLA metadata/doc`](https://commons.wikimedia.org/wiki/Template:DPLA_metadata/doc) on Commons). Leaving stale params in place would mask any future SDC corrections. As of June 2026, files uploaded by PR #291 are in the intermediate "step 1 done, awaiting step 3" state.
+### The post-SDC cleanup pass (implemented, on by default)
 
-### Adoption of community-uploaded files
+Step 3 is implemented in `ingest_wikimedia/wikitext_normalize.py` and runs from `tools/sdc_sync.py`. It is **on by default** — there is no separate `tools/strip_redundant_params.py`; the logic lives in `wikitext_normalize`.
 
-The duplicate-detection logic already handles a related case: a file from a DPLA partner that some Commons editor has already uploaded directly (typically from the partner's online catalog or from Flickr). When the pipeline detects this overlap and adopts the file into DPLA's system — renaming it to the canonical `... - DPLA - <id>.<ext>` form — the planned workflow migrates whatever metadata the original uploader recorded in the existing wikitext into `{{DPLA metadata}}`'s yellow-box parameters. SDC sync then layers the DPLA-authoritative values on top: blue box shows DPLA, yellow box preserves the migrated editor data verbatim.
+- **Entry point.** `tools/sdc_sync.py::_post_sdc_cleanup_for_page` is the dispatcher. After the SDC write for a page, it inspects the current wikitext: a flat-`{{DPLA metadata}}` page goes through the strip path (`wikitext_normalize.normalize_page`); a legacy `{{Artwork}}` (or `{{Information}}` / `{{Photograph}}`) page goes through the migration path (see below).
+- **Flag.** `--normalize-wikitext` / `--no-normalize-wikitext` (default on). Pass `--no-normalize-wikitext` for diagnostic runs that need the pre-strip wikitext intact. The flag propagates to worker processes in partner mode.
+- **What it strips.** `normalize` removes each `{{DPLA metadata}}` param whose value equals the SDC-backed value computed by `dpla_metadata_params` (compared via `_value_matches`). `canonicalize` then enforces the canonical whitespace shape: left-justified template, exactly one blank line after `== {{int:filedesc}} ==`, one `| key = value` per line, closing `}}` on its own line — or, when *every* param has been stripped, collapse to a single-line `{{DPLA metadata}}`.
+- **Safety guard.** Before stripping, the dispatcher fetches the file's MediaInfo entity and refuses to strip if it has *no* DPLA-attributed SDC (`_entity_has_dpla_attributed_claims`). This prevents the failure mode where a dropped or null-pageid SDC write would otherwise leave the page with metadata in *neither* representation. An API failure during the guard is also a hard skip.
 
-The migration step is not yet implemented; today's duplicate-detection flow handles the rename and the `{{Duplicate}}` tagging of the original (see [special-cases.md](special-cases.md#hash-drift-the-four-cases)), but leaves the wikitext at the new title in its `{{Artwork}}` form.
+### The dual-path comparator
 
-### Code changes — current and remaining
+`wikitext_normalize` is shape-tolerant: it strips both the **new flat params** and the **old nested sub-template rows**, so old- and new-shape pages converge to the same stripped output. The legacy-row strippers — `_strip_legacy_source` (`source = {{DPLA|...}}`), `_strip_legacy_institution` (`Institution = {{Institution|wikidata=...}}`), and `_strip_legacy_creator` (`Other fields 1 = {{InFi|Creator|…}}`) — parse each sub-template's inner params and compare them against the flat-canonical equivalents via `_value_matches`. Any unexpected extra arg on the wikitext side disqualifies the strip (an editor may have added something the comparator doesn't know to match).
 
-**Done in PR #291:** `ingest_wikimedia/wikimedia.py::get_wiki_text` was switched from `{{Artwork}}` to `{{DPLA metadata}}` as the wrapper template. The inner parameter set kept the same shape (title / description / date / permission / source-via-`{{DPLA|...}}` / Institution / Creator-via-`InFi`), so no rewrite was needed — just the one-line wrapper-name change. The yellow user-contributed box on a fresh upload is now populated by these params automatically; SDC sync layers the blue box on top in the subsequent phase.
+Two finer behaviours of the comparator:
 
-The template also accepts `author` and `artist` as aliases for `creator` (for editor familiarity with `{{Information}}` and `{{Artwork}}` conventions); `creator` is preferred because of the [archival-records sense the SAA assigns to it](https://dictionary.archivists.org/entry/creator.html), which matches DPLA's source collections better than "Author."
+- **Language-wrapper unwrapping.** A non-rendered `languages` key on the params dict (built by `_extract_unwrap_languages`) carries the per-item allowlist of ISO 639-1 codes the comparator may safely unwrap — always `en`, plus any language the DPLA record itself declares in `sourceResource.language`. The comparator will unwrap a single-language wrapper like `{{es|...}}` only for an allowlisted language; `{{LangSwitch}}` and any unknown/un-allowlisted wrapper are always preserved (the file was deliberately multilingualised by an editor).
+- **Date dedup in migration.** When migrating, an editor's `{{other date|...}}` / circa / year-range value is expanded server-side (`_expand_wikitext_for_date_parse`, via MediaWiki `expandtemplates`) and checked against DPLA's existing `P571` (`_existing_dpla_date_matches_parsed` / `_existing_dpla_date_range_matches`) so a value like `{{other date|between|1934|1948}}` doesn't get imported as a parallel statement alongside the DPLA date it already matches.
 
-**Remaining for step 3 (cleanup):** a new maintenance pass (e.g. `tools/strip_redundant_params.py`) that runs at some interval after SDC sync, scans for files where SDC and wikitext params agree, and strips the params, leaving `{{DPLA metadata}}` as a bare invocation. The licensing template stays separate because Commons' file-curation conventions require the license to remain visible in the wikitext (not just SDC) for human review.
+### Legacy `{{Artwork}}` → `{{DPLA metadata}}` migration (implemented)
 
-### Workstreams the transition would touch
+The migration is implemented in `ingest_wikimedia/legacy_artwork.py` (`migrate_legacy_file`, `plan_migration`, `build_legacy_import_claims`) and runs via the `--migrate-legacy` mode of `tools/sdc_sync.py` as well as from the post-SDC cleanup dispatcher when it encounters a legacy template.
 
-- ~~`ingest_wikimedia/wikimedia.py::get_wiki_text` — new template body with explicit params.~~ Done in PR #291.
-- A new maintenance pass (e.g. `tools/strip_redundant_params.py`) for step 3.
-- The adoption-migration path in `tools/uploader.py::Uploader._resolve_hash_drift` — extend the rename branches to salvage the original editor's wikitext into yellow-box params.
-- Commons-side [`Template:DPLA metadata/doc`](https://commons.wikimedia.org/wiki/Template:DPLA_metadata/doc) — already documents the planned lifecycle.
-- `Commons:Digital Public Library of America/Modeling` — already updated to describe the SDC properties the module reads.
-- Operator runbook in [operations.md](operations.md) — note the change in the "what's on a fresh upload" wording.
-- A staged rollout — flip one hub at a time so a regression doesn't take down every partner.
+The problem it solves: a legacy file may carry community edits made years after the original DPLA upload. A naïve overwrite would discard them. So `plan_migration` walks the file's revision history to separate values DPLA's bot last touched (safe to overwrite with canonical data) from values a community editor contributed (must be preserved). Community values are preserved as SDC *imports* — statements carrying a `P887 → Q131783016` ("inferred from Wikitext") + `P4656 → <permalink-to-source-revision>` reference shape, deliberately *without* the standard DPLA qualifiers (`P459/Q61848113`, `P813`) that would misrepresent them as DPLA-sourced.
 
-No code changes have landed for this transition yet; no TODO/FIXME comments in `tools/uploader.py` or `ingest_wikimedia/wikimedia.py` reference it.
+The order is load-bearing and crash-safe: **SDC import first, wikitext rewrite second.** If the rewrite fails after the import succeeded, the file carries the imported SDC but still has the legacy template, and a follow-up sweep completes it; the reverse order could irrecoverably lose community values. An `entity_was_already_migrated` idempotency guard (it looks for the `P887 → Q131783016` reference shape on the entity) makes re-runs safe. The migrated wikitext is run through the same strip + `canonicalize` pass as the flat-`{{DPLA metadata}}` path, so a migrated file lands in the post-strip steady state in one save.
+
+### Remaining work
+
+One narrow gap remains: the uploader's **duplicate-detection adoption-rename path** — when the pipeline adopts a file a Commons editor already uploaded directly (from the partner's catalog or Flickr) and renames it to the canonical `... - DPLA - <id>.<ext>` form — does **not** itself invoke this provenance-aware migration. `_resolve_hash_drift` / `merge_preserved_wikitext` (in `tools/uploader.py` and `ingest_wikimedia/wikimedia.py`) currently overwrite the metadata template wholesale, discarding any community-contributed params an editor added between the original upload and the rescue. A `TODO` on `merge_preserved_wikitext` flags the integration point: the `legacy_artwork` provenance logic should preserve community values as SDC imports first, then overwrite. (The rename and `{{Duplicate}}` tagging of the original work today — see [special-cases.md](special-cases.md#hash-drift-the-four-cases).)
 
 ## How SDC and templates interact today
 
@@ -146,4 +145,4 @@ A summary diagram:
    └──────────────────────────────────────────────┘
 ```
 
-In the planned future state (step 3 of the lifecycle), the left branch's wikitext params get stripped — the file page wikitext becomes a bare `{{DPLA metadata}}` invocation, and all displayed metadata comes from the SDC sync's writes via `Module:DPLA`. Until that pass exists, the explicit params and the SDC carry redundant copies of the same values.
+Step 3 of the lifecycle (the post-SDC cleanup pass) then strips the left branch's redundant params — once every param is stripped the file-page wikitext becomes a bare single-line `{{DPLA metadata}}` invocation plus the licensing template, and all displayed metadata comes from the SDC sync's writes via `Module:DPLA`. Between the SDC write and the strip, the explicit params and the SDC carry redundant copies of the same values; the cleanup pass runs in the same `sdc_sync` invocation by default.


### PR DESCRIPTION
## Why

The `docs/` set was last updated 2026-06-10 (`4c7fc6d`). **28 PRs (#293–#318)** have merged since — including two whole new subsystems (`worker_slots.py`, `legacy_artwork.py`) — that the docs didn't reflect. This is a docs-only PR bringing the set current; no code changes.

## Biggest gaps closed

- **Concurrency + box-wide slot budget** — `--workers N` (multiprocessing.Pool) and `--workers-budget N` (`WorkerSlotBudget`, flock slot files in `/tmp/sdc-sync-worker-slots`, shared across all sessions). Added to sdc-sync.md (two new sections), architecture.md (shared slot-pool diagram + intra-host concurrency layer), pipeline-phases.md, operations.md (ops note: `lslocks`, budget-consistency invariant), README + maintenance-tools (flags). Defaults are attributed correctly everywhere: **`1`/`0` standalone, `6`/`24` via the launcher/workflow** — not the tool's own defaults.
- **Legacy `{{Artwork}}` → `{{DPLA metadata}}` migration** — `legacy_artwork.py`, both `--migrate-legacy` and the automatic post-SDC pass. templates.md previously said this was "not yet implemented" (now corrected).
- **`docs/templates.md`** — rewrote from the old **nested** sub-template shape to the actual **flat** `{{DPLA metadata}}` params, and from "strip is planned" to "strip + migration shipped, on by default."
- **CommonsDelinker** — now documented as **gated on inbound usage** (self-page excluded; checked before the move), plus the 404-⇒-migrate hash-drift case and the corrected `IGNORE_WIKIMEDIA_WARNINGS` list.
- **Content-hub vs service-hub** partnership model + corrected `Q_ROLE_*` constants (special-cases.md, architecture.md, sdc-sync.md).
- **Metrics/Slack** — corrected counter list, the real `/wikimedia-status` output format (worker-slots + memory line, waiting/queued annotations), and the `notify_sdc_complete` summary (PAGES EDITED, SLOT WAIT).
- **ROADMAP** — marked IIIF v3 parsing and the banned-object-list filter done; noted SDC-sync parallelism shipped; flagged the superseded duplicate-check matrices. (Download parallelization left open — still single-process.)

## How it was produced

Every file was reviewed and rewritten against the actual code on `main` (real symbols cited), then cross-checked for consistency on the load-bearing facts (defaults, slot-dir path, role Q-IDs) and for internal-anchor integrity.

`docs/metrics.md` intentionally unchanged — it covers the pageview-metrics subsystem, not the SDC tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Documentation-only update syncing the `docs/` directory with code changes merged between June 10–17, 2026. Closes 28 documentation gaps and adds documentation for two newly-introduced subsystems: `worker_slots.py` (host-wide Commons write throttling) and `legacy_artwork.py` (template migration).

No manual pipeline trigger, ECS redeployment, environment variable/Secrets Manager key changes, database migration, shared infrastructure configuration changes (CodePipeline/CodeBuild/ECS/IAM), public API shape changes/endpoints, or security-relevant/credential-handling changes are included—only documentation updates.

## Key Documentation Updates

**Concurrency and Worker Slot Budgeting**
- Documented `--workers N` (multiprocessing.Pool) and `--workers-budget N` (WorkerSlotBudget using `flock` slot files under `/tmp/sdc-sync-worker-slots`)
- Corrected defaults:
  - standalone: `1` / `0`
  - launcher/workflow: `6` / `24`
- Added/expanded the host-wide “Intra-host write throttle (WorkerSlotBudget)” model in `docs/architecture.md`, including slot contention and operational expectations

**Legacy Artwork Migration**
- Documented `legacy_artwork.py`, the `--migrate-legacy` one-time migration mode, and the automatic post-SDC legacy-to-`{{DPLA metadata}}` cleanup behavior
- Corrected prior documentation that incorrectly stated the feature was “not yet implemented”
- Added the maintenance tool entry and operational notes for `sdc-sync --migrate-legacy`

**Templates Documentation**
- Rewrote `docs/templates.md` to describe the actual flat top-level `{{DPLA metadata}}` parameter structure (previously documented as nested)
- Updated status from “strip is planned” to “strip + migration shipped, on by default”
- Documented post-SDC cleanup pass behavior, migration/canonicalization rules, and safety guards around redundant-parameter stripping

**CommonsDelinker, Pipeline Special Cases, and Metrics/Monitoring**
- Documented CommonsDelinker gating on inbound usage (excluding self-reference), including timing relative to moves and more precise delinker behavior
- Corrected `/wikimedia-status` output format and counter lists
- Expanded Slack “Wikimedia Upload Status” output specifications, including idle/none-active handling

**Architecture/Operations/Roadmap Corrections**
- Expanded Phase 4 (`sdc-sync`) operational documentation with worker/budget and legacy/wikitext normalization flags
- Updated `ROADMAP.md` to mark IIIF v3 parsing and the banned-object-list filter as complete, and to clarify what is (and is not) parallelized
- Added detailed worker-slot and worker-based counter/wait averaging references in operational docs

## Follow-up Documentation Corrections
- Adjusted `docs/operations.md` to match the exact `worker_slots.py` log line format (including the leading `" -- "` prefix used for grep)
- Removed a fabricated Slack status annotation in `docs/slack-guide.md` to reflect the actual row formatting (`{session:<32}` {phase})

## Files Modified
README.md, ROADMAP.md, `docs/architecture.md`, `docs/maintenance-tools.md`, `docs/operations.md`, `docs/pipeline-phases.md`, `docs/sdc-sync.md`, `docs/slack-guide.md`, `docs/special-cases.md`, `docs/templates.md`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->