### PR TITLE
Maintain mode: /wikimedia-upload maintain Slack + launcher wiring

### DIFF
--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -34,6 +34,10 @@ on:
         description: "SDC-only backfill — skip download + upload phases, just re-enumerate IDs and run sdc-sync"
         type: boolean
         default: false
+      maintain:
+        description: "Maintain mode — re-link + SDC-sync EXISTING Commons files of a (possibly no-longer-participating) hub/institution in place; no uploads, no new files"
+        type: boolean
+        default: false
       workers:
         description: "SDC-sync worker processes per session (parallelism). 1 = single-process."
         required: false
@@ -81,6 +85,7 @@ jobs:
           INPUT_MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days }}
           INPUT_REFRESH_ONLY: ${{ github.event.inputs.refresh_only }}
           INPUT_SDC_ONLY: ${{ github.event.inputs.sdc_only }}
+          INPUT_MAINTAIN: ${{ github.event.inputs.maintain }}
           INPUT_WORKERS: ${{ github.event.inputs.workers }}
           INPUT_WORKERS_BUDGET: ${{ github.event.inputs.workers_budget }}
         run: |
@@ -91,5 +96,6 @@ jobs:
             --max-age-days "$INPUT_MAX_AGE_DAYS" \
             --refresh-only "$INPUT_REFRESH_ONLY" \
             --sdc-only "$INPUT_SDC_ONLY" \
+            --maintain "$INPUT_MAINTAIN" \
             --workers "$INPUT_WORKERS" \
             --workers-budget "$INPUT_WORKERS_BUDGET"

--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -6,6 +6,7 @@ GitHub Actions without installing the full ingest_wikimedia package dependencies
 
 import json
 import re
+import urllib.error
 import urllib.request
 
 # Module-level cache so warm Lambda invocations skip repeated network fetches.
@@ -204,6 +205,80 @@ def is_wikidata_id(s: str) -> bool:
 def is_dpla_id(s: str) -> bool:
     """Return True if s is a 32-hex-char DPLA item ID."""
     return bool(_DPLA_ID_RE.match(s))
