### PR TITLE
partners: filter resolve_wikidata_id by upload eligibility

### DIFF
--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -267,9 +267,27 @@ def canonical_matches_session_component(
 def resolve_wikidata_id(qid: str, timeout: int = 5) -> list[tuple[str, str | None]]:
     """Return (canonical_slug, institution_or_None) pairs matching a Wikidata QID.
 
-    Searches hub-level and institution-level Wikidata fields in institutions_v2.json.
-    Returns an empty list if no match. Multiple matches are possible when the same
-    QID appears under different hubs or institutions in the JSON.
+    Searches hub-level and institution-level Wikidata fields in
+    institutions_v2.json. Returns an empty list if no match. Multiple
+    matches are possible when the same QID appears under different
+    hubs or institutions in the JSON.
+
+    Filters out non-upload-eligible matches using the same rule as
+    :func:`is_item_upload_eligible`:
+
+    * Hub-level match (institution=None) is kept only if the hub
+      itself has ``upload: True``.
+    * Institution-level match is kept only if the hub OR the
+      institution has ``upload: True``.
+
+    Without this filter, a QID like ``Q131454`` (Library of Congress)
+    that appears in the JSON as an *institution* under many hubs
+    (where it's listed but not opted in for upload) AND as a hub
+    (the ``lc`` slug, which is also not upload-eligible) would route
+    the launcher onto the broader ``lc`` hub scope and produce the
+    misleading ``Skipped targets: 'lc'`` error. Filtering here keeps
+    eligibility on the QID resolution side, where the data shape is
+    available, instead of leaking that knowledge into every caller.
     """
     institutions = _get_institutions(timeout)
     results: list[tuple[str, str | None]] = []
@@ -277,10 +295,14 @@ def resolve_wikidata_id(qid: str, timeout: int = 5) -> list[tuple[str, str | Non
         canonical = _SLUG_BY_HUB_NAME.get(hub_name.lower())
         if canonical is None:
             continue
+        hub_upload = bool(hub_data.get("upload"))
         if hub_data.get("Wikidata") == qid:
-            results.append((canonical, None))
-        else:
-            for inst_name, inst_data in hub_data.get("institutions", {}).items():
-                if inst_data.get("Wikidata") == qid:
-                    results.append((canonical, inst_name))
+            if hub_upload:
+                results.append((canonical, None))
+            continue
+        for inst_name, inst_data in hub_data.get("institutions", {}).items():
+            if inst_data.get("Wikidata") != qid:
+                continue
+            if hub_upload or bool(inst_data.get("upload")):
+                results.append((canonical, inst_name))
     return results

--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -296,10 +296,13 @@ def resolve_wikidata_id(qid: str, timeout: int = 5) -> list[tuple[str, str | Non
         if canonical is None:
             continue
         hub_upload = bool(hub_data.get("upload"))
-        if hub_data.get("Wikidata") == qid:
-            if hub_upload:
-                results.append((canonical, None))
-            continue
+        if hub_data.get("Wikidata") == qid and hub_upload:
+            results.append((canonical, None))
+        # Don't ``continue`` on a hub-level QID match — if the same
+        # QID is also used by an institution within this hub, that
+        # match needs to be considered for institution-level
+        # eligibility (hub.upload=false + inst.upload=true is a valid
+        # combination).
         for inst_name, inst_data in hub_data.get("institutions", {}).items():
             if inst_data.get("Wikidata") != qid:
                 continue

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -1,0 +1,145 @@
+"""Tests for ingest_wikimedia/partners.py — focused on the
+upload-eligibility filtering in :func:`resolve_wikidata_id`.
+
+The bug being pinned: ``Q131454`` (Library of Congress) appeared in
+institutions_v2.json both as a hub (``lc``) and as a contributing
+institution under several other hubs (Indiana, Digital Commonwealth,
+HathiTrust, BHL, etc.). All of those entries were marked
+``upload: false``. Pre-fix, ``resolve_wikidata_id`` returned every
+match unconditionally, the launcher saw the hub-level ``(lc, None)``
+pair, and the run died with ``Skipped targets: 'lc': not upload-eligible``.
+The fix is to filter results by ``upload`` at resolution time so
+non-eligible matches never leak to the launcher.
+"""
+
+from unittest.mock import patch
+
+from ingest_wikimedia.partners import resolve_wikidata_id
+
+
+def _mock_institutions(data: dict):
+    """Patch ``_get_institutions`` to return ``data`` instead of fetching
+    institutions_v2.json over the network. Returns the patch context
+    manager for use in ``with`` blocks."""
+    return patch("ingest_wikimedia.partners._get_institutions", return_value=data)
+
+
+def test_resolve_wikidata_id_drops_hub_level_match_when_hub_upload_false():
+    """A QID that matches a hub entry whose ``upload`` is ``False`` must
+    NOT produce a ``(slug, None)`` result, even if other (institution-
+    level) matches exist. Otherwise the launcher's "hub-level scope
+    wins" tie-break routes onto a non-eligible hub.
+
+    Mirrors the production Q131454 case: matches the LC hub itself
+    (upload=false) AND LC-as-institution under several other hubs.
+    """
+    data = {
+        "Library of Congress": {  # hub key matches the "lc" slug
+            "Wikidata": "Q131454",
+            "upload": False,
+            "institutions": {},
+        },
+        "Indiana Memory": {
+            "Wikidata": "Q83878471",
+            "upload": True,
+            "institutions": {
+                "Library of Congress": {"Wikidata": "Q131454", "upload": False},
+            },
+        },
+    }
+    with _mock_institutions(data):
+        results = resolve_wikidata_id("Q131454")
+    # The Indiana-side match survives because its hub has upload=true
+    # (even though the institution entry has upload=false). The LC-hub
+    # match is dropped because the hub itself has upload=false.
+    assert ("lc", None) not in results
+    assert ("indiana", "Library of Congress") in results
+
+
+def test_resolve_wikidata_id_drops_institution_match_when_neither_upload_true():
+    """An institution-level QID match where BOTH the hub and the
+    institution have ``upload: false`` must be dropped. Pins the
+    eligibility rule against the OKHub / Oklahoma Historical Society
+    case the user flagged."""
+    data = {
+        "OKHub": {
+            "Wikidata": "Q123",
+            "upload": False,
+            "institutions": {
+                "Oklahoma Historical Society": {
+                    "Wikidata": "Q7082247",
+                    "upload": False,
+                },
+            },
+        },
+        "The Portal to Texas History": {
+            "Wikidata": "Q456",
+            "upload": True,
+            "institutions": {
+                "Oklahoma Historical Society": {
+                    "Wikidata": "Q7082247",
+                    "upload": False,
+                },
+            },
+        },
+    }
+    with _mock_institutions(data):
+        results = resolve_wikidata_id("Q7082247")
+    # OKHub hub.upload=false AND its OHS entry upload=false → dropped.
+    assert ("oklahoma", "Oklahoma Historical Society") not in results
+    # Texas hub.upload=true makes its OHS entry eligible even though
+    # the institution-level upload flag is false (matches
+    # is_item_upload_eligible's semantics).
+    assert ("texas", "Oklahoma Historical Society") in results
+
+
+def test_resolve_wikidata_id_keeps_hub_level_match_when_hub_upload_true():
+    """Sanity: when the hub itself is upload-eligible, a hub-level QID
+    match still yields ``(slug, None)``. Verifies the filter only
+    drops the non-eligible cases."""
+    data = {
+        "National Archives and Records Administration": {
+            "Wikidata": "Q518155",
+            "upload": True,
+            "institutions": {},
+        },
+    }
+    with _mock_institutions(data):
+        results = resolve_wikidata_id("Q518155")
+    assert results == [("nara", None)]
+
+
+def test_resolve_wikidata_id_keeps_inst_match_when_institution_upload_true():
+    """Institution-level eligibility: hub.upload=false but
+    institution.upload=true → keep. Pins the second leg of the
+    ``hub OR institution`` rule."""
+    data = {
+        "Hub With Opt-In Subset": {
+            "Wikidata": "Qhub",
+            "upload": False,
+            "institutions": {
+                "Eligible Institution": {"Wikidata": "Qinst", "upload": True},
+                "Ineligible Institution": {"Wikidata": "QinstN", "upload": False},
+            },
+        },
+    }
+    # Add a slug for the synthetic hub so _SLUG_BY_HUB_NAME resolves it.
+    with (
+        _mock_institutions(data),
+        patch.dict(
+            "ingest_wikimedia.partners._SLUG_BY_HUB_NAME",
+            {"hub with opt-in subset": "subset-hub"},
+        ),
+    ):
+        eligible = resolve_wikidata_id("Qinst")
+        ineligible = resolve_wikidata_id("QinstN")
+    assert eligible == [("subset-hub", "Eligible Institution")]
+    assert ineligible == []
+
+
+def test_resolve_wikidata_id_no_matches_returns_empty():
+    """Unrecognised QID → empty list (unchanged from pre-fix)."""
+    with _mock_institutions(
+        {"Some Hub": {"Wikidata": "QX", "upload": True, "institutions": {}}}
+    ):
+        assert resolve_wikidata_id("Q-does-not-exist") == []

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -143,3 +143,35 @@ def test_resolve_wikidata_id_no_matches_returns_empty():
         {"Some Hub": {"Wikidata": "QX", "upload": True, "institutions": {}}}
     ):
         assert resolve_wikidata_id("Q-does-not-exist") == []
+
+
+def test_resolve_wikidata_id_same_hub_overlap_picks_up_eligible_institution():
+    """Edge case: a QID matches both the hub-level entry AND an
+    institution within the same hub. If the hub itself is not
+    upload-eligible but the institution is, the institution-level
+    match must still be returned. The first version of this fix
+    used a ``continue`` on the hub-level match, which skipped the
+    institution scan within that hub and dropped this case silently
+    (caught by CodeRabbit on PR #326)."""
+    data = {
+        "Hub Opted Out With One Opted In": {
+            "Wikidata": "QSAME",
+            "upload": False,
+            "institutions": {
+                # Same QID as the hub, but opted in at the institution level.
+                "Self-listed Institution": {"Wikidata": "QSAME", "upload": True},
+            },
+        },
+    }
+    with (
+        _mock_institutions(data),
+        patch.dict(
+            "ingest_wikimedia.partners._SLUG_BY_HUB_NAME",
+            {"hub opted out with one opted in": "overlap-hub"},
+        ),
+    ):
+        results = resolve_wikidata_id("QSAME")
+    # Hub-level match dropped (hub.upload=false).
+    assert ("overlap-hub", None) not in results
+    # Institution-level match preserved (institution.upload=true).
+    assert results == [("overlap-hub", "Self-listed Institution")]


### PR DESCRIPTION
## Summary

Fixes a bug where `/wikimedia-upload <Q-id>` could route to a non-upload-eligible hub when the same QID appears in `institutions_v2.json` under multiple hubs or under both hub-level and institution-level entries.

`resolve_wikidata_id` returned every `(hub, institution)` pair where the QID matched, ignoring the `upload` flag. The launcher then took the hub-level `(slug, None)` pair (its "hub-level scope wins" tie-break) and failed with e.g.:

```
⚠️ Skipped targets: 'lc': not upload-eligible per institutions_v2.json.
```

…even though the QID came from a user-supplied list filtered to upload-eligible institutions. Concrete case: `Q131454` (Library of Congress) appears in the JSON as a hub (`lc`, `upload: false`) AND as a contributing institution named "Library of Congress" under Indiana, Digital Commonwealth, HathiTrust, BHL, Tennessee, and others — every one of those institution entries also `upload: false`. The launcher picked the LC hub and aborted.

## Fix

Filter `resolve_wikidata_id` results using the same rule `is_item_upload_eligible` already applies:

- Hub-level match (`institution=None`) → keep only if `hub.upload` is true.
- Institution-level match → keep only if `hub.upload` OR `institution.upload` is true.

Eligibility now lives at the QID-resolution boundary instead of leaking into the launcher's downstream logic, where the data shape isn't directly visible.

Same pattern also fixes the `Q7082247` ("Oklahoma Historical Society") case (listed under OKHub and Texas, only Texas is opted in).

## Test plan

- [x] 5 new focused tests in `tests/test_partners.py` (LC-hub-as-institution case, OKHub case, sanity for the keep-when-eligible paths, empty-on-miss)
- [x] Full test suite passes (783 / 783)
- [ ] Verify in the field by re-running the user's `/wikimedia-upload` invocation that previously failed; expect the LC-hub skip to disappear and only eligible institutions to be queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes a routing bug in the `/wikimedia-upload <Q-id>` endpoint where a Wikidata QID that appears multiple times in `institutions_v2.json` (e.g., both as a hub entry and as contributing institutions, and/or across multiple hubs) could incorrectly resolve to an upload-ineligible hub and then fail the upload.

## Root Cause
`resolve_wikidata_id` returned all matching `(hub, institution)` pairs without applying the same `upload` eligibility filtering used elsewhere. When multiple matches existed, downstream launcher tie-breaking could select a hub-level entry marked `upload: false`, leading to uploads being skipped as “not upload-eligible” even when an eligible institution match existed.

**Example:** Q131454 (Library of Congress) appears both as a hub entry (`lc`, `upload: false`) and as a contributing institution under multiple other hubs, all marked `upload: false`; the resolver could incorrectly choose the ineligible hub-level match.

## Changes
**`ingest_wikimedia/partners.py`** (+33/-8)
- Updated `resolve_wikidata_id` to filter matches by upload eligibility at QID-resolution time:
  - Hub-level `(slug, None)` matches are kept only if `hub.upload` is `True`
  - Institution-level `(slug, institution)` matches are kept only if `hub.upload` **or** `institution.upload` is `True`
- Adjusted the hub/institution scanning behavior so that a hub-level match no longer suppresses scanning for institution matches within the same hub; eligibility filtering determines what is ultimately returned.

**`tests/test_partners.py`** (+177/-0)
- Added focused unit tests for `resolve_wikidata_id` upload-eligibility filtering, including:
  - Dropping hub-level `(slug, None)` results when the matched hub is `upload: false`
  - Dropping institution-level matches when both the hub and institution are `upload: false`
  - Keeping eligible matches when either the hub or the institution is `upload: true`
  - Returning `[]` for unknown QIDs
  - Pinning the same-hub overlap edge case (hub `upload: false` + institution `upload: true`)
  - Coverage for the Library of Congress and Oklahoma Historical Society scenarios

## Testing
All 783 tests pass, including the new focused tests.

## Operational / Deployment Notes
No database migrations, environment variable/secret changes, shared infrastructure configuration changes, or public API/endpoint shape changes were introduced. No additional manual pipeline trigger is required beyond deploying this code change through the normal workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->