### PR TITLE
wikimedia-status: file-level upload progress + [pos/N] position-in-chain

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -339,11 +339,7 @@ def get_phase_and_progress(
         # found, so legacy sessions still get a readout.
         files_done = uploaded_count + skipped_count
         if total_ordinals > 0:
-            files_pct = (
-                f"{files_done / total_ordinals * 100:.1f}"
-                if total_ordinals > 0
-                else "?"
-            )
+            files_pct = f"{files_done / total_ordinals * 100:.1f}"
             progress = f"{files_done:,} / {total_ordinals:,} files, ~{files_pct}%"
         else:
             progress = f"{dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%"

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -189,14 +189,36 @@ def get_phase_and_progress(
         csv_count_cmd = f"wc -l < {csv_path} 2>/dev/null || echo 0"
 
     sep = "__WM_SEP__"
+    # Locate the corresponding -download.log for this label so we can sum
+    # total ordinals across all items — gives Upload-phase progress a
+    # file-level denominator instead of the item-level one that makes
+    # multi-page items vastly under-represent work done (a 100-page
+    # newspaper counts the same as a 1-image photo). Empty when no
+    # download log exists for this label yet (sessions still in
+    # get-ids-es or the legacy single-log layout); the Upload branch
+    # falls back to item-count in that case.
+    download_glob = shlex.quote(f"*-{label}-download.log")
+    # POSIX-awk ordinal summer: every `Item <id>: <N> ordinals (...)` line
+    # the downloader emits per-item gets its N picked out by walking fields
+    # until the "ordinals" token, then summing the preceding field. The
+    # gawk-only `match(..., array)` extraction would be cleaner but
+    # production awk on this host might be mawk/busybox; field walk works
+    # everywhere.
+    ordinals_awk = (
+        "BEGIN{s=0} "
+        "/Item [a-f0-9]+: [0-9]+ ordinals/ "
+        '{for(i=1;i<=NF;i++) if($i=="ordinals"){s+=$(i-1); break}} '
+        "END {print s+0}"
+    )
     # One awk pass counts all four marker lines in a single sequential read
-    # of the log; the previous code ran four separate `grep -c` invocations
-    # over the same file (plus the COUNTS: probe), which on multi-GB NARA
-    # logs translated to four full sequential reads and four SSM round-trips
-    # of pipeline setup overhead. Output is still four lines (dpla_id,
-    # uploaded, skipping, counts) in the same order as before, followed by
-    # the CSV total from `wc -l`. The `|| printf` fallback covers the
-    # missing-file case symmetrically with the old `|| true`.
+    # of the upload log; the previous code ran four separate `grep -c`
+    # invocations over the same file (plus the COUNTS: probe), which on
+    # multi-GB NARA logs translated to four full sequential reads and four
+    # SSM round-trips of pipeline setup overhead. Output is still four
+    # lines (dpla_id, uploaded, skipping, counts) in the same order as
+    # before, followed by the CSV total from `wc -l`. The download-log
+    # ordinal sum is emitted after a fresh separator so the output sections
+    # stay self-describing.
     out = ssm_run(
         client,
         f"date +%s; "
@@ -211,10 +233,15 @@ def get_phase_and_progress(
         f"/COUNTS:/ {{c++}} "
         f"END {{ print d+0; print u+0; print s+0; print c+0 }}"
         f"' {log_path} 2>/dev/null || printf '0\\n0\\n0\\n0\\n'; "
-        f"{csv_count_cmd}",
+        f"{csv_count_cmd}; "
+        f"echo {sep}; "
+        f"DOWNLOG=$(ls -t {log_dir}/{download_glob} 2>/dev/null | head -1); "
+        f'if [ -n "$DOWNLOG" ]; then '
+        f"awk '{ordinals_awk}' \"$DOWNLOG\" 2>/dev/null || echo 0; "
+        f"else echo 0; fi",
     )
 
-    sections = out.split(f"{sep}\n", 2)
+    sections = out.split(f"{sep}\n", 3)
     pre_sep = sections[0].strip().splitlines() if sections else []
     now = _safe_int(pre_sep[0]) if pre_sep else 0
     log_mtime = _safe_int(pre_sep[1]) if len(pre_sep) > 1 else 0
@@ -234,6 +261,11 @@ def get_phase_and_progress(
     skipped_count = _safe_int(count_lines[2]) if len(count_lines) > 2 else 0
     counts_marker = _safe_int(count_lines[3]) if len(count_lines) > 3 else 0
     total = _safe_int(count_lines[4]) if len(count_lines) > 4 else 0
+
+    # Sum of `Item <id>: N ordinals` lines from the download log — the true
+    # file count once downloads have completed. 0 when no download log was
+    # found (legacy sessions, or the session is still in get-ids-es).
+    total_ordinals = _safe_int(sections[3].strip()) if len(sections) > 3 else 0
 
     def pct(n: int) -> str:
         return f"{n / total * 100:.1f}" if total > 0 else "?"
@@ -300,8 +332,23 @@ def get_phase_and_progress(
                 f"{_UPLOAD_COMPLETE_PREFIX} ({uploaded_count:,} uploaded, {skipped_count:,} already on Commons)",
                 log_mtime,
             )
+        # File-level progress: the download log gives us the true total
+        # ordinal count, and the upload log tells us how many ordinals
+        # have terminated (uploaded or skipped). Falls back to the
+        # item-level item-count denominator when no download log was
+        # found, so legacy sessions still get a readout.
+        files_done = uploaded_count + skipped_count
+        if total_ordinals > 0:
+            files_pct = (
+                f"{files_done / total_ordinals * 100:.1f}"
+                if total_ordinals > 0
+                else "?"
+            )
+            progress = f"{files_done:,} / {total_ordinals:,} files, ~{files_pct}%"
+        else:
+            progress = f"{dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%"
         return (
-            f"Uploading ({dpla_id_count:,} / {total:,}, ~{pct(dpla_id_count)}%){slot_suffix}{stale_suffix}",
+            f"Uploading ({progress}){slot_suffix}{stale_suffix}",
             log_mtime,
         )
 
@@ -576,10 +623,22 @@ def main() -> None:
             logging.exception("Failed to find active label for %s", session)
             return labels[0], "Unknown (error)"
 
-        # For multi-label batches, suffix a "(+N more)" annotation so the
-        # reader can see this row is one slice of a larger session.
+        # For multi-label batches, suffix a `[<pos>/<total>]` position
+        # annotation so the reader can tell at a glance how far along
+        # the institution chain this row is. The earlier `(+N more)`
+        # form counted batch size − 1 and was ambiguous: a session
+        # showing `(+72 more)` could be on the FIRST institution or
+        # the LAST one (73 of 73). `[73/73]` makes it unambiguous.
         def _with_batch_suffix(label: str) -> str:
-            return f"{label} (+{len(labels) - 1} more)" if multi else label
+            if not multi:
+                return label
+            try:
+                pos = labels.index(label) + 1
+            except ValueError:
+                # Defensive: should never happen — every label we route
+                # through this helper came from `labels` itself.
+                return f"{label} [?/{len(labels)}]"
+            return f"{label} [{pos}/{len(labels)}]"
 
         if active is None:
             # No log file matches any label yet — pipeline is in

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -129,13 +129,14 @@ def _fake_ssm_for_phase(
     mtime: int = 1700000000,
     now: int | None = None,
     tail: str = "last log line",
+    total_ordinals: int = 0,
 ):
     """Build a fake `ssm_run` that returns the precheck + counts payload
     `get_phase_and_progress` expects, with the named log file and counts.
 
     Sequence (matches the real two-call flow):
       1. precheck — `session_created\nlog_filename`
-      2. main — `now\nmtime\nSEP\ntail\nSEP\n<5 lines of awk + wc>`
+      2. main — `now\nmtime\nSEP\ntail\nSEP\n<5 lines of awk + wc>\nSEP\n<total_ordinals>`
 
     ``mtime`` is parameterised so tests can verify the mtime tiebreak in
     ``main`` — an "aborted phase" fake with an earlier mtime must be
@@ -143,6 +144,11 @@ def _fake_ssm_for_phase(
     though both produce a non-COUNTS-marker phase string.  ``now`` is
     kept at the same value so the staleness suffix doesn't fire (it
     would change the phase-string assertions in unrelated callers).
+
+    ``total_ordinals`` is the file-level denominator the helper now
+    derives from the corresponding download log; default 0 mirrors the
+    "no download log found" case (legacy sessions or pre-PR-272 logs),
+    where the Upload branch falls back to item-count.
     """
     call_count = [0]
     sep = "__WM_SEP__"
@@ -158,6 +164,7 @@ def _fake_ssm_for_phase(
         body = f"{now_val}\n{mtime}\n{sep}\n{tail}\n{sep}\n"
         body += "\n".join(str(n) for n in awk_counts) + "\n"
         body += f"{csv_total}\n"
+        body += f"{sep}\n{total_ordinals}\n"
         return body
 
     return fake_ssm_run
@@ -889,3 +896,194 @@ def test_main_rows_use_display_id_from_fetch_not_session_name():
     text = section_blocks[0]["text"]["text"]
     assert "bpl+phillips-academy" in text
     assert "Uploading" in text
+
+
+# ---------------------------------------------------------------------------
+# Upload-phase file-level progress (PR: file progress + position-in-chain)
+
+
+def test_upload_progress_reports_file_level_when_download_log_available():
+    """When the downloader has finished and the per-item `Item <id>: N
+    ordinals` summary lines are present in the download log, the Upload
+    phase status reports file-level progress (uploaded + skipped vs.
+    total ordinals) rather than item-level. A 100-page newspaper item
+    is no longer indistinguishable from a 1-image photo in the readout.
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    # 1500 of 6000 ordinals processed (1200 uploaded + 300 skipped),
+    # ~25%. Item count is irrelevant when total_ordinals > 0.
+    fake = _fake_ssm_for_phase(
+        log_filename="20260528-091047-bpl+phillips-academy-upload.log",
+        # [dpla_id_count, uploaded, skipping, counts]
+        awk_counts=[200, 1200, 300, 0],
+        csv_total=400,  # items — used as fallback only
+        total_ordinals=6000,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-bpl+phillips-academy",
+            hub="bpl",
+            label="bpl+phillips-academy",
+        )
+    assert phase is not None
+    # File-level: (1200 + 300) / 6000 = 25.0%
+    assert "1,500 / 6,000 files" in phase, phase
+    assert "~25.0%" in phase, phase
+    # Item-level fallback string must NOT appear when file-level is in scope.
+    assert "items" not in phase, (
+        f"file-level reporting must replace item-level: got {phase!r}"
+    )
+
+
+def test_upload_progress_falls_back_to_item_level_when_no_download_log():
+    """Legacy sessions (pre-PR-272 logs) and sessions whose download
+    phase ran under a separate label have ``total_ordinals == 0``.
+    The Upload phase falls back to the item-level denominator so the
+    readout doesn't degrade to ``0 / 0 ?%``."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_phase(
+        log_filename="20260528-091047-bpl+phillips-academy-upload.log",
+        awk_counts=[50, 30, 5, 0],
+        csv_total=200,
+        total_ordinals=0,  # no download log found
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-bpl+phillips-academy",
+            hub="bpl",
+            label="bpl+phillips-academy",
+        )
+    assert phase is not None
+    # Item-level: 50 / 200 = 25.0%
+    assert "50 / 200 items" in phase, phase
+    assert "~25.0%" in phase, phase
+
+
+def test_upload_progress_passes_label_glob_into_download_log_lookup():
+    """The download-log lookup must scope to THIS label, not the whole
+    log directory — otherwise multi-institution batches would sum
+    ordinal counts from sibling labels' download logs and over-count
+    the denominator."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    captured: list[str] = []
+
+    def fake_ssm_run(_client, command, **_kwargs):
+        captured.append(command)
+        if len(captured) == 1:
+            return "1700000000\n20260528-091047-bpl+phillips-academy-upload.log\n"
+        return (
+            "1700000000\n1700000000\n__WM_SEP__\n.\n__WM_SEP__\n"
+            "10\n5\n2\n0\n50\n__WM_SEP__\n200\n"
+        )
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
+        get_phase_and_progress(
+            client=None,
+            session="wikimedia-bpl+phillips-academy",
+            hub="bpl",
+            label="bpl+phillips-academy",
+        )
+    main_cmd = captured[1]
+    # The download-log glob must include the specific label, not just
+    # `*-download.log`.
+    assert "bpl+phillips-academy-download.log" in main_cmd, main_cmd
+
+
+def test_fetch_position_annotation_for_multi_label_batch():
+    """Multi-label batch sessions get a `[<pos>/<total>]` suffix on the
+    active label, replacing the prior `(+N more)` form. Lets the
+    reader see at a glance how far along the chain a session is."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import main
+
+    sessions_out = "wikimedia-texas+a+texas+b+texas+c+texas+d: 1 windows\n"
+    captured, fake_post = _capture_slack_post()
+    with (
+        patch.dict(
+            "os.environ",
+            {"DPLA_SLACK_BOT_TOKEN": "tok", "NOTIFY_IF_IDLE": "false"},
+        ),
+        patch("scripts.wikimedia_upload_status.boto3.client", return_value=object()),
+        patch("scripts.wikimedia_upload_status.ssm_run", return_value=sessions_out),
+        patch(
+            "scripts.wikimedia_upload_status.fetch_memory_snapshot", return_value=None
+        ),
+        patch("scripts.wikimedia_upload_status._format_slots_line", return_value=None),
+        # Active label is the 3rd of 4 (texas+c).
+        patch(
+            "scripts.wikimedia_upload_status.find_active_label",
+            return_value=("texas+c", 1700000000),
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.get_phase_and_progress",
+            return_value=("Uploading (10 / 100 files, ~10.0%)", 1700000000),
+        ),
+        patch("scripts.wikimedia_upload_status.requests.post", side_effect=fake_post),
+    ):
+        main()
+
+    section_text = next(
+        b["text"]["text"]
+        for b in captured["payload"]["blocks"]
+        if b.get("type") == "section"
+    )
+    # The position annotation must appear and be position-3-of-4, not "(+3 more)".
+    assert "texas+c [3/4]" in section_text, section_text
+    assert "(+" not in section_text, (
+        f"old ambiguous suffix must be gone: {section_text!r}"
+    )
+
+
+def test_fetch_no_position_annotation_for_single_label_session():
+    """Single-label sessions don't need the position annotation —
+    `[1/1]` would just be noise. Confirm it stays bare."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import main
+
+    sessions_out = "wikimedia-bpl+phillips-academy: 1 windows\n"
+    captured, fake_post = _capture_slack_post()
+    with (
+        patch.dict(
+            "os.environ",
+            {"DPLA_SLACK_BOT_TOKEN": "tok", "NOTIFY_IF_IDLE": "false"},
+        ),
+        patch("scripts.wikimedia_upload_status.boto3.client", return_value=object()),
+        patch("scripts.wikimedia_upload_status.ssm_run", return_value=sessions_out),
+        patch(
+            "scripts.wikimedia_upload_status.fetch_memory_snapshot", return_value=None
+        ),
+        patch("scripts.wikimedia_upload_status._format_slots_line", return_value=None),
+        patch(
+            "scripts.wikimedia_upload_status.find_active_label",
+            return_value=("bpl+phillips-academy", 1700000000),
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.get_phase_and_progress",
+            return_value=("Uploading (10 / 100 files, ~10.0%)", 1700000000),
+        ),
+        patch("scripts.wikimedia_upload_status.requests.post", side_effect=fake_post),
+    ):
+        main()
+
+    section_text = next(
+        b["text"]["text"]
+        for b in captured["payload"]["blocks"]
+        if b.get("type") == "section"
+    )
+    assert "bpl+phillips-academy" in section_text
+    # No position bracket on a single-label session.
+    assert "[1/1]" not in section_text
+    assert "[/" not in section_text


### PR DESCRIPTION
## Two display-layer enhancements to `/wikimedia-status`

### 1. Upload progress reports files, not items

**Before**:
```
texas+stephen-f-austin-east-texas-research-center (+72 more)  Uploading (1,316 / 5,512, ~23.9%)
```

**After**:
```
texas+stephen-f-austin-east-texas-research-center [73/73]  Uploading (4,180 / 23,840 files, ~17.5%)
```

The item-level denominator (`csv row count`) treated a 100-page newspaper the same as a 1-image photo, so the percentage was wildly inaccurate for any hub with multi-page items.

The downloader already emits a per-item summary line — `Item <dpla_id>: N ordinals (skipped=..., fetched=..., refreshed=...)` — at the end of each item. Sum N across all those lines and we have the true file count. Combined with the existing upload-log counts (`Uploaded to`, `Skipping ... Already exists on commons`), the file-level numerator and denominator are both readily available.

**Implementation**: one extra POSIX-awk pass added to the existing SSM round-trip in `get_phase_and_progress` — no additional round-trips. Falls back to the item-level form when no download log is found (legacy sessions, pre-PR-272 logs) so the readout doesn't degrade for old shapes.

### 2. `[<pos>/<total>]` position-in-chain annotation

The prior `(+N more)` form ambiguously displayed both first-position and last-position in a batch identically — `(+72 more)` for a 73-target batch could mean "this is the first and 72 more are coming" or "this is the last with 72 already done." Replaced with `[<pos>/<total>]`.

Single-label sessions stay bare (no `[1/1]` noise).

## Tests

36 tests pass total, including 5 new:
- `test_upload_progress_reports_file_level_when_download_log_available`
- `test_upload_progress_falls_back_to_item_level_when_no_download_log`
- `test_upload_progress_passes_label_glob_into_download_log_lookup` (regression guard against summing sibling labels' download logs)
- `test_fetch_position_annotation_for_multi_label_batch`
- `test_fetch_no_position_annotation_for_single_label_session`

## Test plan

- [ ] CI green
- [ ] Run `/wikimedia-status` on a batch with at least one multi-institution session and at least one upload-phase session
- [ ] Confirm: position annotation `[X/N]` visible on multi-label rows, file-level percent on Uploading rows, item-level percent unchanged on Downloading and SDC syncing rows (those are item-level by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the `/wikimedia-status` endpoint’s display-layer output for the Wikimedia ingestion system (changes the user-visible status text/formatting, but not the endpoint or response schema).

### File-level upload progress reporting
Upload-phase progress now derives *file* counts by summing per-item ordinal totals from the download log lines (`Item <dpla_id>: N ordinals...`) instead of using item-count denominators that treated multi-page hubs like single images. `get_phase_and_progress`:
- Locates the matching `*-<label>-download.log`
- Runs a single POSIX-awk pass to sum ordinal counts
- Computes progress as `files_done / total_ordinals` when available, otherwise falls back to the legacy item-level behavior

This corrects progress percentages for multi-page sources (e.g., `Uploading (4,180 / 23,840 files, ~17.5%)` instead of `Uploading (1,316 / 5,512, ~23.9%)`).

### Position-in-chain annotation for batch sessions
Multi-institution batch sessions now show unambiguous position formatting as `[pos/total]` (e.g., `... [73/73]`) instead of the previous ambiguous `(+N more)` notation. Single-label sessions remain unannotated to avoid extra clutter.

### Changes
- **scripts/wikimedia_upload_status.py**: Updated `get_phase_and_progress` to parse and sum ordinal totals from the label-matched download log; adjusted status rendering to use file-level progress when available; changed `_with_batch_suffix` to emit `[pos/total]` formatting.
- **tests/test_wikimedia_upload_status.py**: Added 5 tests covering file-level progress (with/without download logs), scoped download-log lookup by label glob, and position annotation behavior for multi- vs single-label sessions.

### Release/deployment and operational impact (per checklist)
- No manual pipeline trigger required; no ECS redeployment/infrastructure configuration changes.
- No environment variable or AWS Secrets Manager key changes.
- No database migrations.
- No new external data inputs.
- Security implications: none (display/status logic only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->