+
+
+# Wikidata entity-data endpoint — the authoritative source for a hub/
+# institution's exact Commons category (see resolve_commons_category).
+_WIKIDATA_ENTITYDATA_URL = "https://www.wikidata.org/wiki/Special:EntityData/{qid}.json"
+_WIKIDATA_UA = "dpla-ingest-wikimedia/1.0 (https://dp.la; tech@dp.la)"
+# P8464 = "Commons category": on a hub/institution item it points to a Wikidata
+# *category item* whose commonswiki sitelink is the actual Category: page DPLA
+# files are filed under.
+_COMMONS_CATEGORY_PROPERTY = "P8464"
+_commons_category_cache: dict[str, str | None] = {}
+
+
+def wikidata_qid_for_target(
+    canonical_slug: str, institution_name: str | None = None, timeout: int = 5
+) -> str | None:
+    """Return the Wikidata QID for a hub (``institution_name is None``) or for a
+    specific institution under it, read from institutions_v2.json. None if the
+    hub/institution isn't found or carries no Wikidata ID."""
+    hub_name = PARTNER_HUBS.get(canonical_slug)
+    if not hub_name:
+        return None
+    hub = _get_institutions(timeout).get(hub_name, {})
+    if institution_name is None:
+        return hub.get("Wikidata") or None
+    inst = hub.get("institutions", {}).get(institution_name, {})
+    return inst.get("Wikidata") or None
+
+
+def _fetch_wikidata_entity(qid: str, timeout: int) -> dict | None:
+    """Fetch one Wikidata entity's JSON, or None on any network/parse error."""
+    req = urllib.request.Request(
+        _WIKIDATA_ENTITYDATA_URL.format(qid=qid),
+        headers={"User-Agent": _WIKIDATA_UA},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read())["entities"][qid]
+    except (urllib.error.URLError, TimeoutError, KeyError, ValueError):
+        return None
+
+
+def resolve_commons_category(qid: str, timeout: int = 10) -> str | None:
+    """Resolve a hub/institution Wikidata QID to its exact Commons category page
+    title (e.g. ``'Category:Media contributed by the Digital Library of
+    Georgia'``), or None.
+
+    Follows the authoritative chain DPLA's own categorisation relies on — the
+    item's ``P8464`` ('Commons category', a Wikidata *category item*) → that
+    category item's ``commonswiki`` sitelink — so the exact title (including
+    wording such as a leading "the") comes straight from Wikidata and is never
+    derived from the DPLA display string. Cached per QID."""
+    if not is_wikidata_id(qid):
+        return None
+    if qid in _commons_category_cache:
+        return _commons_category_cache[qid]
+    result = None
+    entity = _fetch_wikidata_entity(qid, timeout)
+    if entity:
+        for claim in entity.get("claims", {}).get(_COMMONS_CATEGORY_PROPERTY, []):
+            value = (claim.get("mainsnak", {}).get("datavalue", {}) or {}).get("value")
+            cat_qid = value.get("id") if isinstance(value, dict) else None
+            if not cat_qid:
+                continue
+            cat_entity = _fetch_wikidata_entity(cat_qid, timeout)
+            if cat_entity:
+                title = (
+                    cat_entity.get("sitelinks", {}).get("commonswiki", {}).get("title")
+                )
+                if title:
+                    result = title
+                    break
+    _commons_category_cache[qid] = result
+    return result
 
 
 def parse_session_labels(suffix: str) -> list[str]:

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -342,7 +342,9 @@ def handler(event, context):
                 "To stop a session: `/wikimedia-upload kill <label> [<label> ...]`\n"
                 "To retry transient failures: `/wikimedia-upload retry <days> [<partner>]`\n"
                 "To refresh S3 files: `/wikimedia-upload refresh <target> [<target> ...] <days>`\n"
-                "To re-run only the SDC sync phase: `/wikimedia-upload sdc <target> [<target> ...]`",
+                "To re-run only the SDC sync phase: `/wikimedia-upload sdc <target> [<target> ...]`\n"
+                "To maintain existing files in place (no uploads):"
+                " `/wikimedia-upload maintain <target> [<target> ...]`",
                 ephemeral=True,
             )
 

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -447,6 +447,38 @@ def handler(event, context):
                 ),
             )
 
+        # Maintain subcommand: /wikimedia-upload maintain <target> [<target> ...]
+        # Re-links + SDC-syncs the EXISTING Commons files of a (possibly
+        # no-longer-participating) hub/institution in place. No download, no
+        # upload, no new File pages — so upload-ineligible targets are allowed.
+        if tokens[0] == "maintain":
+            maintain_tokens = tokens[1:]
+            if not maintain_tokens:
+                return _slack_reply(
+                    "Usage: `/wikimedia-upload maintain <target> [<target> ...]`\n"
+                    "Re-links + SDC-syncs files already on Commons for a hub or"
+                    " institution, in place (no uploads, no new files). Works for"
+                    " hubs no longer participating in uploads.\n"
+                    "Example: `/wikimedia-upload maintain digitalnc`\n"
+                    'Example: `/wikimedia-upload maintain "georgia|Atlanta History Center"`',
+                    ephemeral=True,
+                )
+            maintain_targets, err = _validate_launch_targets(maintain_tokens)
+            if err is not None:
+                return err
+            return _launch_with_targets(
+                gh_token,
+                repo,
+                response_url,
+                maintain_targets,
+                {"maintain": "true"},
+                lambda targets_display: (
+                    f"Launching maintain (re-link + SDC sync, no uploads) for"
+                    f" {targets_display} — confirmation will post to"
+                    " #tech-alerts shortly."
+                ),
+            )
+
         # Refresh subcommand: /wikimedia-upload refresh <target> [<target> ...] <days>
         # Re-downloads files older than DAYS days without running the uploader.
         if tokens[0] == "refresh":

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -953,10 +953,17 @@ def main() -> None:
             # resolved to its exact Commons category via Wikidata (authoritative
             # — P8464 → commonswiki sitelink — never derived from the display
             # name), then walked with `sdc-sync --cat ... --maintain`.
