### PR TITLE
uploader: rescue community-contributed metadata in Case-2 hash-drift before duplicate-tagging

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -870,7 +870,24 @@ def merge_preserved_wikitext(existing_text: str, new_wikitext: str) -> str:
     live under that header for proper categorisation, and an MOTD-archive
     scraper expecting that wrapper would miss a bare template.
 
-    Duplicates within each preserved group are collapsed.
+    Duplicates within each preserved group are collapsed. Items that
+    already appear in ``new_wikitext`` are also skipped — the new
+    wikitext sometimes already carries the same license tag or
+    category (the upload's bot-generated block can name common
+    categories that the community happened to also use), and
+    re-emitting them produces visible duplicates in the wikitext
+    source. MediaWiki dedupes them at render time, but the source
+    diff is unsightly and confuses Commons editors reviewing the
+    rescue edit.
+
+    Category-block formatting: a blank-line separator is emitted
+    before the rescued categories ONLY when ``new_wikitext`` does
+    not already end with a category line. When it does, the
+    preserved categories are appended directly so existing + rescued
+    categories flow as a single contiguous block. (Templates above
+    the category block — PD-USGov, Image extracted — always get a
+    blank-line separator, since they conventionally sit in their
+    own section between the description and the categories.)
 
     TODO (Goal 2 follow-up): the title-drift rescue currently
     overwrites the metadata template wholesale, discarding any
@@ -881,17 +898,35 @@ def merge_preserved_wikitext(existing_text: str, new_wikitext: str) -> str:
     then overwrite. Out of scope for the flat-shape uploader PR;
     flagged here so the integration point doesn't get lost.
     """
-    parts: list[str] = [new_wikitext.rstrip()]
-    assessment = list(dict.fromkeys(_ASSESSMENT_TEMPLATE_RE.findall(existing_text)))
+    new_stripped = new_wikitext.rstrip()
+    parts: list[str] = [new_stripped]
+
+    def _fresh(items: list[str]) -> list[str]:
+        """Items, deduped against each other AND against the new wikitext.
+        ``new_stripped`` already carries some of what the regexes find
+        in ``existing_text`` (especially common categories); re-emitting
+        those produces duplicates in the saved wikitext."""
+        return [i for i in dict.fromkeys(items) if i not in new_stripped]
+
+    assessment = _fresh(_ASSESSMENT_TEMPLATE_RE.findall(existing_text))
     if assessment:
         parts.append("")
         parts.append("=={{Assessment}}==")
         parts.extend(assessment)
-    for pattern in (_PD_USGOV_RE, _IMAGE_EXTRACTED_RE, _CATEGORY_RE):
-        group = list(dict.fromkeys(pattern.findall(existing_text)))
+    for pattern in (_PD_USGOV_RE, _IMAGE_EXTRACTED_RE):
+        group = _fresh(pattern.findall(existing_text))
         if group:
             parts.append("")
             parts.extend(group)
+    categories = _fresh(_CATEGORY_RE.findall(existing_text))
+    if categories:
+        # Append directly (no blank line) when the new wikitext already
+        # ends with a category line, so existing + rescued categories
+        # flow as a single block.
+        last_line = new_stripped.rsplit("\n", 1)[-1].strip()
+        if not _CATEGORY_RE.match(last_line):
+            parts.append("")
+        parts.extend(categories)
     return "\n".join(parts) + "\n"
 
 

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -77,6 +77,25 @@ def _break_query_string_pattern(title: str) -> str:
     return title
 
 
+def escape_template_param(value: str) -> str:
+    """Escape `=` to ``{{=}}`` for safe use inside a template parameter.
+
+    The MediaWiki template parser treats ``=`` in a parameter as the
+    separator between parameter name and value: ``{{Foo|a=b|c=d}}`` parses
+    as named params ``a=b`` and ``c=d``. When a positional parameter's
+    value happens to contain ``=``, the parser splits at the first ``=``
+    and the positional value is lost. DPLA preserves equals signs from
+    source titles (e.g. ``"height of camera objective = 6.5 feet"`` on a
+    Massachusetts Archives photo) so this is a real shape callers can
+    produce, observed breaking a ``{{Duplicate}}`` tag in the wild.
+
+    The ``{{=}}`` magic word renders as a literal ``=`` after parsing,
+    so it's safe to insert anywhere ``=`` would otherwise be consumed
+    by the parser.
+    """
+    return value.replace("=", "{{=}}")
+
+
 def get_page_title(
     item_title: str, dpla_identifier: str, suffix: str, page=None
 ) -> str:
@@ -724,8 +743,8 @@ def post_commonsdelinker_request(
     page = pywikibot.Page(site, COMMONSDELINKER_PAGE)
     template = (
         f"{{{{universal replace"
-        f"|{old_filename}"
-        f"|{new_filename}"
+        f"|{escape_template_param(old_filename)}"
+        f"|{escape_template_param(new_filename)}"
         f"|reason={_COMMONSDELINKER_REASON}}}}}"
     )
     summary = f"universal replace: [[File:{old_filename}]] → [[File:{new_filename}]]"
@@ -901,24 +920,36 @@ def merge_preserved_wikitext(existing_text: str, new_wikitext: str) -> str:
     new_stripped = new_wikitext.rstrip()
     parts: list[str] = [new_stripped]
 
-    def _fresh(items: list[str]) -> list[str]:
-        """Items, deduped against each other AND against the new wikitext.
-        ``new_stripped`` already carries some of what the regexes find
-        in ``existing_text`` (especially common categories); re-emitting
-        those produces duplicates in the saved wikitext."""
-        return [i for i in dict.fromkeys(items) if i not in new_stripped]
+    def _fresh(pattern: "re.Pattern[str]") -> list[str]:
+        """Items the existing text emits for ``pattern``, deduped both
+        against each other AND against what the SAME pattern extracts
+        from the new wikitext.
 
