### PR TITLE
tools: regenerate institutions_v2.json from the live index

### DIFF
--- a/tests/test_regen_institutions.py
+++ b/tests/test_regen_institutions.py
@@ -1,0 +1,192 @@
+"""Tests for tools/regen_institutions.py — the institutions_v2.json regenerator.
+
+The ES fetch is exercised separately (composite pagination over a stubbed
+`post_es`); the merge rules and serialisation are pure functions tested with
+fixtures.
+"""
+
+import json
+from unittest.mock import patch
+
+from tools import regen_institutions as r
+
+
+def _doc(**hubs):
+    return dict(hubs)
+
+
+def _hub(wikidata="", upload=False, institutions=None):
+    return {"Wikidata": wikidata, "upload": upload, "institutions": institutions or {}}
+
+
+def _inst(wikidata="", upload=False):
+    return {"Wikidata": wikidata, "upload": upload}
+
+
+# --- reconcile: institutions -------------------------------------------------
+
+
+def test_new_institution_added_as_blank_opt_out():
+    current = _doc(Alpha=_hub(institutions={"Old Inst": _inst("Q1", upload=True)}))
+    index = {"Alpha": {"Old Inst", "New Inst"}}
+    result, report = r.reconcile(current, index)
+    assert result["Alpha"]["institutions"]["New Inst"] == {
+        "Wikidata": "",
+        "upload": False,
+    }
+    # Existing entry untouched (QID + opt-in preserved).
+    assert result["Alpha"]["institutions"]["Old Inst"] == {
+        "Wikidata": "Q1",
+        "upload": True,
+    }
+    assert report["insts_added"] == {"Alpha": ["New Inst"]}
+
+
+def test_dropped_institution_without_qid_is_removed():
+    current = _doc(Alpha=_hub(institutions={"Gone": _inst("")}))
+    index = {"Alpha": {"Still Here"}}
+    result, report = r.reconcile(current, index)
+    assert "Gone" not in result["Alpha"]["institutions"]
+    assert "Still Here" in result["Alpha"]["institutions"]
+    assert report["insts_removed"] == {"Alpha": ["Gone"]}
+
+
+def test_dropped_institution_with_qid_is_kept():
+    current = _doc(Alpha=_hub(institutions={"Drifted": _inst("Q42")}))
+    index = {"Alpha": {"Other"}}  # 'Drifted' no longer in index
+    result, report = r.reconcile(current, index)
+    assert result["Alpha"]["institutions"]["Drifted"] == {
+        "Wikidata": "Q42",
+        "upload": False,
+    }
+    assert report["insts_dropped_kept"] == {"Alpha": ["Drifted"]}
+    assert "Drifted" not in report.get("insts_removed", {}).get("Alpha", [])
+
+
+# --- reconcile: hubs ---------------------------------------------------------
+
+
+def test_new_hub_added():
+    current = _doc()
+    index = {"BrandNew": {"Inst A", "Inst B"}}
+    result, report = r.reconcile(current, index)
+    assert result["BrandNew"]["Wikidata"] == ""
+    assert result["BrandNew"]["upload"] is False
+    assert set(result["BrandNew"]["institutions"]) == {"Inst A", "Inst B"}
+    assert report["hubs_added"] == ["BrandNew"]
+
+
+def test_dropped_hub_without_any_qid_is_removed():
+    current = _doc(Ghost=_hub(institutions={"X": _inst(""), "Y": _inst("")}))
+    index = {"Alpha": {"Z"}}  # Ghost absent from index
+    result, report = r.reconcile(current, index)
+    assert "Ghost" not in result
+    assert report["hubs_removed"] == ["Ghost"]
+
+
+def test_dropped_hub_kept_when_hub_has_qid():
+    current = _doc(Ghost=_hub(wikidata="Q100", institutions={"X": _inst("")}))
+    index = {"Alpha": {"Z"}}
+    result, report = r.reconcile(current, index)
+    assert "Ghost" in result
+    # Its QID-less institution still drops (no QID, not in index).
+    assert result["Ghost"]["institutions"] == {}
+    assert "Ghost" in report["hubs_dropped_kept"]
+
+
+def test_dropped_hub_kept_when_an_institution_has_qid():
+    current = _doc(Ghost=_hub(institutions={"Keep": _inst("Q7"), "Drop": _inst("")}))
+    index = {"Alpha": {"Z"}}
+    result, report = r.reconcile(current, index)
+    assert "Ghost" in result
+    assert "Keep" in result["Ghost"]["institutions"]
+    assert "Drop" not in result["Ghost"]["institutions"]
+    assert "Ghost" in report["hubs_dropped_kept"]
+
+
+def test_hub_still_in_index_is_never_in_removed_or_dropped_kept():
+    current = _doc(Alpha=_hub(institutions={"A": _inst("")}))
+    index = {"Alpha": {"A"}}
+    result, report = r.reconcile(current, index)
+    assert "Alpha" in result
+    assert report["hubs_removed"] == []
+    assert report["hubs_dropped_kept"] == []
+
+
+# --- serialisation -----------------------------------------------------------
+
+
+def test_dump_json_shape_order_and_sorting():
+    doc = _doc(
+        Zeta=_hub(wikidata="Q9", upload=True, institutions={"Bee": _inst("Q2", True)}),
+        Alpha=_hub(institutions={"Yak": _inst(""), "Ant": _inst("Q1")}),
+    )
+    out = r.dump_json(doc)
+    parsed = json.loads(out)
+    # Hubs and institutions plain-sorted.
+    assert list(parsed) == ["Alpha", "Zeta"]
+    assert list(parsed["Alpha"]["institutions"]) == ["Ant", "Yak"]
+    # Fixed key order on both levels.
+    assert list(parsed["Zeta"]) == ["Wikidata", "institutions", "upload"]
+    assert list(parsed["Zeta"]["institutions"]["Bee"]) == ["Wikidata", "upload"]
+    # 2-space indent + trailing newline.
+    assert out.endswith("}\n")
+    assert '\n  "Alpha"' in out
+
+
+def test_dump_json_ascii_escapes_non_ascii():
+    doc = _doc(Alpha=_hub(institutions={"Café": _inst("")}))
+    out = r.dump_json(doc)
+    assert "\\u00e9" in out  # é escaped, matching the committed file's style
+
+
+# --- composite-aggregation pagination ---------------------------------------
+
+
+def _agg_page(buckets, after_key):
+    return {
+        "aggregations": {"pairs": {"buckets": buckets, "after_key": after_key}},
+        "_shards": {"failed": 0},
+    }
+
+
+def test_fetch_index_providers_paginates_and_groups():
+    page1 = _agg_page(
+        [
+            {"key": {"provider": "Alpha", "dp": "Inst A"}},
+            {"key": {"provider": "Alpha", "dp": "Inst B"}},
+        ],
+        after_key={"provider": "Alpha", "dp": "Inst B"},
+    )
+    page2 = _agg_page(
+        [{"key": {"provider": "Beta", "dp": "Inst C"}}],
+        after_key={"provider": "Beta", "dp": "Inst C"},
+    )
+    page3 = {"aggregations": {"pairs": {"buckets": []}}, "_shards": {"failed": 0}}
+
+    responses = [page1, page2, page3]
+    calls = []
+
+    class _Resp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    def fake_post(query):
+        calls.append(query)
+        return _Resp(responses[len(calls) - 1])
+
+    with patch.object(r, "post_es", side_effect=fake_post):
+        out = r.fetch_index_providers(page_size=2)
+
+    assert out == {"Alpha": {"Inst A", "Inst B"}, "Beta": {"Inst C"}}
+    # Second call carried the after_key from page 1.
+    assert calls[1]["aggs"]["pairs"]["composite"]["after"] == {
+        "provider": "Alpha",
+        "dp": "Inst B",
+    }

