### PR TITLE
wikimedia-status: fix file-level upload progress (glob quoting) + extend to SDC phase

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -197,7 +197,13 @@ def get_phase_and_progress(
     # download log exists for this label yet (sessions still in
     # get-ids-es or the legacy single-log layout); the Upload branch
     # falls back to item-count in that case.
-    download_glob = shlex.quote(f"*-{label}-download.log")
+    #
+    # The label is interpolated directly into the glob pattern below
+    # (NOT shlex.quote'd) — single-quoting would disable shell glob
+    # expansion: `ls -t '*-foo.log'` looks for a literal file named
+    # `*-foo.log` rather than expanding the `*`. Labels are pure slug
+    # characters ([a-z0-9+\-]) with no shell metacharacters, so direct
+    # interpolation is safe.
     # POSIX-awk ordinal summer: every `Item <id>: <N> ordinals (...)` line
     # the downloader emits per-item gets its N picked out by walking fields
     # until the "ordinals" token, then summing the preceding field. The
@@ -235,7 +241,7 @@ def get_phase_and_progress(
         f"' {log_path} 2>/dev/null || printf '0\\n0\\n0\\n0\\n'; "
         f"{csv_count_cmd}; "
         f"echo {sep}; "
-        f"DOWNLOG=$(ls -t {log_dir}/{download_glob} 2>/dev/null | head -1); "
+        f"DOWNLOG=$(ls -t {log_dir}/*-{label}-download.log 2>/dev/null | head -1); "
         f'if [ -n "$DOWNLOG" ]; then '
         f"awk '{ordinals_awk}' \"$DOWNLOG\" 2>/dev/null || echo 0; "
         f"else echo 0; fi",

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -237,8 +237,9 @@ def get_phase_and_progress(
         f"/Uploaded to/ {{u++}} "
         f"/Skipping.*Already exists on commons/ {{s++}} "
         f"/COUNTS:/ {{c++}} "
-        f"END {{ print d+0; print u+0; print s+0; print c+0 }}"
-        f"' {log_path} 2>/dev/null || printf '0\\n0\\n0\\n0\\n'; "
+        f"/-- Ordinal [0-9]+:/ {{o++}} "
+        f"END {{ print d+0; print u+0; print s+0; print c+0; print o+0 }}"
+        f"' {log_path} 2>/dev/null || printf '0\\n0\\n0\\n0\\n0\\n'; "
         f"{csv_count_cmd}; "
         f"echo {sep}; "
         f"DOWNLOG=$(ls -t {log_dir}/*-{label}-download.log 2>/dev/null | head -1); "
@@ -260,13 +261,17 @@ def get_phase_and_progress(
     count_lines = sections[2].strip().splitlines() if len(sections) > 2 else []
 
     # Layout matches the awk-then-wc shell command above: the awk pass emits
-    # four counts (DPLA-ID, Uploaded, Skipping, COUNTS) and then `wc -l`
-    # emits the CSV total — five lines in total.
+    # five counts (DPLA-ID, Uploaded, Skipping, COUNTS, Ordinal) and then
+    # `wc -l` emits the CSV total — six lines in total. ``ordinal_count``
+    # is the count of ``-- Ordinal N:`` markers in the active log, which
+    # the SDC phase emits one of per file (numerator for SDC's file-level
+    # progress).
     dpla_id_count = _safe_int(count_lines[0]) if len(count_lines) > 0 else 0
     uploaded_count = _safe_int(count_lines[1]) if len(count_lines) > 1 else 0
     skipped_count = _safe_int(count_lines[2]) if len(count_lines) > 2 else 0
     counts_marker = _safe_int(count_lines[3]) if len(count_lines) > 3 else 0
-    total = _safe_int(count_lines[4]) if len(count_lines) > 4 else 0
+    ordinal_count = _safe_int(count_lines[4]) if len(count_lines) > 4 else 0
+    total = _safe_int(count_lines[5]) if len(count_lines) > 5 else 0
 
     # Sum of `Item <id>: N ordinals` lines from the download log — the true
     # file count once downloads have completed. 0 when no download log was
@@ -356,14 +361,17 @@ def get_phase_and_progress(
 
     if log_file.endswith("-sdc.log"):
         # sdc-sync's _run_partner_mode logs `DPLA ID: <id> (n/total)` per
-        # item — same `DPLA ID:` marker the awk pass already counts. Uses
-        # the COUNTS: terminal marker as the completion signal, matching
-        # the downloader/uploader convention. The reported figure is
-        # "items processed" (i.e. iterated by the loop) rather than
-        # "items synced" because some processed items may have been
-        # skipped for missing sidecars or mapping issues — the Slack
-        # summary surfaces the real synced count via the tracker's
-        # SDC_ITEMS_SYNCED line.
+        # item and `-- Ordinal N: <mediaid>` per ordinal. Uses the
+        # COUNTS: terminal marker as the completion signal, matching the
+        # downloader/uploader convention. The reported in-progress
+        # figure is file-level (`ordinal_count` numerator over
+        # `total_ordinals` denominator from the download log) when both
+        # are available — same rationale as the Upload branch, since
+        # multi-page items take proportionally more SDC-write work than
+        # 1-image items. Falls back to item-level when no download log
+        # has been found (legacy sessions). Terminal completion still
+        # reports items, since the tracker's SDC_ITEMS_SYNCED is per
+        # item.
         if dpla_id_count == 0:
             start_state = "queued" if waiting_on_slots else "starting..."
             return f"SDC syncing ({start_state}){slot_suffix}", log_mtime
@@ -372,8 +380,13 @@ def get_phase_and_progress(
                 f"{_SDC_COMPLETE_PREFIX} ({dpla_id_count:,} items processed)",
                 log_mtime,
             )
+        if total_ordinals > 0 and ordinal_count > 0:
+            files_pct = f"{ordinal_count / total_ordinals * 100:.1f}"
+            progress = f"{ordinal_count:,} / {total_ordinals:,} files, ~{files_pct}%"
+        else:
+            progress = f"{dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%"
         return (
-            f"SDC syncing ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){slot_suffix}{stale_suffix}",
+            f"SDC syncing ({progress}){slot_suffix}{stale_suffix}",
             log_mtime,
         )
 

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -51,6 +51,14 @@ _DOWNLOAD_COMPLETE_PREFIX = "Download complete"
 # Uploads normally complete items in seconds; downloads in seconds to low minutes.
 _STALE_SECONDS = 1800  # 30 minutes
 
+# Labels constructed by ``parse_session_labels`` and ``PARTNER_HUBS`` are
+# slug-form: hub-name-or-institution-name lowercase plus ``+`` and ``-``.
+# The download-log glob below interpolates ``label`` directly into a
+# shell command (unquoted, so the ``*`` expands), so we enforce the
+# slug shape at runtime to keep that interpolation safe regardless of
+# how callers obtain the label.
+_LABEL_SLUG_RE = re.compile(r"[a-z0-9+\-]+")
+
 
 def find_active_label(client, labels: list[str]) -> tuple[str, int] | None:
     """Return ``(label, log_mtime)`` for the most-recently-written log file
@@ -113,7 +121,18 @@ def get_phase_and_progress(
     didn't write a ``COUNTS:`` terminal marker (so it doesn't look
     "complete" via the count-marker test) must not eclipse a subsequent
     label that's actively progressing now.
+
+    ``label`` MUST be slug-shaped (``[a-z0-9+\\-]+``) — the download-log
+    glob below interpolates it unquoted into a shell command. A
+    non-slug label is rejected here so the shell-interpolation
+    contract is enforced at the boundary rather than relying on every
+    caller to feed only slug-form values.
     """
+    if not _LABEL_SLUG_RE.fullmatch(label):
+        raise ValueError(
+            f"label must be slug-shaped ([a-z0-9+-]+) for safe shell "
+            f"interpolation; got {label!r}"
+        )
 
     def _safe_int(s: str) -> int:
         try:
@@ -190,20 +209,18 @@ def get_phase_and_progress(
 
     sep = "__WM_SEP__"
     # Locate the corresponding -download.log for this label so we can sum
-    # total ordinals across all items — gives Upload-phase progress a
-    # file-level denominator instead of the item-level one that makes
-    # multi-page items vastly under-represent work done (a 100-page
-    # newspaper counts the same as a 1-image photo). Empty when no
-    # download log exists for this label yet (sessions still in
-    # get-ids-es or the legacy single-log layout); the Upload branch
-    # falls back to item-count in that case.
+    # total ordinals across all items — gives Upload- and SDC-phase
+    # progress a file-level denominator instead of the item-level one
+    # that makes multi-page items vastly under-represent work done (a
+    # 100-page newspaper counts the same as a 1-image photo). Empty
+    # when no download log exists for this label yet (sessions still
+    # in get-ids-es or the legacy single-log layout); the file-level
+    # branches fall back to item-count in that case.
     #
-    # The label is interpolated directly into the glob pattern below
-    # (NOT shlex.quote'd) — single-quoting would disable shell glob
-    # expansion: `ls -t '*-foo.log'` looks for a literal file named
-    # `*-foo.log` rather than expanding the `*`. Labels are pure slug
-    # characters ([a-z0-9+\-]) with no shell metacharacters, so direct
-    # interpolation is safe.
+    # The label is interpolated directly into the glob below (no
+    # shlex.quote) — single-quoting would disable shell glob expansion
+    # so the ``*`` would no longer expand. The slug-shape guard at the
+    # top of this function makes the unquoted interpolation safe.
     # POSIX-awk ordinal summer: every `Item <id>: <N> ordinals (...)` line
     # the downloader emits per-item gets its N picked out by walking fields
     # until the "ordinals" token, then summing the preceding field. The

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -136,7 +136,12 @@ def _fake_ssm_for_phase(
 
     Sequence (matches the real two-call flow):
       1. precheck — `session_created\nlog_filename`
-      2. main — `now\nmtime\nSEP\ntail\nSEP\n<5 lines of awk + wc>\nSEP\n<total_ordinals>`
+      2. main — `now\nmtime\nSEP\ntail\nSEP\n<6 lines of awk + wc>\nSEP\n<total_ordinals>`
+
+    ``awk_counts`` is the five-element awk-emitted prefix in order:
+    ``[dpla_id_count, uploaded_count, skipped_count, counts_marker,
+    ordinal_count]``. The trailing ``csv_total`` from ``wc -l`` is
+    appended automatically.
 
     ``mtime`` is parameterised so tests can verify the mtime tiebreak in
     ``main`` — an "aborted phase" fake with an earlier mtime must be
@@ -148,7 +153,7 @@ def _fake_ssm_for_phase(
     ``total_ordinals`` is the file-level denominator the helper now
     derives from the corresponding download log; default 0 mirrors the
     "no download log found" case (legacy sessions or pre-PR-272 logs),
-    where the Upload branch falls back to item-count.
+    where the Upload and SDC branches fall back to item-count.
     """
     call_count = [0]
     sep = "__WM_SEP__"
@@ -195,7 +200,7 @@ def test_get_phase_and_progress_retry_label_reads_retry_dir_csvs():
         # then csv total = 5 (sum of download+upload retry CSVs)
         return (
             "1700000000\n1700000000\n__WM_SEP__\nDownloading something\n"
-            "__WM_SEP__\n2\n0\n0\n0\n5\n"
+            "__WM_SEP__\n2\n0\n0\n0\n0\n5\n"
         )
 
     with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
@@ -242,7 +247,7 @@ def test_get_phase_and_progress_retry_label_uses_partner_dir_name():
         captured.append(command)
         if len(captured) == 1:
             return "1700000000\n20260601-120000-retry-si-download.log\n"
-        return "1700000000\n1700000000\n__WM_SEP__\n.\n__WM_SEP__\n1\n0\n0\n0\n3\n"
+        return "1700000000\n1700000000\n__WM_SEP__\n.\n__WM_SEP__\n1\n0\n0\n0\n0\n3\n"
 
     with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
         get_phase_and_progress(
@@ -270,7 +275,7 @@ def test_get_phase_and_progress_reports_sdc_syncing_in_progress():
     # awk_counts layout: [dpla_id_count, uploaded, skipping, counts_marker]
     fake = _fake_ssm_for_phase(
         log_filename="20260525-200000-minnesota-sdc.log",
-        awk_counts=[3, 0, 0, 0],
+        awk_counts=[3, 0, 0, 0, 0],
         csv_total=10,
     )
     with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
@@ -298,7 +303,7 @@ def test_get_phase_and_progress_flags_waiting_on_slots():
 
     fake = _fake_ssm_for_phase(
         log_filename="20260616-000000-nara+x-sdc.log",
-        awk_counts=[100, 0, 0, 0],
+        awk_counts=[100, 0, 0, 0, 0],
         csv_total=200,
         mtime=1700000000,
         now=1700000000
@@ -324,7 +329,7 @@ def test_get_phase_and_progress_reports_sdc_complete():
 
     fake = _fake_ssm_for_phase(
         log_filename="20260525-200000-minnesota-sdc.log",
-        awk_counts=[10, 0, 0, 1],  # 10 items, COUNTS marker present
+        awk_counts=[10, 0, 0, 1, 0],  # 10 items, COUNTS marker present
         csv_total=10,
     )
     with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
@@ -347,7 +352,7 @@ def test_get_phase_and_progress_reports_sdc_starting_with_no_items():
 
     fake = _fake_ssm_for_phase(
         log_filename="20260525-200000-minnesota-sdc.log",
-        awk_counts=[0, 0, 0, 0],
+        awk_counts=[0, 0, 0, 0, 0],
         csv_total=10,
     )
     with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
@@ -369,7 +374,7 @@ def test_get_phase_and_progress_reports_sdc_queued_when_waiting():
 
     fake = _fake_ssm_for_phase(
         log_filename="20260525-200000-minnesota-sdc.log",
-        awk_counts=[0, 0, 0, 0],
+        awk_counts=[0, 0, 0, 0, 0],
         csv_total=10,
         tail=" -- All 16 worker slots busy; waiting for capacity.",
     )
@@ -414,7 +419,7 @@ def test_main_picks_latest_active_label_by_mtime_when_earlier_label_aborted():
 
     aborted = _fake_ssm_for_phase(
         log_filename="20260528-091047-nara+william-j-clinton-library-sdc.log",
-        awk_counts=[250, 0, 0, 0],  # no COUNTS marker → not complete
+        awk_counts=[250, 0, 0, 0, 0],  # no COUNTS marker → not complete
         csv_total=4879,
         mtime=ABORT_MTIME,
     )
@@ -428,7 +433,7 @@ def test_main_picks_latest_active_label_by_mtime_when_earlier_label_aborted():
 
     active = _fake_ssm_for_phase(
         log_filename="20260528-140954-nara+center-for-legislative-archives-sdc.log",
-        awk_counts=[3101, 0, 0, 0],
+        awk_counts=[3101, 0, 0, 0, 0],
         csv_total=6946,
         mtime=ACTIVE_MTIME,
     )
@@ -918,7 +923,7 @@ def test_upload_progress_reports_file_level_when_download_log_available():
     fake = _fake_ssm_for_phase(
         log_filename="20260528-091047-bpl+phillips-academy-upload.log",
         # [dpla_id_count, uploaded, skipping, counts]
-        awk_counts=[200, 1200, 300, 0],
+        awk_counts=[200, 1200, 300, 0, 0],
         csv_total=400,  # items — used as fallback only
         total_ordinals=6000,
     )
@@ -950,7 +955,7 @@ def test_upload_progress_falls_back_to_item_level_when_no_download_log():
 
     fake = _fake_ssm_for_phase(
         log_filename="20260528-091047-bpl+phillips-academy-upload.log",
-        awk_counts=[50, 30, 5, 0],
+        awk_counts=[50, 30, 5, 0, 0],
         csv_total=200,
         total_ordinals=0,  # no download log found
     )
@@ -965,6 +970,92 @@ def test_upload_progress_falls_back_to_item_level_when_no_download_log():
     # Item-level: 50 / 200 = 25.0%
     assert "50 / 200 items" in phase, phase
     assert "~25.0%" in phase, phase
+
+
+def test_sdc_progress_reports_file_level_when_download_log_available():
+    """Mirror of the Upload-phase file-level test for SDC. When the
+    SDC log carries per-ordinal ``-- Ordinal N:`` markers and the
+    download log gives a total file count, SDC progress is file-level.
+    Multi-page newspaper items would otherwise hide the actual SDC
+    work — the bot writes structured data on every ordinal, not just
+    once per item."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    # 400 items processed, 1,800 ordinals touched, 6,000 total = 30.0%
+    fake = _fake_ssm_for_phase(
+        log_filename="20260622-161651-texas+stephen-f-austin-sdc.log",
+        awk_counts=[400, 0, 0, 0, 1800],
+        csv_total=939,
+        total_ordinals=6000,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-texas+stephen-f-austin",
+            hub="texas",
+            label="texas+stephen-f-austin",
+        )
+    assert phase is not None
+    assert "1,800 / 6,000 files" in phase, phase
+    assert "~30.0%" in phase, phase
+    assert "items" not in phase, (
+        f"file-level reporting must replace item-level in SDC: got {phase!r}"
+    )
+
+
+def test_sdc_progress_falls_back_to_item_level_when_no_download_log():
+    """SDC's item-level fallback fires when no download log was found
+    (legacy sessions, or download phase lives elsewhere)."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_phase(
+        log_filename="20260622-161651-texas+stephen-f-austin-sdc.log",
+        awk_counts=[400, 0, 0, 0, 1800],
+        csv_total=939,
+        total_ordinals=0,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-texas+stephen-f-austin",
+            hub="texas",
+            label="texas+stephen-f-austin",
+        )
+    assert phase is not None
+    assert "400 / 939 items" in phase, phase
+
+
+def test_sdc_progress_falls_back_to_item_level_when_no_ordinal_markers_yet():
+    """Defensive: a download log can be present (total_ordinals > 0)
+    while the SDC log is too new to have emitted any
+    ``-- Ordinal N:`` markers yet (just-started session — items are
+    starting but their first ordinals haven't been touched). Use the
+    item-level form rather than reporting 0.0%, which would look
+    visually identical to "not started" while the session is in fact
+    running its first item."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_phase(
+        log_filename="20260622-161651-texas+stephen-f-austin-sdc.log",
+        awk_counts=[5, 0, 0, 0, 0],
+        csv_total=939,
+        total_ordinals=6000,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-texas+stephen-f-austin",
+            hub="texas",
+            label="texas+stephen-f-austin",
+        )
+    assert phase is not None
+    assert "5 / 939 items" in phase, phase
 
 
 def test_upload_progress_passes_label_glob_into_download_log_lookup():
@@ -984,7 +1075,7 @@ def test_upload_progress_passes_label_glob_into_download_log_lookup():
             return "1700000000\n20260528-091047-bpl+phillips-academy-upload.log\n"
         return (
             "1700000000\n1700000000\n__WM_SEP__\n.\n__WM_SEP__\n"
-            "10\n5\n2\n0\n50\n__WM_SEP__\n200\n"
+            "10\n5\n2\n0\n0\n50\n__WM_SEP__\n200\n"
         )
 
     with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
@@ -1024,7 +1115,7 @@ def test_download_log_glob_is_not_single_quoted():
             return "1700000000\n20260528-091047-bpl+phillips-academy-upload.log\n"
         return (
             "1700000000\n1700000000\n__WM_SEP__\n.\n__WM_SEP__\n"
-            "10\n5\n2\n0\n50\n__WM_SEP__\n200\n"
+            "10\n5\n2\n0\n0\n50\n__WM_SEP__\n200\n"
         )
 
     with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -1091,6 +1091,37 @@ def test_upload_progress_passes_label_glob_into_download_log_lookup():
     assert "bpl+phillips-academy-download.log" in main_cmd, main_cmd
 
 
+def test_get_phase_and_progress_rejects_non_slug_label():
+    """Defense-in-depth: the label is interpolated unquoted into the
+    download-log glob, so the function MUST refuse non-slug-shaped
+    labels rather than relying on caller discipline. A maliciously
+    crafted label like ``"bpl;rm -rf /tmp"`` would otherwise produce
+    a shell-command injection at the SSM round-trip.
+
+    The slug shape is ``[a-z0-9+\\-]+`` — what ``parse_session_labels``
+    and ``PARTNER_HUBS`` produce. Anything else raises ``ValueError``
+    at the function boundary."""
+    import pytest
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    for bad in (
+        "bpl; echo pwned",  # command separator
+        "bpl|echo pwned",  # pipe
+        "bpl$(id)",  # command substitution
+        "bpl`id`",  # backtick command substitution
+        "bpl 'a",  # quote + space
+        "bpl/../etc/passwd",  # path traversal
+        "bpl*",  # raw glob metachar
+        "BPL",  # uppercase (slug is lowercase only)
+        "",  # empty
+    ):
+        with pytest.raises(ValueError, match="slug-shaped"):
+            get_phase_and_progress(
+                client=None, session="wikimedia-x", hub="bpl", label=bad
+            )
+
+
 def test_download_log_glob_is_not_single_quoted():
     """Regression: the original implementation shlex.quote'd the glob
     pattern, which wraps it in single quotes and disables shell glob

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -1000,6 +1000,53 @@ def test_upload_progress_passes_label_glob_into_download_log_lookup():
     assert "bpl+phillips-academy-download.log" in main_cmd, main_cmd
 
 
+def test_download_log_glob_is_not_single_quoted():
+    """Regression: the original implementation shlex.quote'd the glob
+    pattern, which wraps it in single quotes and disables shell glob
+    expansion. ``ls -t '*-foo-download.log'`` looks for a literal file
+    named ``*-foo-download.log`` rather than expanding the ``*``. The
+    bug silently fell back to item-level reporting in production
+    because total_ordinals was always 0.
+
+    Pin the contract: the glob's ``*`` must be unquoted in the rendered
+    SSM command so the shell expands it. Labels are pure slug
+    characters with no shell metacharacters, so direct interpolation
+    is safe."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    captured: list[str] = []
+
+    def fake_ssm_run(_client, command, **_kwargs):
+        captured.append(command)
+        if len(captured) == 1:
+            return "1700000000\n20260528-091047-bpl+phillips-academy-upload.log\n"
+        return (
+            "1700000000\n1700000000\n__WM_SEP__\n.\n__WM_SEP__\n"
+            "10\n5\n2\n0\n50\n__WM_SEP__\n200\n"
+        )
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
+        get_phase_and_progress(
+            client=None,
+            session="wikimedia-bpl+phillips-academy",
+            hub="bpl",
+            label="bpl+phillips-academy",
+        )
+    main_cmd = captured[1]
+    # The bug shape was `ls -t <log_dir>/'*-bpl+phillips-academy-download.log'`
+    # — i.e. the literal `'*-` pattern. The fix renders it as
+    # `ls -t <log_dir>/*-bpl+phillips-academy-download.log` (no quotes
+    # around the asterisk), so shell glob expansion fires.
+    assert "/'*-" not in main_cmd, (
+        "download-log glob must not be wrapped in single quotes — "
+        f"shell glob expansion would be disabled. Rendered: {main_cmd!r}"
+    )
+    # Positive check: the unquoted glob is present.
+    assert "/*-bpl+phillips-academy-download.log" in main_cmd, main_cmd
+
+
 def test_fetch_position_annotation_for_multi_label_batch():
     """Multi-label batch sessions get a `[<pos>/<total>]` suffix on the
     active label, replacing the prior `(+N more)` form. Lets the


### PR DESCRIPTION
## Two related fixes/enhancements to `/wikimedia-status`

### 1. Bugfix: file-level upload progress was silently disabled

PR #333 shipped file-level upload progress but it never fired in production — Slack continued to post `Uploading (1,322 / 5,512 items, ~24.0%)` (item-level fallback) instead of the file-level form.

**Root cause**:

```python
download_glob = shlex.quote(f"*-{label}-download.log")
... f"DOWNLOG=$(ls -t {log_dir}/{download_glob} ..."
```

`shlex.quote` wraps its value in single quotes. The rendered SSM command became:

```
ls -t '/home/ec2-user/.../logs'/'*-nara+...-download.log'
```

Bash does **not** expand globs inside single quotes — `ls` looked for a literal file named `*-…-download.log`, `DOWNLOG` came back empty, the awk pass over the download log never fired, `total_ordinals` stayed at 0, the Upload branch's `if total_ordinals > 0` guard fell through.

Verified directly: 5,512 items + 229,105 ordinals in the active NARA Kennedy-papers session's download log. Awk + grep work fine; only the production glob was broken.

**Fix**: interpolate the label directly into the glob (no quoting). Labels are pure slug characters (`[a-z0-9+\-]`) with no shell metacharacters, so direct interpolation is safe — and the `*` needs to be outside any quoting to expand. Regression test pins both the bug shape (`/'*-` must not appear) and the fix shape (unquoted glob must).

### 2. Enhancement: extend file-level progress to the SDC phase

PR #333 scoped to upload progress only, but the SDC phase has the same defect — it reports items but does per-ordinal work (`{{Touched}}` + per-ordinal MediaInfo writes). A 100-page newspaper item takes ~100× the SDC work of a 1-image item; reporting at item-level under- or over-represents real progress.

**Same data source**: the SDC log emits `-- Ordinal N: <mediaid>` on every ordinal it touches. Counting those gives the numerator; the denominator is the same `total_ordinals` from the download log.

The awk pass now emits five counts (DPLA-ID, Uploaded, Skipping, COUNTS, Ordinal) plus the CSV total instead of four+total. SDC branch reports `SDC syncing (3,575 / 23,840 files, ~15.0%)` when both `total_ordinals > 0` and `ordinal_count > 0`; falls back to item-level otherwise (legacy sessions; just-started SDC sessions before the first ordinal marker is emitted).

## Tests

40 tests pass total. New since the original PR:

- `test_download_log_glob_is_not_single_quoted` — pin the glob-quoting bug shape
- `test_sdc_progress_reports_file_level_when_download_log_available` — happy path for SDC
- `test_sdc_progress_falls_back_to_item_level_when_no_download_log` — legacy fallback
- `test_sdc_progress_falls_back_to_item_level_when_no_ordinal_markers_yet` — defensive against just-started sessions

## Test plan

- [ ] CI green
- [ ] Run `/wikimedia-status` against the same active session(s) and confirm BOTH Upload-phase AND SDC-phase rows now show file-level progress (instead of `items, ~%`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a bug in `get_phase_and_progress()` where file-level progress reporting silently fell back to item-level metrics in production. The root cause was using `shlex.quote()` on the download-log glob pattern, which wrapped the glob in single quotes; in bash, `*` does not expand inside single quotes. As a result, the rendered SSM command searched for a literal filename (e.g., `*-<label>-download.log`) instead of expanding the glob, leaving `DOWNLOG` empty. That skipped the download-log `awk` probe, kept `total_ordinals` at 0, and triggered the item-level fallback—showing progress like “Uploading (1,322 / 5,512 items, ~24.0%)” instead of file-level metrics.

The fix interpolates the label unquoted into the glob pattern. Since labels are slug-safe, this restores correct glob expansion and file-level progress.

In addition, the PR extends file-level progress reporting to the SDC syncing phase by counting per-ordinal markers emitted by the SDC sync log and using the same `total_ordinals` denominator from the download log. If `total_ordinals` or the ordinal marker count is unavailable/0, the logic falls back to item-level reporting.

## Changes

- **`scripts/wikimedia_upload_status.py`**
  - Removes single-quoting around the `ls -t` download-log glob so shell glob expansion occurs.
  - Adds defensive label validation via a module-scope `_LABEL_SLUG_RE` check at the top of `get_phase_and_progress()`; invalid (non-slug-shaped) labels raise `ValueError` to prevent unsafe unquoted interpolation.
  - Updates the `awk`-probe counting contract to include ordinal marker counts (adjusting parsing accordingly).
  - Updates SDC in-progress computation to prefer file-level progress (`ordinal_count / total_ordinals`) when both values are present; otherwise falls back to item-level progress.

- **`tests/test_wikimedia_upload_status.py`**
  - Adds `test_download_log_glob_is_not_single_quoted()` to assert the rendered SSM command does not single-quote the glob and therefore will expand `*`.
  - Adds label-safety coverage to ensure `get_phase_and_progress()` rejects non-slug-shaped inputs.
  - Adds/extends SDC tests to validate file-level vs item-level fallback behavior depending on download-log availability and whether ordinal markers have appeared.

## Testing & Validation

- **41 tests pass total**.
- Manual verification confirmed **5,512 items** and **229,105 ordinals** in the active NARA Kennedy-papers session’s download log.

## Deployment / Infra impact

- **No manual pipeline trigger or ECS redeployment required**; changes take effect on the next scheduled/triggered workflow run.
- **No environment variables or AWS Secrets Manager keys changed**.
- **No database migration**.
- **No shared infrastructure configuration changes** (CodePipeline/CodeBuild/ECS/IAM).
- **No public API response shape changes or endpoint additions/removals**.

## Security considerations

- Addresses a shell-safety risk by adding explicit runtime validation of `label` against the required slug shape before using unquoted interpolation into an `ls ... *` glob.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->