### PR TITLE
sdc-sync: reference refresh rebuilds the full canonical DPLA reference (repairs partials)

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -4168,6 +4168,124 @@ def test_p813_refresh_preserves_user_added_references():
     sdc_sync._reset_per_file_accumulators()
 
 
+def test_reference_refresh_repairs_partial_dpla_reference():
+    """A DPLA reference that is the publisher marker (P123) but is MISSING
+    P854 — e.g. one a foreign bot wrote, or an older sdc-sync left partial —
+    is rebuilt to the full canonical P854+P123+P813 triple, EVEN when its
+    P813 is already today (the old date-only refresh would have skipped it).
+    This is the shape repair that lets us always re-assert the expected
+    reference without a separate reconcile pass."""
+    import datetime as _dt
+    import json
+
+    from tools import sdc_sync
+
+    today_iso = "+" + _dt.date.today().isoformat() + "T00:00:00Z"
+    partial_ref = {
+        "snaks": {
+            # No P854 — the partial/broken shape.
+            "P123": _qual_entity("P123", "Q2944483"),
+            "P813": [
+                {
+                    "snaktype": "value",
+                    "property": "P813",
+                    "datavalue": {
+                        "type": "time",
+                        "value": {
+                            "time": today_iso,
+                            "timezone": 0,
+                            "before": 0,
+                            "after": 0,
+                            "precision": 11,
+                            "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
+                        },
+                    },
+                }
+            ],
+        }
+    }
+    claim = {
+        "id": "M999$partial",
+        "mainsnak": {
+            "property": "P275",
+            "snaktype": "value",
+            "datavalue": {
+                "value": {"entity-type": "item", "numeric-id": 6938433},
+                "type": "wikibase-entityid",
+            },
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [partial_ref],
+    }
+    entity = {"pageid": 999, "statements": {"P275": [claim]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    sdc_sync.removals.append("M999$some-other-claim")
+
+    submit_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync,
+            "_submit_sdc_write",
+            side_effect=lambda *a, **kw: submit_calls.append((a, kw)),
+        ),
+    ):
+        sdc_sync._flush_per_file_edits("M999", "abcdef")
+
+    payload = json.loads(submit_calls[0][1]["data"])
+    repaired = next(c for c in payload["claims"] if c.get("id") == "M999$partial")
+    ref_snaks = repaired["references"][0]["snaks"]
+    assert ref_snaks["P854"][0]["datavalue"]["value"] == "https://dp.la/item/abcdef"
+    assert ref_snaks["P123"][0]["datavalue"]["value"]["id"] == "Q2944483"
+    assert ref_snaks["P813"][0]["datavalue"]["value"]["time"] == today_iso
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_reference_refresh_skips_fully_canonical_reference():
+    """A DPLA reference already at the full canonical shape (P854 for this
+    item + P123 + P813 today) produces no fragment — no spurious edit."""
+    import json
+
+    from tools import sdc_sync
+
+    canonical = sdc_sync._build_dpla_reference("abcdef")
+    claim = {
+        "id": "M999$canon",
+        "mainsnak": {
+            "property": "P275",
+            "snaktype": "value",
+            "datavalue": {
+                "value": {"entity-type": "item", "numeric-id": 6938433},
+                "type": "wikibase-entityid",
+            },
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [canonical],
+    }
+    entity = {"pageid": 999, "statements": {"P275": [claim]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    sdc_sync.removals.append("M999$some-other-claim")
+
+    submit_calls = []
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "invalidate_entity"),
+        patch.object(
+            sdc_sync,
+            "_submit_sdc_write",
+            side_effect=lambda *a, **kw: submit_calls.append((a, kw)),
+        ),
+    ):
+        sdc_sync._flush_per_file_edits("M999", "abcdef")
+
+    payload = json.loads(submit_calls[0][1]["data"])
+    assert [c for c in payload["claims"] if c.get("id") == "M999$canon"] == []
+    sdc_sync._reset_per_file_accumulators()
+
+
 def test_flush_emits_type_statement_on_every_non_removal_fragment():
     """Regression: wbeditentity rejects the entire bundle with
     ``invalid-claim: Type is missing`` unless every non-removal claim

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2698,8 +2698,6 @@ def _build_reference_refresh_fragments(mediaid, dpla_id, already_touched_ids):
     only when the bundle is otherwise non-empty) — so a file where every DPLA
     reference is already canonical gets no spurious edit.
     """
-    import copy as _copy
-
     # One date for the whole file's rebuilds, so fragments built either side
     # of a UTC midnight boundary still agree on the retrieved date.
     today = datetime.date.today()
@@ -2741,9 +2739,9 @@ def _build_reference_refresh_fragments(mediaid, dpla_id, already_touched_ids):
                     {
                         "id": stmt_id,
                         "type": "statement",
-                        "mainsnak": _copy.deepcopy(stmt["mainsnak"]),
+                        "mainsnak": copy.deepcopy(stmt["mainsnak"]),
                         "rank": stmt.get("rank", "normal"),
-                        "qualifiers": _copy.deepcopy(stmt.get("qualifiers") or {}),
+                        "qualifiers": copy.deepcopy(stmt.get("qualifiers") or {}),
                         "references": new_refs,
                     }
                 )

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -627,7 +627,7 @@ def formattedclaim(prop, value, value_type, dpla_id):
     # retrieved date. ``_is_dpla_reference`` keys on the P123 publisher
     # snak to recognise this reference shape on read-back.
     ref_url = pywikibot.Claim(site, "P854", is_reference=True)
-    ref_url.setTarget(f"https://dp.la/item/{dpla_id}")
+    ref_url.setTarget(_dpla_item_url(dpla_id))
     ref_publisher = pywikibot.Claim(site, "P123", is_reference=True)
     ref_publisher.setTarget(pywikibot.ItemPage(repo, "Q2944483"))
     today = datetime.date.today()
@@ -2500,7 +2500,7 @@ def _submit_per_item_edit(
     # lacks this field, and atomicity means one malformed fragment
     # silently drops every other edit on the file. The two known
     # builders (``_build_qualifier_update_fragments`` /
-    # ``_build_p813_refresh_fragments``) set it themselves, but adding
+    # ``_build_reference_refresh_fragments``) set it themselves, but adding
     # the guard here makes any future builder that forgets — or any
     # external caller passing hand-built fragments — fail closed
     # instead of nuking the whole edit. Removals (``{"id": ...,
@@ -2611,29 +2611,98 @@ def _build_qualifier_update_fragments(mediaid):
     return fragments
 
 
-def _build_p813_refresh_fragments(mediaid, dpla_id, already_touched_ids):
-    """Build reference-update fragments that refresh the ``P813``
-    (retrieved on) date in each DPLA-authored claim's reference to
-    today's date.
+def _dpla_item_url(dpla_id):
+    """The dp.la item URL used as the P854 (reference URL) value in a DPLA
+    reference. Single source so the value the writers stamp and the value
+    ``_dpla_reference_is_canonical`` compares against can't drift apart."""
+    return f"https://dp.la/item/{dpla_id}"
 
-    Only fires for claims NOT already covered by another fragment in
-    this file's edit (``already_touched_ids``). For each remaining
-    DPLA-authored claim on the file, we replace just the DPLA reference
-    in the claim's references list, leaving any user-added references
-    untouched. Claims whose DPLA reference's P813 is already today's
-    date are skipped — no spurious edit on already-fresh references.
 
-    Conditional on the dispatcher already deciding to make some other
-    edit on this file (the call site only constructs these fragments
-    when ``combined_claims`` is otherwise non-empty). The point is to
-    refresh "as-of" dates across every DPLA assertion on a file we're
-    touching anyway, signalling to downstream consumers that the
-    metadata was re-verified against DPLA on that date — without
-    introducing a wave of edits on files where nothing else changed.
+def _string_snak(prop, value):
+    """A value-typed string snak in wbeditentity wire shape."""
+    return {
+        "snaktype": "value",
+        "property": prop,
+        "datavalue": {"type": "string", "value": value},
+    }
+
+
+def _entity_snak(prop, qid):
+    """A value-typed wikibase-item snak; ``numeric-id`` is derived from the
+    QID so the numeric and string forms can't fall out of sync."""
+    return {
+        "snaktype": "value",
+        "property": prop,
+        "datavalue": {
+            "type": "wikibase-entityid",
+            "value": {"entity-type": "item", "numeric-id": int(qid[1:]), "id": qid},
+        },
+    }
+
+
+def _build_dpla_reference(dpla_id, retrieved=None):
+    """The canonical DPLA reference as a wbeditentity reference dict: the
+    3-snak group ``P854`` (this item's dp.la URL) + ``P123`` (publisher =
+    DPLA, Q2944483) + ``P813`` (retrieved date, default today). Same shape
+    ``formattedclaim`` stamps on new claims (P813 via the shared
+    ``_build_p813_snak``), so a rebuilt reference is indistinguishable from
+    a freshly authored one."""
+    return {
+        "snaks": {
+            "P854": [_string_snak("P854", _dpla_item_url(dpla_id))],
+            "P123": [_entity_snak("P123", "Q2944483")],
+            "P813": [_build_p813_snak(retrieved or datetime.date.today())],
+        }
+    }
+
+
+def _dpla_reference_is_canonical(reference, dpla_id):
+    """True iff ``reference`` is already the complete, current DPLA reference
+    — publisher = DPLA (P123), this item's dp.la URL (P854), and today's
+    retrieved date (P813). A DPLA reference missing or wrong on any of these
+    is treated as needing a rebuild, so the refresh repairs a partial
+    reference (e.g. a foreign-bot rights claim that only ever carried P123)
+    in the same write that refreshes the date — no separate reconcile pass.
+
+    Identity keys on the P123 publisher marker (via ``_is_dpla_reference``);
+    a reference that lost P123 entirely reads as foreign and is left
+    untouched here — a deliberate known limitation, since "repairing" it
+    would risk overwriting a genuinely third-party reference."""
+    if not _is_dpla_reference(reference):
+        return False
+    expected_url = _dpla_item_url(dpla_id)
+    snaks = reference.get("snaks") or {}
+    p854_ok = any(
+        (snak.get("datavalue") or {}).get("value") == expected_url
+        for snak in snaks.get("P854") or []
+    )
+    return p854_ok and _p813_already_today(reference)
+
+
+def _build_reference_refresh_fragments(mediaid, dpla_id, already_touched_ids):
+    """Build reference-update fragments that make each DPLA-authored claim's
+    DPLA reference *canonical and current* — the full P854+P123+P813-today
+    triple — rewriting it wholesale rather than only swapping the P813 date.
+
+    This both refreshes the "as-of" retrieved date AND repairs a partial or
+    stale DPLA reference (e.g. one a foreign bot wrote with P123 but no P854)
+    in a single write — relying on the fact that re-asserting an identical
+    reference is a Wikibase no-op, so the only claims that actually change are
+    those whose DPLA reference isn't already canonical. User-added (non-DPLA)
+    references are preserved verbatim; a duplicate second DPLA reference (rare
+    legacy state) is collapsed to the single canonical one.
+
+    Only fires for claims NOT already covered by another fragment in this
+    file's edit (``already_touched_ids``), and only when the dispatcher is
+    already making some other edit on the file (the call site builds these
+    only when the bundle is otherwise non-empty) — so a file where every DPLA
+    reference is already canonical gets no spurious edit.
     """
     import copy as _copy
 
-    today_p813_snak = _build_p813_snak(datetime.date.today())
+    # One date for the whole file's rebuilds, so fragments built either side
+    # of a UTC midnight boundary still agree on the retrieved date.
+    today = datetime.date.today()
     entity = get_entity(mediaid)
     fragments = []
     for prop_stmts in (entity.get("statements") or {}).values():
@@ -2644,35 +2713,30 @@ def _build_p813_refresh_fragments(mediaid, dpla_id, already_touched_ids):
             existing_refs = stmt.get("references") or []
             if not existing_refs:
                 continue
-            # Locate the DPLA reference; preserve every user-added
-            # reference unchanged. If multiple references match (rare;
-            # legacy duplicates) refresh all of them.
+            # Rebuild the (first) DPLA reference to canonical; preserve every
+            # user-added reference verbatim and at its position; drop any
+            # extra duplicate DPLA references.
             new_refs = []
             changed = False
+            seen_dpla = False
             for ref in existing_refs:
                 if not _is_dpla_reference(ref):
                     new_refs.append(ref)
                     continue
-                if _p813_already_today(ref):
-                    new_refs.append(ref)
+                if seen_dpla:
+                    changed = True  # duplicate DPLA reference — drop it
                     continue
-                refreshed = _copy.deepcopy(ref)
-                refreshed.setdefault("snaks", {})["P813"] = [today_p813_snak]
-                # Drop the snaks-hashes for the refreshed P813 so
-                # Wikibase recomputes it on save (the snak content
-                # changed); leave the other snaks alone.
-                snaks_order = refreshed.get("snaks-order") or []
-                if "P813" not in snaks_order:
-                    snaks_order = list(snaks_order) + ["P813"]
-                    refreshed["snaks-order"] = snaks_order
-                new_refs.append(refreshed)
-                changed = True
+                seen_dpla = True
+                if _dpla_reference_is_canonical(ref, dpla_id):
+                    new_refs.append(ref)
+                else:
+                    new_refs.append(_build_dpla_reference(dpla_id, today))
+                    changed = True
             if changed:
                 # Same wholesale-replace contract as
-                # _build_qualifier_update_fragments: include the
-                # statement's existing mainsnak / qualifiers / rank so
-                # wbeditentity preserves them and only diffs the
-                # references field.
+                # _build_qualifier_update_fragments: include the statement's
+                # existing mainsnak / qualifiers / rank so wbeditentity
+                # preserves them and only diffs the references field.
                 fragments.append(
                     {
                         "id": stmt_id,
@@ -2729,14 +2793,16 @@ def _flush_per_file_edits(mediaid, dpla_id):
     the one POST per file that replaces the previous five-to-seven
     separate API calls.
 
-    When any other edit fragments are present, opportunistically refresh
-    the ``P813`` (retrieved on) date on every other DPLA-authored claim
-    on the file to today. The premise: the bot has just re-verified the
-    file's structured data against DPLA's current source metadata, so
-    every DPLA assertion on the file is effectively "as-of today" — that
-    information is useful to downstream consumers and free to write
-    inside an edit we're making anyway. No spurious edits when the file
-    has nothing else to change.
+    When any other edit fragments are present, opportunistically make
+    every other DPLA-authored claim's DPLA reference canonical and current
+    — the full P854+P123+P813-today triple — via
+    ``_build_reference_refresh_fragments``. This both refreshes the
+    "retrieved on" date (the bot has just re-verified the file against
+    DPLA's source metadata, so every assertion is effectively "as-of
+    today") AND repairs a partial or stale DPLA reference left by an older
+    sync or a foreign bot. Re-asserting an already-canonical reference is a
+    Wikibase no-op, so there are no spurious edits when the file has
+    nothing else to change.
 
     After a successful write, invalidate the cached entity once so any
     follow-up code reading from cache picks up the new revision.
@@ -2758,7 +2824,7 @@ def _flush_per_file_edits(mediaid, dpla_id):
             if fid:
                 touched_ids.add(fid)
         reference_updates.extend(
-            _build_p813_refresh_fragments(mediaid, dpla_id, touched_ids)
+            _build_reference_refresh_fragments(mediaid, dpla_id, touched_ids)
         )
 
     _submit_per_item_edit(


### PR DESCRIPTION
## Background

A DPLA reference is a 3-snak group: **P854** (dp.la item URL) + **P123** (publisher = DPLA) + **P813** (retrieved date). Reference handling was split across two paths and neither ever *repaired* a reference:

- `check()`/`add_ref` stamped the DPLA reference only when a statement had **no** references at all.
- The coincident-edit refresh (`_build_p813_refresh_fragments`) patched **only the P813 date** in place.

So a **partial or stale** DPLA reference — e.g. one a foreign bot wrote with P123 but **no P854** (the common Smithsonian case, where `Module:DPLA` then suppressed the license), or an older sync's reference-less rights cluster — was recognized as "already a DPLA reference" (`_is_dpla_reference` keys on P123 alone) and never fixed.

## Change

Make the refresh **rebuild each DPLA reference to the full canonical triple** (P854 + P123 + P813-today) whenever it isn't already canonical, instead of only swapping the date. Wikibase content-hashes references, so **re-asserting an identical reference is a no-op** — the only claims that actually change are those whose DPLA reference is missing/stale. One wholesale write therefore *both* refreshes the as-of date *and* repairs partial references, with **no separate reconcile/compare pass** and no spurious edits.

This is the realization of "just always apply the expected reference, and let Wikibase no-op when it matches" — verified against the code: identical references no-op (hash-keyed), and a partial-but-P123 reference is overwritten in place (it's classified as DPLA, so safe), not duplicated.

- Renamed `_build_p813_refresh_fragments` → `_build_reference_refresh_fragments` (its job widened); updated call site, dispatcher comment, and `_flush_per_file_edits` docstring.
- New helpers: `_build_dpla_reference(dpla_id, retrieved)`, `_dpla_reference_is_canonical(reference, dpla_id)`, and shared `_dpla_item_url` / `_string_snak` / `_entity_snak` (single definition of the URL + snak shapes; numeric-id derived from the QID; `formattedclaim` now uses the URL helper too).
- Non-DPLA references preserved verbatim; a duplicate second DPLA reference collapsed to one.

## Known limitations (documented in code)

1. A reference that lost the **P123 marker entirely** reads as foreign and is left untouched — "repairing" it would risk overwriting genuinely third-party data.
2. The refresh is gated to **coincident edits**, so a partial reference on an otherwise-clean file is repaired on the file's *next touch*, not eagerly (deliberate — avoids a wave of edits). Re-syncs cover this.

## Tests

- Existing P813-refresh tests still pass (date refresh + user-reference preservation unchanged).
- Added: `test_reference_refresh_repairs_partial_dpla_reference` (P813 already today but P854 missing → rebuilt with P854 — the old date-only path would have skipped it) and `test_reference_refresh_skips_fully_canonical_reference` (no spurious edit).

Full suite: 771 passed. `ruff` clean. simplify pass applied (URL/snak helpers, date hoist, doc updates).

Builds on #322 / #323. With this, a single `si` re-sync both stamps the missing reference (one pass, via #322) and brings any partial references to canonical shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## DPLA Reference Canonicalization in `sdc-sync`

This PR fixes DPLA reference handling in the `sdc-sync` module by ensuring DPLA-authored claims have complete, canonical references rather than partial or stale ones.

### Problem
Previously, reference handling was split across two separate code paths:
- `check()`/`add_ref` only stamped new DPLA references when statements had no references
- `_build_p813_refresh_fragments` only patched the P813 (retrieved date) in place

This meant partial references (e.g., missing P854 URL but present P123 publisher marker) and stale references were skipped because they were recognized as “already DPLA references.”

### Solution
Rebuilds each DPLA-authored claim’s reference to the full canonical triple (P854 URL + P123 publisher marker + P813 retrieved date) whenever it isn’t already canonical. Since Wikibase content-hashes references, re-asserting an identical reference is a no-op, affecting only claims with missing or stale DPLA references.

### Key Changes
- **Renamed** `_build_p813_refresh_fragments` → `_build_reference_refresh_fragments` to reflect expanded responsibility
- **Added helper functions** for reusable reference/URL/snak definitions:
  - `_dpla_item_url(dpla_id)` — canonical dp.la URL format
  - `_build_dpla_reference()` — full DPLA reference construction
  - `_dpla_reference_is_canonical()` — checks reference completeness
  - `_string_snak()`, `_entity_snak()` — snak shape normalization
- **Enhanced refresh logic** to:
  - preserve non-DPLA references verbatim
  - keep an already-canonical DPLA reference if present
  - otherwise replace it with the canonical (P854 + P123 + P813=today) reference
  - drop duplicate second DPLA references and only emit refresh fragments when the DPLA reference set actually changes
- **Documentation/behavior notes** reflect that repairs happen during coincident-edit refresh and that references missing the P123 marker entirely are not repaired.

### Testing
- Added two new unit tests in `tests/test_sdc_sync.py`:
  - `test_reference_refresh_repairs_partial_dpla_reference` — verifies partial DPLA references are repaired to full canonical form
  - `test_reference_refresh_skips_fully_canonical_reference` — verifies canonical references don’t generate spurious edits/fragments
- All **771 tests pass** with clean `ruff` output.

### Operational / Security / Compatibility Impact
- No manual pipeline trigger, ECS redeployment, environment variable/Secrets Manager key changes, infrastructure configuration changes, database migrations, public API/endpoint changes, or security/auth changes. 
- Change is scoped to `sdc-sync` reference construction/refresh behavior during coincident edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->