### PR TITLE
sdc-sync: coalesce same-id wbeditentity fragments (defense-in-depth)

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -3808,6 +3808,40 @@ def test_coalesce_merges_reference_and_qualifier_fragments_for_one_id():
     assert merged["references"] == [dpla_ref]
 
 
+def test_coalesce_does_not_resurrect_removed_qualifier():
+    """If the edit intends to delete a qualifier (its hash is in
+    removed_qualifier_hashes_by_id), the union must not re-add it even when a
+    colliding fragment still carries that stale snak — otherwise the merge
+    would undo an authoritative qualifier removal."""
+    from tools import sdc_sync
+
+    stale = {
+        "hash": "deadbeef",
+        "snaktype": "value",
+        "property": "P1545",
+        "datavalue": {"type": "string", "value": "A2"},
+    }
+    reduced = {
+        "id": "M1$q",
+        "type": "statement",
+        "mainsnak": {"property": "P275"},
+        "qualifiers": {"P459": _dpla_p459()},
+    }
+    stale_carrier = {
+        "id": "M1$q",
+        "type": "statement",
+        "mainsnak": {"property": "P275"},
+        "qualifiers": {"P459": _dpla_p459(), "P1545": [stale]},
+    }
+
+    out = sdc_sync._coalesce_same_id_fragments(
+        [reduced, stale_carrier], {"M1$q": {"deadbeef"}}
+    )
+    assert len(out) == 1
+    assert "P1545" not in out[0]["qualifiers"]  # removed snak not resurrected
+    assert "P459" in out[0]["qualifiers"]
+
+
 def test_coalesce_dedupes_identical_references_ignoring_hash():
     """Two fragments carrying the same reference (one with a server hash,
     one without) merge to a single reference, not a duplicate."""

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -3750,6 +3750,82 @@ def test_submit_per_item_edit_bundles_all_fragments_into_one_post():
     assert payload["claims"] == [new_claim, ref_update, expected_qual_update, removal]
 
 
+def test_coalesce_passes_through_when_no_collision():
+    """A bundle with no repeated statement id is returned unchanged (same
+    objects, same order) — the common case must not be perturbed."""
+    from tools import sdc_sync
+
+    frags = [
+        {"mainsnak": {"property": "P760"}, "type": "statement"},  # new claim, no id
+        {"id": "M1$a", "type": "statement", "references": [{"snaks": {}}]},
+        {"id": "M1$b", "type": "statement", "qualifiers": {"P459": []}},
+        {"id": "M1$gone", "remove": ""},
+    ]
+    assert sdc_sync._coalesce_same_id_fragments(frags) == frags
+
+
+def test_coalesce_merges_reference_and_qualifier_fragments_for_one_id():
+    """The bug's shape: a reference-update fragment (full DPLA reference) and
+    a qualifier-only fragment (stale empty references) for the SAME id must
+    fold into one fragment carrying BOTH — not two entries where the second
+    wholesale-replaces and erases the first's reference."""
+    from tools import sdc_sync
+
+    dpla_ref = {"snaks": {"P123": _qual_entity("P123", "Q2944483")}}
+    ref_fragment = {
+        "id": "M1$rights",
+        "type": "statement",
+        "mainsnak": {
+            "property": "P275",
+            "snaktype": "value",
+            "datavalue": {
+                "value": {"entity-type": "item", "numeric-id": 6938433},
+                "type": "wikibase-entityid",
+            },
+        },
+        "rank": "normal",
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [dpla_ref],
+    }
+    qual_fragment = {
+        "id": "M1$rights",
+        "type": "statement",
+        "mainsnak": ref_fragment["mainsnak"],
+        "rank": "normal",
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [],  # the stale, reference-less cache copy
+    }
+
+    out = sdc_sync._coalesce_same_id_fragments([ref_fragment, qual_fragment])
+
+    assert len(out) == 1
+    merged = out[0]
+    assert merged["id"] == "M1$rights"
+    # P459 appears once (deduped), not twice.
+    assert len(merged["qualifiers"]["P459"]) == 1
+    # The DPLA reference survived — it is NOT erased by the qualifier
+    # fragment's empty reference set.
+    assert merged["references"] == [dpla_ref]
+
+
+def test_coalesce_dedupes_identical_references_ignoring_hash():
+    """Two fragments carrying the same reference (one with a server hash,
+    one without) merge to a single reference, not a duplicate."""
+    from tools import sdc_sync
+
+    ref_no_hash = {"snaks": {"P123": _qual_entity("P123", "Q2944483")}}
+    ref_with_hash = {
+        "hash": "abc123",
+        "snaks": {"P123": _qual_entity("P123", "Q2944483")},
+    }
+    a = {"id": "M1$x", "mainsnak": {"property": "P275"}, "references": [ref_no_hash]}
+    b = {"id": "M1$x", "mainsnak": {"property": "P275"}, "references": [ref_with_hash]}
+
+    out = sdc_sync._coalesce_same_id_fragments([a, b])
+    assert len(out) == 1
+    assert len(out[0]["references"]) == 1
+
+
 def test_submit_per_item_edit_increments_qualifier_counter():
     """Qualifier-only fragments still represent a real ``wbeditentity``
     write on a Commons file, so the dispatcher must bump

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2315,7 +2315,7 @@ def _reference_content_key(reference):
     )
 
 
-def _merge_fragment_group(frags):
+def _merge_fragment_group(frags, removed_qualifier_hashes=frozenset()):
     """Merge several non-removal claim fragments that target the same
     statement id into one, unioning their qualifiers and references.
 
