### PR TITLE
Add hub||collection target form for cross-institution collections

### DIFF
--- a/docs/slack-guide.md
+++ b/docs/slack-guide.md
@@ -83,6 +83,16 @@ Use `hub|institution|collection` to scope down to a single named collection with
 
 The collection name must match exactly what appears in `sourceResource.collection.title` for items in DPLA's index. If you're not sure of the exact string, run an institution-level upload instead — extra items are skipped at item level by eligibility, so over-scoping is cheap.
 
+### Hub-wide collections (cross-institution)
+
+Not every collection belongs to a single institution — some span multiple `dataProvider`s under one hub (NARA record groups are the common case: e.g. *General Records of the United States Government* sits under "National Archives at Washington, DC — Textual Reference," not "College Park"). To match a collection across **every** upload-eligible institution in the hub, leave the institution slot empty — `hub||collection` (two pipes, nothing between them):
+
+```text
+/wikimedia-upload "nara||General Records of the United States Government"
+```
+
+This matches the collection title across all of the hub's eligible institutions, so you don't have to know — or guess — which `dataProvider` holds it. (No real item has an empty institution, so the empty slot is unambiguous.) The standard item-level eligibility filters — rights and a usable media asset — still apply, so over-scoping remains cheap. The two-pipe form is required: `hub|collection` would be read as `hub|institution` and can't be distinguished from one.
+
 ## 4. Wikidata QID
 
 If you know a hub's or institution's Wikidata QID, pass it instead of a slug. The launcher resolves QIDs against `institutions_v2.json`:

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -8,8 +8,11 @@ all targets run sequentially), and posts a Slack confirmation to #tech-alerts.
 
 Each target in --partner is a hub slug ("bpl"), a hub|institution pair
 ("indiana|Indiana State Library"), a hub|institution|collection triple
-("bpl|Digital Commonwealth|Boston City Archives"), a Wikidata QID ("Q1234567"),
-or a 32-hex-char DPLA item ID ("abc123def456789012345678901234ab").  Multiple
+("bpl|Digital Commonwealth|Boston City Archives"), a hub||collection triple with
+an empty institution slot ("nara||General Records of the United States
+Government") that matches the collection across every upload-eligible
+institution in the hub, a Wikidata QID ("Q1234567"), or a 32-hex-char DPLA item
+ID ("abc123def456789012345678901234ab").  Multiple
 targets run sequentially in one tmux session; a failing target posts a Slack
 error and continues with the next target.
 
@@ -118,6 +121,39 @@ def _slack_fail(response_url: str, msg: str, *, operational: bool = False) -> No
             except Exception as e:
                 logging.warning("Fallback post to #tech-alerts also failed: %s", e)
     sys.exit(1)
+
+
+def _build_get_ids_command(
+    canonical: str,
+    institutions: tuple[str, ...],
+    collection: str | None,
+    dpla_id: str | None,
+    csv_file: str,
+) -> str:
+    """Build the get-ids command that stages the ID CSV for one target.
+
+    Routing rules:
+    - A ``--single-id`` target re-runs get-ids-es so dpla-map.json and sdc.json
+      are restaged with the current mapping code before download/upload/sync.
+    - Hub-level NARA with no institution and no collection uses get-ids-nara
+      (its bespoke NARA catalog walk). A NARA *collection* target (e.g.
+      ``nara||General Records…``) must instead go through get-ids-es, which is
+      the only path that filters on ``sourceResource.collection.title``.
+    - Every other target uses get-ids-es, repeating ``--institution`` per
+      resolved name (ORed in the ES dataProvider filter) and adding
+      ``--collection`` when set. Omitting ``--institution`` matches the
+      collection across every upload-eligible institution in the hub.
+    """
+    if dpla_id is not None:
+        return f"get-ids-es {canonical} --single-id {shlex.quote(dpla_id)} > {csv_file}"
+    if canonical == "nara" and not institutions and collection is None:
+        return f"get-ids-nara > {csv_file}"
+    cmd = f"get-ids-es {canonical}"
+    for inst in institutions:
+        cmd += f" --institution {shlex.quote(inst)}"
+    if collection is not None:
+        cmd += f" --collection {shlex.quote(collection)}"
+    return cmd + f" > {csv_file}"
 
 
 def main() -> None:
@@ -243,10 +279,11 @@ def main() -> None:
         #                     uploader, one sdc-sync — so the operator sees
         #                     one tmux session and one set of Slack
         #                     notifications instead of N chained sessions.
-        if collection is not None and len(institutions) != 1:
+        if collection is not None and len(institutions) > 1:
             skipped_warnings.append(
-                f"Collection '{collection}' requires exactly one institution"
-                " (collection scoping is per-institution)."
+                f"Collection '{collection}' cannot be combined with multiple"
+                " institutions. Use one institution (hub|institution|collection)"
+                " or none (hub||collection, matched across the whole hub)."
             )
             return
         stripped: list[str] = []
@@ -277,8 +314,11 @@ def main() -> None:
                     f"'{canonical}': not upload-eligible per institutions_v2.json."
                 )
                 return
