### PR TITLE
docs: fix Jekyll Pages build by escaping literal {{ }} template examples

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Pipeline Architecture
 
 This document describes how an upload run flows from a Slack slash command through the dispatch chain into a long-running pipeline on EC2, and how the components fit together. For operator-level instructions (how to *use* the pipeline), see [slack-guide.md](slack-guide.md) and [operations.md](operations.md).
@@ -211,3 +212,4 @@ The downloader and uploader also handle per-item failures internally; they only 
 | Banlist | `ingest_wikimedia/banlist.py` + `dpla-id-banlist.txt` | Per-DPLA-ID skip list |
 
 The shared library (`ingest_wikimedia/`) is deliberately layered so `partners.py` is stdlib-only — the Lambda only needs that one module and `urllib`, no AWS SDK, no requests, no pywikibot. That keeps the Lambda cold-start fast.
+{% endraw %}

--- a/docs/maintenance-tools.md
+++ b/docs/maintenance-tools.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Maintenance Tools
 
 These tools sit alongside the four pipeline phases but are not part of the Slack-launched pipeline chain. They are invoked manually by operators (usually via SSM on EC2) for specific maintenance jobs.
@@ -247,3 +248,4 @@ aws ssm send-command \
 ```
 
 No Slack slash command exists for any of these — they're considered "operator-level" maintenance, and the operational friction of going through SSM is intentional.
+{% endraw %}

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Metrics
 
 A separate, scheduled workflow tracks monthly pageview metrics for DPLA-uploaded files on Wikimedia Commons. This is independent of the ingest pipeline — it does not upload, does not move files, and does not call any of the four pipeline phases.
@@ -124,3 +125,4 @@ The only connection is the bot identity (`User:DPLA bot`), and `dpla-id-banlist.
 - **Removing a category** — remove `{{views from category}}` from its category page; the next `data` job will stop touching it. The Commons `Data:Views/<category>.tab` and `.chart` pages can be deleted manually if desired.
 - **Manual catch-up after a data outage** — trigger the workflow manually with `mode=data` (admin-only via GitHub Actions UI). The 120-minute timeout is sized for the full category set.
 - **Bot password rotation** — rotate `PYWIKIBOT_PASSWORD` in the repo's secret store. No code change needed.
+{% endraw %}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Wikimedia Upload Pipeline — Operations Guide
 
 This guide covers running, monitoring, and troubleshooting the DPLA Wikimedia upload pipeline. The pipeline uploads public-domain media from DPLA partner collections to Wikimedia Commons.
