### PR TITLE
sdc-sync: stop qualifier amend from erasing the reference on bare rights claims

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -322,9 +322,19 @@ def test_check_dpla_only_match_no_reference_captures_ref():
     assert result == (False, "M999$ours")
 
 
-def test_check_no_qualifier_match_stamps_p459_via_add_det():
-    """An existing matching statement with no qualifiers triggers
-    branch 2's add_det call (wbsetqualifier — non-destructive)."""
+def test_check_bare_match_defers_to_add_ref_not_add_det():
+    """A matching statement with neither a qualifier nor a reference (e.g. a
+    rights claim a foreign bot wrote) must be healed by the caller's add_ref
+    full-claim rewrite alone — NOT also by add_det.
+
+    Regression for the rights-license bug: when both fire, the dispatcher
+    emits two same-id fragments (add_ref's full claim with the DPLA reference,
+    and add_det's qualifier-only fragment built from the cached reference-less
+    statement). wbeditentity applies same-id fragments as wholesale replacements
+    in array order, so the qualifier fragment's empty references silently erase
+    the reference, and the file renders no license until a second sync pass.
+    The bare statement's id equals the captured ref, so check() must return
+    (False, ref) without calling add_det."""
     from tools import sdc_sync
 
     empty_stmt = _item_statement("M999$empty", "Q19652")
@@ -334,8 +344,28 @@ def test_check_no_qualifier_match_stamps_p459_via_add_det():
         patch.object(sdc_sync, "add_det", return_value=None) as mock_add_det,
     ):
         result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
-    mock_add_det.assert_called_once_with("M999", "M999$empty")
-    assert result == (None, "M999$empty")
+    mock_add_det.assert_not_called()
+    assert result == (False, "M999$empty")
+
+
+def test_check_no_qualifier_but_referenced_still_uses_add_det():
+    """A matching statement with no qualifiers but that already carries a
+    reference is NOT captured for ref-stamping (loop 1 requires no references),
+    so its id != ref and add_det remains the path that stamps P459 — there is
+    no competing reference fragment to clobber here."""
+    from tools import sdc_sync
+
+    ref_no_qual = _item_statement(
+        "M999$refnoqual", "Q19652", references=[_dpla_reference()]
+    )
+    fake_entity = {"pageid": 999, "statements": {"P6216": [ref_no_qual]}}
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=fake_entity),
+        patch.object(sdc_sync, "add_det", return_value=None) as mock_add_det,
+    ):
+        result = sdc_sync.check("M999", ("item", "Q19652"), "P6216")
+    mock_add_det.assert_called_once_with("M999", "M999$refnoqual")
+    assert result == (None, "")
 
 
 def test_check_no_matching_statement_adds_new():

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -368,6 +368,76 @@ def test_check_no_qualifier_but_referenced_still_uses_add_det():
     assert result == (None, "")
 
 
+def test_check_bare_string_match_defers_to_add_ref():
+    """The string branch has the same two-loop pattern as item: a bare match
+    (no qualifier, no reference) must defer to add_ref, not also queue add_det."""
+    from tools import sdc_sync
+
+    bare = _stmt("M999$str", "P760", "value", "abc123")
+    entity = {"pageid": 999, "statements": {"P760": [bare]}}
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "add_det", return_value=None) as mock_add_det,
+    ):
+        result = sdc_sync.check("M999", ("string", "abc123"), "P760")
+    mock_add_det.assert_not_called()
+    assert result == (False, "M999$str")
+
+
+def test_check_bare_monolingualtext_match_defers_to_add_ref():
+    """Same guard for the monolingualtext branch (titles/descriptions)."""
+    from tools import sdc_sync
+
+    bare = {
+        "id": "M999$ml",
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P1476",
+            "datavalue": {
+                "value": {"text": "A Title", "language": "en"},
+                "type": "monolingualtext",
+            },
+        },
+    }
+    entity = {"pageid": 999, "statements": {"P1476": [bare]}}
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "add_det", return_value=None) as mock_add_det,
+    ):
+        result = sdc_sync.check("M999", ("monolingualtext", "A Title"), "P1476")
+    mock_add_det.assert_not_called()
+    assert result == (False, "M999$ml")
+
+
+def test_check_bare_time_match_defers_to_add_ref():
+    """Same guard for the time branch (P571) — flagged by CodeRabbit."""
+    from tools import sdc_sync
+
+    bare = {
+        "id": "M999$t",
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P571",
+            "datavalue": {
+                "value": _time_value("+1945-01-01T00:00:00Z", 9),
+                "type": "time",
+            },
+        },
+    }
+    entity = {"pageid": 999, "statements": {"P571": [bare]}}
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "add_det", return_value=None) as mock_add_det,
+    ):
+        result = sdc_sync.check("M999", ("time", "+1945-01-01T00:00:00Z|P9"), "P571")
+    mock_add_det.assert_not_called()
+    assert result == (False, "M999$t")
+
+
 def test_check_no_matching_statement_adds_new():
     """No existing P6216 statement at all → add new, no ref to amend."""
     from tools import sdc_sync

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1017,6 +1017,21 @@ def check(mediaid, qid, prop):
             if statement["mainsnak"]["datavalue"]["value"]["id"] == qid[
                 1
             ] and not statement.get("qualifiers"):
