### PR TITLE
Maintain mode: in-place upkeep of existing uploads (no-create fence + ID-drift re-link)

### DIFF
--- a/ingest_wikimedia/maintain.py
+++ b/ingest_wikimedia/maintain.py
@@ -1,0 +1,220 @@
+"""Re-link engine for maintain mode.
+
+Maintain mode keeps already-uploaded Commons files current (SDC sync, template
+migration, title/hash/ID-drift correction) for institutions no longer
+authorized for *new* uploads. The hard sub-problem is **DPLA ID drift**: a
+file's embedded DPLA ID (in its filename / ``dpla_id=`` param / SDC ``P760``)
+can go dead while the same item lives on under a *new* DPLA ID, so the
+``dp.la/item/<id>`` links 404. We must re-link the orphaned Commons file to its
+current DPLA record.
+
+The durable anchor is the provider's own source URL (the legacy ``url=`` ↔ the
+record's ``isShownAt``), which sampling shows is present on essentially every
+legacy upload. This module resolves the current DPLA ID via a provider-agnostic
+ladder — no per-institution URL parsing, validated against the live index
+(``isShownAt`` is a ``keyword`` field, exact ``term`` queries work):
+
+  1. **embedded** — the file's embedded DPLA ID still resolves in the index.
+     No drift; use it. (The common case; callers pass it first.)
+  2. **isShownAt** — exact ``term`` match on ``isShownAt`` over a few
+     *normalized* variants (http/https, trailing slash). Catches both genuinely
+     stable URLs and the very common trivial mismatch where the old upload
+     recorded ``http://`` but the index stores ``https://``.
+  3. **wildcard** — institution-scoped ``wildcard`` on the longest stable
+     id-like token from the URL path. Catches real domain drift where the
+     record-id token persists. Bounded by the institution scope; only accepted
+     when it resolves to exactly one record.
+  4. **unresolved** — anything left (ambiguous or no match) is reported for
+     content-hash confirmation or human review. Never guessed, never deleted.
+
+The ES-querying resolver takes an injectable ``query_fn`` (defaults to
+:func:`ingest_wikimedia.es.post_es`) so the ladder logic is unit-tested without
+a live cluster. The pure helpers below carry no ES dependency at all.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable
+from urllib.parse import urlparse
+
+from ingest_wikimedia.es import check_es_response, post_es
+from ingest_wikimedia.partners import is_dpla_id
+
+# Tokens shorter than this are too generic to anchor a wildcard match on
+# (e.g. "id", "ref", "cdm"); below it we decline rather than risk a broad scan.
+_MIN_TOKEN_LEN = 6
+
+
+def normalize_url_candidates(url: str) -> list[str]:
+    """Return exact-match candidate strings for ``url``, most-specific first.
+
+    The old upload's recorded ``url=`` and the index's ``isShownAt`` are
+    frequently the same record but differ in scheme (``http`` vs ``https``) or a
+    trailing slash — trivial, extremely common mismatches that would defeat an
+    exact ``term`` query. Emit the original plus those normalized variants
+    (deduped, order-preserving) so the resolver can try each as an exact match.
+    """
+    url = (url or "").strip()
+    if not url:
+        return []
+    bases: list[str] = [url]
+    # http <-> https
+    if url.startswith("http://"):
+        bases.append("https://" + url[len("http://") :])
+    elif url.startswith("https://"):
+        bases.append("http://" + url[len("https://") :])
+    # +/- a single trailing slash for each scheme variant
+    out: list[str] = []
+    for b in bases:
+        for v in (b, b.rstrip("/") if b.endswith("/") else b + "/"):
+            if v not in out:
+                out.append(v)
+    return out
+
+
+def extract_stable_token(url: str) -> str | None:
+    """Return the longest id-like token from ``url``'s path/query, or None.
+
+    Provider-agnostic: split the path and query on common identifier
+    delimiters and pick the longest token (ties broken toward a token
+    containing a digit). For the providers seen across hubs this yields the
+    record id — DigitalNC ``/record/100550`` -> ``100550``, DLG
+    ``/id:arl_awc_awc337`` -> ``arl_awc_awc337``, Illinois ``/items/<uuid>`` ->
+    the uuid, archive.org ``/details/<id>`` -> the id. It is only a *narrowing*
+    signal for the scoped wildcard (anchor 3), never a sole re-link key, so an
+    imperfect pick (e.g. a CONTENTdm collection slug) merely yields an ambiguous
+    result that falls through to human review — never a wrong re-link.
+    """
+    parsed = urlparse(url or "")
+    haystack = f"{parsed.path}?{parsed.query}" if parsed.query else parsed.path
+    tokens = [t for t in re.split(r"[^A-Za-z0-9_-]+", haystack) if t]
+    if not tokens:
+        return None
+    best = max(
+        tokens,
+        key=lambda t: (len(t), any(c.isdigit() for c in t)),
+    )
+    return best if len(best) >= _MIN_TOKEN_LEN else None
+
+
+# --- ES query builders (pure) -----------------------------------------------
+
+
+def _ids_query(dpla_id: str) -> dict:
+    """Count query: does a record with this id exist? (id is the ES _id.)"""
+    return {"size": 0, "query": {"ids": {"values": [dpla_id]}}}
+
+
+def _isshownat_terms_query(urls: list[str]) -> dict:
+    """Exact ``terms`` on the ``isShownAt`` keyword field over all normalized
+    URL variants in ONE round-trip — a record matches if its ``isShownAt``
+    equals any variant. ``size`` 2 so the ">1 record" ambiguity check still
+    sees a second hit. (One query instead of one-per-variant matters at the
+    per-file scale this runs at.)
+    """
+    return {
+        "size": 2,
+        "query": {"terms": {"isShownAt": urls}},
+        "_source": ["isShownAt"],
+    }
+
+
+def _scoped_wildcard_query(token: str, scope_filter: dict) -> dict:
+    """Institution-scoped ``wildcard`` on ``isShownAt`` for ``*token*``.
+
+    ``scope_filter`` is an ES filter clause the caller builds to bound the scan
+    to one institution (e.g. ``{"term": {"dataProvider.name.not_analyzed":
+    "..."}}``) — required, because a leading-wildcard scan over the whole index
+    is prohibitively expensive.
+    """
+    return {
+        "size": 3,
+        "query": {
+            "bool": {
+                "filter": [scope_filter],
+                "must": [{"wildcard": {"isShownAt": f"*{token}*"}}],
+            }
+        },
+        "_source": ["isShownAt"],
+    }
+
+
+# --- resolver ----------------------------------------------------------------
+
+
+@dataclass
+class ResolveResult:
+    """Outcome of re-linking one orphaned file to a current DPLA record.
+
+    ``anchor`` is the rung that resolved it ("embedded" / "isShownAt" /
+    "wildcard") or "unresolved". ``dpla_id`` is the current id when resolved,
+    else None. ``ambiguous`` flags a multi-hit (more than one current record
+    matched) — never auto-applied; surfaced for content-hash/human review.
+    """
+
+    dpla_id: str | None
+    anchor: str
+    ambiguous: bool = False
+    tried: list[str] = field(default_factory=list)
+
+
+def _total(resp_json: dict) -> int:
+    check_es_response(resp_json)
+    total = resp_json.get("hits", {}).get("total", 0)
+    return total.get("value", 0) if isinstance(total, dict) else total
+
+
+def _hit_ids(resp_json: dict) -> list[str]:
+    return [h.get("_id") for h in resp_json.get("hits", {}).get("hits", [])]
+
+
+def resolve_current_dpla_id(
+    *,
+    embedded_id: str | None,
+    recorded_url: str | None,
+    scope_filter: dict | None,
+    query_fn: Callable[[dict], object] = post_es,
+) -> ResolveResult:
+    """Resolve the *current* DPLA ID for one orphaned Commons file.
+
+    Walks the validated ladder (embedded -> exact isShownAt -> scoped wildcard)
+    and stops at the first unambiguous hit. ``query_fn`` runs an ES query and
+    returns a ``requests``-style response exposing ``.json()`` — injected so the
+    ladder is testable without a cluster. ``scope_filter`` bounds the wildcard
+    rung to one institution; pass None to skip that rung (e.g. when the
+    institution is unknown).
+    """
+    tried: list[str] = []
+
+    # Anchor 1: embedded id still live in the index.
+    if embedded_id and is_dpla_id(embedded_id):
+        tried.append("embedded")
+        if _total(query_fn(_ids_query(embedded_id)).json()) > 0:
+            return ResolveResult(embedded_id, "embedded", tried=tried)
+
+    # Anchor 2: exact isShownAt over all normalized URL variants, one query.
+    candidates = normalize_url_candidates(recorded_url or "")
+    if candidates:
+        tried.append("isShownAt")
+        data = query_fn(_isshownat_terms_query(candidates)).json()
+        total = _total(data)
+        if total == 1:
+            return ResolveResult(_hit_ids(data)[0], "isShownAt", tried=tried)
+        if total > 1:
+            # A variant matches more than one record — don't guess.
+            return ResolveResult(None, "unresolved", ambiguous=True, tried=tried)
+
+    # Anchor 3: institution-scoped wildcard on the stable URL token.
+    token = extract_stable_token(recorded_url or "")
+    if token and scope_filter:
+        tried.append("wildcard")
+        data = query_fn(_scoped_wildcard_query(token, scope_filter)).json()
+        total = _total(data)
+        if total == 1:
+            return ResolveResult(_hit_ids(data)[0], "wildcard", tried=tried)
+        if total > 1:
+            return ResolveResult(None, "unresolved", ambiguous=True, tried=tried)
+
+    return ResolveResult(None, "unresolved", tried=tried)

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -14,6 +14,11 @@ class Result(Enum):
     # download-only formats staged for conversion).
     UPLOAD_SKIPPED_NOT_PRESENT = auto()
     UPLOAD_SKIPPED_INELIGIBLE = auto()
+    # Maintain (no-create) mode: an upload would have created a File page
+    # that does not already exist on Commons, so the fence blocked it. The
+    # core safety invariant of maintain mode — maintenance never emits a new
+    # File page — surfaces here so operators can audit that it held.
+    UPLOAD_SKIPPED_WOULD_CREATE = auto()
     UPLOADED = auto()
     BYTES = auto()
     ITEM_NOT_PRESENT = auto()

--- a/tests/test_get_ids_es.py
+++ b/tests/test_get_ids_es.py
@@ -429,3 +429,30 @@ def test_sort_key_dpla_id_tiebreaks_identical_titles():
     a = _key(_sr("Same Title"), "00000000000000000000000000000001")
     b = _key(_sr("Same Title"), "00000000000000000000000000000002")
     assert a < b
+
+
+def test_load_eligible_dp_names_maintain_includes_ineligible_with_qid():
+    """Maintain mode drops the upload-flag gate but keeps the QID gate, so a
+    formerly-participating institution (upload=False, has a QID) is included
+    while a never-onboarded one (no QID) still is not."""
+    from unittest.mock import patch
+
+    from tools import get_ids_es
+
+    insts = {
+        "Some Hub": {
+            "Wikidata": "Q100",
+            "institutions": {
+                "Active Inst": {"upload": True, "Wikidata": "Q1"},
+                "Former Inst": {"upload": False, "Wikidata": "Q2"},
+                "No QID Inst": {"upload": False, "Wikidata": ""},
+            },
+        }
+    }
+    with patch.object(get_ids_es, "PARTNER_HUBS", {"x": "Some Hub"}):
+        normal = get_ids_es.load_eligible_dp_names(insts, "x")
+        maintain = get_ids_es.load_eligible_dp_names(insts, "x", maintain=True)
+
+    assert normal == ["Active Inst"]
+    # Former Inst now included (upload=False but has a QID); No QID Inst never.
+    assert sorted(maintain) == ["Active Inst", "Former Inst"]

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -1,0 +1,188 @@
+"""Tests for ingest_wikimedia/maintain.py — the maintain-mode re-link engine.
+
+Pure helpers (URL normalization, token extraction) are tested directly. The
+anchor ladder is tested with a fake ``query_fn`` that routes on ES query shape,
+so the rung-selection logic is exercised without a live cluster.
+"""
+
+from ingest_wikimedia.maintain import (
+    ResolveResult,
+    extract_stable_token,
+    normalize_url_candidates,
+    resolve_current_dpla_id,
+)
+
+NC = "https://lib.digitalnc.org/record/100550"
+CURRENT_ID = "26f8310936c0321a8c611703751034ee"
+DEAD_ID = "496453e05948633e07ab9cdeb8c99cd8"
+
+
+# --- pure helpers ------------------------------------------------------------
+
+
+def test_normalize_url_candidates_scheme_and_slash():
+    out = normalize_url_candidates("http://x.org/record/1")
+    assert out[0] == "http://x.org/record/1"  # original first
+    assert "https://x.org/record/1" in out  # scheme flip (the common drift)
+    assert "http://x.org/record/1/" in out  # trailing-slash variant
+    # No duplicates.
+    assert len(out) == len(set(out))
+
+
+def test_normalize_url_candidates_empty():
+    assert normalize_url_candidates("") == []
+    assert normalize_url_candidates("   ") == []
+
+
+def test_extract_stable_token_across_providers():
+    assert extract_stable_token("https://lib.digitalnc.org/record/100550") == "100550"
+    assert (
+        extract_stable_token("http://dlg.galileo.usg.edu/id:arl_awc_awc337")
+        == "arl_awc_awc337"
+    )
+    assert (
+        extract_stable_token(
+            "https://digital.library.illinois.edu/items/"
+            "f9708790-cebe-0134-238a-0050569601ca-7"
+        )
+        == "f9708790-cebe-0134-238a-0050569601ca-7"
+    )
+    assert (
+        extract_stable_token("https://archive.org/details/billcontinuingin00conf")
+        == "billcontinuingin00conf"
+    )
+
+
+def test_extract_stable_token_too_short_declines():
+    # Nothing long enough to safely anchor a wildcard on.
+    assert extract_stable_token("https://x.org/a/b") is None
+    assert extract_stable_token("") is None
+
+
+# (DPLA-ID validation is reused from ingest_wikimedia.partners.is_dpla_id and
+# tested there; the resolver just consumes it.)
+
+
+# --- fake ES for the ladder --------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, ids):
+        self._ids = ids
+
+    def json(self):
+        return {
+            "_shards": {"failed": 0},
+            "hits": {
+                "total": {"value": len(self._ids)},
+                "hits": [{"_id": i} for i in self._ids],
+            },
+        }
+
+
+class FakeES:
+    """Routes a query dict to canned hits by shape."""
+
+    def __init__(self, *, live_ids=(), isshownat=None, wildcard=None):
+        self.live_ids = set(live_ids)
+        self.isshownat = isshownat or {}
+        self.wildcard = wildcard or {}
+        self.calls = []
+
+    def __call__(self, query):
+        self.calls.append(query)
+        q = query["query"]
+        if "ids" in q:
+            wanted = q["ids"]["values"][0]
+            return _Resp([wanted] if wanted in self.live_ids else [])
+        if "terms" in q and "isShownAt" in q["terms"]:
+            ids: list[str] = []
+            for u in q["terms"]["isShownAt"]:
+                for i in self.isshownat.get(u, []):
+                    if i not in ids:
+                        ids.append(i)
+            return _Resp(ids)
+        if "bool" in q:
+            patt = q["bool"]["must"][0]["wildcard"]["isShownAt"]  # "*token*"
+            token = patt.strip("*")
+            return _Resp(self.wildcard.get(token, []))
+        raise AssertionError(f"unexpected query shape: {query}")
+
+
+# --- ladder ------------------------------------------------------------------
+
+
+def test_anchor1_embedded_id_live():
+    es = FakeES(live_ids={CURRENT_ID})
+    r = resolve_current_dpla_id(
+        embedded_id=CURRENT_ID, recorded_url=NC, scope_filter=None, query_fn=es
+    )
+    assert r == ResolveResult(CURRENT_ID, "embedded", tried=["embedded"])
+    # Resolved on rung 1 — never queried isShownAt.
+    assert len(es.calls) == 1
+
+
+def test_anchor2_exact_isshownat_when_embedded_dead():
+    es = FakeES(live_ids=set(), isshownat={NC: [CURRENT_ID]})
+    r = resolve_current_dpla_id(
+        embedded_id=DEAD_ID, recorded_url=NC, scope_filter=None, query_fn=es
+    )
+    assert r.dpla_id == CURRENT_ID
+    assert r.anchor == "isShownAt"
+
+
+def test_anchor2_recovers_via_scheme_normalization():
+    # Old upload recorded http://; index stores https:// — the common case.
+    recorded_http = "http://lib.digitalnc.org/record/100550"
+    stored_https = "https://lib.digitalnc.org/record/100550"
+    es = FakeES(isshownat={stored_https: [CURRENT_ID]})
+    r = resolve_current_dpla_id(
+        embedded_id=None, recorded_url=recorded_http, scope_filter=None, query_fn=es
+    )
+    assert r.dpla_id == CURRENT_ID
+    assert r.anchor == "isShownAt"
+
+
+def test_anchor2_multi_hit_is_ambiguous_not_guessed():
+    es = FakeES(isshownat={NC: [CURRENT_ID, "other"]})
+    r = resolve_current_dpla_id(
+        embedded_id=None, recorded_url=NC, scope_filter=None, query_fn=es
+    )
+    assert r.dpla_id is None
+    assert r.anchor == "unresolved"
+    assert r.ambiguous is True
+
+
+def test_anchor3_scoped_wildcard_on_token():
+    scope = {"term": {"dataProvider.name.not_analyzed": "Athens-Clarke County Library"}}
+    ga = "http://dlg.galileo.usg.edu/id:arl_awc_awc337"
+    es = FakeES(wildcard={"arl_awc_awc337": ["0ff4842c996e3abab8cff9b3f8f8b297"]})
+    r = resolve_current_dpla_id(
+        embedded_id=DEAD_ID, recorded_url=ga, scope_filter=scope, query_fn=es
+    )
+    assert r.dpla_id == "0ff4842c996e3abab8cff9b3f8f8b297"
+    assert r.anchor == "wildcard"
+
+
+def test_anchor3_skipped_without_scope_filter():
+    ga = "http://dlg.galileo.usg.edu/id:arl_awc_awc337"
+    es = FakeES(wildcard={"arl_awc_awc337": ["whatever"]})
+    r = resolve_current_dpla_id(
+        embedded_id=None, recorded_url=ga, scope_filter=None, query_fn=es
+    )
+    assert r.anchor == "unresolved"
+    # Wildcard rung never ran (no scope to bound it).
+    assert "wildcard" not in r.tried
+
+
+def test_all_anchors_miss_is_unresolved():
+    es = FakeES()
+    r = resolve_current_dpla_id(
+        embedded_id=DEAD_ID,
+        recorded_url=NC,
+        scope_filter={"term": {"dataProvider.name.not_analyzed": "X"}},
+        query_fn=es,
+    )
+    assert r.dpla_id is None
+    assert r.anchor == "unresolved"
+    assert r.ambiguous is False

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -5189,3 +5189,62 @@ def test_find_existing_commons_files_skips_non_canonical_titles(monkeypatch):
 
     found = sdc_sync._find_existing_commons_files_by_dpla_id(dpla_id)
     assert list(found.keys()) == ["1"]
+
+
+# --- maintain mode: ID-drift re-link in --cat / --file ----------------------
+
+
+def test_extract_source_url_from_legacy_wikitext():
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.text = (
+        "== {{int:filedesc}} ==\n{{Artwork\n| source = {{DPLA | Q1 | hub=Q2 |"
+        " url=https://lib.digitalnc.org/record/100550 | dpla_id=abc }}\n}}"
+    )
+    assert (
+        sdc_sync._extract_source_url(page) == "https://lib.digitalnc.org/record/100550"
+    )
+
+
+def test_extract_source_url_absent_or_unreadable():
+    from tools import sdc_sync
+
+    no_url = MagicMock()
+    no_url.text = "{{DPLA metadata}}"
+    assert sdc_sync._extract_source_url(no_url) is None
+
+    raises = MagicMock()
+    type(raises).text = property(lambda self: (_ for _ in ()).throw(RuntimeError()))
+    assert sdc_sync._extract_source_url(raises) is None
+
+
+def test_maintain_relink_uses_current_id_when_drifted():
+    from ingest_wikimedia.maintain import ResolveResult
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.text = "url=https://lib.digitalnc.org/record/100550"
+    with patch.object(
+        sdc_sync,
+        "resolve_current_dpla_id",
+        return_value=ResolveResult("26f8310936c0321a8c611703751034ee", "isShownAt"),
+    ):
+        out = sdc_sync._maintain_relink("File:X (cropped).jpg", "deadbeef", page)
+    assert out == "26f8310936c0321a8c611703751034ee"
+
+
+def test_maintain_relink_keeps_embedded_when_unresolved():
+    from ingest_wikimedia.maintain import ResolveResult
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.text = ""
+    with patch.object(
+        sdc_sync,
+        "resolve_current_dpla_id",
+        return_value=ResolveResult(None, "unresolved"),
+    ):
+        out = sdc_sync._maintain_relink("File:Y.jpg", "origid12345", page)
+    # Unresolved → keep the embedded id; process_one then skips a dead id as today.
+    assert out == "origid12345"

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -10,8 +10,12 @@ from unittest.mock import MagicMock, patch
 from ingest_wikimedia.tracker import Result, Tracker
 from ingest_wikimedia.wikimedia import WMC_UPLOAD_CHUNK_SIZE
 from ingest_wikimedia.worker_slots import WorkerSlotBudget
+import pytest
+
 from tools.uploader import (
     LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES,
+    NewFilePageBlocked,
+    Uploader,
     _post_item_orphan_check,
     _post_upload_touch_new_institutions,
     is_dup_sha1_sibling_at_expected_title,
@@ -1708,3 +1712,83 @@ def test_tag_failure_does_not_swallow_successful_rescue(caplog):
     assert "[[Category:Community]]" in new_page.text
     # Tag failure is logged but didn't raise.
     assert any("Failed to tag" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Maintain-mode no-create fence: _safe_upload is the single sanctioned upload
+# path. In no_create mode it must refuse to write to a File page that does not
+# already exist (blocking new-page creation), while still allowing overwrites
+# of existing pages. This is the safety backbone of maintain mode.
+# ---------------------------------------------------------------------------
+
+
+def _uploader(no_create: bool) -> Uploader:
+    return Uploader(
+        tracker=MagicMock(),
+        local_fs=MagicMock(),
+        s3_client=MagicMock(),
+        dpla=MagicMock(),
+        site=MagicMock(),
+        category_ensurer=None,
+        no_create=no_create,
+    )
+
+
+def _filepage(exists: bool, is_redirect: bool = False) -> MagicMock:
+    page = MagicMock()
+    page.exists.return_value = exists
+    page.isRedirectPage.return_value = is_redirect
+    page.title.return_value = "File:Example - DPLA - deadbeef (page 1).jpg"
+    return page
+
+
+def test_safe_upload_blocks_new_filepage_in_no_create_mode():
+    uploader = _uploader(no_create=True)
+    page = _filepage(exists=False)
+    with pytest.raises(NewFilePageBlocked):
+        uploader._safe_upload(
+            filepage=page,
+            source_filename="/tmp/x.jpg",
+            comment="c",
+            text="t",
+            ignore_warnings=True,
+            asynchronous=True,
+            chunk_size=0,
+        )
+    # The fence must prevent the actual Commons write entirely.
+    uploader.site.upload.assert_not_called()
+
+
+def test_safe_upload_blocks_redirect_title_in_no_create_mode():
+    # A redirect page reports exists() == True but holds no file of its own;
+    # uploading there would create file content at a title that had none.
+    uploader = _uploader(no_create=True)
+    page = _filepage(exists=True, is_redirect=True)
+    with pytest.raises(NewFilePageBlocked):
+        uploader._safe_upload(filepage=page, source_filename="/tmp/x.jpg")
+    uploader.site.upload.assert_not_called()
+
+
+def test_safe_upload_allows_overwrite_of_existing_in_no_create_mode():
+    uploader = _uploader(no_create=True)
+    page = _filepage(exists=True)
+    uploader.site.upload.return_value = "ok"
+    result = uploader._safe_upload(
+        filepage=page, source_filename="/tmp/x.jpg", comment="c", text="t"
+    )
+    assert result == "ok"
+    uploader.site.upload.assert_called_once_with(
+        filepage=page, source_filename="/tmp/x.jpg", comment="c", text="t"
+    )
+
+
+def test_safe_upload_allows_new_filepage_when_not_in_no_create_mode():
+    # Default (normal upload) mode: creating a new page is allowed, so the
+    # fence is inert and the existence check is never even consulted.
+    uploader = _uploader(no_create=False)
+    page = _filepage(exists=False)
+    uploader.site.upload.return_value = "ok"
+    result = uploader._safe_upload(filepage=page, source_filename="/tmp/x.jpg")
+    assert result == "ok"
+    uploader.site.upload.assert_called_once()
+    page.exists.assert_not_called()

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -128,7 +128,9 @@ def _title_sort_key(source: dict, dpla_id: str) -> str:
     return prefix.casefold().lstrip(_TITLE_SORT_STRIP) + "\x00" + dpla_id
 
 
-def load_eligible_dp_names(institutions: dict, partner: str) -> list[str]:
+def load_eligible_dp_names(
+    institutions: dict, partner: str, maintain: bool = False
+) -> list[str]:
     """
     Return the list of dataProvider name strings eligible for upload for the
     given hub, given an already-loaded institutions_v2.json document.