-            if dpla_id is not None:
+            if dpla_id is not None or collection is not None:
+                # Maintain resolves to a hub/institution Commons category and
+                # walks the WHOLE category — there is no per-collection or
+                # per-item Commons category to scope to. Reject these targets
+                # loudly rather than silently widening the write scope to the
+                # entire category (a collection-scoped request must not quietly
+                # touch every file in the institution).
+                unit = "single DPLA-ID" if dpla_id is not None else "collection-scoped"
                 msg = (
-                    "maintain mode does not support single DPLA-ID targets;"
-                    " it operates on a hub/institution Commons category."
+                    f"maintain mode does not support {unit} targets; it operates"
+                    " on a whole hub/institution Commons category."
                 )
                 pipeline_steps = [f"cd {base}", f"echo {shlex.quote(msg)} >&2; exit 1"]
             else:

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -42,9 +42,11 @@ from ingest_wikimedia.partners import (
     is_upload_eligible,
     is_wikidata_id,
     parse_session_labels,
+    resolve_commons_category,
     resolve_slug,
     resolve_wikidata_id,
     slugify_session_label_component,
+    wikidata_qid_for_target,
 )
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run, stage_and_launch_tmux
@@ -187,6 +189,7 @@ def main() -> None:
     parser.add_argument("--max-age-days", default="")
     parser.add_argument("--refresh-only", default="false")
     parser.add_argument("--sdc-only", default="false")
+    parser.add_argument("--maintain", default="false")
     # Keep in sync with .github/workflows/wikimedia-launch.yml inputs.workers
     # / inputs.workers_budget (currently 6 / 24), which the workflow always
     # passes explicitly. These defaults only apply to a bare manual launch —
@@ -199,6 +202,7 @@ def main() -> None:
     force = _parse_bool(args.force)
     refresh_only = _parse_bool(args.refresh_only)
     sdc_only = _parse_bool(args.sdc_only)
+    maintain = _parse_bool(args.maintain)
 
     # Normalize the response_url first so the mutual-exclusion check below
     # can use the validated value rather than re-implementing the same
@@ -211,12 +215,13 @@ def main() -> None:
     if raw_url and not response_url:
         print(f"Ignoring invalid response_url: {raw_url!r}", file=sys.stderr)
 
-    if refresh_only and sdc_only:
+    if sum([refresh_only, sdc_only, maintain]) > 1:
         _slack_fail(
             response_url,
-            "Cannot combine --refresh-only and --sdc-only — they're mutually"
-            " exclusive run modes (refresh skips upload + SDC; sdc-only skips"
-            " download + upload).",
+            "Cannot combine --refresh-only, --sdc-only, and --maintain — they're"
+            " mutually exclusive run modes (refresh skips upload + SDC; sdc-only"
+            " skips download + upload; maintain re-links + SDC-syncs existing"
+            " Commons files only, creating nothing).",
         )
     max_age_days: int | None = None
     if args.max_age_days.strip():
@@ -317,8 +322,16 @@ def main() -> None:
                 return
             stripped.append(name)
         institutions = tuple(stripped)
-        if dpla_id is None and canonical != "nara" and not institutions:
+        if (
+            not maintain
+            and dpla_id is None
+            and canonical != "nara"
+            and not institutions
+        ):
             # Hub-level target: check that any institution in the hub is eligible.
+            # Skipped in maintain mode — maintain operates ONLY on files already
+            # on Commons (no uploads), so an institution being upload-ineligible
+            # is exactly when it applies, not a reason to skip.
             # Skipped for DPLA item ID targets — item-level eligibility (rights
             # statement + media presence) was already verified by resolve-dpla-ids.
             # Institution-level and collection-level eligibility is not checked here —