@@ -2323,6 +2323,13 @@ def _merge_fragment_group(frags):
     (the real builders always do); qualifier snaks and reference groups are
     deduplicated by content (ignoring server-assigned hashes) so a value
     present in more than one fragment lands exactly once.
+
+    ``removed_qualifier_hashes`` is the set of existing-qualifier snak hashes
+    this file's edit intends to *delete* (from the ``qualifier_removals``
+    accumulator). A qualifier-update fragment has already excluded them, but
+    a different colliding fragment could still carry the stale snak; skipping
+    any snak whose hash is in this set keeps the union from resurrecting a
+    qualifier the edit means to remove.
     """
     merged = {"id": frags[0]["id"], "type": "statement"}
     for frag in frags:
@@ -2336,6 +2343,8 @@ def _merge_fragment_group(frags):
     for frag in frags:
         for prop, slist in (frag.get("qualifiers") or {}).items():
             for snak in slist:
+                if snak.get("hash") in removed_qualifier_hashes:
+                    continue
                 key = (prop, _snak_content_key(snak))
                 if key in qual_keys:
                     continue
@@ -2356,7 +2365,7 @@ def _merge_fragment_group(frags):
     return merged
 
 
-def _coalesce_same_id_fragments(fragments):
+def _coalesce_same_id_fragments(fragments, removed_qualifier_hashes_by_id=None):
     """Fold non-removal claim fragments that target the same statement id
     into a single fragment, unioning their qualifiers and references.
 