--- a/tools/regen_institutions.py
+++ b/tools/regen_institutions.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Regenerate ``institutions_v2.json`` from the live DPLA index.
+
+``institutions_v2.json`` (in dpla/ingestion3 at
+``src/main/resources/wiki/institutions_v2.json``) is the upload-eligibility +
+Wikidata-QID registry the Wikimedia pipeline reads. Its top-level keys are hub
+(provider) display names; under each is an ``institutions`` map keyed by
+dataProvider display name. Both levels carry ``upload`` (bool) and ``Wikidata``
+(a QID string, ``""`` when unknown).
+
+Institution names — and, rarely, hub names — appear, drift, and disappear with
+every re-index. This tool reconciles the file against the current index:
+
+  * **ADD** every (provider, dataProvider) pair present in the index but
+    missing from the file, as ``{"Wikidata": "", "upload": false}``.
+  * **REMOVE** entries no longer in the index — but ONLY when their
+    ``Wikidata`` is empty. Any entry carrying a QID is preserved: a name may
+    have only drifted slightly and the QID is worth recovering by hand.
+  * **PRESERVE** every retained entry's existing ``upload`` and ``Wikidata``
+    verbatim — this tool never flips an opt-in or drops a QID.
+  * A **hub** is removed only when it is absent from the index AND its own
+    ``Wikidata`` is empty AND no surviving institution under it carries a QID.
+
+Unique dataProvider names are taken *per provider* (within each hub) via a
+composite aggregation over ``provider.name.not_analyzed`` ×
+``dataProvider.name.not_analyzed`` — composite, not ``terms``, so a large hub
+(Digital Maryland alone has ~2,650 institutions) cannot silently truncate.
+
+Output is written byte-faithful to the file's conventions (2-space indent,
+ASCII-escaped, plain-sorted keys, key order ``Wikidata`` / ``institutions`` /
+``upload``, trailing newline) so the resulting PR diff is purely semantic.
+
+Must run where the internal DPLA ES is reachable (the wiki/ingest EC2 box),
+since :mod:`ingest_wikimedia.es` points at ``search-prod1.internal.dp.la``.
+"""
+
+import argparse
+import json
+import sys
+import urllib.request
+
+from ingest_wikimedia.es import check_es_response, post_es
+from ingest_wikimedia.partners import INSTITUTIONS_URL
+
+# Composite-aggregation page size. Each page is one ES request returning this
+# many (provider, dataProvider) pairs; ~9,300 pairs today ⇒ ~10 pages.
+_PAGE_SIZE = 1000
+
+
+def fetch_index_providers(page_size: int = _PAGE_SIZE) -> dict[str, set[str]]:
+    """Return ``{provider_name: {dataProvider_name, …}}`` for every unique
+    (provider, dataProvider) pair in the live index.
+
+    Uses a composite aggregation paginated via ``after_key`` so the full set
+    is enumerated exhaustively — a ``terms`` aggregation would silently cap at
+    its ``size`` and drop the tail of a large hub.
+    """
+    out: dict[str, set[str]] = {}
+    after: dict | None = None
+    while True:
+        composite: dict = {
+            "size": page_size,
+            "sources": [
+                {"provider": {"terms": {"field": "provider.name.not_analyzed"}}},
+                {"dp": {"terms": {"field": "dataProvider.name.not_analyzed"}}},
+            ],
+        }
+        if after is not None:
+            composite["after"] = after
+        resp = post_es({"size": 0, "aggs": {"pairs": {"composite": composite}}})
+        resp.raise_for_status()
+        data = resp.json()
+        check_es_response(data)
+        agg = data["aggregations"]["pairs"]
+        buckets = agg.get("buckets") or []
+        if not buckets:
+            break
+        for bucket in buckets:
+            provider = bucket["key"].get("provider")
+            dataprovider = bucket["key"].get("dp")
+            if provider is None or dataprovider is None:
+                continue
+            out.setdefault(provider, set()).add(dataprovider)
+        after = agg.get("after_key")
+        if after is None:
+            break
+    return out
+
+
+def load_current(source: str) -> dict:
+    """Load the current institutions_v2.json from a URL or a local path."""
+    if source.startswith(("http://", "https://")):
+        with urllib.request.urlopen(source, timeout=30) as resp:
+            return json.loads(resp.read())
+    with open(source, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _has_qid(obj: dict) -> bool:
+    """True iff the entry carries a non-empty Wikidata value.
+
+    Deliberately a presence check, NOT ``partners.is_wikidata_id`` (which
+    enforces ``^Q\\d+$``). This gates the protect-from-removal rule, so the
+    safe failure mode is to over-preserve: a malformed or hand-entered value
+    is exactly the kind of thing worth keeping for human recovery, never
+    silently deleting. Do not "tighten" this to the regex.
+    """
+    return bool((obj.get("Wikidata") or "").strip())
+
+
+def reconcile(current: dict, index: dict[str, set[str]]) -> tuple[dict, dict]:
+    """Merge the live ``index`` into the ``current`` document.
+
+    Returns ``(new_document, report)``. ``report`` records every add, removal,
+    and dropped-but-kept-for-QID entry for the human-readable summary.
+    """
+    report: dict = {
+        "hubs_added": [],
+        "hubs_removed": [],
+        "hubs_dropped_kept": [],
+        "insts_added": {},
+        "insts_removed": {},
+        "insts_dropped_kept": {},
+    }
+    result: dict = {}
+
+    for hub in set(current) | set(index):
+        es_insts = index.get(hub, set())
+        cur = current.get(hub)
+        is_new_hub = cur is None
+        if is_new_hub:
+            cur = {"Wikidata": "", "upload": False, "institutions": {}}
+        cur_insts = cur.get("institutions") or {}
+
+        new_insts: dict = {}
+        for name, obj in cur_insts.items():
+            if name in es_insts:
+                new_insts[name] = obj  # still in the index — keep, untouched
+            elif _has_qid(obj):
+                new_insts[name] = obj  # dropped but protected by its QID
+                report["insts_dropped_kept"].setdefault(hub, []).append(name)
+            else:
+                report["insts_removed"].setdefault(hub, []).append(name)
+        for name in es_insts:
+            if name not in new_insts:
+                new_insts[name] = {"Wikidata": "", "upload": False}
+                report["insts_added"].setdefault(hub, []).append(name)
+        cur["institutions"] = new_insts
+
+        hub_in_index = hub in index
+        # Keep the hub if it's still aggregating items, or if a QID (its own or
+        # any surviving institution's) makes it worth preserving for recovery.
+        hub_protected = _has_qid(cur) or any(_has_qid(o) for o in new_insts.values())
+        if hub_in_index or hub_protected:
+            result[hub] = cur
+            if is_new_hub:
+                report["hubs_added"].append(hub)
+            elif not hub_in_index:
+                report["hubs_dropped_kept"].append(hub)
+        else:
+            report["hubs_removed"].append(hub)
+
+    return result, report
+
+
+def dump_json(doc: dict) -> str:
+    """Serialise ``doc`` byte-faithfully to the file's conventions: 2-space
+    indent, ASCII-escaped, plain-sorted hub and institution keys, fixed key
+    order, trailing newline."""
+    ordered: dict = {}
+    for hub in sorted(doc):
+        node = doc[hub]
+        insts = node.get("institutions") or {}
+        ordered[hub] = {
+            "Wikidata": node.get("Wikidata", ""),
+            "institutions": {
+                name: {
+                    "Wikidata": insts[name].get("Wikidata", ""),
+                    "upload": bool(insts[name].get("upload", False)),
+                }
+                for name in sorted(insts)
+            },
+            "upload": bool(node.get("upload", False)),
+        }
+    return json.dumps(ordered, indent=2, ensure_ascii=True) + "\n"
+
+
+def format_report(report: dict, current: dict, result: dict) -> str:
+    """Render the change summary for an operator / PR description."""
+    lines = ["== institutions_v2.json regeneration =="]
+    n_add = sum(len(v) for v in report["insts_added"].values())
+    n_rem = sum(len(v) for v in report["insts_removed"].values())
+    n_kept = sum(len(v) for v in report["insts_dropped_kept"].values())
+    lines.append(
+        f"hubs: {len(current)} -> {len(result)} "
+        f"(+{len(report['hubs_added'])} added, -{len(report['hubs_removed'])} removed)"
+    )
+    lines.append(
+        f"institutions: +{n_add} added, -{n_rem} removed, "
+        f"{n_kept} dropped-from-index but kept (carry a QID)"
+    )
+
+    def hub_list(items: list, header: str, sign: str) -> None:
+        if items:
+            lines.append("\n" + header)
+            lines.extend(f"  {sign} {h}" for h in sorted(items))
+
+    def per_hub_counts(by_hub: dict, header: str, sign: str) -> None:
+        if by_hub:
+            lines.append("\n" + header)
+            lines.extend(f"  {hub}: {sign}{len(by_hub[hub])}" for hub in sorted(by_hub))
+
+    hub_list(report["hubs_added"], "Hubs ADDED:", "+")
+    hub_list(report["hubs_removed"], "Hubs REMOVED (absent from index, no QID):", "-")
+    if report["insts_dropped_kept"]:
+        lines.append("\nInstitutions dropped from index but KEPT (carry a QID):")
+        for hub in sorted(report["insts_dropped_kept"]):
+            for name in sorted(report["insts_dropped_kept"][hub]):
+                qid = current[hub]["institutions"][name].get("Wikidata", "")
+                lines.append(f"  ~ {hub} / {name} ({qid})")
+    per_hub_counts(report["insts_added"], "Institutions ADDED (per hub):", "+")
+    per_hub_counts(report["insts_removed"], "Institutions REMOVED (per hub):", "-")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--current",
+        default=INSTITUTIONS_URL,
+        help="Current institutions_v2.json (URL or local path). "
+        "Defaults to the live file on dpla/ingestion3 main.",
+    )
+    parser.add_argument(
+        "--out",
+        default="-",
+        help="Where to write the regenerated JSON ('-' for stdout).",
+    )
+    args = parser.parse_args()
+
+    current = load_current(args.current)
+    index = fetch_index_providers()
+    result, report = reconcile(current, index)
+    output = dump_json(result)
+
+    if args.out == "-":
+        sys.stdout.write(output)
+    else:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            fh.write(output)
+    sys.stderr.write(format_report(report, current, result) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

A maintenance CLI, `tools/regen_institutions.py`, that reconciles dpla/ingestion3's [`institutions_v2.json`](https://github.com/dpla/ingestion3/blob/main/src/main/resources/wiki/institutions_v2.json) against the live DPLA index.

That file is the upload-eligibility + Wikidata-QID registry the Wikimedia pipeline reads — top-level keys are hub (provider) display names; under each, an `institutions` map keyed by dataProvider name; both levels carry `upload` (bool) and `Wikidata` (QID, `""` when unknown). Institution names — and rarely hub names — appear, drift, and disappear with each re-index, so the file needs periodic reconciliation.

## How

- **Source of truth:** a *composite* aggregation over `provider.name.not_analyzed` × `dataProvider.name.not_analyzed` → every unique (provider, dataProvider) pair. Composite, not `terms`, so a large hub can't silently truncate (Digital Maryland alone has ~2,650 institutions). Reuses `ingest_wikimedia.es.post_es` + `check_es_response` (SIGALRM timeout + partial-response guards).
- **Reconcile rules:**
  - **Add** index entries missing from the file as `{"Wikidata": "", "upload": false}`.
  - **Remove** entries no longer in the index **only if** their `Wikidata` is empty — anything with a QID is **preserved** (a name may have only drifted slightly and the QID is worth recovering by hand).
  - **Preserve** every retained entry's existing `upload` + `Wikidata` verbatim — never flips an opt-in or drops a QID.
  - A **hub** is removed only when it's absent from the index **and** neither it nor any surviving institution carries a QID.
- **Output:** byte-faithful to the file's conventions (`json.dumps` indent=2, ASCII-escaped, plain-sorted keys, fixed key order, trailing newline) so the resulting ingestion3 PR diff is purely semantic — verified by a round-trip against the live file (only diff: it normalizes Indiana Memory's one out-of-order entry). Prints a per-hub change report.

Run where internal ES is reachable (the EC2 box):
```
python -m tools.regen_institutions --out institutions_v2.json
```

## Validation against the live index (already run)

- 46 providers in ES vs 46 hubs in the file; exact-string match on 44.
- 2 hubs to **add** (in the index + `PARTNER_HUBS`, missing from the file): *Jewish Heritage and History Hub*, *Mississippi Digital Library*.
- 2 hubs absent from the index (*District Digital*, *University of Washington*) — kept or removed per the QID rule.

## Tests

`tests/test_regen_institutions.py` — merge rules (add / drop-no-QID / drop-with-QID-kept / new hub / dropped hub removed-or-kept), serialization (shape, key order, sorting, ASCII escaping), and composite-aggregation pagination. 11 pass, ruff clean, simplify pass applied.

This adds only the tool. The actual regenerated `institutions_v2.json` goes to dpla/ingestion3 as a separate, human-reviewed data PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Maintenance CLI Tool for Institutions Registry Regeneration

Adds `tools/regen_institutions.py`, a maintenance utility to regenerate `institutions_v2.json` (the upload-eligibility and Wikidata-QID registry in `dpla/ingestion3`) from the live DPLA Elasticsearch index. The tool is accompanied by a comprehensive test suite (`tests/test_regen_institutions.py`) with 11 passing tests.

**Key Functionality:**
- Enumerates all unique (provider, dataProvider) pairs from the index using composite aggregation with pagination via `after_key`, preventing silent truncation of large hubs (e.g., Digital Maryland's ~2,650 institutions)
- Applies reconciliation rules:
  - Adds index entries missing from the file as `{"Wikidata": "", "upload": false}`
  - Removes entries no longer in the index only when their `Wikidata` field is empty; preserves entries carrying QIDs
  - Preserves existing `upload` and `Wikidata` values for all retained entries
  - Removes a hub only when absent from the index and lacking QIDs (both at hub and institution level)
- Serializes output with byte-fidelity to original formatting (2-space indent, ASCII escaping, sorted keys, fixed key order, trailing newline)
- Generates a per-hub human-readable change report to stderr

**Note on Deployment:**
This is a standalone CLI tool intended for manual execution on systems with access to the internal DPLA Elasticsearch cluster (`search-prod1.internal.dp.la`). It is not integrated into any automated pipeline or CI/CD workflow. No environment variables, secrets, infrastructure configurations, or API changes are involved.

Test coverage includes institution reconciliation logic, hub management based on index membership and QID presence, JSON serialization determinism, and composite aggregation pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->