@@ -141,6 +143,15 @@ def load_eligible_dp_names(institutions: dict, partner: str) -> list[str]:
 
     Name strings are used rather than Wikidata URIs so that two provider name
     variants mapping to the same Wikidata ID can carry independent upload flags.
+
+    ``maintain`` (maintain mode) drops ONLY the ``upload`` requirement: every
+    QID-bearing institution under the hub is included regardless of its upload
+    flag. This is what lets the pipeline regenerate sdc.json / dpla-map.json for
+    institutions no longer authorized for *new* uploads, so their already-on-
+    Commons files can still be maintained in place. The Wikidata-ID requirement
+    is kept (it gates Commons categorisation and the P195 institution claim);
+    new-upload prevention is enforced downstream by the uploader's no-create
+    fence, never by this worklist.
     """
     hub_name = PARTNER_HUBS[partner]
 
@@ -155,7 +166,8 @@ def load_eligible_dp_names(institutions: dict, partner: str) -> list[str]:
     for inst_name, inst_info in hub.get("institutions", {}).items():
         wikidata_id = inst_info.get("Wikidata", "")
         inst_upload = inst_info.get("upload", False)
-        if hub_wikidata and wikidata_id and (hub_upload or inst_upload):
+        upload_ok = maintain or hub_upload or inst_upload
+        if hub_wikidata and wikidata_id and upload_ok:
             eligible.append(inst_name)
 
     return eligible
@@ -251,11 +263,23 @@ def build_query(
         " re-check — the operator's submission is treated as authoritative."
     ),
 )
+@click.option(
+    "--maintain",
+    is_flag=True,
+    help=(
+        "Maintain mode: include institutions regardless of their upload flag"
+        " (QID still required), so IDs + sdc.json are generated for already-"
+        "uploaded files of institutions no longer authorized for new uploads."
+        " New-upload prevention is enforced by the uploader's --no-create"
+        " fence, not by this worklist."
+    ),
+)
 def main(
     partner: str,
     institutions: tuple[str, ...],
     collection: str | None,
     single_id: str | None,
+    maintain: bool,
 ) -> None:
     """Print wiki-eligible DPLA IDs for PARTNER to stdout, one per line.
 