-    assessment = _fresh(_ASSESSMENT_TEMPLATE_RE.findall(existing_text))
+        Dedup is by exact regex-match equality, not substring
+        containment, so e.g. ``[[Category:American]]`` and
+        ``[[Category:American history]]`` are correctly treated as
+        distinct even though one is a prefix of the other inside the
+        ``[[Category:…]]`` shell. (Practically prevented today by the
+        closing ``]]`` / ``}}`` terminator on every preserve pattern,
+        but matching by set membership is the right contract.)"""
+        already_present = set(pattern.findall(new_stripped))
+        return [
+            i
+            for i in dict.fromkeys(pattern.findall(existing_text))
+            if i not in already_present
+        ]
+
+    assessment = _fresh(_ASSESSMENT_TEMPLATE_RE)
     if assessment:
         parts.append("")
         parts.append("=={{Assessment}}==")
         parts.extend(assessment)
     for pattern in (_PD_USGOV_RE, _IMAGE_EXTRACTED_RE):
-        group = _fresh(pattern.findall(existing_text))
+        group = _fresh(pattern)
         if group:
             parts.append("")
             parts.extend(group)
-    categories = _fresh(_CATEGORY_RE.findall(existing_text))
+    categories = _fresh(_CATEGORY_RE)
     if categories:
         # Append directly (no blank line) when the new wikitext already
         # ends with a category line, so existing + rescued categories
@@ -974,7 +1005,13 @@ def tag_as_duplicate(
             f"already tagged as duplicate."
         )
         return
-    tag = f"{{{{Duplicate|{correct_filename}|{reason}}}}}"
+    # Escape `=` so a filename or reason containing literal equals signs
+    # doesn't break the template — see escape_template_param.
+    tag = (
+        f"{{{{Duplicate"
+        f"|{escape_template_param(correct_filename)}"
+        f"|{escape_template_param(reason)}}}}}"
+    )
     summary = f"Tagging as duplicate: correct title is [[File:{correct_filename}]]"
     # Trailing newline so the tag sits on its own line above whatever
     # wikitext currently starts the page.

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1532,11 +1532,14 @@ def _drift_uploader_with_pages(
     *,
     old_exists: bool = True,
     save_raises: Exception | None = None,
-    tag_raises: Exception | None = None,
 ):
     """Build ``(uploader, old_page, new_page)`` for direct invocation of
     ``_tag_drift_duplicate``. The new page is a write-only sink — we