@@ -932,7 +945,42 @@ def main() -> None:
         # overrun maxlag. Only the budget — no --workers (no upload
         # parallelism).
         upload_opts = f" --workers-budget {sdc_workers_budget}"
-        if sdc_only:
+        if maintain:
+            # Maintain mode: re-link + SDC-sync the EXISTING Commons files for
+            # this scope in place. No get-ids / download / upload, and no new
+            # File pages — sdc-sync --maintain only edits SDC and migrates
+            # wikitext on files already on Commons. Each hub/institution is
+            # resolved to its exact Commons category via Wikidata (authoritative
+            # — P8464 → commonswiki sitelink — never derived from the display
+            # name), then walked with `sdc-sync --cat ... --maintain`.
+            if dpla_id is not None:
+                msg = (
+                    "maintain mode does not support single DPLA-ID targets;"
+                    " it operates on a hub/institution Commons category."
+                )
+                pipeline_steps = [f"cd {base}", f"echo {shlex.quote(msg)} >&2; exit 1"]
+            else:
+                cat_steps = []
+                for inst in institutions or (None,):
+                    qid = wikidata_qid_for_target(canonical, inst)
+                    category = resolve_commons_category(qid) if qid else None
+                    if category:
+                        # No --workers/--workers-budget: --cat mode is
+                        # single-process (one Commons writer at a time), so it
+                        # neither uses the pool nor needs the box-wide slot budget.
+                        cat_steps.append(
+                            f"sdc-sync --cat {shlex.quote(category)} --maintain"
+                        )
+                    else:
+                        who = inst or canonical
+                        msg = (
+                            f"maintain: could not resolve a Commons category for"
+                            f" {who} (missing Wikidata QID or P8464 Commons-category"
+                            f" link); skipping."
+                        )
+                        cat_steps.append(f"echo {shlex.quote(msg)} >&2; exit 1")
+                pipeline_steps = [f"cd {base}", *cat_steps]
+        elif sdc_only:
             # SDC-only backfill: re-enumerate the partner's items (which
             # also refreshes sdc.json sidecars from the latest ingestion3
             # data) then run sdc-sync. No downloader, no uploader — the
@@ -1002,6 +1050,12 @@ def main() -> None:
             batch_labels = [_target_label(c, i, col) for c, i, _, col in batch_targets]
             if refresh_only:
                 msg = f"▶ Launching `{session_name}` refresh: {', '.join(batch_labels)}{refresh_suffix}."