@@ -544,3 +545,4 @@ du -sh /home/ec2-user/ingest-wikimedia/*/logs/
 ```
 
 Old logs can be deleted safely — they are not read by the pipeline after the run completes.
+{% endraw %}

--- a/docs/pipeline-phases.md
+++ b/docs/pipeline-phases.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Pipeline Phases
 
 Four sequential phases per target. All four are idempotent — re-running picks up where it left off. All four operate per-partner, reading and writing under `s3://dpla-wikimedia/<partner>/images/<sharded-prefix>/<dpla-id>/` (see [sidecars.md](sidecars.md) for the path layout and file inventory).
@@ -201,3 +202,4 @@ The SDC phase resets the tracker at the start of `_run_partner_mode` so per-part
 | `downloader` | ⬇ | `wikimedia-<label>: starting downloader` |
 | `uploader` | ⬆ | `wikimedia-<label>: starting uploader` |
 | `sdc-sync` | 🔗 | `wikimedia-<label>: starting sdc-sync` |
+{% endraw %}

--- a/docs/sdc-sync.md
+++ b/docs/sdc-sync.md
@@ -1,3 +1,4 @@
+{% raw %}
 # SDC Sync
 
 The `sdc-sync` phase reconciles each DPLA-uploaded Commons file's MediaInfo structured data against the per-item `sdc.json` envelope staged by `get-ids-es`. It is the only phase that talks to Commons' Wikibase API directly.
@@ -281,3 +282,4 @@ The hash-preserving merge is what keeps a P2699 backfill from re-stamping every 
 ### Regression test
 
 The shape contract — every hand-built dict in `wbeditentity`'s `data.claims` list that isn't a removal must carry `type: "statement"` AND `mainsnak` — is asserted by the regression test `test_flush_emits_type_statement_on_every_non_removal_fragment`. Tests that mock `_submit_sdc_write` don't catch this class of bug because they never inspect the actual payload shape; the regression test exercises a realistic mix of fragment kinds (new claim, qualifier amend, P813 refresh, removal) and asserts both fields are present on every non-removal entry of the bundle. New fragment builders should be added to the same scenario so the contract stays enforced.
+{% endraw %}

--- a/docs/sidecars.md
+++ b/docs/sidecars.md
@@ -1,3 +1,4 @@
+{% raw %}
 # S3 Sidecars
 
 The four pipeline phases communicate via JSON / text sidecar files in S3, plus the media bytes themselves. Every sidecar for a DPLA item lives under one prefix:
@@ -254,3 +255,4 @@ The phases hand off via these sidecars:
 | Download → SDC (separate pass) | `file-list.txt` | sdc-sync uses per-ordinal URL for `P2699` qualifier |
 
 This decoupling is what lets `sdc-sync` re-run independently of the other phases (the `sdc_only` mode), and lets `refresh-only` re-download without disturbing already-uploaded files.
+{% endraw %}

--- a/docs/slack-guide.md
+++ b/docs/slack-guide.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Slack Guide
 
 Non-technical reference for triggering Wikimedia upload runs from Slack. Every command in this guide is something you type into a Slack channel; nothing here requires shell access or a GitHub login. For the full operations reference, see [operations.md](operations.md).
@@ -302,3 +303,4 @@ Re-downloads any S3 key older than 30 days. No uploads, no SDC sync. The complet
 | Scheduled status report (every 6 h, only when sessions active) | #tech-alerts |
 | `/wikimedia-upload retry` immediate response | Ephemeral to you |
 | `/wikimedia-upload refresh` download-complete summary | #tech-alerts |
+{% endraw %}

--- a/docs/special-cases.md
+++ b/docs/special-cases.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Special Cases: Duplicate Detection, File Renames, CommonsDelinker
 
 The uploader carries the bulk of the pipeline's "what if Commons-side state doesn't match what I'm about to upload?" logic. This document covers:
@@ -252,3 +253,4 @@ UPLOADED and SKIPPED ordinals carry a `title` and `pageid` and are eligible for 
 ## Limitations
 
 **Duplicate detection is SHA1-only.** `find_file_by_hash` queries Commons' `allimages?sha1=...`, so the entire decision tree above keys on exact byte-for-byte hash matches. It does **not** catch visually-identical re-encodes: a different encoding of the same image produces different bytes → a different SHA1 → no match, so the uploader treats it as net-new (or uploads a new version over the existing title). This is known and accepted behavior, not a bug.
+{% endraw %}

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Templates and the Lua Module
 
 How the pipeline uses Commons templates to display item metadata — and how the transition from the legacy `{{Artwork}}`-based wikitext to the SDC-backed `{{DPLA metadata}}` works.
@@ -146,3 +147,4 @@ A summary diagram:
 ```
 
 Step 3 of the lifecycle (the post-SDC cleanup pass) then strips the left branch's redundant params — once every param is stripped the file-page wikitext becomes a bare single-line `{{DPLA metadata}}` invocation plus the licensing template, and all displayed metadata comes from the SDC sync's writes via `Module:DPLA`. Between the SDC write and the strip, the explicit params and the SDC carry redundant copies of the same values; the cleanup pass runs in the same `sdc_sync` invocation by default.
+{% endraw %}


### PR DESCRIPTION
## Problem

The **pages build and deployment** workflow has been failing on every push to `main` (e.g. [run 27782423455](https://github.com/dpla/ingest-wikimedia/actions/runs/27782423455), and identically on the 2026-06-17 run before it). It is **not** caused by any specific merge — merging anything to `main` re-triggers the Pages build, which then fails.

### Root cause

GitHub Pages (Jekyll 3.10) evaluates **Liquid before Markdown**, and this happens even inside fenced code blocks. `docs/templates.md` contains a literal wikitext example:

````
```wikitext
{{DPLA metadata
| date = <date_string>
...
```
````

Jekyll reads `{{ ... | date ... }}` as a Liquid expression and `| date` as the `date` filter (which requires a format argument), so the build dies with:

```
Liquid error (line 18): wrong number of arguments (given 1, expected 2) in docs/templates.md
```

The whole build fails and the `deploy` job is skipped, so the published docs site silently goes stale.

## Fix

Wrap every `docs/*.md` file body in `{% raw %}` / `{% endraw %}` so Jekyll never parses the literal `{{...}}` template examples as Liquid. These docs contain no intentional Liquid (no `{% %}` tags, no `{{ site.* }}`, no front matter), so whole-file wrapping is safe.

Wrapping the **entire** `docs/` directory — not just the 8 files that currently contain braces — makes the docs Liquid-raw by convention and prevents recurrence when a future doc adds a template example.

`render_with_liquid: false` front matter would be cleaner, but it needs Jekyll ≥ 4.0; GitHub Pages runs 3.10, so `{% raw %}` is the available option.

## Verification

`liquid`/`jekyll` aren't installed locally, so the authoritative test is the Pages build itself — I'll confirm the **pages build and deployment** run goes green on this branch / after merge. The change is the canonical Jekyll fix and the failing `| date` input is now entirely inside a `{% raw %}` region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a Jekyll 3.10 GitHub Pages build failure caused by Liquid template processing. The issue occurs because Jekyll interprets literal template syntax in documentation (specifically `{{DPLA metadata | date = ...}}` in `docs/templates.md`) as Liquid expressions. Since the `date` filter receives only one argument instead of the required two, the build fails with: "Liquid error (line 18): wrong number of arguments (given 1, expected 2)".

## Solution

All documentation files in `docs/` are now wrapped with Jekyll's `{% raw %}` and `{% endraw %}` tags to prevent Liquid interpretation of literal template examples. This approach was chosen because GitHub Pages runs Jekyll 3.10, which does not support the cleaner `render_with_liquid: false` front matter option (available in Jekyll 4.0+).

## Files Modified

The following 10 documentation files were wrapped with `{% raw %}`/`{% endraw %}` tags:
- `docs/architecture.md`
- `docs/maintenance-tools.md`
- `docs/metrics.md`
- `docs/operations.md`
- `docs/pipeline-phases.md`
- `docs/sdc-sync.md`
- `docs/sidecars.md`
- `docs/slack-guide.md`
- `docs/special-cases.md`
- `docs/templates.md`

Each file received **+2/-0 lines** (one opening tag, one closing tag). No content was modified.

## Deployment & Infrastructure Impact

- No manual pipeline trigger or ECS redeployment required
- No environment variables or AWS Secrets Manager keys affected
- No database migrations
- No shared infrastructure changes
- No API modifications
- No security implications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->