-        if collection is not None:
+        if collection is not None and institutions:
             target_str = f"{canonical}|{institutions[0]}|{collection}"
+        elif collection is not None:
+            # Hub-wide collection: empty institution slot (hub||collection).
+            target_str = f"{canonical}||{collection}"
         elif len(institutions) == 1:
             target_str = f"{canonical}|{institutions[0]}"
         elif institutions:
@@ -326,9 +366,13 @@ def main() -> None:
                     f"'{target_str}': collection name normalizes to an empty slug."
                 )
                 return
-            label = f"{canonical}+{inst_label}+{coll_label}"
+            # Hub-wide collection has no institution slug (inst_label is None,
+            # filtered out below) → hub+collection; the session-label parser
+            # treats the collection slug as the hub's suffix, same shape as an
+            # institution slug.
+            label = "+".join(p for p in (canonical, inst_label, coll_label) if p)
         else:
-            label = f"{canonical}+{inst_label}" if inst_label is not None else canonical
+            label = "+".join(p for p in (canonical, inst_label) if p)
         if label in seen_session_labels:
             skipped_warnings.append(
                 f"'{target_str}': normalizes to the same session label ('{label}') as a previous target."
@@ -386,9 +430,17 @@ def main() -> None:
                 continue
             if len(token_parts) == 3:
                 _, institution, collection = token_parts
-                _add_target(
-                    canonical, institutions=(institution,), collection=collection
-                )
+                if institution.strip() == "":
+                    # hub||collection — empty institution slot means "match the
+                    # collection across every upload-eligible institution in the
+                    # hub" (some collections span multiple institutions). No real
+                    # item has an empty institution, so the empty slot is
+                    # unambiguous.
+                    _add_target(canonical, institutions=(), collection=collection)
+                else:
+                    _add_target(
+                        canonical, institutions=(institution,), collection=collection
+                    )
             else:
                 _, institution = token_parts
                 _add_target(canonical, institutions=(institution,))
@@ -689,20 +741,21 @@ def main() -> None:
             elif collection is not None:
                 # Collection-level request conflicts with:
                 #   1. An existing hub-level session for the same hub
-                #   2. An existing institution-level session for the same institution
-                #      (the collection is a subset; running both simultaneously would
-                #      duplicate work, though it is technically idempotent)
+                #   2. An existing institution-level session for the institution the
+                #      collection is scoped to (the collection is a subset; running
+                #      both duplicates work, though it is technically idempotent)
                 #   3. An existing session for the exact same collection label
                 # A collection does NOT conflict with a different collection from the
                 # same institution — those are independent, disjoint subsets.
-                # ``institutions`` is exactly one element when collection is set
-                # (enforced by _add_target).
-                inst_label = f"{canonical}+{_slugify(institutions[0])}"
+                # A hub-wide collection (hub||collection) has no single institution
+                # — ``institutions`` is empty — so only the hub-level and exact-label
+                # conflicts apply.
                 conflicts_this = (
-                    canonical in existing_labels
-                    or inst_label in existing_labels
-                    or label in existing_labels
+                    canonical in existing_labels or label in existing_labels
                 )
+                if institutions:
+                    inst_label = f"{canonical}+{_slugify(institutions[0])}"
+                    conflicts_this = conflicts_this or inst_label in existing_labels
             elif dpla_id is None:
                 # Institution-level (or multi-institution-combined) requests
                 # conflict with:
@@ -817,34 +870,9 @@ def main() -> None:
         # Use a per-target CSV filename so concurrent institution-level and
         # collection-level sessions don't clobber each other's ID lists.
         csv_file = f"{session_label}.csv"
-        if dpla_id is not None:
-            # Single-item target: re-run get-ids-es in ``--single-id`` mode so
-            # dpla-map.json AND sdc.json are staged with the latest mapping
-            # code before the downloader/uploader/sdc-sync chain reads them.
-            # Without this re-staging, sdc-sync would diff against whatever
-            # sdc.json the partner's last full run produced — silently missing
-            # any subsequent ingest_wikimedia.sdc changes (e.g. PR #279's
-            # opportunistic date parsing, PR #278's NARA stdlib XML).
-            # ``resolve-dpla-ids`` (the pre-launch eligibility check) is
-            # still useful because it short-circuits ineligible IDs with a
-            # clean Slack message before the tmux session is even launched,
-            # but the per-item S3 staging it does is superseded here.
-            get_ids_cmd = (
-                f"get-ids-es {canonical}"
-                f" --single-id {shlex.quote(dpla_id)} > {csv_file}"
-            )
-        elif canonical == "nara" and not institutions:
-            get_ids_cmd = f"get-ids-nara > {csv_file}"
-        else:
-            get_ids_cmd = f"get-ids-es {canonical}"
-            # ``--institution`` is repeated per name when the QID resolved
-            # to multiple institutions under this hub; get-ids-es ORs them
-            # in the Elasticsearch dataProvider filter.
-            for inst in institutions:
-                get_ids_cmd += f" --institution {shlex.quote(inst)}"
-            if collection is not None:
-                get_ids_cmd += f" --collection {shlex.quote(collection)}"
-            get_ids_cmd += f" > {csv_file}"
+        get_ids_cmd = _build_get_ids_command(
+            canonical, institutions, collection, dpla_id, csv_file
+        )
         # Export the session label (and single-item flag) before the group so the
         # failure handler and logging have the correct context even if cd itself fails.
         # WIKIMEDIA_SINGLE_ITEM must be explicitly unset for hub targets so that it

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -156,6 +156,29 @@ def _build_get_ids_command(
     return cmd + f" > {csv_file}"
 
 
+def _target_label(
+    canonical: str, institutions: tuple[str, ...], collection: str | None
+) -> str:
+    """Format a batch target as the pipe-separated string shown in Slack.
+
+    For a combined-institution target (multiple institutions from a single
+    QID under one hub), shows the first institution + a ``(+N more)`` hint —
+    the full list would blow up the Slack message width for QIDs with many
+    sub-institutions. A collection target is either institution-scoped
+    (``hub|institution|collection``) or hub-wide with an empty institution
+    slot (``hub||collection``).
+    """
+    if collection:
+        if institutions:
+            return f"`{canonical}|{institutions[0]}|{collection}`"
+        return f"`{canonical}||{collection}`"
+    if len(institutions) == 1:
+        return f"`{canonical}|{institutions[0]}`"
+    if institutions:
+        return f"`{canonical}|{institutions[0]} (+{len(institutions) - 1} more)`"
+    return f"`{canonical}`"
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--partner", required=True)
@@ -949,24 +972,6 @@ def main() -> None:
     pipeline_cmd = f"{setup} && {{ {'; '.join(target_blocks)}; }}"
 
     if slack_token:
-
-        def _target_label(c: str, insts: tuple[str, ...], col: str | None) -> str:
-            """Format a batch target as the pipe-separated string shown in Slack.
-
-            For a combined-institution target (multiple institutions from a
-            single QID under one hub), shows the first institution + a
-            ``(+N more)`` hint — full list would blow up the Slack message
-            width for QIDs with many sub-institutions.
-            """
-            if col:
-                # Collection-level is always single-institution by construction.
-                return f"`{c}|{insts[0]}|{col}`"
-            if len(insts) == 1:
-                return f"`{c}|{insts[0]}`"
-            if insts:
-                return f"`{c}|{insts[0]} (+{len(insts) - 1} more)`"
-            return f"`{c}`"
-
         single_item_targets = [
             (c, lbl, did) for c, _, lbl, did, _ in targets if did is not None
         ]

--- a/tests/test_get_ids_es.py
+++ b/tests/test_get_ids_es.py
@@ -69,22 +69,26 @@ def _invoke(*args: str):
         return runner.invoke(get_ids_es.main, list(args))
 
 
-def test_collection_requires_exactly_one_institution_zero():
-    """``--collection`` with no ``--institution`` must fail validation
-    (collection scoping is per-institution)."""
+def test_collection_without_institution_is_hub_wide():
+    """``--collection`` with no ``--institution`` is valid: the collection
+    is matched across every upload-eligible institution in the hub (some
+    collections span multiple institutions). It must pass validation and
+    reach the ID-generation path (the stubbed ``fetch_subjects_json``
+    sentinel proves it got past validation)."""
     result = _invoke(
         "bpl",
         "--collection",
         "Some Collection",
     )
-    assert result.exit_code == 1, result.output
-    assert "exactly one --institution" in result.output
+    assert isinstance(result.exception, RuntimeError)
+    assert "stop-after-validation" in str(result.exception)
 
 
-def test_collection_requires_exactly_one_institution_many():
-    """``--collection`` with multiple ``--institution`` values must fail
-    validation — combining a collection scope across institutions is
-    not meaningful."""
+def test_collection_with_multiple_institutions_passes():
+    """``--collection`` combined with multiple ``--institution`` values is
+    accepted at the tool level — the ES query simply ANDs the collection
+    with the institution set. (The launch script restricts pipe-target
+    SYNTAX to zero or one institution; the tool itself is permissive.)"""
     result = _invoke(
         "bpl",
         "--institution",
@@ -94,8 +98,15 @@ def test_collection_requires_exactly_one_institution_many():
         "--collection",
         "Some Collection",
     )
+    assert isinstance(result.exception, RuntimeError)
+    assert "stop-after-validation" in str(result.exception)
+
+
+def test_collection_empty_string_rejected():
+    """An empty ``--collection`` value is still rejected."""
+    result = _invoke("bpl", "--collection", "   ")
     assert result.exit_code == 1, result.output
-    assert "exactly one --institution" in result.output
+    assert "--collection cannot be empty" in result.output
 
 
 def test_multiple_institutions_pass_validation_and_combine():

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -343,3 +343,30 @@ def test_get_ids_command_single_id_takes_precedence():
     """--single-id re-stages via get-ids-es regardless of hub (incl. NARA)."""
     cmd = _build("nara", dpla_id="abc123")
     assert cmd == "get-ids-es nara --single-id abc123 > out.csv"
+
+
+def _label(canonical, institutions=(), collection=None):
+    import scripts.wikimedia_launch as launch_mod
+
+    return launch_mod._target_label(canonical, institutions, collection)
+
+
+def test_target_label_hub_wide_collection_does_not_crash():
+    """A hub-wide collection target (institutions=()) must render without an
+    IndexError on the Slack message path — it has no institution to index."""
+    assert _label("nara", collection="General Records") == "`nara||General Records`"
+
+
+def test_target_label_institution_collection():
+    assert _label("bpl", ("Boston Public Library",), "Maps") == (
+        "`bpl|Boston Public Library|Maps`"
+    )
+
+
+def test_target_label_single_and_multi_institution():
+    assert _label("bpl", ("A",)) == "`bpl|A`"
+    assert _label("bpl", ("A", "B", "C")) == "`bpl|A (+2 more)`"
+
+
+def test_target_label_hub_only():
+    assert _label("bpl") == "`bpl`"

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -293,3 +293,53 @@ def test_workers_budget_zero_is_accepted(capsys):
     assert "Invalid --workers-budget value" not in err, (
         f"--workers-budget 0 must pass the budget gate, not trip it; got: {err!r}"
     )
+
+
+def _build(canonical, institutions=(), collection=None, dpla_id=None):
+    import scripts.wikimedia_launch as launch_mod
+
+    return launch_mod._build_get_ids_command(
+        canonical, institutions, collection, dpla_id, "out.csv"
+    )
+
+
+def test_get_ids_command_nara_hub_uses_get_ids_nara():
+    """Hub-level NARA with no institution/collection takes the bespoke
+    get-ids-nara catalog walk."""
+    assert _build("nara") == "get-ids-nara > out.csv"
+
+
+def test_get_ids_command_nara_collection_routes_to_get_ids_es():
+    """A NARA *collection* target (nara||collection) must go through
+    get-ids-es — get-ids-nara has no collection filter and would silently
+    ingest the entire hub instead of the requested collection."""
+    cmd = _build("nara", collection="General Records of the United States Government")
+    assert cmd.startswith("get-ids-es nara")
+    assert "get-ids-nara" not in cmd
+    assert "--collection 'General Records of the United States Government'" in cmd
+    assert "--institution" not in cmd
+
+
+def test_get_ids_command_hub_wide_collection_omits_institution():
+    """Hub-wide collection on a non-NARA hub: --collection with no
+    --institution, matched across every eligible institution."""
+    cmd = _build("bpl", collection="Maps")
+    assert cmd == "get-ids-es bpl --collection Maps > out.csv"
+
+
+def test_get_ids_command_institution_collection_combines_both():
+    cmd = _build("bpl", institutions=("Boston Public Library",), collection="Maps")
+    assert cmd == (
+        "get-ids-es bpl --institution 'Boston Public Library' --collection Maps > out.csv"
+    )
+
+
+def test_get_ids_command_multiple_institutions_repeat_flag():
+    cmd = _build("bpl", institutions=("A", "B"))
+    assert cmd == "get-ids-es bpl --institution A --institution B > out.csv"
+
+
+def test_get_ids_command_single_id_takes_precedence():
+    """--single-id re-stages via get-ids-es regardless of hub (incl. NARA)."""
+    cmd = _build("nara", dpla_id="abc123")
+    assert cmd == "get-ids-es nara --single-id abc123 > out.csv"

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -177,8 +177,11 @@ def build_query(
     "--collection",
     default=None,
     help=(
-        "Restrict to items in a specific collection title. Requires exactly"
-        " one --institution (collection scoping is per-institution)."
+        "Restrict to items in a specific collection title. Combine with"
+        " --institution to scope the collection to specific institution(s);"
+        " omit --institution to match the collection across every"
+        " upload-eligible institution in the hub (some collections span"
+        " multiple institutions)."
     ),
 )
 @click.option(
@@ -238,13 +241,10 @@ def main(
         if not collection:
             print("--collection cannot be empty.", file=sys.stderr)
             sys.exit(1)
-        if len(institutions) != 1:
-            print(
-                "--collection requires exactly one --institution to be specified"
-                " (collection scoping is per-institution).",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        # No institution-count requirement: a collection can be scoped to one
+        # or more --institution flags, or left hub-wide (no --institution), in
+        # which case it is matched across every upload-eligible institution in
+        # the hub. Some DPLA collections span multiple institutions.
 
     try:
         DPLA.check_partner(partner)


### PR DESCRIPTION
## Problem

Some DPLA collections span multiple `dataProvider`s under one hub. NARA record groups are the common case — e.g. *General Records of the United States Government* (~4,360 items) sits almost entirely under "National Archives at Washington, DC - Textual Reference", with a single stray item under "College Park". The existing target grammar (`hub`, `hub|institution`, `hub|institution|collection`) assumes a collection is always a subset of one institution. So a command like:

```
/wikimedia-upload "nara|National Archives at College Park - Textual Reference|General Records of the United States Government"
```

matched only the one College Park item, even though ~4,500 items carry that collection title under other institutions. There was no way to say "every item in this hub with this collection value, regardless of `dataProvider`" without conflating the institution and collection slots.

## Change

Add a `hub||collection` form — an **empty institution slot** — that matches the collection title across **every upload-eligible institution** in the hub:

```
/wikimedia-upload "nara||General Records of the United States Government"
```

The two-pipe form is unambiguous: no real item has an empty institution value, and `hub|collection` could not be distinguished from `hub|institution`.

### Details

- **`tools/get_ids_es.py`** — drop the *collection-requires-exactly-one-institution* guard. The Elasticsearch `dataProvider` filter already ORs across zero/one/many institutions, so the restriction was an artificial CLI constraint, not a query limitation. Omitting `--institution` now matches the collection hub-wide. Empty `--collection` is still rejected.
- **`scripts/wikimedia_launch.py`**
  - Relax the `_add_target` guard: reject only **more than one** institution combined with a collection (one or zero is fine).
  - Add empty-institution `target_str` (`hub||collection`) and label (`hub+collection`) branches, and parse the empty middle token.
  - **Route NARA collection targets to `get-ids-es`**, not `get-ids-nara` — the bespoke NARA catalog walk has no collection filter and would silently ingest the entire hub. Hub-level NARA (no collection) still uses `get-ids-nara`.
  - Extract the get-ids command construction into a unit-tested `_build_get_ids_command` helper.
  - Fix an `IndexError` in collection conflict-detection when `institutions` is empty.
- **`docs/slack-guide.md`** — document the hub-wide collection form in the operator guide.

## Tests

- `tests/test_get_ids_es.py` — hub-wide collection now passes validation; multi-institution collection is accepted at the tool level; empty `--collection` still rejected.
- `tests/test_wikimedia_launch.py` — full `_build_get_ids_command` routing matrix, including the critical `nara||collection` → `get-ids-es` (not `get-ids-nara`) case.

Full suite: 757 passed. `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds support for `hub||collection` target syntax to enable hub-wide collection ingestion across multiple institutions in DPLA. Previously, the target grammar required explicit institution specification (`hub|institution|collection`), making it impossible to target all items matching a collection title across an entire hub.

## Key Changes

**Core functionality changes:**
- **`tools/get_ids_es.py`**: Removed the constraint that `--collection` must be paired with exactly one `--institution`. Collections can now be filtered hub-wide when no institution is specified, or across multiple institutions.
- **`scripts/wikimedia_launch.py`**:
  - Extended target parsing to handle the `hub||collection` form (empty institution slot parsed as `institutions=()`)
  - **Critical routing change**: NARA collection targets are now routed to `get-ids-es` instead of `get-ids-nara` to prevent accidental full-hub ingestion (the NARA catalog walk lacks collection filtering)
  - Extracted command-line construction into a testable `_build_get_ids_command()` helper (and refactored pipeline building to use it)
  - Fixed an `IndexError` in collection conflict detection when no institutions are specified
  - Relaxed validation to accept collections with zero or one institution (and correctly validate multi-institution cases)

**Documentation:**
- **`docs/slack-guide.md`**: Added operator guide documentation for the new two-pipe `hub||collection` syntax with an example.

**Test coverage:**
- Added/updated validation tests in **`tests/test_get_ids_es.py`** for hub-wide collections, multi-institution acceptance, and rejection of empty/whitespace-only collection values.
- Added comprehensive routing/label tests in **`tests/test_wikimedia_launch.py`**, including the critical `nara||collection` → `get-ids-es` routing behavior.

## Validation

- 757 tests passed
- Code passes `ruff check` and formatting requirements

## Deployment Notes

No manual pipeline trigger, ECS redeployment, environment variables/secrets changes, database migration, shared infrastructure configuration changes, or public API response/endpoint changes are included. This is an application-logic update that changes command routing for NARA collection targets and expands target parsing to support hub-wide collection runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->