+            elif maintain:
+                msg = (
+                    f"▶ Launching `{session_name}` maintain:"
+                    f" {', '.join(batch_labels)} — re-linking + SDC-syncing existing"
+                    " Commons files in place (no uploads, no new files)."
+                )
             elif sdc_only:
                 msg = (
                     f"▶ Launching `{session_name}` SDC backfill:"

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -145,6 +145,7 @@ def test_top_level_usage_mentions_sdc_subcommand(monkeypatch, handler_module):
     assert reply["statusCode"] == 200
     text = _decode_reply(reply)["text"]
     assert "/wikimedia-upload sdc" in text
+    assert "/wikimedia-upload maintain" in text
 
 
 def test_dispatch_helper_treats_raw_timeout_as_possibly_dispatched(

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -243,3 +243,37 @@ def test_dispatch_helper_non_timeout_urlerror_is_hard_failure(
     text = _decode_reply(reply)["text"]
     assert "may have been dispatched" not in text
     assert "internal error" in text.lower()
+
+
+def test_maintain_subcommand_dispatches_launch_with_maintain_true(
+    monkeypatch, handler_module
+):
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(_make_event("maintain digitalnc"), None)
+
+    assert reply["statusCode"] == 200
+    assert len(dispatched) == 1
+    call = dispatched[0]
+    assert call["workflow"] == "wikimedia-launch.yml"
+    assert call["inputs"]["maintain"] == "true"
+    # Maintain is its own run mode — must never set the others.
+    assert "sdc_only" not in call["inputs"]
+    assert "refresh_only" not in call["inputs"]
+    assert call["inputs"]["partner"] == "digitalnc"
+    assert len(call["inputs"]["concurrency_key"]) == 16
+    assert "maintain" in _decode_reply(reply)["text"].lower()
+
+
+def test_maintain_subcommand_with_no_targets_returns_usage(monkeypatch, handler_module):
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(_make_event("maintain"), None)
+
+    assert reply["statusCode"] == 200
+    assert dispatched == []
+    text = _decode_reply(reply)["text"]
+    assert "Usage:" in text
+    assert "/wikimedia-upload maintain" in text

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -14,7 +14,12 @@ non-eligible matches never leak to the launcher.
 
 from unittest.mock import patch
 
-from ingest_wikimedia.partners import resolve_wikidata_id
+from ingest_wikimedia import partners
+from ingest_wikimedia.partners import (
+    resolve_commons_category,
+    resolve_wikidata_id,
+    wikidata_qid_for_target,
+)
 
 
 def _mock_institutions(data: dict):
@@ -175,3 +180,65 @@ def test_resolve_wikidata_id_same_hub_overlap_picks_up_eligible_institution():
     assert ("overlap-hub", None) not in results
     # Institution-level match preserved (institution.upload=true).
     assert results == [("overlap-hub", "Self-listed Institution")]
+
+
+# --- maintain mode: slug/target -> QID -> exact Commons category -------------
+
+
+def test_wikidata_qid_for_target_hub_and_institution():
+    # Keys are hub DISPLAY names (as in institutions_v2.json); the slug maps
+    # to the display name via PARTNER_HUBS ("georgia" -> "Digital Library of
+    # Georgia").
+    data = {
+        "Digital Library of Georgia": {
+            "Wikidata": "Q5275908",
+            "institutions": {"Some Library": {"Wikidata": "Q42"}},
+        }
+    }
+    with _mock_institutions(data):
+        assert wikidata_qid_for_target("georgia") == "Q5275908"
+        assert wikidata_qid_for_target("georgia", "Some Library") == "Q42"
+        assert wikidata_qid_for_target("georgia", "Unknown Inst") is None
+        assert wikidata_qid_for_target("not-a-slug") is None
+
+
+def test_resolve_commons_category_follows_p8464_to_sitelink():
+    # Hub item Q5275908 has P8464 -> category item Q999, whose commonswiki
+    # sitelink is the real Category page (authoritative; note the "the").
+    entities = {
+        "Q5275908": {
+            "claims": {
+                "P8464": [{"mainsnak": {"datavalue": {"value": {"id": "Q999"}}}}]
+            }
+        },
+        "Q999": {
+            "sitelinks": {
+                "commonswiki": {
+                    "title": "Category:Media contributed by the Digital Library of Georgia"
+                }
+            }
+        },
+    }
+    with (
+        patch.object(partners, "_commons_category_cache", {}),
+        patch.object(
+            partners, "_fetch_wikidata_entity", side_effect=lambda q, t: entities.get(q)
+        ),
+    ):
+        cat = resolve_commons_category("Q5275908")
+    assert cat == "Category:Media contributed by the Digital Library of Georgia"
+
+
+def test_resolve_commons_category_none_when_no_p8464():
+    with (
+        patch.object(partners, "_commons_category_cache", {}),
+        patch.object(partners, "_fetch_wikidata_entity", return_value={"claims": {}}),
+    ):
+        assert resolve_commons_category("Q123") is None
+
+
+def test_resolve_commons_category_rejects_non_qid():
+    # No network call for a non-QID input.
+    with patch.object(partners, "_fetch_wikidata_entity") as fetch:
+        assert resolve_commons_category("georgia") is None
+        fetch.assert_not_called()

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -370,3 +370,41 @@ def test_target_label_single_and_multi_institution():
 
 def test_target_label_hub_only():
     assert _label("bpl") == "`bpl`"
+
+
+def test_maintain_mutually_exclusive_with_sdc_only():
+    exit_info = _run_main(
+        ["--partner", "georgia", "--maintain", "true", "--sdc-only", "true"]
+    )
+    assert exit_info is not None
+    assert exit_info.code == 1
+
+
+def test_maintain_mutually_exclusive_with_refresh_only():
+    exit_info = _run_main(
+        ["--partner", "georgia", "--maintain", "true", "--refresh-only", "true"]
+    )
+    assert exit_info is not None
+    assert exit_info.code == 1
+
+
+def test_maintain_bypasses_upload_eligibility_gate(monkeypatch, capsys):
+    """`--maintain true` for an upload-INELIGIBLE hub must parse and get PAST
+    the eligibility gate — maintain operates only on files already on Commons,
+    so ineligibility is exactly when it applies. Stub the EC2 path so the exit
+    comes from a deterministic post-parse point, then assert it is neither the
+    mutual-exclusion error nor a 'not upload-eligible' skip."""
+    monkeypatch.setattr(
+        "scripts.wikimedia_launch.boto3.client", lambda *a, **kw: object()
+    )
+    monkeypatch.setattr(
+        "scripts.wikimedia_launch.ssm_run",
+        lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("ssm stubbed")),
+    )
+    # "digitalnc" (North Carolina Digital Heritage Center) is upload=false in
+    # institutions_v2.json — the canonical maintain target.
+    exit_info = _run_main(["--partner", "digitalnc", "--maintain", "true"])
+    assert exit_info is not None
+    captured = capsys.readouterr()
+    assert "mutually exclusive" not in captured.err
+    assert "not upload-eligible" not in captured.err


### PR DESCRIPTION
## What

Makes the maintain mode merged in #330 triggerable from Slack:

```
/wikimedia-upload maintain digitalnc
/wikimedia-upload maintain "georgia|Atlanta History Center"
```

This re-links + SDC-syncs the **existing** Commons files of a hub/institution in place — fixing ID-drifted (404'd) `dp.la` links and migrating legacy templates — **with no uploads and no new File pages**. It's the operational entry point for maintaining institutions no longer participating in uploads (e.g. NCDHC's ~484K files).

## How (Slack → Lambda → workflow → launcher)

- **Lambda** (`handler.py`): a `maintain` subcommand mirroring `sdc`, dispatching `wikimedia-launch.yml` with `maintain=true`. Upload-ineligible targets are allowed (the Lambda validates only target *syntax*).
- **Workflow** (`wikimedia-launch.yml`): a `maintain` boolean input → `--maintain`.
- **Launcher** (`wikimedia_launch.py`): `--maintain` flag (mutually exclusive with `--refresh-only`/`--sdc-only`); **bypasses the hub upload-eligibility gate** (ineligibility is exactly when maintain applies); resolves each target to its exact Commons category and emits a single `sdc-sync --cat "<category>" --maintain` step — no get-ids/download/upload, single-process (one Commons writer).
- **Resolver** (`partners.py`, stdlib-only so it's Lambda/Actions-safe): `wikidata_qid_for_target` (slug/institution → QID from `institutions_v2.json`) and `resolve_commons_category` (QID → **P8464** "Commons category" item → that item's `commonswiki` sitelink). The category title comes **straight from Wikidata** — never derived from the DPLA display name — so there's no `"the"`/wording guessing. Validated live: `georgia → Q5275908 → "Category:Media contributed by the Digital Library of Georgia"`.

## Tests

**54 pass** across `test_partners.py` (resolver: QID lookup, P8464→sitelink chain, non-QID/no-P8464 → None), `test_wikimedia_launch.py` (mutual exclusion; **eligibility-gate bypass** for the ineligible `digitalnc` hub), and `test_lambda_handler.py` (maintain subcommand → `maintain=true` dispatch; usage on no targets). ruff + simplify clean; SSM-staged command uses `shlex.quote`.

## Notes / still deferred (from #330)

- `--cat --maintain` is single-process by design (gentle on Commons; one writer). High-throughput parallelism for very large hubs is a later optimization.
- Anchor-3 (institution-scoped wildcard), title/ID-drift **rename**, duplicate resolution, content-hash anchor, and a pre-flight sizing pass remain follow-ups — the SDC re-link already fixes the rendered `dp.la` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Maintain Mode Slack Integration

This PR adds end-to-end Slack triggering for “maintain mode”, enabling re-linking and SDC-syncing of existing Commons files for targeted hubs/institutions that are no longer participating in uploads (without creating new File pages or uploading files).

### Overview
Maintain mode processes existing Commons files by:
- Re-linking stale/broken file page links
- Running `sdc-sync` to update structured data
- Avoiding file uploads and new page creation
- Using Wikidata-driven Commons category resolution (via P8464) instead of the previous DPLA/category lookup

### Implementation Details

**Slack Lambda handler** (`lambda/wikimedia-slack-dispatch/handler.py`)
- Adds `/wikimedia-upload maintain <target> [<target> ...]`
- Validates targets using the existing parsing/validation helpers
- Dispatches the `wikimedia-launch.yml` workflow with `maintain="true"` (and does not fail on upload-ineligible targets)
- Returns usage/help text when called without maintain targets

**GitHub Actions workflow** (`.github/workflows/wikimedia-launch.yml`)
- Adds a workflow dispatch input: `maintain` (boolean, default `false`)
- Passes it into the job environment as `INPUT_MAINTAIN` and forwards it to `scripts/wikimedia_launch.py` via `--maintain "$INPUT_MAINTAIN"`

**Launcher** (`scripts/wikimedia_launch.py`)
- Implements `--maintain` as mutually exclusive with `--sdc-only` and `--refresh-only`
- In maintain mode, skips the hub upload-eligibility gate (maintain is for ineligible targets)
- For each target, resolves the exact Commons category and runs a single `sdc-sync --cat "<category>" --maintain` step (no get-ids/download/upload stages)
- Rejects `dpla_id` (single DPLA-ID) and collection-scoped targets in maintain mode to prevent silent scope widening

**Resolver** (`ingest_wikimedia/partners.py`)
- Adds `wikidata_qid_for_target` to resolve a partner hub/institution slug (and optional institution name) to a Wikidata QID using `institutions_v2.json`
- Adds `resolve_commons_category` which follows P8464 (“Commons category”) to a category item and extracts the authoritative Commons category title from that item’s `commonswiki` sitelink
- Implements defensive HTTP/parse handling and per-QID caching to reduce repeated Wikidata fetches

### Testing
Adds/extends unit coverage for:
- QID lookup and P8464 → commonswiki category resolution
- `--maintain` mutual exclusion
- Eligibility-gate bypass behavior in maintain mode
- Negative cases for invalid/unsupported maintain targets

### Deployment / Operational Notes
- **AWS Lambda redeployment required** to activate the new `/wikimedia-upload maintain` subcommand.
- Workflow changes take effect immediately after merge.
- **No database migrations**.
- **No ECS/CodePipeline/CodeBuild/IAM policy changes**.

### Environment / Secrets / Security
- Adds a workflow/job environment variable: `INPUT_MAINTAIN` (derived from the workflow dispatch input).
- **No changes to AWS Secrets Manager keys**.
- Security implications: introduces additional outbound HTTP calls to the **Wikidata EntityData API** (with timeouts and defensive error handling); no credential-handling/auth changes.
- No endpoint changes or changes to the Slack response shape beyond the new usage/confirmation text for the `maintain` subcommand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->