@@ -303,7 +327,9 @@ def main(
     # Load institutions_v2.json once and reuse it for both eligibility
     # filtering and the SDC pre-compute pass.
     institutions_json = fetch_institutions_v2()
-    eligible_dp_names = load_eligible_dp_names(institutions_json, partner)
+    eligible_dp_names = load_eligible_dp_names(
+        institutions_json, partner, maintain=maintain
+    )
     if not eligible_dp_names:
         print(
             f"No eligible institutions found for {partner} in institutions_v2.json",
@@ -314,8 +340,10 @@ def main(
     if institutions:
         ineligible = [name for name in institutions if name not in eligible_dp_names]
         if ineligible:
+            # In maintain mode the gate is QID presence, not the upload flag.
+            reason = "lack a Wikidata ID" if maintain else "not upload-eligible"
             print(
-                f"Institution(s) not upload-eligible for {partner}: {ineligible}.",
+                f"Institution(s) {reason} for {partner}: {ineligible}.",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -23,6 +23,7 @@ from ingest_wikimedia.sdc import (
     parse_other_date_template,
 )
 from ingest_wikimedia import legacy_artwork, wikimedia, wikitext_normalize
+from ingest_wikimedia.maintain import resolve_current_dpla_id
 from ingest_wikimedia.slack import notify_phase_start, notify_sdc_complete
 from ingest_wikimedia.tracker import Result, Tracker
 from ingest_wikimedia.wikimedia import extract_dpla_id_from_commons_title
@@ -182,6 +183,21 @@ def _build_parser() -> argparse.ArgumentParser:
             "(upload → SDC → wikitext cleanup). Pass --no-normalize-wikitext "
             "to disable for diagnostic runs that need the pre-strip wikitext "
             "intact."
+        ),
+    )
+    p.add_argument(
+        "--maintain",
+        dest="maintain",
+        action="store_true",
+        default=False,
+        help=(
+            "Maintain mode (for --cat / --file). Before syncing each file, "
+            "re-link its DPLA id to the current record via the provider source "
+            "URL (ingest_wikimedia.maintain), so files whose embedded DPLA id "
+            "has gone dead (ID drift → 404 dp.la links) sync against the live "
+            "record instead. SDC sync + template migration only; no uploads. "
+            "Use to maintain already-uploaded files of institutions no longer "
+            "authorized for new uploads."
         ),
     )
     p.add_argument(
@@ -3614,6 +3630,52 @@ def _resolve_dpla_id(title, dpla_api):
     return title
 
 
+def _extract_source_url(file_page) -> str | None:
+    """Best-effort: the provider source URL from a file's wikitext — the
+    ``url=`` parameter of a legacy ``{{DPLA|...}}`` block or a flat
+    ``{{DPLA metadata}}`` param. Returns None when absent or unreadable.
+    Used by maintain mode to re-link an ID-drifted file to its current record.
+    """
+    try:
+        text = file_page.text
+    except Exception:
+        return None
+    m = re.search(r"\burl\s*=\s*(https?://[^|}\s\n]+)", text or "")
+    return m.group(1).strip() if m else None
+
+
+def _maintain_relink(title, embedded_id, file_page):
+    """Maintain mode: resolve the CURRENT DPLA id for a (possibly ID-drifted)
+    Commons file, so SDC sync targets the live record and the rendered
+    dp.la link resolves again. Returns the live id, or the original
+    ``embedded_id`` when re-linking finds nothing (``process_one`` then skips
+    a genuinely-dead id the same as today).
+
+    Anchors 1 (embedded id still live) and 2 (exact ``isShownAt`` over
+    normalized URL variants) only — the institution-scoped wildcard (anchor 3)
+    needs a reliable scope filter, which ``--cat`` lacks (Commons category
+    names don't map 1:1 to DPLA dataProvider names); it's left for a later pass.
+    """
+    result = resolve_current_dpla_id(
+        embedded_id=embedded_id,
+        recorded_url=_extract_source_url(file_page),
+        scope_filter=None,
+    )
+    if result.dpla_id and result.dpla_id != embedded_id:
+        logging.info(
+            f"maintain: re-linked {title}: {embedded_id} ->"
+            f" {result.dpla_id} (via {result.anchor})"
+        )
+        return result.dpla_id
+    if result.dpla_id is None:
+        logging.info(
+            f"maintain: could not re-link {title}"
+            f" (embedded {embedded_id}); leaving as-is."
+        )
+        return embedded_id
+    return result.dpla_id
+
+
 def process_one(mediaid, dpla_id):
     """Fetch DPLA metadata and sync SDC claims for a single Commons file."""
     # Drop every prior file's cached entity at the file boundary so the
@@ -5151,6 +5213,8 @@ def main() -> None:
                 continue
             mediaid = "M" + str(page.pageid)
             dpla_id = _resolve_dpla_id(title, dpla_api)
+            if args.maintain:
+                dpla_id = _maintain_relink(title, dpla_id, page)
             count += 1
             print(f"{count}: {mediaid}")
             _safe_process_one(mediaid, dpla_id, file_page=page)
@@ -5165,6 +5229,8 @@ def main() -> None:
             print("\n" + title)
             mediaid = "M" + str(page.pageid)
             dpla_id = _resolve_dpla_id(title, dpla_api)
+            if args.maintain:
+                dpla_id = _maintain_relink(title, dpla_id, page)
             count += 1
             print(f"{count}: {mediaid}")
             # CategorizedPageGenerator yields generic Page objects;

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -183,6 +183,20 @@ class UploadTimeoutError(RuntimeError):
     """
 
 
+class NewFilePageBlocked(RuntimeError):
+    """Raised by the no-create fence when an upload would create a File page
+    that does not already exist on Commons.
+
+    This is the safety backbone of "maintain" mode (in-place upkeep of
+    already-uploaded files for institutions no longer authorized for new
+    uploads): every existing maintenance action is idempotent and repairable,
+    so the one invariant that must hold absolutely is that maintenance never
+    emits a *new* File page. The fence enforces that at the single upload
+    call site; this exception is caught per-ordinal in process_item() and
+    recorded as ``UPLOAD_SKIPPED_WOULD_CREATE`` — never fatal, never retried.
+    """
+
+
 class Uploader:
     def __init__(
         self,
@@ -192,6 +206,7 @@ class Uploader:
         dpla: DPLA,
         site: BaseSite,
         category_ensurer: CategoryEnsurer | None = None,
+        no_create: bool = False,
     ):
         self.tracker = tracker
         self.local_fs = local_fs
@@ -199,6 +214,35 @@ class Uploader:
         self.site = site
         self.dpla = dpla
         self.category_ensurer = category_ensurer
+        # no_create: maintain-mode fence. When True, _safe_upload refuses to
+        # write to a File page that does not already exist, so no run can
+        # create a new Commons file. Defaults False (normal upload behaviour).
+        self.no_create = no_create
+
+    def _safe_upload(self, *, filepage, **kwargs):
+        """Sole sanctioned wrapper around ``site.upload`` — every upload in
+        this module MUST go through here so the no-create fence cannot be
+        bypassed by adding a new call site.
+
+        In no-create (maintain) mode, write only when the target is an existing
+        real File page (an overwrite / new version); otherwise raise
+        :class:`NewFilePageBlocked`. Two cases are blocked:
+
+          * the title doesn't exist — a net-new upload; and
+          * the title is a *redirect* — it holds no file of its own, so
+            uploading there would create file content at a title that had
+            none. ``FilePage.exists()`` returns True for a redirect (and
+            pywikibot transparently follows it when reading properties), so
+            the explicit ``isRedirectPage()`` guard is required — see the
+            "Pywikibot ... transparently follows redirects" lesson. A genuine
+            de-redirect belongs in the explicit move/redirect path, not here.
+
+        Moving and editing existing pages are unaffected — only *creating* a
+        new File page is fenced.
+        """
+        if self.no_create and (not filepage.exists() or filepage.isRedirectPage()):
+            raise NewFilePageBlocked(filepage.title())
+        return self.site.upload(filepage=filepage, **kwargs)
 
     def _refresh_pageid_with_retries(self, page_title: str) -> int | None:
         """Resolve the Commons pageid for ``page_title`` post-upload,
@@ -633,7 +677,7 @@ class Uploader:
                         future = None
                         try:
                             future = executor.submit(
-                                self.site.upload,
+                                self._safe_upload,
                                 filepage=wiki_file_page,
                                 source_filename=temp_file.name,
                                 comment=upload_comment,
@@ -1391,6 +1435,25 @@ class Uploader:
                     }
                     self.handle_upload_exception(ex)
                     break
+                except NewFilePageBlocked as ex:
+                    # Maintain-mode fence tripped: this ordinal would have
+                    # created a new File page. Record a would-create skip
+                    # (never fatal, never retried) and move on — other ordinals
+                    # of the same item may legitimately already exist. Status
+                    # INELIGIBLE keeps SDC sync from targeting a page that
+                    # isn't there.
+                    logging.info(
+                        f"maintain: blocked net-new upload for {dpla_id} "
+                        f"ordinal {ordinal} ({ex})"
+                    )
+                    self._track_ordinal_skip(Result.UPLOAD_SKIPPED_WOULD_CREATE)
+                    ordinal_results[str(ordinal)] = {
+                        "status": ORDINAL_INELIGIBLE,
+                        "title": None,
+                        "pageid": None,
+                        "error": "would create a new File page (blocked in maintain mode)",
+                    }
+                    continue
 
             # After the per-asset loop, look for "trailing-page orphan" Commons
             # files for this item — pages whose ordinal exceeds the current
@@ -1471,6 +1534,18 @@ class Uploader:
 @click.option("--dry-run", is_flag=True)
 @click.option("--verbose", is_flag=True)
 @click.option(
+    "--no-create",
+    is_flag=True,
+    help=(
+        "Maintain mode: never create a new Commons File page. Overwrites of "
+        "existing files (new versions) and moves/edits still proceed, but any "
+        "upload that would create a not-yet-existing File page is blocked and "
+        "recorded as UPLOAD_SKIPPED_WOULD_CREATE. Use when maintaining "
+        "already-uploaded files for institutions no longer authorized for new "
+        "uploads."
+    ),
+)
+@click.option(
     "--workers-budget",
     type=int,
     default=0,
@@ -1487,7 +1562,12 @@ class Uploader:
     ),
 )
 def main(
-    ids_file, partner: str, dry_run: bool, verbose: bool, workers_budget: int
+    ids_file,
+    partner: str,
+    dry_run: bool,
+    verbose: bool,
+    no_create: bool,
+    workers_budget: int,
 ) -> None:
     start_time = time.time()
     tools_context = ToolsContext.init(partner)
@@ -1502,6 +1582,7 @@ def main(
         tools_context.get_dpla(),
         commons_site,
         category_ensurer,
+        no_create=no_create,
     )
 
     dpla = tools_context.get_dpla()
@@ -1528,6 +1609,10 @@ def main(
         notify_phase_start(partner, "upload")
         if dry_run:
             logging.warning("---=== DRY RUN ===---")
+        if no_create:
+            logging.warning(
+                "---=== MAINTAIN MODE (no-create): no new File pages will be created ===---"
+            )
 
         providers_json = dpla.get_providers_data()
         logging.info(f"Starting upload for {partner}")


### PR DESCRIPTION
## Problem

Prior uploads exist for institutions no longer participating in the DPLA pipeline (e.g. the ~484K files under `Category:Media contributed by the North Carolina Digital Heritage Center`). They're marked `upload: false` in `institutions_v2.json`, and because that flag gates the *entire* pipeline, we can't maintain those already-on-Commons files in place — SDC sync, legacy-template migration, and DPLA-ID-drift correction are all blocked — even though no new uploads are wanted.

This adds a **maintain mode**: in-place upkeep of existing files, with the absolute invariant that **no new Commons File page is ever created**.

## Design

Maintain mode is defined by an invariant + a Commons-anchored worklist, not by a participant list. The pieces:

**1. No-create fence (safety backbone).** `_safe_upload` is now the sole sanctioned wrapper around `site.upload` (verified single call site). In `no_create` mode it raises `NewFilePageBlocked` unless the target is an existing **real** File page — net-new titles *and* redirect titles are blocked (a redirect holds no file; `FilePage.exists()` is True for one, so an explicit `isRedirectPage()` guard is required — per the pywikibot redirect-follow lesson). Caught per-ordinal as `UPLOAD_SKIPPED_WOULD_CREATE`; never fatal, never retried. `--no-create` CLI flag. Everything else maintenance does is idempotent and repairable, so this one fence is what makes the whole thing low-risk.

**2. Provider-agnostic ID-drift re-link engine** (`ingest_wikimedia/maintain.py`). A file's embedded DPLA id can go dead while the same item lives under a new id (so its `dp.la/item/<id>` 404s). The durable anchor is the provider source URL (legacy `url=` ↔ the record's `isShownAt`), present on essentially every legacy upload. Ladder, validated against the live index (`isShownAt` is a `keyword` field):
   1. embedded id still resolves → use it;
   2. exact `isShownAt` over normalized http/https±slash variants, **one `terms` query** (most "drift" is just `http`→`https`);
   3. institution-scoped `wildcard` on the longest stable URL token (real domain drift);
   4. unresolved — never guessed.
   No per-provider URL parsing. ES access via an injectable `query_fn` so the ladder is unit-tested without a cluster.

**3. get-ids `--maintain` bypass.** `load_eligible_dp_names(maintain=)` drops **only** the `upload`-flag gate (QID + rights gates kept), so `sdc.json`/`dpla-map.json` get regenerated for ineligible institutions. New-upload prevention stays with the fence, never the worklist.

**4. `--cat` / `--file --maintain` orchestrator** (`sdc_sync.py`). Reuses the existing Commons-driven, sidecar-free category walker: per file it resolves the embedded id, then `_maintain_relink` re-links to the current record via the engine, so an ID-drifted file syncs against the live record (fixing the 404 dp.la link). Reuses `process_one` (live SDC build) + `_safe_process_one` (per-file boundary + template migration / wikitext normalize). No upload phase, no eligibility gate, no new File pages — metadata-only.

Usable today on EC2: `sdc-sync --cat "Category:Media contributed by <institution>" --maintain`.

## Verification

- Internal-ES validation: `isShownAt` exact `term` returns the live NC record from a dead-id file's URL; wildcard finds the GA token; confirmed the common "drift" is `http`/`https`.
- **251 tests pass** across `test_uploader`, `test_maintain`, `test_get_ids_es`, `test_sdc_sync` (incl. fence blocks net-new + redirect; engine ladder + ambiguity; bypass; re-link). ruff + simplify + lessons clean.

## Deferred (scoped follow-ups, not in this PR)

- **Launcher + Slack `/wikimedia-upload maintain …`** wiring (spans the Slack Lambda + GH Actions workflow + launcher). The CLI is fully functional now; this is invocation convenience.
- **Pre-flight sizing** (counts per anchor tier before a run).
- **Anchor 3 in `--cat`** (needs a reliable DPLA-dataProvider scope; Commons category names don't map 1:1).
- **Title/ID-drift rename + duplicate resolution + content-hash anchor** (the SDC re-link already fixes the rendered dp.la link; the file-rename is cosmetic and a higher-risk write — deliberately separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Maintain Mode for Commons File Metadata Updates

This PR introduces "maintain mode," a workflow to enable metadata updates (SDC synchronization, template migration, DPLA-ID corrections) for approximately 484,000 files contributed by institutions marked `upload: false` that cannot currently receive maintenance.

## Key Components

**No-create fence (`tools/uploader.py`):**
- New `NewFilePageBlocked` exception and `_safe_upload()` wrapper prevent new Commons File page creation in maintain mode (`--no-create` flag)
- Redirect pages are explicitly blocked (they hold no file); existing real File pages can be overwritten
- Violations are caught per-ordinal as `UPLOAD_SKIPPED_WOULD_CREATE` and are non-fatal, non-retried

**ID-drift re-link engine (`ingest_wikimedia/maintain.py`):**
- Provider-agnostic system to resolve DPLA IDs that become invalid during record migrations
- Multi-rung validation ladder: live embedded ID resolution → exact `isShownAt` matching (normalized HTTP/HTTPS variants via single Elasticsearch `terms` query) → institution-scoped wildcard on stable URL tokens → unresolved
- Never guesses; returns ambiguous results rather than incorrect IDs
- Elasticsearch access is injectable for testability; pure helper functions (URL normalization, token extraction) are separated from resolver logic

**Get-IDs bypass (`tools/get_ids_es.py`):**
- `load_eligible_dp_names(maintain=)` drops only the upload-flag gate while preserving QID and rights gates
- Enables `sdc.json` and `dpla-map.json` regeneration for ineligible institutions via `--maintain` CLI flag

**SDC sync orchestrator (`tools/sdc_sync.py`):**
- New `--maintain` flag for `--file` and `--cat` runs
- Per-file extraction of provider URL from page wikitext and relink resolution before SDC sync
- No upload phase, no eligibility checks—metadata-only operations

## New Exports

- `ingest_wikimedia/maintain.py`: `ResolveResult` dataclass, `normalize_url_candidates()`, `extract_stable_token()`, `resolve_current_dpla_id()`
- `ingest_wikimedia/tracker.py`: `Result.UPLOAD_SKIPPED_WOULD_CREATE` status enum
- `tools/uploader.py`: `NewFilePageBlocked` exception
- `tools/get_ids_es.py`: `maintain` parameter to `load_eligible_dp_names()` and CLI `--maintain` flag
- `tools/sdc_sync.py`: `--maintain` flag

## Testing

251 passing tests across `test_uploader`, `test_maintain`, `test_get_ids_es`, and `test_sdc_sync` validate:
- Safe upload behavior in no-create mode (blocks nonexistent pages, redirects; allows overwriting)
- URL normalization and stable token extraction
- Full re-link resolution ladder (direct ID hits, exact isShownAt matching, scheme normalization, wildcard queries, ambiguity detection)
- Maintain-mode eligibility filtering and parameter threading
- Source URL extraction and ID-drift relink scenarios

## Immediate Usage

Feature is ready to use: `sdc-sync --cat "Category:Media contributed by <institution>" --maintain`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->