+                if statement["id"] == ref:
+                    # This is the same statement loop 1 captured for
+                    # ref-stamping (no references, safe to amend). The caller
+                    # rewrites it as a full formattedclaim — mainsnak + P459
+                    # qualifier + DPLA reference — in one reference-update
+                    # fragment. Calling add_det too would queue a SECOND,
+                    # qualifier-only fragment for the same claim id, built from
+                    # the cached (still reference-less) statement; the dispatcher
+                    # concatenates it after the reference fragment, and
+                    # wbeditentity applies same-id fragments as wholesale
+                    # replacements in array order — so the qualifier fragment's
+                    # empty references silently erase the reference we just
+                    # added (the file then renders no license until a second
+                    # pass). Deferring to add_ref adds both in one fragment.
+                    return False, ref
                 return add_det(mediaid, statement["id"]), ref
 
         if any(

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1082,6 +1082,13 @@ def check(mediaid, qid, prop):
                 if statement["mainsnak"]["datavalue"][
                     "value"
                 ] == target_value and not statement.get("qualifiers"):
+                    if statement["id"] == ref:
+                        # See the item branch: add_ref already rewrites this
+                        # statement as a full claim with the P459 qualifier and
+                        # the DPLA reference; also calling add_det would queue a
+                        # competing same-id qualifier-only fragment whose stale
+                        # empty references erase the reference. Defer to add_ref.
+                        return False, ref
                     return add_det(mediaid, statement["id"]), ref
 
         if any(
@@ -1126,6 +1133,13 @@ def check(mediaid, qid, prop):
                 if statement["mainsnak"]["datavalue"]["value"][
                     "text"
                 ] == target_value and not statement.get("qualifiers"):
+                    if statement["id"] == ref:
+                        # See the item branch: add_ref already rewrites this
+                        # statement as a full claim with the P459 qualifier and
+                        # the DPLA reference; also calling add_det would queue a
+                        # competing same-id qualifier-only fragment whose stale
+                        # empty references erase the reference. Defer to add_ref.
+                        return False, ref
                     return add_det(mediaid, statement["id"]), ref
 
         if any(
@@ -1246,6 +1260,13 @@ def check(mediaid, qid, prop):
             if _statement_value_time_matches(statement) and not statement.get(
                 "qualifiers"
             ):
+                if statement["id"] == ref:
+                    # See the item branch: add_ref already rewrites this
+                    # statement as a full claim with the P459 qualifier and the
+                    # DPLA reference; also calling add_det would queue a
+                    # competing same-id qualifier-only fragment whose stale empty
+                    # references erase the reference. Defer to add_ref.
+                    return False, ref
                 return add_det(mediaid, statement["id"]), ref
 
         if any(


### PR DESCRIPTION
## The bug

CC0 (and other) rights licenses weren't rendering on some DPLA files — e.g. [1909 Wright Military Flyer (page 20)](https://commons.wikimedia.org/wiki/File:1909_Wright_Military_Flyer_-_DPLA_-_399d43f0c2b7de2633d60e2e812ddf78_(page_20).jpg). The rights cluster (P275/P6216) carried the P459 determination-method qualifier but **no P123=DPLA reference**, so `Module:DPLA`'s `permissionMarkup` (which requires a DPLA-authored reference) suppressed the license box and never reached `{{License from structured data}}`.

The reference-less statements are the ones a **foreign bot wrote before DPLA's sync** (`BotMultichillT`, *"Adding structured data: copyright & camera"*) — common for Smithsonian Open Access content already on Commons with CC0 SDC.

## Root cause (in our code, not the foreign bot's)

When `check()` sees a matching statement with **neither a qualifier nor a reference**, `add_rs` queues **two operations on the same claim id** in one combined `wbeditentity`:

1. loop 1 captures it for ref-stamping → `add_ref` queues a **full** `formattedclaim` (mainsnak + P459 + DPLA reference) into `reference_updates`;
2. the *"no qualifiers"* branch → `add_det` → `_build_qualifier_update_fragments` builds a qualifier-only fragment from the **cached, still reference-less** statement, carrying `references: []`.

`_submit_per_item_edit` concatenates `reference_updates + qualifier_updates`, and `wbeditentity` applies same-id claim fragments as **wholesale replacements in array order** — so the qualifier fragment lands last and its empty `references` **silently erase** the reference `add_ref` just added. The statement keeps P459 but loses the reference. It only "heals" on a *second* sync pass, once the qualifier exists and the no-qualifier branch no longer fires (which is why a manual re-sync appeared to fix it).

`check`, `add_rs`, and the dispatcher are byte-identical to the code that ran on June 13, so this is current, not a since-fixed regression.

## Fix

When the no-qualifier statement is the **same one** captured for ref-stamping (`statement["id"] == ref`), defer to `add_ref`'s full-claim rewrite — which already carries both P459 **and** the reference — instead of also queuing the competing qualifier-only fragment. One pass now adds both. A statement that has a reference but no qualifier still uses `add_det` (there's no competing reference fragment to clobber).

## Tests

- Replace `test_check_no_qualifier_match_stamps_p459_via_add_det` (which encoded the buggy two-op behavior) with `test_check_bare_match_defers_to_add_ref_not_add_det` — asserts `add_det` is **not** called and `check` returns `(False, ref)`.
- Add `test_check_no_qualifier_but_referenced_still_uses_add_det` — guards the path where `add_det` is still correct.

Full suite: 762 passed. `ruff` clean.

## Follow-up (not in this PR)

Defense-in-depth: `_submit_per_item_edit` silently tolerates two non-removal fragments sharing a claim id. A guard there (merge same-id fragments, or fail loud) would prevent this whole class of silent clobber from any future path. Happy to do it as a separate PR.

## Remediation

Re-syncing the affected files heals them (stamps the reference in one pass with this fix). Scope is essentially `si` (Smithsonian) — files whose rights SDC predates DPLA's sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Bug Fix: Prevent Rights Claims from Losing DPLA References During Sync

### Problem
A race condition caused rights statements to lose their DPLA references during the sync, preventing license boxes from rendering (e.g., Wikimedia Commons files like the 1909 Wright Military Flyer).

### Root Cause
In `check()`, when encountering a rights statement that had **neither** the P459 qualifier **nor** any references (common for older Smithsonian Open Access content written by foreign bots pre–DPLA sync), the code queued **two competing** same-claim-id operations in a single API call:

- `add_ref`: queued the full claim update (adds P459 + DPLA reference)
- `add_det`: queued a qualifier-only fragment for the same statement id, built from a cached reference-less version

Because the dispatcher applies same-id fragments as wholesale replacements in array order, the qualifier-only fragment (with an **empty** references array) overwrote the reference added by `add_ref`, leaving the P459 qualifier but removing the DPLA reference.

### Fix / Solution
`check()` now detects when the “bare/no-qualifier” matching statement is the **same statement id** as the one previously captured for reference-stamping (`ref`). When they match, `check()` returns `(False, ref)` so the caller defers to the `add_ref` full-claim rewrite **without** scheduling `add_det`.

This guard is applied consistently across all affected value-type branches:
- `qid[0] == "item"`
- `qid[0] == "string"`
- `qid[0] == "monolingualtext"`
- `qid[0] == "time"`

Statements that already have a reference but lack a qualifier continue using the `add_det` path (no competing reference fragment exists to clobber).

### Changes
- **tools/sdc_sync.py**
  - Updated `check()` to defer `add_det` when the candidate bare match `statement["id"] == ref`, for the `item`, `string`, `monolingualtext`, and `time` branches.
- **tests/test_sdc_sync.py**
  - Replaced/added regression tests to ensure:
    - Bare (no qualifier, no reference) matches **defer to `add_ref`** and **do not** call `add_det`.
    - “No qualifiers but already referenced” still uses `add_det` and does not trigger reference-stamping capture (`(None, "")`).
    - The same behavior holds for `string`, `monolingualtext`, and `time`.

### Impact
- No manual pipeline trigger, redeploy, environment/secret changes, database migrations, shared infrastructure changes, or API response shape changes.
- No security implications.
- Test suite updated; **762 tests passed** with clean linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->