### PR TITLE
Maintain mode: SDC-sidecar sync at hub scale + pre-flight sizing + institution-scoped re-link

### DIFF
--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -38,6 +38,10 @@ on:
         description: "Maintain mode — re-link + SDC-sync EXISTING Commons files of a (possibly no-longer-participating) hub/institution in place; no uploads, no new files"
         type: boolean
         default: false
+      count_only:
+        description: "Maintain pre-flight sizing — resolve how each file would re-link and print a per-anchor breakdown; writes nothing (requires maintain)"
+        type: boolean
+        default: false
       workers:
         description: "SDC-sync worker processes per session (parallelism). 1 = single-process."
         required: false
@@ -86,6 +90,7 @@ jobs:
           INPUT_REFRESH_ONLY: ${{ github.event.inputs.refresh_only }}
           INPUT_SDC_ONLY: ${{ github.event.inputs.sdc_only }}
           INPUT_MAINTAIN: ${{ github.event.inputs.maintain }}
+          INPUT_COUNT_ONLY: ${{ github.event.inputs.count_only }}
           INPUT_WORKERS: ${{ github.event.inputs.workers }}
           INPUT_WORKERS_BUDGET: ${{ github.event.inputs.workers_budget }}
         run: |
@@ -97,5 +102,6 @@ jobs:
             --refresh-only "$INPUT_REFRESH_ONLY" \
             --sdc-only "$INPUT_SDC_ONLY" \
             --maintain "$INPUT_MAINTAIN" \
+            --count-only "$INPUT_COUNT_ONLY" \
             --workers "$INPUT_WORKERS" \
             --workers-budget "$INPUT_WORKERS_BUDGET"

--- a/ingest_wikimedia/maintain.py
+++ b/ingest_wikimedia/maintain.py
@@ -174,7 +174,7 @@ def resolve_current_dpla_id(
     *,
     embedded_id: str | None,
     recorded_url: str | None,
-    scope_filter: dict | None,
+    scope_filter: dict | Callable[[], dict | None] | None,
     query_fn: Callable[[dict], object] = post_es,
 ) -> ResolveResult:
     """Resolve the *current* DPLA ID for one orphaned Commons file.
@@ -182,9 +182,14 @@ def resolve_current_dpla_id(
     Walks the validated ladder (embedded -> exact isShownAt -> scoped wildcard)
     and stops at the first unambiguous hit. ``query_fn`` runs an ES query and
     returns a ``requests``-style response exposing ``.json()`` — injected so the
-    ladder is testable without a cluster. ``scope_filter`` bounds the wildcard
-    rung to one institution; pass None to skip that rung (e.g. when the
-    institution is unknown).
+    ladder is testable without a cluster.
+
+    ``scope_filter`` bounds the wildcard rung to one institution. It may be a
+    ready ES filter clause, or a zero-arg callable that returns one (or None) —
+    the callable is invoked **only** if the ladder reaches the wildcard rung, so
+    the per-file work of deriving the scope (e.g. reading the file's existing
+    P195 institution) is skipped for the common embedded/isShownAt hits. Pass
+    None to skip the wildcard rung entirely.
     """
     tried: list[str] = []
 