-    just upload + save into it; nothing reads its state."""
+    just upload + save into it; nothing reads its state.
+
+    Tag-step failures are injected via ``patch("tools.uploader.tag_as_duplicate")``
+    at the call site, not here — the helper only needs to control the
+    rescue-side mocks."""
     from tools.uploader import Uploader
 
     uploader = Uploader.__new__(Uploader)

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1509,3 +1509,199 @@ def test_main_acquires_one_budget_slot_per_item():
     assert len(acquire_calls) == 3, (
         f"expected one slot acquire per item; got {len(acquire_calls)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# _tag_drift_duplicate — rescue + tag combined operation
+#
+# Case 2 hash-drift (``upload_and_tag``) is the only title-correction path
+# where the bot must explicitly preserve community-contributed metadata
+# from the file it's about to queue for deletion (the move and redirect
+# paths do this via merge_preserved_wikitext inline). _tag_drift_duplicate
+# now does both: rescue community categories/licenses/assessments into the
+# new (correct-title) file, then tag the old one. The two steps are
+# independently best-effort so a rescue failure does not block the tag.
+
+
+_NEW_WIKI_MARKUP = "{{DPLA metadata}}\n"
+_DPLA_ID = "abcdef0123456789abcdef0123456789"
+
+
+def _drift_uploader_with_pages(
+    old_text: str,
+    *,
+    old_exists: bool = True,
+    save_raises: Exception | None = None,
+    tag_raises: Exception | None = None,
+):
+    """Build ``(uploader, old_page, new_page)`` for direct invocation of
+    ``_tag_drift_duplicate``. The new page is a write-only sink — we
+    just upload + save into it; nothing reads its state."""
+    from tools.uploader import Uploader
+
+    uploader = Uploader.__new__(Uploader)
+    uploader.site = MagicMock(name="site")
+
+    old_page = MagicMock(name="old_page")
+    old_page.text = old_text
+    old_page.exists.return_value = old_exists
+
+    new_page = MagicMock(name="new_page")
+    if save_raises is not None:
+        new_page.save.side_effect = save_raises
+    return uploader, old_page, new_page
+
+
+def _patch_get_page(old_page, new_page):
+    """Side-effect for ``get_page`` that returns the right mock by title.
+    Tests use ``File:old.jpg`` and ``File:new.jpg`` consistently."""
+
+    def _side(_site, title):
+        if title == "File:old.jpg":
+            return old_page
+        if title == "File:new.jpg":
+            return new_page
+        raise AssertionError(f"unexpected get_page title: {title!r}")
+
+    return _side
+
+
+def _call_tag_drift(uploader, old_page, new_page, **patches):
+    """Invoke ``_tag_drift_duplicate`` with the standard arg shape so
+    each test asserts on outcomes instead of plumbing the call."""
+    extras = {f"tools.uploader.{name}": value for name, value in patches.items()}
+    with patch(
+        "tools.uploader.get_page",
+        side_effect=_patch_get_page(old_page, new_page),
+    ):
+        if extras:
+            from contextlib import ExitStack
+
+            with ExitStack() as stack:
+                for target, value in extras.items():
+                    stack.enter_context(patch(target, value))
+                uploader._tag_drift_duplicate(
+                    "old.jpg", "new.jpg", _NEW_WIKI_MARKUP, _DPLA_ID
+                )
+        else:
+            uploader._tag_drift_duplicate(
+                "old.jpg", "new.jpg", _NEW_WIKI_MARKUP, _DPLA_ID
+            )
+
+
+def test_rescue_preserves_community_categories_into_new_file():
+    """The headline rescue: a community-curated category on the old
+    file must end up in the new file's wikitext."""
+    old_text = (
+        "{{Information|description=Old description}}\n"
+        "[[Category:Curated by community]]\n"
+        "[[Category:Some 1842 thing]]\n"
+    )
+    uploader, old_page, new_page = _drift_uploader_with_pages(old_text)
+
+    with patch("tools.uploader.tag_as_duplicate"):
+        _call_tag_drift(uploader, old_page, new_page)
+
+    assert new_page.save.called, (
+        "Save must be called when the old page has community categories"
+    )
+    saved_text = new_page.text
+    assert "[[Category:Curated by community]]" in saved_text
+    assert "[[Category:Some 1842 thing]]" in saved_text
+    assert saved_text.lstrip().startswith("{{DPLA metadata}}")
+
+
+def test_rescue_preserves_assessment_and_license_templates():
+    """Featured-picture / PD-USGov templates survive the rescue."""
+    old_text = (
+        "=={{Assessment}}==\n"
+        "{{Featured picture|com|nominator=Curator}}\n"
+        "{{PD-USGov-Military}}\n"
+        "[[Category:Notable images]]\n"
+    )
+    uploader, old_page, new_page = _drift_uploader_with_pages(old_text)
+
+    with patch("tools.uploader.tag_as_duplicate"):
+        _call_tag_drift(uploader, old_page, new_page)
+
+    saved_text = new_page.text
+    assert "{{Featured picture|com|nominator=Curator}}" in saved_text
+    assert "{{PD-USGov-Military}}" in saved_text
+    assert "[[Category:Notable images]]" in saved_text
+
+
+def test_rescue_no_save_when_nothing_to_preserve():
+    """If the old page has nothing in merge_preserved_wikitext's
+    pattern set, the new page must NOT be saved — calling save() on
+    identical content would emit a no-op revision on Commons."""
+    # Information template alone is NOT in the preserve set.
+    old_text = "{{Information|description=Plain text}}\n"
+    uploader, old_page, new_page = _drift_uploader_with_pages(old_text)
+
+    with patch("tools.uploader.tag_as_duplicate"):
+        _call_tag_drift(uploader, old_page, new_page)
+
+    assert not new_page.save.called
+
+
+def test_rescue_skips_when_old_page_does_not_exist():
+    """Defensive: if the old page is gone (concurrent admin action),
+    don't crash — skip the rescue and proceed with the tag attempt."""
+    uploader, old_page, new_page = _drift_uploader_with_pages(
+        old_text="", old_exists=False
+    )
+
+    with patch("tools.uploader.tag_as_duplicate") as tag_mock:
+        _call_tag_drift(uploader, old_page, new_page)
+
+    assert not new_page.save.called
+    # Tag still runs — best-effort independence.
+    assert tag_mock.called
+
+
+def test_rescue_save_failure_does_not_block_tag(caplog):
+    """A save() failure mid-rescue must not block the subsequent tag.
+    The old page history still has the community contributions, so
+    manual recovery remains possible. Tag must still fire so the
+    duplicate-resolution path completes."""
+    import logging
+
+    uploader, old_page, new_page = _drift_uploader_with_pages(
+        old_text="[[Category:Community]]\n",
+        save_raises=RuntimeError("API timeout"),
+    )
+
+    with (
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+        caplog.at_level(logging.WARNING),
+    ):
+        _call_tag_drift(uploader, old_page, new_page)
+
+    assert any("Failed to rescue" in r.message for r in caplog.records)
+    # Tag must still fire — independent best-effort.
+    assert tag_mock.called
+
+
+def test_tag_failure_does_not_swallow_successful_rescue(caplog):
+    """Symmetric: if the tag step fails, the rescue is still recorded
+    in logs and the new page's saved text reflects the merge."""
+    import logging
+
+    uploader, old_page, new_page = _drift_uploader_with_pages(
+        old_text="[[Category:Community]]\n",
+    )
+
+    with (
+        patch(
+            "tools.uploader.tag_as_duplicate",
+            side_effect=RuntimeError("Commons API down"),
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        _call_tag_drift(uploader, old_page, new_page)
+
+    # Rescue succeeded.
+    assert new_page.save.called
+    assert "[[Category:Community]]" in new_page.text
+    # Tag failure is logged but didn't raise.
+    assert any("Failed to tag" in r.message for r in caplog.records)

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -404,6 +404,89 @@ def test_merge_preserved_wikitext_no_metadata_returns_new_wikitext_unchanged():
     assert result == NEW_WIKITEXT + "\n"
 
 
+def test_merge_preserved_wikitext_dedupes_against_new_wikitext():
+    """If the new wikitext already carries the same category /
+    license / image-extracted template that the existing page has,
+    the rescue must NOT re-emit it. MediaWiki silently dedupes
+    repeated category memberships at render time, but the saved
+    wikitext source would show two ``[[Category:X]]`` lines and
+    confuse Commons editors reviewing the rescue edit.
+
+    Regression: caught in production on rev 1235738403 (Heartland
+    "1813 Five Francs Coin" rescue) where the new file already had
+    ``[[Category:Gifts to Charles Lindbergh]]`` and the old file
+    contributed the same category — the merged result re-emitted it.
+    """
+    new_with_category = NEW_WIKITEXT + "\n\n[[Category:Already Present]]\n"
+    existing = (
+        "{{PD-USGov}}\n"
+        "{{Image extracted|1=Parent.jpg}}\n"
+        "[[Category:Already Present]]\n"
+        "[[Category:Brand New From Existing]]\n"
+    )
+    result = merge_preserved_wikitext(existing, new_with_category)
+    # The duplicate category must appear exactly once.
+    assert result.count("[[Category:Already Present]]") == 1
+    # The new category from the existing page must still be added.
+    assert "[[Category:Brand New From Existing]]" in result
+    # Non-category preserves that aren't in new_wikitext go through normally.
+    assert "{{PD-USGov}}" in result
+    assert "{{Image extracted|1=Parent.jpg}}" in result
+
+
+def test_merge_preserved_wikitext_dedupes_non_category_templates_too():
+    """Same dedup contract applies to PD-USGov, Image-extracted,
+    and Assessment templates — not just categories."""
+    new_with_pd = NEW_WIKITEXT + "\n{{PD-USGov}}\n"
+    existing = "{{PD-USGov}}\n[[Category:Foo]]\n"
+    result = merge_preserved_wikitext(existing, new_with_pd)
+    assert result.count("{{PD-USGov}}") == 1
+    assert "[[Category:Foo]]" in result
+
+
+def test_merge_preserved_wikitext_categories_flow_without_blank_line():
+    """When the new wikitext already ends with a category line,
+    the rescued categories must append directly — no blank-line
+    separator between the existing categories and the rescued ones.
+
+    Regression: same Heartland rescue rev 1235738403 had a blank
+    line between the new wikitext's last category and the rescued
+    block, making the source diff look like two separate category
+    groups rather than one contiguous block.
+    """
+    new_ending_in_category = (
+        "{{ Artwork | title = X }}\n\n[[Category:NewA]]\n[[Category:NewB]]\n"
+    )
+    existing = "[[Category:OldA]]\n[[Category:OldB]]\n"
+    result = merge_preserved_wikitext(existing, new_ending_in_category)
+    # All four categories should appear, contiguous, no blank line between.
+    lines = [ln for ln in result.splitlines() if ln.strip()]
+    cat_indices = [i for i, ln in enumerate(lines) if ln.startswith("[[Category:")]
+    # The four category lines must occupy four consecutive positions.
+    assert cat_indices == list(range(cat_indices[0], cat_indices[0] + 4))
+    # The rescued categories come after the existing ones (preserve order).
+    assert lines[cat_indices[0]] == "[[Category:NewA]]"
+    assert lines[cat_indices[0] + 1] == "[[Category:NewB]]"
+    assert lines[cat_indices[0] + 2] == "[[Category:OldA]]"
+    assert lines[cat_indices[0] + 3] == "[[Category:OldB]]"
+    # No blank line inside the category block.
+    cat_block_text = "\n".join(result.splitlines()[cat_indices[0] : cat_indices[0] + 4])
+    assert "\n\n" not in cat_block_text
+
+
+def test_merge_preserved_wikitext_blank_line_still_present_when_new_does_not_end_in_category():
+    """The blank-line separator is only suppressed when the new
+    wikitext already ends with a category line. When it ends with
+    a template (the common path — new wikitext is a freshly
+    generated ``{{DPLA metadata}}`` block with no categories), the
+    rescue still emits a blank line before the categories for
+    readability."""
+    existing = "[[Category:OldA]]\n[[Category:OldB]]\n"
+    # NEW_WIKITEXT ends with `{{DPLA metadata|title=Example}}` — not a category.
+    result = merge_preserved_wikitext(existing, NEW_WIKITEXT)
+    assert "{{DPLA metadata|title=Example}}\n\n[[Category:OldA]]" in result
+
+
 # ---------------------------------------------------------------------------
 # Assessment-template preservation (Media of the day, etc.)
 # ---------------------------------------------------------------------------

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -3,6 +3,7 @@ from ingest_wikimedia.wikimedia import (
     COMMONSDELINKER_PAGE,
     MAX_COMMENT_BYTES,
     build_title_drift_move_reason,
+    escape_template_param,
     get_site,
     get_page_title,
     get_wiki_text,
@@ -472,6 +473,29 @@ def test_merge_preserved_wikitext_categories_flow_without_blank_line():
     # No blank line inside the category block.
     cat_block_text = "\n".join(result.splitlines()[cat_indices[0] : cat_indices[0] + 4])
     assert "\n\n" not in cat_block_text
+
+
+def test_merge_preserved_wikitext_overlapping_category_names():
+    """Two categories that share a name-prefix (e.g.
+    ``[[Category:American]]`` and ``[[Category:American history]]``)
+    are distinct categories — the dedup must NOT filter one because
+    it appears as a substring of the other. The closing ``]]``
+    terminator on every preserve pattern already prevents this in
+    practice (``[[Category:American]]`` is not a substring of
+    ``[[Category:American history]]``), but pinning the contract by
+    test rules out the regression if the regex shape changes."""
+    new_with_longer = NEW_WIKITEXT + "\n\n[[Category:American history]]\n"
+    existing = "[[Category:American]]\n"
+    result = merge_preserved_wikitext(existing, new_with_longer)
+    assert "[[Category:American history]]" in result
+    assert "[[Category:American]]" in result
+    # Both appear exactly once.
+    assert (
+        result.count("[[Category:American]]\n")
+        + result.count("[[Category:American]]")
+        - result.count("[[Category:American history]]")
+        == 1
+    )
 
 
 def test_merge_preserved_wikitext_blank_line_still_present_when_new_does_not_end_in_category():
@@ -1279,6 +1303,121 @@ def test_tag_as_duplicate_idempotency_detects_whitespace_variants():
             f"prior tag {prior_tag!r} should have been detected; "
             f"editpage was called {site.editpage.call_count} time(s)"
         )
+
+
+def test_escape_template_param_replaces_equals_with_magic_word():
+    """`=` inside a template positional parameter is interpreted by
+    the MediaWiki parser as a named-parameter separator. The escape
+    must replace every `=` with the ``{{=}}`` magic word so the
+    rendered text is identical but the parser sees no splitter."""
+    assert escape_template_param("no equals") == "no equals"
+    assert escape_template_param("a=b") == "a{{=}}b"
+    assert escape_template_param("multi=one=two") == "multi{{=}}one{{=}}two"
+    assert escape_template_param("") == ""
+
+
+def test_tag_as_duplicate_escapes_equals_in_filename():
+    """Regression: a Spot Pond Reservoir file with a DPLA-preserved
+    source title containing ``"height of camera objective = 6.5
+    feet"`` produced a `{{Duplicate|...=...|...}}` template that
+    MediaWiki parsed as a named parameter, breaking the link and
+    showing an empty positional-1 slot. The bug was visible on
+    Commons rev 1234551826.
+
+    The fix: escape `=` in the correct-filename parameter via the
+    standard ``{{=}}`` magic word."""
+    site = MagicMock()
+    file_page = MagicMock()
+    type(file_page).text = property(lambda self: "")
+    file_page.title.return_value = "Stranded.jpg"
+
+    nasty_title = (
+        'Distribution Department, "height of camera objective = 6.5 feet", '
+        "Ston - DPLA - 01e81012a2a12fa66704075773b08b0c.jpg"
+    )
+    tag_as_duplicate(
+        site,
+        file_page,
+        correct_filename=nasty_title,
+        reason="Other file has the correct title.",
+    )
+
+    assert site.editpage.call_count == 1
+    _, kwargs = site.editpage.call_args
+    rendered = kwargs["prependtext"]
+    # A bare `=` between the first `|` and the second `|` would be the
+    # bug — assert there's no raw `=` between the template-open and the
+    # reason parameter separator.
+    duplicate_open = rendered.index("{{Duplicate|")
+    first_pipe = duplicate_open + len("{{Duplicate|")
+    # Find the SECOND pipe (parameter separator between filename and reason).
+    second_pipe = rendered.index("|", first_pipe + 1)
+    filename_param = rendered[first_pipe:second_pipe]
+    # The filename param must NOT contain a raw `=` — only the {{=}} form.
+    assert "=" not in filename_param.replace("{{=}}", ""), (
+        f"raw `=` survived inside template-parameter position: {filename_param!r}"
+    )
+    assert "{{=}}" in filename_param, (
+        f"escape did not fire on title with `=`: {filename_param!r}"
+    )
+
+
+def test_tag_as_duplicate_escapes_equals_in_reason():
+    """The reason parameter is the second positional param of
+    ``{{Duplicate}}`` — same template-parser hazard. Today the
+    default reason has no `=`, but any future change that introduces
+    one (e.g. embedding a URL fragment) must not break the template."""
+    site = MagicMock()
+    file_page = MagicMock()
+    type(file_page).text = property(lambda self: "")
+    file_page.title.return_value = "Stranded.jpg"
+
+    tag_as_duplicate(
+        site,
+        file_page,
+        correct_filename="Correct.jpg",
+        reason="see https://example.org/?id=42 for context",
+    )
+
+    rendered = site.editpage.call_args.kwargs["prependtext"]
+    assert "?id{{=}}42" in rendered
+    assert "?id=42" not in rendered.replace("?id{{=}}42", "")
+
+
+def test_post_commonsdelinker_request_escapes_equals_in_filenames():
+    """Same `=` escape contract applies to the
+    ``{{universal replace|<old>|<new>|reason=...}}`` template that
+    ``post_commonsdelinker_request`` posts to the CommonsDelinker
+    page. Filenames with `=` would otherwise corrupt the positional
+    params and the delinker would silently no-op."""
+    site = MagicMock()
+    # ``pywikibot.Page(site, ...)`` rejects a MagicMock site, so stub
+    # the page constructor too. ``file_has_inbound_usage`` returns True
+    # so the post path is reached.
+    with (
+        patch("ingest_wikimedia.wikimedia.pywikibot.Page", return_value=MagicMock()),
+        patch("ingest_wikimedia.wikimedia.file_has_inbound_usage", return_value=True),
+    ):
+        post_commonsdelinker_request(
+            site,
+            old_filename="Foo = bar.jpg",
+            new_filename="Foo = bar - DPLA - abc.jpg",
+            check_usage=True,
+        )
+
+    assert site.editpage.call_count == 1
+    appended = site.editpage.call_args.kwargs.get("appendtext", "")
+    # Both positional params must use the {{=}} escape.
+    assert "|Foo {{=}} bar.jpg|" in appended
+    assert "|Foo {{=}} bar - DPLA - abc.jpg|" in appended
+    # And no raw `=` in the positional-param region (the `reason=` named
+    # param is fine; that's a legitimate named-param assignment).
+    template_body = appended[
+        appended.index("{{universal replace") : appended.index("|reason=")
+    ]
+    assert "=" not in template_body.replace("{{=}}", ""), (
+        f"raw `=` survived in positional region: {template_body!r}"
+    )
 
 
 def test_tag_as_duplicate_idempotency_does_not_match_unrelated_templates():

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -699,7 +699,9 @@ class Uploader:
 
                 logging.info(f"Uploaded to {wikimedia_url(page_title)}")
                 if drift_old_filename:
-                    self._tag_drift_duplicate(drift_old_filename, page_title, dpla_id)
+                    self._tag_drift_duplicate(
+                        drift_old_filename, page_title, wiki_markup, dpla_id
+                    )
                 self.tracker.increment(Result.UPLOADED)
                 self.tracker.increment(Result.BYTES, file_size)
                 # `wiki_file_page.pageid` is stale for net-new uploads:
@@ -1131,11 +1133,69 @@ class Uploader:
         self,
         old_filename: str,
         new_filename: str,
+        wiki_markup: str,
         dpla_id: str,
     ) -> None:
-        """Tag a stranded file page as a duplicate after its hash was uploaded elsewhere."""
+        """Tag a stranded file as duplicate of the new (correct-title)
+        file, AND carry any community-contributed metadata from the
+        old page across to the new one before the admin-side delete.
+
+        Mirrors what ``_move_to_correct_title`` and
+        ``_resolve_redirect_overwrite`` already do in the move and
+        redirect-overwrite paths: license tags, assessment templates,
+        ``{{Image extracted}}`` parents, and category links community
+        editors have added are preserved via
+        :func:`merge_preserved_wikitext`.
+
+        Rescue and tag are independent best-effort steps — a failure
+        on either is logged and does NOT block the other. The old
+        file's revision history still contains the community
+        contributions even if the rescue's save fails, so manual
+        recovery from page history is always possible.
+        """
+        old_page = get_page(self.site, f"File:{old_filename}")
+
+        # Rescue community contributions, if any.
         try:
-            old_page = get_page(self.site, f"File:{old_filename}")
+            if old_page.exists():
+                merged = merge_preserved_wikitext(old_page.text or "", wiki_markup)
+                # Equality means nothing matched merge_preserved_wikitext's
+                # patterns. Skip the save so we don't emit a no-op revision
+                # on the new file (the other two preserve sites — move,
+                # redirect-overwrite — don't need this guard because their
+                # destination text always differs from wiki_markup before
+                # the merge, but here new_page already carries wiki_markup
+                # from the upload we just completed).
+                if merged.rstrip() != wiki_markup.rstrip():
+                    # `get_page` is a constructor — no API hit — and we
+                    # know the page exists and isn't a redirect because
+                    # we just uploaded it. Skip the exists/redirect
+                    # round-trips and write directly.
+                    new_page = get_page(self.site, f"File:{new_filename}")
+                    new_page.text = merged
+                    new_page.save(
+                        summary=(
+                            f"Rescue community-contributed metadata from "
+                            f"[[File:{old_filename}]] (DPLA ID "
+                            f"[[dpla:{dpla_id}|{dpla_id}]])"
+                        ),
+                        minor=False,
+                    )
+                    logging.info(
+                        f"Rescued community-contributed metadata from "
+                        f"[[File:{old_filename}]] into "
+                        f"[[File:{new_filename}]] (DPLA ID {dpla_id})"
+                    )
+        except Exception as ex:
+            logging.warning(
+                f"Failed to rescue community contributions from "
+                f"[[File:{old_filename}]]: {ex}"
+            )
+
+        # Tag the stranded file. Independent of the rescue: even if the
+        # save above failed, queue the old title for speedy deletion so
+        # the search-time SHA1 collision is resolved.
+        try:
             tag_as_duplicate(
                 self.site,
                 old_page,


### PR DESCRIPTION
## Why

Case 2 hash-drift (`upload_and_tag`) is the title-correction path that fires when our content already exists on Commons at a wrong title AND the correct (DPLA-suffixed) title also already exists with a different SHA1. The bot uploads to the correct title (overwriting the wrong-hash placeholder there) and tags the stranded same-SHA1 file at the wrong title for speedy deletion.

The other two title-correction paths — `_move_to_correct_title` (Case 1/3) and `_resolve_redirect_overwrite` — already preserve community-contributed metadata via `merge_preserved_wikitext`. **Case 2 was the only path that didn't.** Admin-side speedy deletion then took license tags, assessment templates, `{{Image extracted}}` parents, and category links along with the file.

This was visible in the community-facing edit log as DPLA bot replacing long-curated human-titled GLAM uploads with hash-suffixed bot versions stripped of their original categories. Specific recent case: the May 2026 [Missouri History Museum "Advertisment for the St. Louis and St. Clair Ferry, July 4, 1842"](https://commons.wikimedia.org/w/index.php?title=File:Advertisment_for_the_St._Louis_and_St._Clair_Ferry,_July_4,_1842.jpg&diff=prev&oldid=1235607994) edit, which queued the original Fæ upload for deletion without rescuing its categories.

## What this PR changes

### 1. Extend `_tag_drift_duplicate` to rescue community metadata before tagging

The function now:

1. Reads the old (about-to-be-tagged) file's wikitext
2. Runs `merge_preserved_wikitext(old.text, wiki_markup)` — same call the other two paths make
3. If anything was preserved, saves the merged result to the new file
4. Tags the old file as duplicate (always)

Rescue and tag are independent best-effort steps. A failure on either is logged and does NOT block the other. Old page history still retains the contributions even on save failure, so manual recovery from history remains possible.

Call site (`process_file:701-704`) is unchanged in shape — just threads `wiki_markup` through to the existing call.

### 2. Two `merge_preserved_wikitext` defects (fixes apply to all 3 preservation paths)

Surfaced from a live rescue (rev 1235738403 on the Heartland "1813 Five Francs Coin"):

- **Doubled categories**: when the new file's wikitext already carries a category that the existing page also has, the merge re-emitted it. MediaWiki silently dedupes at render time but the saved wikitext source shows two `[[Category:X]]` lines side by side.
- **Blank-line break inside the category block**: the merge unconditionally inserted a blank line before each preserved group, including categories. When the new wikitext already ended with categories, that blank line split the category block visually.

Fixed in the shared helper itself via a new `_fresh()` closure (dedupes against the SAME pattern's matches in the new wikitext, by set membership — robust against overlapping prefixes per CR review). Blank-line separator before categories is suppressed when the new wikitext already ends with a category line. Move-path and redirect-overwrite path automatically benefit.

### 3. `=` in template-parameter positions breaks the template

When a DPLA-preserved source title contains a literal `=` (e.g. "height of camera objective = 6.5 feet" on a Massachusetts Archives Spot Pond Reservoir photo), the corresponding Commons filename also carries the `=`. The MediaWiki template parser interprets `=` in a positional parameter as the named-parameter separator, so `{{Duplicate|<filename-with-equals>|<reason>}}` produces an empty positional slot and the duplicate-link is broken. Observed at [Commons rev 1234551826](https://commons.wikimedia.org/w/index.php?title=File:Distribution_Department,_Low_Service_Spot_Pond_Reservoir,_verso,_%22height_of_camera_objective_-_6.5_feet;_note_that_a_rise_of_water_level_will_expose_a_new_but_excellent_front%22,_Ston_-_DPLA_-_01e81012a2a12fa66704075773b08b0c.jpg&oldid=1234551826).

New `escape_template_param(value)` helper swaps `=` → `{{=}}` (the MediaWiki magic word that renders as a literal `=` after parsing). Applied at both call sites that emit a filename into a template-positional position:

- `tag_as_duplicate` — both `correct_filename` and `reason` parameters
- `post_commonsdelinker_request` — both old/new filename positional params of `{{universal replace}}`

Edit-summary `[[File:…]]` link targets are unchanged — `=` is valid inside link targets.

### 4. CR review

- Drop unused `tag_raises` parameter from `_drift_uploader_with_pages` test helper (CR finding on the original push)
- Switch `_fresh` from substring containment to set-of-regex-extractions for correct dedup contract (CR finding on the second push)

## Tests

150 unit tests pass. New:

- `test_rescue_*` — 6 tests covering rescue-preserves-categories/assessments/licenses, no-op-skip when nothing to preserve, rescue/tag failure independence in both directions, old-page-missing graceful skip
- `test_merge_preserved_wikitext_dedupes_against_new_wikitext`
- `test_merge_preserved_wikitext_dedupes_non_category_templates_too`
- `test_merge_preserved_wikitext_categories_flow_without_blank_line`
- `test_merge_preserved_wikitext_blank_line_still_present_when_new_does_not_end_in_category`
- `test_merge_preserved_wikitext_overlapping_category_names`
- `test_escape_template_param_replaces_equals_with_magic_word`
- `test_tag_as_duplicate_escapes_equals_in_filename` (the Spot Pond Reservoir regression)
- `test_tag_as_duplicate_escapes_equals_in_reason`
- `test_post_commonsdelinker_request_escapes_equals_in_filenames`

## Test plan

- [ ] CI green
- [ ] Watch the next Case-2 drift event on Commons recent-changes — the new file's revision after upload should contain the original community categories merged in, no doubled categories, and contiguous category block (no blank-line gap)
- [ ] Verify any new `{{Duplicate}}` tag whose correct-filename contains `=` renders with `{{=}}` and the link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)