@@ -2374,6 +2383,7 @@ def _coalesce_same_id_fragments(fragments):
     position. So a collision-free bundle (the overwhelming common case) is
     returned byte-for-byte unchanged.
     """
+    removed_by_id = removed_qualifier_hashes_by_id or {}
     groups = {}
     for frag in fragments:
         fid = frag.get("id")
@@ -2403,7 +2413,9 @@ def _coalesce_same_id_fragments(fragments):
             if fid in emitted:
                 continue  # later occurrences folded into the first
             emitted.add(fid)
-            out.append(_merge_fragment_group(groups[fid]))
+            out.append(
+                _merge_fragment_group(groups[fid], removed_by_id.get(fid, frozenset()))
+            )
         else:
             out.append(frag)
     return out
@@ -2504,8 +2516,15 @@ def _submit_per_item_edit(
     # entries for one id silently clobber — the later one's qualifiers/
     # references erase the earlier's. Merging them into one fragment makes
     # the combined edit carry every qualifier and reference exactly once,
-    # regardless of which builders contributed them.
-    all_fragments = _coalesce_same_id_fragments(all_fragments)
+    # regardless of which builders contributed them. The removed-qualifier
+    # hash map (from this file's ``qualifier_removals``) is passed so the
+    # union can't resurrect a snak the edit intends to delete.
+    removed_qualifier_hashes_by_id = {}
+    for claimid, snak_hash in qualifier_removals:
+        removed_qualifier_hashes_by_id.setdefault(claimid, set()).add(snak_hash)
+    all_fragments = _coalesce_same_id_fragments(
+        all_fragments, removed_qualifier_hashes_by_id
+    )
 
     _submit_sdc_write(
         "wbeditentity",

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2294,6 +2294,121 @@ def _submit_sdc_write(action, mediaid, dpla_id, **params):
         ) from e
 
 
+def _snak_content_key(snak):
+    """Stable content key for a snak, ignoring the volatile ``hash`` key
+    Wikibase assigns. Two snaks with the same property + value compare equal
+    regardless of whether one carries a server-assigned hash."""
+    return json.dumps({k: v for k, v in snak.items() if k != "hash"}, sort_keys=True)
+
+
+def _reference_content_key(reference):
+    """Stable content key for a reference group, keyed on its snak set and
+    ignoring the volatile per-reference ``hash`` / ``snaks-order`` keys. Two
+    references carrying the same snaks (e.g. the same P854+P123+P813 triple)
+    compare equal even if only one has a server hash."""
+    return json.dumps(
+        {
+            prop: sorted(_snak_content_key(s) for s in slist)
+            for prop, slist in (reference.get("snaks") or {}).items()
+        },
+        sort_keys=True,
+    )
+
+
+def _merge_fragment_group(frags):
+    """Merge several non-removal claim fragments that target the same
+    statement id into one, unioning their qualifiers and references.
+
+    mainsnak/rank are taken from the first fragment that carries a mainsnak
+    (the real builders always do); qualifier snaks and reference groups are
+    deduplicated by content (ignoring server-assigned hashes) so a value
+    present in more than one fragment lands exactly once.
+    """
+    merged = {"id": frags[0]["id"], "type": "statement"}
+    for frag in frags:
+        if "mainsnak" in frag:
+            merged["mainsnak"] = copy.deepcopy(frag["mainsnak"])
+            merged["rank"] = frag.get("rank", "normal")
+            break
+
+    quals, qual_keys = {}, set()
+    refs, ref_keys = [], set()
+    for frag in frags:
+        for prop, slist in (frag.get("qualifiers") or {}).items():
+            for snak in slist:
+                key = (prop, _snak_content_key(snak))
+                if key in qual_keys:
+                    continue
+                qual_keys.add(key)
+                quals.setdefault(prop, []).append(copy.deepcopy(snak))
+        for ref in frag.get("references") or []:
+            key = _reference_content_key(ref)
+            if key in ref_keys:
+                continue
+            ref_keys.add(key)
+            cleaned = copy.deepcopy(ref)
+            cleaned.pop("snaks-order", None)
+            refs.append(cleaned)
+    if quals:
+        merged["qualifiers"] = quals
+    if refs:
+        merged["references"] = refs
+    return merged
+
+
+def _coalesce_same_id_fragments(fragments):
+    """Fold non-removal claim fragments that target the same statement id
+    into a single fragment, unioning their qualifiers and references.
+
+    ``wbeditentity`` applies every id-bearing claim entry in ``data.claims``
+    as a *wholesale replacement* of that statement, in array order — so two
+    entries for one id silently clobber each other: the later one's
+    (possibly empty or stale) qualifier/reference sets erase whatever the
+    earlier one set. That is a silent-data-loss footgun whenever two
+    independently-built fragments (e.g. an add_ref reference rewrite and an
+    add_det qualifier amend) land on the same claim in one edit.
+
+    Only ids that actually appear more than once are merged; every other
+    fragment — new-claim creates (no ``id``), removals, and singleton
+    id-bearing fragments — is passed through untouched, in its original
+    position. So a collision-free bundle (the overwhelming common case) is
+    returned byte-for-byte unchanged.
+    """
+    groups = {}
+    for frag in fragments:
+        fid = frag.get("id")
+        if fid and frag.get("remove") != "":
+            groups.setdefault(fid, []).append(frag)
+    collided = {fid for fid, group in groups.items() if len(group) > 1}
+    if not collided:
+        return fragments
+
+    # Reaching here means two fragments targeted one statement id — the
+    # upstream guards (check()'s ref-stamp/qualifier dedup, _build_p813_
+    # refresh_fragments' touched_ids) are expected to prevent that. Merging
+    # resolves it safely, but log it so a regression in those guards is
+    # visible rather than silently absorbed.
+    logging.warning(
+        " -- Coalesced %d statement id(s) with multiple fragments in one"
+        " edit (%s); merging qualifiers + references to avoid silent"
+        " wbeditentity clobber.",
+        len(collided),
+        ", ".join(sorted(collided)),
+    )
+
+    out, emitted = [], set()
+    for frag in fragments:
+        fid = frag.get("id")
+        if fid in collided and frag.get("remove") != "":
+            if fid in emitted:
+                continue  # later occurrences folded into the first
+            emitted.add(fid)
+            out.append(_merge_fragment_group(groups[fid]))
+        else:
+            out.append(frag)
+    return out
+
+
 def _submit_per_item_edit(
     mediaid,
     dpla_id,
@@ -2383,6 +2498,14 @@ def _submit_per_item_edit(
         if fragment.get("remove") == "":
             continue
         fragment.setdefault("type", "statement")
+
+    # Coalesce fragments that target the same statement id. wbeditentity
+    # treats each id-bearing claim entry as a wholesale replacement, so two
+    # entries for one id silently clobber — the later one's qualifiers/
+    # references erase the earlier's. Merging them into one fragment makes
+    # the combined edit carry every qualifier and reference exactly once,
+    # regardless of which builders contributed them.
+    all_fragments = _coalesce_same_id_fragments(all_fragments)
 
     _submit_sdc_write(
         "wbeditentity",


### PR DESCRIPTION
## Background

`wbeditentity` applies every id-bearing entry in `data.claims` as a **wholesale replacement** of that statement, in array order. So two fragments targeting the same statement id in one edit silently clobber each other — the later one's (possibly empty or stale) qualifier/reference set erases whatever the earlier one wrote, with **no error**. That is the exact failure mode behind the rights-license bug fixed in [#322](https://github.com/dpla/ingest-wikimedia/pull/322): an `add_ref` reference fragment followed by an `add_det` qualifier fragment whose `references: []` (copied from a stale cache) wiped the DPLA reference.

#322 fixed the specific `check()` callers so they no longer emit two fragments for one id. But correctness there rests on an unwritten invariant — *"no two of the four fragment accumulators ever target the same id"* — that nothing enforces, and that a future builder (or external caller) could silently re-break. The codebase already half-defends against this asymmetrically: `_build_p813_refresh_fragments` is passed `touched_ids` to avoid colliding with other fragments, but nothing generalizes that to the reference × qualifier collision.

## Change

Add the structural backstop at the **one layer that sees the whole bundle** — `_submit_per_item_edit`. After type-stamping, `_coalesce_same_id_fragments` folds non-removal fragments sharing a statement id into a single fragment, **unioning** their qualifiers and references (deduped by content, ignoring server-assigned hashes). So a same-id collision is resolved safely (every qualifier and reference lands exactly once) instead of silently dropping data — regardless of which builders contributed the fragments.

- Only ids that **actually appear more than once** are merged; new-claim creates (no id), removals, and singleton fragments pass through untouched in original position. A collision-free bundle (the common case) is returned unchanged — verified by the existing `bundles_all_fragments` dispatcher test passing as-is, and serialization/deepcopy work stays entirely off the no-collision path.
- A `logging.warning` fires when a collision is actually coalesced, so a regression in the upstream guards is **visible** rather than absorbed.
- The P813 `touched_ids` guard is intentionally **kept**: it suppresses redundant refresh fragments upstream, which is cleaner than relying on the content-keyed merge (two DPLA references differing only by retrieved-on date wouldn't dedup, so merging would leave duplicates — `touched_ids` prevents the fragment ever being created).

## Tests

- `_coalesce_same_id_fragments`: no-collision passthrough (returns input unchanged); merge a reference fragment + a qualifier fragment for one id → one fragment carrying both, P459 deduped, reference preserved; dedupe identical references that differ only by server hash.
- Existing `test_submit_per_item_edit_bundles_all_fragments_into_one_post` passes unchanged (common path untouched).

Full suite: 764 passed. `ruff` clean. simplify pass applied (added the collision warning; inlined a helper).

This retires the footgun behind #322 at the layer where it actually happens. It does **not** address the separate question of *partial/incomplete* existing references (a reconciler-detection concern) — see the discussion thread; happy to follow up on that next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a content-aware deduplication/coalescing safeguard to the Wikibase edit submission pipeline to prevent silent data loss when multiple non-removal claim fragments in the same edit target the same statement `id`.

### Changes
**tools/sdc_sync.py**
- Adds `_coalesce_same_id_fragments()` (plus helpers) to detect same-`id` fragment collisions in a fully assembled fragment bundle.
- Merges colliding non-removal fragments into a single fragment by unioning qualifiers and references with content-based deduplication (ignoring server-assigned/volatile hash fields).
- Preserves removals and singleton fragments without reordering them; only statement IDs that appear multiple times among non-removal fragments are merged.
- Emits a warning log when coalescing occurs so upstream regressions (e.g., duplicate-fragment emission) become visible rather than silent.
- Strengthens merge behavior to avoid “resurrecting” qualifiers that were explicitly marked for removal (excluded using tracked removed qualifier snak hashes).
- Keeps the existing P813 refresh fragment guard (`touched_ids`) upstream to suppress redundant fragments.

**tests/test_sdc_sync.py**
- Adds/extends unit tests for `_coalesce_same_id_fragments()` covering:
  - collision-free passthrough (unchanged list/order/content)
  - reference + qualifier merging for same-`id` collisions with reference preservation and qualifier deduplication
  - reference deduplication when one reference includes a server-side `hash` and the other does not
  - “don’t resurrect removed qualifiers” behavior when qualifier removals are present
  - ensuring existing dispatcher behavior remains unaffected.

### Infrastructure Impact
- No manual pipeline trigger or ECS redeployment required to take effect.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migration added (and nothing affecting migration reversibility).
- No changes to shared infrastructure configuration (CodePipeline/CodeBuild/ECS/IAM).
- No changes to any public-facing API response shape or new/removal of endpoints.
- No security/auth changes; only internal edit-fragment merge logic and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->