@@ -208,13 +213,17 @@ def resolve_current_dpla_id(
 
     # Anchor 3: institution-scoped wildcard on the stable URL token.
     token = extract_stable_token(recorded_url or "")
-    if token and scope_filter:
-        tried.append("wildcard")
-        data = query_fn(_scoped_wildcard_query(token, scope_filter)).json()
-        total = _total(data)
-        if total == 1:
-            return ResolveResult(_hit_ids(data)[0], "wildcard", tried=tried)
-        if total > 1:
-            return ResolveResult(None, "unresolved", ambiguous=True, tried=tried)
+    if token:
+        # Resolve a lazy scope only now — deriving it (a P195 read on Commons)
+        # is wasted work on the embedded/isShownAt hits handled above.
+        scope = scope_filter() if callable(scope_filter) else scope_filter
+        if scope:
+            tried.append("wildcard")
+            data = query_fn(_scoped_wildcard_query(token, scope)).json()
+            total = _total(data)
+            if total == 1:
+                return ResolveResult(_hit_ids(data)[0], "wildcard", tried=tried)
+            if total > 1:
+                return ResolveResult(None, "unresolved", ambiguous=True, tried=tried)
 
     return ResolveResult(None, "unresolved", tried=tried)

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -455,27 +455,43 @@ def handler(event, context):
         # upload, no new File pages — so upload-ineligible targets are allowed.
         if tokens[0] == "maintain":
             maintain_tokens = tokens[1:]
+            # `maintain count <target> ...` is the pre-flight sizing variant:
+            # resolve how each file would re-link and report a per-anchor
+            # breakdown without writing anything.
+            count_only = bool(maintain_tokens) and maintain_tokens[0] == "count"
+            if count_only:
+                maintain_tokens = maintain_tokens[1:]
             if not maintain_tokens:
                 return _slack_reply(
-                    "Usage: `/wikimedia-upload maintain <target> [<target> ...]`\n"
+                    "Usage: `/wikimedia-upload maintain [count] <target> [<target> ...]`\n"
                     "Re-links + SDC-syncs files already on Commons for a hub or"
                     " institution, in place (no uploads, no new files). Works for"
                     " hubs no longer participating in uploads.\n"
+                    "Add `count` to size the re-link without writing anything.\n"
                     "Example: `/wikimedia-upload maintain digitalnc`\n"
+                    "Example: `/wikimedia-upload maintain count digitalnc`\n"
                     'Example: `/wikimedia-upload maintain "georgia|Atlanta History Center"`',
                     ephemeral=True,
                 )
             maintain_targets, err = _validate_launch_targets(maintain_tokens)
             if err is not None:
                 return err
+            inputs = {"maintain": "true"}
+            if count_only:
+                inputs["count_only"] = "true"
+            action = (
+                "maintain pre-flight sizing (count-only, writes nothing)"
+                if count_only
+                else "maintain (re-link + SDC sync, no uploads)"
+            )
             return _launch_with_targets(
                 gh_token,
                 repo,
                 response_url,
                 maintain_targets,
-                {"maintain": "true"},
+                inputs,
                 lambda targets_display: (
-                    f"Launching maintain (re-link + SDC sync, no uploads) for"
+                    f"Launching {action} for"
                     f" {targets_display} — confirmation will post to"
                     " #tech-alerts shortly."
                 ),

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -158,6 +158,72 @@ def _build_get_ids_command(
     return cmd + f" > {csv_file}"
 
 
+def _build_maintain_pipeline_steps(
+    canonical: str,
+    institutions: tuple[str, ...],
+    collection: str | None,
+    dpla_id: str | None,
+    base: str,
+    csv_file: str,
+    count_only: bool,
+) -> list[str]:
+    """Pipeline steps for one maintain target (`cd` + the maintain commands).
+
+    Maintain re-links + SDC-syncs the EXISTING Commons files for this scope in
+    place: no download, no upload, no new File pages. Each hub/institution is
+    resolved to its exact Commons category via Wikidata (P8464 → commonswiki
+    sitelink — authoritative, never derived from the display name) and walked
+    with ``sdc-sync --cat … --maintain``.
+
+    The sync reads each (re-linked) item's claims from its precomputed
+    ``sdc.json`` sidecar (``--from-s3``) rather than calling ``api.dp.la`` per
+    file, so a real run first stages those sidecars with ONE ``get-ids-es
+    --maintain`` ES scan over the scope (drops only the upload gate, keeps the
+    QID requirement). ``count_only`` is a pre-flight that just resolves how each
+    file would re-link and writes nothing — it needs neither the staging step
+    nor ``--from-s3``.
+
+    A single-DPLA-id or collection-scoped target has no whole-category to walk,
+    so it's rejected loudly rather than silently widening the write scope.
+    """
+    if dpla_id is not None or collection is not None:
+        unit = "single DPLA-ID" if dpla_id is not None else "collection-scoped"
+        msg = (
+            f"maintain mode does not support {unit} targets; it operates"
+            " on a whole hub/institution Commons category."
+        )
+        return [f"cd {base}", f"echo {shlex.quote(msg)} >&2; exit 1"]
+
+    # count-only and --from-s3 are mutually exclusive: pre-flight sizing only
+    # resolves the re-link (no sidecar read, no write), so it skips both the
+    # staging scan and --from-s3.
+    sync_tail = " --count-only" if count_only else f" --from-s3 {canonical}"
+    steps = []
+    if not count_only:
+        stage_cmd = f"get-ids-es {canonical}"
+        for inst in institutions:
+            stage_cmd += f" --institution {shlex.quote(inst)}"
+        steps.append(stage_cmd + f" --maintain > {csv_file}")
+    for inst in institutions or (None,):
+        qid = wikidata_qid_for_target(canonical, inst)
+        category = resolve_commons_category(qid) if qid else None
+        if category:
+            # No --workers/--workers-budget: --cat mode is single-process (one
+            # Commons writer at a time), so it neither uses the pool nor needs
+            # the box-wide slot budget.
+            steps.append(
+                f"sdc-sync --cat {shlex.quote(category)} --maintain{sync_tail}"
+            )
+        else:
+            who = inst or canonical
+            msg = (
+                f"maintain: could not resolve a Commons category for {who}"
+                " (missing Wikidata QID or P8464 Commons-category link); skipping."
+            )
+            steps.append(f"echo {shlex.quote(msg)} >&2; exit 1")
+    return [f"cd {base}", *steps]
+
+
 def _target_label(
     canonical: str, institutions: tuple[str, ...], collection: str | None
 ) -> str:
@@ -190,6 +256,7 @@ def main() -> None:
     parser.add_argument("--refresh-only", default="false")
     parser.add_argument("--sdc-only", default="false")
     parser.add_argument("--maintain", default="false")
+    parser.add_argument("--count-only", default="false")
     # Keep in sync with .github/workflows/wikimedia-launch.yml inputs.workers
     # / inputs.workers_budget (currently 6 / 24), which the workflow always
     # passes explicitly. These defaults only apply to a bare manual launch —
@@ -203,6 +270,7 @@ def main() -> None:
     refresh_only = _parse_bool(args.refresh_only)
     sdc_only = _parse_bool(args.sdc_only)
     maintain = _parse_bool(args.maintain)
+    count_only = _parse_bool(args.count_only)
 
     # Normalize the response_url first so the mutual-exclusion check below
     # can use the validated value rather than re-implementing the same
@@ -222,6 +290,12 @@ def main() -> None:
             " mutually exclusive run modes (refresh skips upload + SDC; sdc-only"
             " skips download + upload; maintain re-links + SDC-syncs existing"
             " Commons files only, creating nothing).",
+        )
+    if count_only and not maintain:
+        _slack_fail(
+            response_url,
+            "--count-only is a maintain-mode pre-flight (it sizes the re-link"
+            " without writing); it has no meaning outside --maintain.",
         )
     max_age_days: int | None = None
     if args.max_age_days.strip():
@@ -946,47 +1020,15 @@ def main() -> None:
         # parallelism).
         upload_opts = f" --workers-budget {sdc_workers_budget}"
         if maintain:
-            # Maintain mode: re-link + SDC-sync the EXISTING Commons files for
-            # this scope in place. No get-ids / download / upload, and no new
-            # File pages — sdc-sync --maintain only edits SDC and migrates
-            # wikitext on files already on Commons. Each hub/institution is
-            # resolved to its exact Commons category via Wikidata (authoritative
-            # — P8464 → commonswiki sitelink — never derived from the display
-            # name), then walked with `sdc-sync --cat ... --maintain`.
-            if dpla_id is not None or collection is not None:
-                # Maintain resolves to a hub/institution Commons category and
-                # walks the WHOLE category — there is no per-collection or
-                # per-item Commons category to scope to. Reject these targets
-                # loudly rather than silently widening the write scope to the
-                # entire category (a collection-scoped request must not quietly
-                # touch every file in the institution).
-                unit = "single DPLA-ID" if dpla_id is not None else "collection-scoped"
-                msg = (
-                    f"maintain mode does not support {unit} targets; it operates"
-                    " on a whole hub/institution Commons category."
-                )
-                pipeline_steps = [f"cd {base}", f"echo {shlex.quote(msg)} >&2; exit 1"]
-            else:
-                cat_steps = []
-                for inst in institutions or (None,):
-                    qid = wikidata_qid_for_target(canonical, inst)
-                    category = resolve_commons_category(qid) if qid else None
-                    if category:
-                        # No --workers/--workers-budget: --cat mode is
-                        # single-process (one Commons writer at a time), so it
-                        # neither uses the pool nor needs the box-wide slot budget.
-                        cat_steps.append(
-                            f"sdc-sync --cat {shlex.quote(category)} --maintain"
-                        )
-                    else:
-                        who = inst or canonical
-                        msg = (
-                            f"maintain: could not resolve a Commons category for"
-                            f" {who} (missing Wikidata QID or P8464 Commons-category"
-                            f" link); skipping."
-                        )
-                        cat_steps.append(f"echo {shlex.quote(msg)} >&2; exit 1")
-                pipeline_steps = [f"cd {base}", *cat_steps]
+            pipeline_steps = _build_maintain_pipeline_steps(
+                canonical,
+                institutions,
+                collection,
+                dpla_id,
+                base,
+                csv_file,
+                count_only,
+            )
         elif sdc_only:
             # SDC-only backfill: re-enumerate the partner's items (which
             # also refreshes sdc.json sidecars from the latest ingestion3

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -278,3 +278,41 @@ def test_maintain_subcommand_with_no_targets_returns_usage(monkeypatch, handler_
     text = _decode_reply(reply)["text"]
     assert "Usage:" in text
     assert "/wikimedia-upload maintain" in text
+
+
+def test_maintain_count_subcommand_dispatches_with_count_only_true(
+    monkeypatch, handler_module
+):
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(_make_event("maintain count digitalnc"), None)
+
+    assert reply["statusCode"] == 200
+    assert len(dispatched) == 1
+    inputs = dispatched[0]["inputs"]
+    assert inputs["maintain"] == "true"
+    assert inputs["count_only"] == "true"
+    assert inputs["partner"] == "digitalnc"
+    assert "sizing" in _decode_reply(reply)["text"].lower()
+
+
+def test_maintain_count_with_no_targets_returns_usage(monkeypatch, handler_module):
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(_make_event("maintain count"), None)
+
+    assert reply["statusCode"] == 200
+    assert dispatched == []
+    assert "Usage:" in _decode_reply(reply)["text"]
+
+
+def test_plain_maintain_does_not_set_count_only(monkeypatch, handler_module):
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(_make_event("maintain digitalnc"), None)
+
+    assert reply["statusCode"] == 200
+    assert "count_only" not in dispatched[0]["inputs"]

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -175,6 +175,52 @@ def test_anchor3_skipped_without_scope_filter():
     assert "wildcard" not in r.tried
 
 
+def test_lazy_scope_callable_invoked_only_at_wildcard_rung():
+    # An embedded hit resolves on rung 1 — the scope callable (a per-file P195
+    # read in production) must not run.
+    es = FakeES(live_ids={CURRENT_ID})
+    calls = []
+
+    def scope():
+        calls.append(1)
+        return {"term": {"dataProvider.name.not_analyzed": "X"}}
+
+    r = resolve_current_dpla_id(
+        embedded_id=CURRENT_ID, recorded_url=NC, scope_filter=scope, query_fn=es
+    )
+    assert r.anchor == "embedded"
+    assert calls == []
+
+
+def test_lazy_scope_callable_bounds_wildcard_when_reached():
+    ga = "http://dlg.galileo.usg.edu/id:arl_awc_awc337"
+    es = FakeES(wildcard={"arl_awc_awc337": ["0ff4842c996e3abab8cff9b3f8f8b297"]})
+    calls = []
+
+    def scope():
+        calls.append(1)
+        return {
+            "term": {"dataProvider.name.not_analyzed": "Athens-Clarke County Library"}
+        }
+
+    r = resolve_current_dpla_id(
+        embedded_id=DEAD_ID, recorded_url=ga, scope_filter=scope, query_fn=es
+    )
+    assert r.dpla_id == "0ff4842c996e3abab8cff9b3f8f8b297"
+    assert r.anchor == "wildcard"
+    assert calls == [1]  # invoked exactly once, at the wildcard rung
+
+
+def test_lazy_scope_callable_returning_none_skips_wildcard():
+    ga = "http://dlg.galileo.usg.edu/id:arl_awc_awc337"
+    es = FakeES(wildcard={"arl_awc_awc337": ["whatever"]})
+    r = resolve_current_dpla_id(
+        embedded_id=DEAD_ID, recorded_url=ga, scope_filter=lambda: None, query_fn=es
+    )
+    assert r.anchor == "unresolved"
+    assert "wildcard" not in r.tried
+
+
 def test_all_anchors_miss_is_unresolved():
     es = FakeES()
     r = resolve_current_dpla_id(

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -5219,7 +5219,7 @@ def test_extract_source_url_absent_or_unreadable():
     assert sdc_sync._extract_source_url(raises) is None
 
 
-def test_maintain_relink_uses_current_id_when_drifted():
+def test_maintain_resolve_uses_current_id_when_drifted():
     from ingest_wikimedia.maintain import ResolveResult
     from tools import sdc_sync
 
@@ -5230,11 +5230,13 @@ def test_maintain_relink_uses_current_id_when_drifted():
         "resolve_current_dpla_id",
         return_value=ResolveResult("26f8310936c0321a8c611703751034ee", "isShownAt"),
     ):
-        out = sdc_sync._maintain_relink("File:X (cropped).jpg", "deadbeef", page)
-    assert out == "26f8310936c0321a8c611703751034ee"
+        result = sdc_sync._maintain_resolve(
+            "File:X (cropped).jpg", "deadbeef", page, "M1"
+        )
+    assert result.dpla_id == "26f8310936c0321a8c611703751034ee"
 
 
-def test_maintain_relink_keeps_embedded_when_unresolved():
+def test_maintain_resolve_unresolved_so_caller_keeps_embedded():
     from ingest_wikimedia.maintain import ResolveResult
     from tools import sdc_sync
 
@@ -5245,6 +5247,192 @@ def test_maintain_relink_keeps_embedded_when_unresolved():
         "resolve_current_dpla_id",
         return_value=ResolveResult(None, "unresolved"),
     ):
-        out = sdc_sync._maintain_relink("File:Y.jpg", "origid12345", page)
-    # Unresolved → keep the embedded id; process_one then skips a dead id as today.
-    assert out == "origid12345"
+        result = sdc_sync._maintain_resolve("File:Y.jpg", "origid12345", page, "M2")
+    # Unresolved → dpla_id is None, so _maintain_process_file keeps the embedded
+    # id (process_one then skips a dead id as today).
+    assert result.dpla_id is None
+    assert (result.dpla_id or "origid12345") == "origid12345"
+
+
+def test_maintain_qid_name_map_reverses_institutions_v2():
+    from tools import sdc_sync
+
+    fake_hubs = {
+        "Digital Library of Georgia": {
+            "Wikidata": "Q5275908",
+            "institutions": {
+                "Athens-Clarke County Library": {"Wikidata": "Q100"},
+                "Atlanta History Center": {"Wikidata": "Q200"},
+            },
+        }
+    }
+    with patch.object(sdc_sync, "hubs", fake_hubs):
+        # Cache is module-level; clear it so this test's hubs are used.
+        sdc_sync._maintain_qid_to_name = None
+        mapping = sdc_sync._maintain_qid_name_map()
+        sdc_sync._maintain_qid_to_name = None
+    assert mapping["Q100"] == "Athens-Clarke County Library"
+    assert mapping["Q200"] == "Atlanta History Center"
+
+
+def test_existing_p195_qid_reads_collection_statement():
+    from tools import sdc_sync
+
+    entity = {
+        "statements": {
+            "P195": [
+                {
+                    "mainsnak": {
+                        "datavalue": {"value": {"id": "Q100", "entity-type": "item"}}
+                    }
+                }
+            ]
+        }
+    }
+    assert sdc_sync._existing_p195_qid(entity) == "Q100"
+    assert sdc_sync._existing_p195_qid({"statements": {}}) is None
+    assert sdc_sync._existing_p195_qid({}) is None
+
+
+def test_maintain_scope_filter_builds_term_from_p195():
+    from tools import sdc_sync
+
+    entity = {
+        "statements": {"P195": [{"mainsnak": {"datavalue": {"value": {"id": "Q100"}}}}]}
+    }
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(
+            sdc_sync,
+            "_maintain_qid_name_map",
+            return_value={"Q100": "Athens-Clarke County Library"},
+        ),
+    ):
+        scope = sdc_sync._maintain_scope_filter("M1")
+    assert scope == {
+        "term": {"dataProvider.name.not_analyzed": "Athens-Clarke County Library"}
+    }
+
+
+def test_maintain_scope_filter_none_when_qid_unknown():
+    from tools import sdc_sync
+
+    entity = {
+        "statements": {"P195": [{"mainsnak": {"datavalue": {"value": {"id": "Q999"}}}}]}
+    }
+    with (
+        patch.object(sdc_sync, "get_entity", return_value=entity),
+        patch.object(sdc_sync, "_maintain_qid_name_map", return_value={"Q100": "X"}),
+    ):
+        assert sdc_sync._maintain_scope_filter("M1") is None
+
+
+def test_maintain_sidecar_payload_parses_and_handles_missing():
+    from tools import sdc_sync
+
+    fake_client = MagicMock()
+    fake_client.get_sdc_json.return_value = '{"claims": [{"a": 1}]}'
+    with (
+        patch.object(sdc_sync, "_s3_partner", "digitalnc"),
+        patch.object(sdc_sync, "_s3_client", fake_client),
+    ):
+        assert sdc_sync._maintain_sidecar_payload("abc") == {"claims": [{"a": 1}]}
+        fake_client.get_sdc_json.return_value = None
+        assert sdc_sync._maintain_sidecar_payload("missing") is None
+        fake_client.get_sdc_json.return_value = "not json{"
+        assert sdc_sync._maintain_sidecar_payload("bad") is None
+    # No --from-s3 → no client → None without touching S3.
+    with patch.object(sdc_sync, "_s3_partner", None):
+        assert sdc_sync._maintain_sidecar_payload("x") is None
+
+
+def test_maintain_process_file_count_only_tallies_and_writes_nothing():
+    from ingest_wikimedia.maintain import ResolveResult
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.text = "url=https://x/1"
+    tally = dict.fromkeys((*sdc_sync._MAINTAIN_TALLY_ANCHORS, "ambiguous"), 0)
+    with (
+        patch.object(
+            sdc_sync,
+            "_maintain_resolve",
+            return_value=ResolveResult("liveid", "isShownAt"),
+        ),
+        patch.object(sdc_sync, "_safe_process_one") as mock_sync,
+    ):
+        sdc_sync._maintain_process_file("M1", "deadid", page, "File:X.jpg", tally=tally)
+    assert tally["isShownAt"] == 1
+    mock_sync.assert_not_called()
+
+
+def test_maintain_process_file_syncs_from_sidecar_with_page_number():
+    from ingest_wikimedia.maintain import ResolveResult
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.text = "url=https://x/1"
+    payload = {"claims": [{"a": 1}]}
+    with (
+        patch.object(
+            sdc_sync,
+            "_maintain_resolve",
+            return_value=ResolveResult("liveid", "embedded"),
+        ),
+        patch.object(sdc_sync, "_s3_partner", "digitalnc"),
+        patch.object(sdc_sync, "_maintain_sidecar_payload", return_value=payload),
+        patch.object(
+            sdc_sync.wikimedia,
+            "extract_page_ordinal_from_commons_title",
+            return_value=3,
+        ),
+        patch.object(sdc_sync, "_safe_process_one") as mock_sync,
+    ):
+        sdc_sync._maintain_process_file(
+            "M1", "liveid", page, "File:X (page 3).jpg", tally=None
+        )
+    mock_sync.assert_called_once_with(
+        "M1", "liveid", file_page=page, sdc_payload=payload, page_number=3
+    )
+
+
+def test_maintain_process_file_skips_when_no_sidecar():
+    from ingest_wikimedia.maintain import ResolveResult
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.text = "url=https://x/1"
+    fake_tracker = MagicMock()
+    with (
+        patch.object(
+            sdc_sync,
+            "_maintain_resolve",
+            return_value=ResolveResult("liveid", "embedded"),
+        ),
+        patch.object(sdc_sync, "_s3_partner", "digitalnc"),
+        patch.object(sdc_sync, "_maintain_sidecar_payload", return_value=None),
+        patch.object(sdc_sync, "tracker", fake_tracker),
+        patch.object(sdc_sync, "_safe_process_one") as mock_sync,
+    ):
+        sdc_sync._maintain_process_file("M1", "liveid", page, "File:X.jpg", tally=None)
+    mock_sync.assert_not_called()
+    fake_tracker.increment.assert_called_once_with(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
+
+
+def test_maintain_process_file_live_fallback_without_from_s3():
+    from ingest_wikimedia.maintain import ResolveResult
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.text = "url=https://x/1"
+    with (
+        patch.object(
+            sdc_sync,
+            "_maintain_resolve",
+            return_value=ResolveResult("liveid", "embedded"),
+        ),
+        patch.object(sdc_sync, "_s3_partner", None),
+        patch.object(sdc_sync, "_safe_process_one") as mock_sync,
+    ):
+        sdc_sync._maintain_process_file("M1", "liveid", page, "File:X.jpg", tally=None)
+    mock_sync.assert_called_once_with("M1", "liveid", file_page=page)

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -372,6 +372,82 @@ def test_target_label_hub_only():
     assert _label("bpl") == "`bpl`"
 
 
+def test_count_only_requires_maintain():
+    exit_info = _run_main(["--partner", "digitalnc", "--count-only", "true"])
+    assert exit_info is not None
+    assert exit_info.code == 1
+
+
+def _maintain_steps(
+    canonical, institutions, count_only, *, collection=None, dpla_id=None
+):
+    """Run _build_maintain_pipeline_steps with Wikidata resolution stubbed."""
+    import scripts.wikimedia_launch as launch_mod
+
+    with (
+        patch.object(launch_mod, "wikidata_qid_for_target", return_value="Q123"),
+        patch.object(
+            launch_mod,
+            "resolve_commons_category",
+            return_value="Category:Media contributed by X",
+        ),
+    ):
+        return launch_mod._build_maintain_pipeline_steps(
+            canonical,
+            institutions,
+            collection,
+            dpla_id,
+            "/srv/base",
+            "out.csv",
+            count_only,
+        )
+
+
+def test_maintain_real_run_stages_sidecars_then_syncs_from_s3():
+    steps = _maintain_steps("digitalnc", (), count_only=False)
+    # One ES scan stages sdc.json sidecars, then the category walk reads them.
+    assert steps[0] == "cd /srv/base"
+    assert steps[1] == "get-ids-es digitalnc --maintain > out.csv"
+    assert steps[2] == (
+        "sdc-sync --cat 'Category:Media contributed by X' --maintain"
+        " --from-s3 digitalnc"
+    )
+    assert "--count-only" not in steps[2]
+
+
+def test_maintain_per_institution_get_ids_repeats_institution_flags():
+    steps = _maintain_steps(
+        "georgia", ("Athens-Clarke County Library", "Atlanta History Center"), False
+    )
+    assert steps[1] == (
+        "get-ids-es georgia --institution 'Athens-Clarke County Library'"
+        " --institution 'Atlanta History Center' --maintain > out.csv"
+    )
+    # One --cat sync per institution category, all reading from S3.
+    syncs = [s for s in steps if s.startswith("sdc-sync")]
+    assert len(syncs) == 2
+    assert all("--from-s3 georgia" in s for s in syncs)
+
+
+def test_maintain_count_only_skips_staging_and_from_s3():
+    steps = _maintain_steps("digitalnc", (), count_only=True)
+    assert steps == [
+        "cd /srv/base",
+        "sdc-sync --cat 'Category:Media contributed by X' --maintain --count-only",
+    ]
+    # Pre-flight sizing never stages sidecars and never reads from S3.
+    assert not any("get-ids-es" in s for s in steps)
+    assert not any("--from-s3" in s for s in steps)
+
+
+def test_maintain_rejects_collection_and_single_id_targets():
+    coll = _maintain_steps("georgia", (), False, collection="Maps")
+    assert coll[-1].endswith("exit 1")
+    assert "does not support" in coll[-1]
+    single = _maintain_steps("georgia", (), False, dpla_id="abc123")
+    assert single[-1].endswith("exit 1")
+
+
 def test_maintain_mutually_exclusive_with_sdc_only():
     exit_info = _run_main(
         ["--partner", "georgia", "--maintain", "true", "--sdc-only", "true"]

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -49,6 +49,10 @@ rights: dict
 subject_ids: dict
 _s3_partner: str | None = None
 _s3_client = None
+# Maintain mode: {institution Wikidata QID -> dataProvider name}, built lazily
+# from ``hubs`` (institutions_v2.json) the first time the anchor-3 wildcard
+# needs to scope a re-link to the file's own institution. None until built.
+_maintain_qid_to_name: dict[str, str] | None = None
 # Legacy-mode (``--file`` / ``--cat`` / ``--list``) DPLA-doc cache.
 # ``parsed()`` populates it during ``process_one``; the post-SDC
 # cleanup helper pops on read so the same S3 / api.dp.la doc isn't
@@ -198,6 +202,20 @@ def _build_parser() -> argparse.ArgumentParser:
             "record instead. SDC sync + template migration only; no uploads. "
             "Use to maintain already-uploaded files of institutions no longer "
             "authorized for new uploads."
+        ),
+    )
+    p.add_argument(
+        "--count-only",
+        dest="count_only",
+        action="store_true",
+        default=False,
+        help=(
+            "Maintain-mode pre-flight sizing: walk the --cat/--file scope, "
+            "resolve how each file would re-link (embedded id still live / "
+            "isShownAt-recovered / institution-wildcard / unresolved), print a "
+            "per-anchor breakdown, and write nothing. Run this before a real "
+            "maintain pass to size the work and spot a scope that re-links "
+            "poorly. No effect without --maintain."
         ),
     )
     p.add_argument(
@@ -3644,36 +3662,181 @@ def _extract_source_url(file_page) -> str | None:
     return m.group(1).strip() if m else None
 
 
-def _maintain_relink(title, embedded_id, file_page):
-    """Maintain mode: resolve the CURRENT DPLA id for a (possibly ID-drifted)
-    Commons file, so SDC sync targets the live record and the rendered
-    dp.la link resolves again. Returns the live id, or the original
-    ``embedded_id`` when re-linking finds nothing (``process_one`` then skips
-    a genuinely-dead id the same as today).
+def _maintain_qid_name_map() -> dict[str, str]:
+    """``{institution Wikidata QID -> dataProvider name}`` from institutions_v2.
 
-    Anchors 1 (embedded id still live) and 2 (exact ``isShownAt`` over
-    normalized URL variants) only — the institution-scoped wildcard (anchor 3)
-    needs a reliable scope filter, which ``--cat`` lacks (Commons category
-    names don't map 1:1 to DPLA dataProvider names); it's left for a later pass.
+    The dataProvider name is the institutions_v2.json institution key — the
+    exact string the DPLA index stores in ``dataProvider.name`` — so a QID read
+    off a file's existing P195 (collection) statement maps straight to the ES
+    scope term for the anchor-3 wildcard. Built once per run from ``hubs`` and
+    memoised. Only service-hub *institution* QIDs are mapped; a content hub's
+    own QID (NARA/Smithsonian, where P195 carries the hub) has no single
+    dataProvider name, so those files simply don't get an anchor-3 scope.
     """
-    result = resolve_current_dpla_id(
+    global _maintain_qid_to_name
+    if _maintain_qid_to_name is None:
+        mapping: dict[str, str] = {}
+        for hub_data in (hubs or {}).values():
+            for inst_name, inst_data in (hub_data.get("institutions") or {}).items():
+                qid = (inst_data or {}).get("Wikidata")
+                if qid:
+                    mapping[qid] = inst_name
+        _maintain_qid_to_name = mapping
+    return _maintain_qid_to_name
+
+
+def _existing_p195_qid(entity: dict) -> str | None:
+    """The institution QID from a Commons file's existing P195 (collection)
+    statement, or None. P195 is written by ``add_collection`` as the institution
+    (service hub) or the hub itself (content hub), and is stable under DPLA ID
+    drift — which is what makes it a reliable scope anchor when the id is dead.
+    """
+    statements = entity.get("statements") or entity.get("claims") or {}
+    for stmt in statements.get("P195", []) or []:
+        snak = stmt.get("mainsnak") if isinstance(stmt, dict) else None
+        val = ((snak or {}).get("datavalue") or {}).get("value")
+        if isinstance(val, dict) and val.get("id"):
+            return val["id"]
+    return None
+
+
+def _maintain_scope_filter(mediaid: str) -> dict | None:
+    """ES filter clause scoping the anchor-3 wildcard to ``mediaid``'s own
+    institution, or None when it can't be derived (no P195, or a QID that isn't
+    a known service-hub institution). Reads the file's *existing* P195 — so the
+    wildcard never runs an unbounded whole-index scan. Invoked lazily by
+    :func:`resolve_current_dpla_id`, only for files that fall through to the
+    wildcard rung.
+    """
+    try:
+        entity = get_entity(mediaid)
+    except Exception:
+        # A missing/deleted entity or transient API error here only costs the
+        # wildcard rung for this one file; the resolver falls back to unresolved.
+        return None
+    qid = _existing_p195_qid(entity)
+    if not qid:
+        return None
+    name = _maintain_qid_name_map().get(qid)
+    if not name:
+        return None
+    return {"term": {"dataProvider.name.not_analyzed": name}}
+
+
+def _maintain_resolve(title, embedded_id, file_page, mediaid):
+    """Resolve the CURRENT DPLA id for a (possibly ID-drifted) Commons file and
+    return the full :class:`ResolveResult` (id + which anchor resolved it).
+
+    Walks the full ladder: embedded id still live, exact ``isShownAt`` over
+    normalized URL variants, then the institution-scoped wildcard — the last
+    bounded by the file's own P195 institution, derived lazily so only
+    domain-drifted files pay for it.
+    """
+    return resolve_current_dpla_id(
         embedded_id=embedded_id,
         recorded_url=_extract_source_url(file_page),
-        scope_filter=None,
+        scope_filter=lambda: _maintain_scope_filter(mediaid),
     )
+
+
+def _maintain_sidecar_payload(dpla_id):
+    """Maintain mode: load the precomputed ``sdc.json`` for ``dpla_id`` from S3
+    (staged by ``get-ids-es --maintain``) so the sync runs through
+    :func:`process_one_from_sdc` — no ``api.dp.la`` call, no runtime claim
+    build. Requires ``--from-s3 <partner>`` (which sets ``_s3_partner`` /
+    ``_s3_client``); returns the parsed payload, or None when no sidecar is
+    staged for this id. A None result means the caller should SKIP the file
+    rather than fall back to a per-file live API call — at hub scale (100Ks of
+    files, possibly parallel) that fallback is exactly the api.dp.la load this
+    path exists to avoid.
+    """
+    if _s3_partner is None:
+        return None
+    raw = _s3_client.get_sdc_json(_s3_partner, dpla_id)
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+# Pre-flight sizing (``--count-only``) tally: one bucket per resolver anchor
+# plus ``ambiguous`` (a multi-hit the resolver refused to auto-apply). Order is
+# the ladder order so the printed breakdown reads top-to-bottom.
+_MAINTAIN_TALLY_ANCHORS = ("embedded", "isShownAt", "wildcard", "unresolved")
+
+
+def _maintain_process_file(mediaid, embedded_id, file_page, title, tally=None):
+    """Maintain one Commons file: re-link to its current DPLA id, then either
+    tally the resolver outcome (``--count-only`` pre-flight sizing — ``tally``
+    given, nothing written) or SDC-sync it.
+
+    The sync runs through the staged ``sdc.json`` sidecar (``--from-s3``) so it
+    never calls ``api.dp.la`` and materialises P304 from the page ordinal in the
+    title. With no sidecar staged for the (re-linked) id the file is skipped
+    rather than falling back to a per-file live fetch — at hub scale that
+    fallback is the api.dp.la load this path exists to avoid. When ``--from-s3``
+    is not set at all (e.g. an ad-hoc ``--file`` run), it falls back to the live
+    ``process_one`` for that single file.
+    """
+    result = _maintain_resolve(title, embedded_id, file_page, mediaid)
+    dpla_id = result.dpla_id or embedded_id
     if result.dpla_id and result.dpla_id != embedded_id:
         logging.info(
             f"maintain: re-linked {title}: {embedded_id} ->"
             f" {result.dpla_id} (via {result.anchor})"
         )
-        return result.dpla_id
-    if result.dpla_id is None:
+    elif result.dpla_id is None:
         logging.info(
             f"maintain: could not re-link {title}"
             f" (embedded {embedded_id}); leaving as-is."
         )
-        return embedded_id
-    return result.dpla_id
+
+    if tally is not None:
+        tally[result.anchor] += 1
+        if result.ambiguous:
+            tally["ambiguous"] += 1
+        return
+
+    if _s3_partner is not None:
+        payload = _maintain_sidecar_payload(dpla_id)
+        if payload is None:
+            logging.info(
+                f"maintain: no staged sdc.json for {dpla_id} ({title}); skipping."
+            )
+            tracker.increment(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR)
+            return
+        page_number = wikimedia.extract_page_ordinal_from_commons_title(title)
+        _safe_process_one(
+            mediaid,
+            dpla_id,
+            file_page=file_page,
+            sdc_payload=payload,
+            page_number=page_number,
+        )
+    else:
+        _safe_process_one(mediaid, dpla_id, file_page=file_page)
+
+
+def _new_maintain_tally(enabled):
+    """A zero-initialised per-anchor tally for ``--count-only`` sizing, or None
+    when sizing is off. dict.fromkeys keeps a 0 for every bucket so
+    :func:`_report_maintain_tally` never KeyErrors on an unseen tier.
+    """
+    if not enabled:
+        return None
+    return dict.fromkeys((*_MAINTAIN_TALLY_ANCHORS, "ambiguous"), 0)
+
+
+def _report_maintain_tally(tally, total):
+    """Print the ``--count-only`` per-anchor sizing breakdown."""
+    print(f"\nmaintain pre-flight sizing ({total} files in scope):")
+    for anchor in _MAINTAIN_TALLY_ANCHORS:
+        print(f"  {anchor:>12}: {tally[anchor]}")
+    print(f"  {'ambiguous':>12}: {tally['ambiguous']} (multi-hit, not auto-applied)")
+    resolved = total - tally["unresolved"]
+    print(f"  {'-> resolved':>12}: {resolved}/{total}")
 
 
 def process_one(mediaid, dpla_id):
@@ -5089,9 +5252,23 @@ def _run_partner_mode(partner, ids_file):
 # We can use a PWB generator to programatically make the list of files we are working on based on a set of criteria. Here, we are generating the page titles from a Wikimedia Commons search and categories. For other types of available page generators, see <https://doc.wikimedia.org/pywikibot/master/api_ref/pywikibot.html#module-pywikibot.pagegenerators>. As an additional step, we take the pageid provided by the generator and prepend "M" for the mediaid needed for posting SDC statements.
 
 
-def _safe_process_one(mediaid: str, dpla_id: str, file_page=None) -> None:
+def _safe_process_one(
+    mediaid: str,
+    dpla_id: str,
+    file_page=None,
+    sdc_payload=None,
+    page_number=None,
+) -> None:
     """Run ``process_one`` with the per-file exception boundary the
     legacy ``--list`` / ``--files`` / ``--cat`` loops need.
+
+    When ``sdc_payload`` is supplied (maintain mode against staged S3
+    sidecars — see the ``--cat``/``--file`` loops), the precomputed
+    :func:`process_one_from_sdc` path is used instead of the live
+    :func:`process_one`: no ``api.dp.la`` call and no runtime claim build,
+    and ``page_number`` (parsed from the file title) materialises the P304
+    page qualifier. With no payload it runs the live ``process_one`` exactly
+    as before.
 
     Without this, a transient pywikibot APIError on any one file
     aborts the entire loop — and on ``--list``, leaves WORKING-*.txt
@@ -5119,7 +5296,12 @@ def _safe_process_one(mediaid: str, dpla_id: str, file_page=None) -> None:
     writes_before = _sdc_writes_total()
     try:
         try:
-            process_one(mediaid, dpla_id)
+            if sdc_payload is not None:
+                process_one_from_sdc(
+                    mediaid, dpla_id, sdc_payload, page_number=page_number
+                )
+            else:
+                process_one(mediaid, dpla_id)
         except _MissingEntityError:
             logging.info(
                 f" -- {mediaid} for {dpla_id}: Commons MediaInfo entity"
@@ -5205,6 +5387,9 @@ def main() -> None:
                 pass
 
     elif args.files:
+        # ``--count-only`` is a maintain-mode pre-flight: tally how each file
+        # would re-link without writing anything.
+        tally = _new_maintain_tally(args.maintain and args.count_only)
         for title in args.files:
             print("\n" + title)
             page = pywikibot.FilePage(site, title)
@@ -5212,25 +5397,27 @@ def main() -> None:
                 print(f" -- Page not found on Commons: {title}")
                 continue
             mediaid = "M" + str(page.pageid)
-            dpla_id = _resolve_dpla_id(title, dpla_api)
-            if args.maintain:
-                dpla_id = _maintain_relink(title, dpla_id, page)
+            embedded_id = _resolve_dpla_id(title, dpla_api)
             count += 1
             print(f"{count}: {mediaid}")
-            _safe_process_one(mediaid, dpla_id, file_page=page)
+            if args.maintain:
+                _maintain_process_file(mediaid, embedded_id, page, title, tally=tally)
+            else:
+                _safe_process_one(mediaid, embedded_id, file_page=page)
+        if tally is not None:
+            _report_maintain_tally(tally, count)
 
     elif args.cat:
         category = pywikibot.Category(site, args.cat)
         generator = pagegenerators.CategorizedPageGenerator(
             category, namespaces=[6], recurse=args.recurse
         )
+        tally = _new_maintain_tally(args.maintain and args.count_only)
         for page in generator:
             title = page.title()
             print("\n" + title)
             mediaid = "M" + str(page.pageid)
-            dpla_id = _resolve_dpla_id(title, dpla_api)
-            if args.maintain:
-                dpla_id = _maintain_relink(title, dpla_id, page)
+            embedded_id = _resolve_dpla_id(title, dpla_api)
             count += 1
             print(f"{count}: {mediaid}")
             # CategorizedPageGenerator yields generic Page objects;
@@ -5238,10 +5425,17 @@ def main() -> None:
             # right type (its normalize / migrate helpers expect a
             # FilePage handle).
             file_page = pywikibot.FilePage(site, title)
-            _safe_process_one(mediaid, dpla_id, file_page=file_page)
+            if args.maintain:
+                _maintain_process_file(
+                    mediaid, embedded_id, file_page, title, tally=tally
+                )
+            else:
+                _safe_process_one(mediaid, embedded_id, file_page=file_page)
             if args.limit and count >= args.limit:
                 print(f" -- Reached --limit {args.limit}, stopping.")
                 break
+        if tally is not None:
+            _report_maintain_tally(tally, count)
 
     elif args.partner:
         _ids_file = args.ids_file or os.path.join(args.partner, f"{args.partner}.csv")


### PR DESCRIPTION
Builds on the maintain mode shipped in #330 (core) and #331 (Slack/launcher). Makes maintain safe to run over a whole hub by re-routing it through the precomputed-SDC path, and adds the two pieces that make a hub-scale run operable: pre-flight sizing and institution-scoped re-linking.

## Why

The merged maintain mode reused the live `process_one`, which (a) calls `api.dp.la` once per file — the exact per-file API load that historically brought down DPLA's own API under batch pressure — and (b) never set P304 (page number). Both are unsafe over a 100Ks-file hub like NCDHC, and worse under the parallelism that follows. This PR fixes the root cause rather than patching the symptom.

## A0 — sidecar sync path

- `get-ids-es --maintain` stages an `sdc.json` sidecar per eligible item with **one** ES scan over the scope (it drops only the upload gate, keeping the QID requirement).
- `sdc-sync --cat <category> --maintain --from-s3 <hub>` then syncs each re-linked id from its staged sidecar via `process_one_from_sdc` — **no `api.dp.la` call, no runtime claim build** — and materialises **P304** from the page ordinal in the Commons title.
- No staged sidecar for a (re-linked) id ⇒ the file is **skipped** (`SDC_ITEMS_SKIPPED_NO_SIDECAR`), never a per-file live fetch. An ad-hoc `--file` run without `--from-s3` still falls back to the live `process_one`.

## A (#1) — pre-flight sizing

- `sdc-sync --count-only` (Slack: `/wikimedia-upload maintain count <hub>`) walks the scope, resolves how each file *would* re-link, and prints a per-anchor breakdown (embedded / isShownAt / wildcard / unresolved / ambiguous) **without writing anything** — so an operator can size a pass and spot a poorly-re-linking scope before committing edits.

## A (#2) — anchor-3 institution scope

- `resolve_current_dpla_id`'s `scope_filter` now accepts a **lazy callable**, invoked only if the ladder reaches the institution-scoped wildcard rung — so the per-file scope derivation is skipped for the common embedded/isShownAt hits.
- The scope is derived from the file's **own existing P195 (collection)** institution QID, reverse-mapped via `institutions_v2.json` to the `dataProvider.name` the index stores. The wildcard is therefore bounded to one institution even on a whole-hub run, and never scans the whole index.

## Launcher / wiring

- Extracted `_build_maintain_pipeline_steps` as a pure, unit-tested function (staging + per-institution `--cat` sync, count-only passthrough).
- `count_only` wired end to end: `wikimedia-launch.yml` input, `--count-only` flag + maintain-only validation in `wikimedia_launch.py`, and the `maintain count` Slack subcommand in the Lambda.

## Design note

A#2 scopes the wildcard from each file's own P195 (works on whole-hub runs, costs a P195 read only on the drifted minority that reach anchor 3). The alternative — passing one institution scope from the launch target — was rejected because it only helps `hub|institution` targets and not the common bare-hub maintain run.

## Tests

Sidecar route (payload + page-number, no-sidecar skip, live fallback), P195 scope filter + QID reverse map, lazy-callable resolver (invoked only at the wildcard rung), count tally, launcher staging/count-only/reject-collection command strings, and the Slack `maintain count` dispatch. Full suite: **858 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR extends the maintain mode workflow to operate safely at hub scale by routing operations through precomputed sidecars instead of live API calls to `api.dp.la`. It introduces three core capabilities:

**Sidecar sync path (A0)**: Replaces the previous maintain mode's per-file live API calls with a staged sidecar workflow. `get-ids-es --maintain` performs a single Elasticsearch scan and stages `sdc.json` sidecars per eligible item. `sdc-sync --cat <category> --maintain --from-s3 <hub>` then syncs each re-linked ID from its staged sidecar via `process_one_from_sdc`, eliminating `api.dp.la` calls and runtime claim builds. P304 (page number) fields are now materialized from the page ordinal in the Commons title. Files without staged sidecars are skipped rather than fetched live.

**Pre-flight sizing (A1)**: New `--count-only` flag across the stack enables assess-only runs that walk the scope and resolve how each file would re-link without writing anything, producing a per-anchor breakdown (embedded/isShownAt/wildcard/unresolved/ambiguous). This allows operators to validate a pass before committing edits. The flag flows through the Slack `/wikimedia-upload maintain count` subcommand, the workflow dispatch input, `wikimedia_launch.py`, and down to `sdc_sync.py`.

**Institution-scoped re-linking (A2)**: `resolve_current_dpla_id` now accepts a lazy callable `scope_filter` that is only invoked when resolution reaches the wildcard rung, avoiding redundant scope derivation for common embedded/isShownAt hits. Scope is derived from each file's existing P195 (collection) institution QID via reverse mapping through `institutions_v2.json`, bounding the wildcard to a single institution even on hub-wide runs.

## Changes across files

- **Workflow** (`.github/workflows/wikimedia-launch.yml`): Adds `count_only` input to workflow dispatch, wired to `wikimedia_launch.py` via `INPUT_COUNT_ONLY`.
- **Slack handler** (`lambda/wikimedia-slack-dispatch/handler.py`): Extends `/wikimedia-upload maintain` subcommand to recognize `maintain count <target>` syntax, dispatching with both `maintain=true` and `count_only=true`.
- **Pipeline launcher** (`scripts/wikimedia_launch.py`): Adds `--count-only` CLI flag (valid only with `--maintain`), refactors `--maintain` logic into reusable `_build_maintain_pipeline_steps` helper, and builds appropriate `get-ids-es` + `sdc-sync` or `sdc-sync --count-only` sequences.
- **Core maintain logic** (`ingest_wikimedia/maintain.py`): Updates `resolve_current_dpla_id` signature to accept `scope_filter` as `dict | Callable[[], dict | None] | None`, deferring callable invocation to the wildcard rung.
- **SDC sync** (`tools/sdc_sync.py`): Adds institution-QID-to-provider cache, P195 extraction, per-institution scope filter builder, S3 sidecar payload loading, and `_maintain_process_file` flow that supports both tally-only and sidecar-synced re-linking. Generalizes `_safe_process_one` to optionally accept sidecar payload and page number.
- **Tests**: Full test suite coverage for lazy scope evaluation, Slack `maintain count` dispatch, maintain pipeline step generation, and SDC sync maintain-mode flows (858 tests passing).

## Deployment notes

- **Workflow trigger**: The new `count_only` input is a workflow_dispatch parameter and requires no ECS redeployment; manual triggers or Slack commands can use it immediately after merge.
- **No environment variables added**: The changes do not introduce new AWS Secrets Manager keys or environment variables.
- **No database migrations**: All changes are confined to the ingest workflow tooling.
- **No shared infrastructure changes**: No updates to CodePipeline, CodeBuild, ECS task definitions, or IAM policies.
- **Performance and reliability**: The elimination of live `api.dp.la` calls per file significantly reduces ingest load on DPLA's public API and removes a potential failure point.
- **Backwards compatibility**: Ad-hoc `--file` runs without `--from-s3` still fall back to the live `process_one` code path, preserving existing manual-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->