### PR TITLE
Maintain mode: title-drift rename (#3) + status-report cooperation

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -415,6 +415,7 @@ def notify_sdc_complete(
     elapsed_seconds: float,
     dry_run: bool = False,
     workers: int = 1,
+    maintain: bool = False,
 ) -> None:
     """Post the SDC phase's completion summary to #tech-alerts.
 
@@ -445,24 +446,41 @@ def notify_sdc_complete(
     avg_wait = tracker.count(Result.SDC_SLOT_WAIT_SECONDS) / max(1, workers)
     wait_pct = (avg_wait / elapsed_seconds * 100) if elapsed_seconds > 0 else 0
 
+    stats_lines = [
+        f"ITEMS SYNCED:         {tracker.count(Result.SDC_ITEMS_SYNCED):,}",
+        f"ITEMS PARTIAL:        {tracker.count(Result.SDC_ITEMS_PARTIALLY_SYNCED):,}",
+        f"PAGES EDITED:         {tracker.count(Result.SDC_PAGES_EDITED):,}",
+        f"CLAIMS ADDED:         {tracker.count(Result.SDC_CLAIMS_ADDED):,}",
+        f"REFS ADDED:           {tracker.count(Result.SDC_REFS_ADDED):,}",
+        f"REMOVALS:             {tracker.count(Result.SDC_REMOVALS):,}",
+        f"SKIPPED (no sidecar): {tracker.count(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR):,}",
+        f"SKIPPED (mapping):    {tracker.count(Result.SDC_ITEMS_SKIPPED_MAPPING):,}",
+        f"SKIPPED (error):      {tracker.count(Result.SDC_ITEMS_SKIPPED_ERROR):,}",
+        f"ORDINAL MISSING:      {tracker.count(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY):,}",
+        f"ORDINAL NO PAGEID:    {tracker.count(Result.SDC_ORDINALS_SKIPPED_MISSING_PAGEID):,}",
+        f"ORDINAL ERRORS:       {tracker.count(Result.SDC_ORDINALS_SKIPPED_ERROR):,}",
+    ]
+    # Maintain mode also renames title-drifted files to their canonical title;
+    # surface those outcomes (only on maintain runs, to keep the regular SDC
+    # summary uncluttered). RENAME BLOCKED counts files left non-canonical
+    # because the canonical title was occupied — flagged for DPLA follow-up.
+    if maintain:
+        stats_lines.extend(
+            [
+                f"RENAMED:              {tracker.count(Result.MAINTAIN_RENAMED):,}",
+                f"RENAME BLOCKED:       {tracker.count(Result.MAINTAIN_RENAME_BLOCKED):,}",
+            ]
+        )
+    stats_lines.extend(
+        [
+            f"SLOT WAIT (avg/wkr):  {_format_runtime(avg_wait)} ({wait_pct:.0f}% of runtime)",
+            f"Runtime:              {runtime}",
+        ]
+    )
+
     _post_completion_notice(
         token=token,
         header=f"*Wikimedia SDC Complete: {effective_label}*{dry_run_note}",
         plain_text=f"Wikimedia SDC complete: {effective_label}",
-        stats_lines=[
-            f"ITEMS SYNCED:         {tracker.count(Result.SDC_ITEMS_SYNCED):,}",
-            f"ITEMS PARTIAL:        {tracker.count(Result.SDC_ITEMS_PARTIALLY_SYNCED):,}",
-            f"PAGES EDITED:         {tracker.count(Result.SDC_PAGES_EDITED):,}",
-            f"CLAIMS ADDED:         {tracker.count(Result.SDC_CLAIMS_ADDED):,}",
-            f"REFS ADDED:           {tracker.count(Result.SDC_REFS_ADDED):,}",
-            f"REMOVALS:             {tracker.count(Result.SDC_REMOVALS):,}",
-            f"SKIPPED (no sidecar): {tracker.count(Result.SDC_ITEMS_SKIPPED_NO_SIDECAR):,}",
-            f"SKIPPED (mapping):    {tracker.count(Result.SDC_ITEMS_SKIPPED_MAPPING):,}",
-            f"SKIPPED (error):      {tracker.count(Result.SDC_ITEMS_SKIPPED_ERROR):,}",
-            f"ORDINAL MISSING:      {tracker.count(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY):,}",
-            f"ORDINAL NO PAGEID:    {tracker.count(Result.SDC_ORDINALS_SKIPPED_MISSING_PAGEID):,}",
-            f"ORDINAL ERRORS:       {tracker.count(Result.SDC_ORDINALS_SKIPPED_ERROR):,}",
-            f"SLOT WAIT (avg/wkr):  {_format_runtime(avg_wait)} ({wait_pct:.0f}% of runtime)",
-            f"Runtime:              {runtime}",
-        ],
+        stats_lines=stats_lines,
     )

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -105,6 +105,15 @@ class Result(Enum):
     # Aggregate worker-seconds blocked on a box-wide slot (WorkerSlotBudget
     # contention). Summed across workers; the consumer divides by worker count.
     SDC_SLOT_WAIT_SECONDS = auto()
+    # Maintain-mode title-drift rename (PR B). A maintained file whose current
+    # Commons title differs from the canonical title for its re-linked DPLA id
+    # is moved to the canonical title. MAINTAIN_RENAMED counts successful
+    # moves; MAINTAIN_RENAME_BLOCKED counts files left at a non-canonical title
+    # because the canonical title was already occupied by a different page —
+    # logged as an error for DPLA to resolve later (maintain has no source
+    # bytes, so it neither inspects hashes nor picks a winner).
+    MAINTAIN_RENAMED = auto()
+    MAINTAIN_RENAME_BLOCKED = auto()
 
 
 class Tracker:

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -17,6 +17,7 @@ NOT safe — the wbeditentity round-trip would erase that data.
 """
 
 import contextlib
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -5380,6 +5381,9 @@ def test_maintain_process_file_syncs_from_sidecar_with_page_number():
             return_value=ResolveResult("liveid", "embedded"),
         ),
         patch.object(sdc_sync, "_s3_partner", "digitalnc"),
+        # Rename is exercised in its own tests; here keep it a no-op so this
+        # test isolates the sidecar sync dispatch.
+        patch.object(sdc_sync, "_maintain_rename", side_effect=lambda fp, did: fp),
         patch.object(sdc_sync, "_maintain_sidecar_payload", return_value=payload),
         patch.object(
             sdc_sync.wikimedia,
@@ -5410,6 +5414,7 @@ def test_maintain_process_file_skips_when_no_sidecar():
             return_value=ResolveResult("liveid", "embedded"),
         ),
         patch.object(sdc_sync, "_s3_partner", "digitalnc"),
+        patch.object(sdc_sync, "_maintain_rename", side_effect=lambda fp, did: fp),
         patch.object(sdc_sync, "_maintain_sidecar_payload", return_value=None),
         patch.object(sdc_sync, "tracker", fake_tracker),
         patch.object(sdc_sync, "_safe_process_one") as mock_sync,
@@ -5436,3 +5441,165 @@ def test_maintain_process_file_live_fallback_without_from_s3():
     ):
         sdc_sync._maintain_process_file("M1", "liveid", page, "File:X.jpg", tally=None)
     mock_sync.assert_called_once_with("M1", "liveid", file_page=page)
+
+
+def _dpla_map(title):
+    return json.dumps({"sourceResource": {"title": [title]}})
+
+
+def test_maintain_canonical_title_preserves_ordinal_and_ext():
+    from tools import sdc_sync
+
+    # Real DPLA ids are 32-char md5 hex; the page-ordinal parser requires that
+    # shape, so the test uses realistically-shaped ids.
+    dead = "0123456789abcdef0123456789abcdef"
+    live = "fedcba9876543210fedcba9876543210"
+    page = MagicMock()
+    page.title.return_value = f"Old Name - DPLA - {dead} (page 2).jpg"
+    fake_client = MagicMock()
+    fake_client.get_item_metadata.return_value = _dpla_map("New Name")
+    with (
+        patch.object(sdc_sync, "_s3_partner", "digitalnc"),
+        patch.object(sdc_sync, "_s3_client", fake_client),
+    ):
+        out = sdc_sync._maintain_canonical_title(page, live)
+    # Same authority the uploader uses: new id + current title text, preserving
+    # the existing page ordinal and extension.
+    assert out == f"New Name - DPLA - {live} (page 2).jpg"
+
+
+def test_maintain_canonical_title_none_without_metadata_or_title():
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.title.return_value = "X - DPLA - id.jpg"
+    fake_client = MagicMock()
+    with (
+        patch.object(sdc_sync, "_s3_partner", "digitalnc"),
+        patch.object(sdc_sync, "_s3_client", fake_client),
+    ):
+        fake_client.get_item_metadata.return_value = None
+        assert sdc_sync._maintain_canonical_title(page, "id") is None
+        fake_client.get_item_metadata.return_value = _dpla_map("")
+        assert sdc_sync._maintain_canonical_title(page, "id") is None
+    # No --from-s3 → no canonical title (can't read the source title).
+    with patch.object(sdc_sync, "_s3_partner", None):
+        assert sdc_sync._maintain_canonical_title(page, "id") is None
+
+
+def test_maintain_rename_noop_when_already_canonical():
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.title.return_value = "Canonical - DPLA - id.jpg"
+    with (
+        patch.object(
+            sdc_sync,
+            "_maintain_canonical_title",
+            return_value="Canonical - DPLA - id.jpg",
+        ),
+    ):
+        out = sdc_sync._maintain_rename(page, "id")
+    assert out is page
+    page.move.assert_not_called()
+
+
+def test_maintain_rename_moves_and_posts_delinker_on_drift():
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.title.return_value = "Old - DPLA - deadid.jpg"
+    moved = MagicMock(name="moved_page")
+    fake_tracker = MagicMock()
+    with (
+        patch.object(
+            sdc_sync,
+            "_maintain_canonical_title",
+            return_value="Old - DPLA - liveid.jpg",
+        ),
+        patch.object(sdc_sync, "tracker", fake_tracker),
+        patch.object(sdc_sync, "site", MagicMock(), create=True),
+        patch.object(sdc_sync.wikimedia, "file_has_inbound_usage", return_value=True),
+        patch.object(
+            sdc_sync.wikimedia,
+            "build_title_drift_move_reason",
+            return_value="reason",
+        ),
+        patch.object(sdc_sync.wikimedia, "post_commonsdelinker_request") as mock_delink,
+        patch.object(
+            sdc_sync.wikimedia, "get_page", return_value=moved
+        ) as mock_getpage,
+    ):
+        out = sdc_sync._maintain_rename(page, "liveid")
+    page.move.assert_called_once()
+    assert page.move.call_args.args[0] == "File:Old - DPLA - liveid.jpg"
+    assert page.move.call_args.kwargs["noredirect"] is False
+    # Usage existed → CommonsDelinker posted with check_usage=False (gated pre-move).
+    mock_delink.assert_called_once()
+    assert mock_delink.call_args.kwargs["check_usage"] is False
+    fake_tracker.increment.assert_any_call(Result.MAINTAIN_RENAMED)
+    # Re-fetches the moved page (at the canonical title) to sync against.
+    assert mock_getpage.call_args.args[1] == "File:Old - DPLA - liveid.jpg"
+    assert out is moved
+
+
+def test_maintain_rename_blocked_when_target_occupied():
+    import pywikibot
+
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.title.return_value = "Old - DPLA - deadid.jpg"
+    page.move.side_effect = pywikibot.exceptions.ArticleExistsConflictError(page)
+    fake_tracker = MagicMock()
+    with (
+        patch.object(
+            sdc_sync,
+            "_maintain_canonical_title",
+            return_value="Old - DPLA - liveid.jpg",
+        ),
+        patch.object(sdc_sync, "tracker", fake_tracker),
+        patch.object(sdc_sync, "site", MagicMock(), create=True),
+        patch.object(sdc_sync.wikimedia, "file_has_inbound_usage", return_value=False),
+        patch.object(
+            sdc_sync.wikimedia, "build_title_drift_move_reason", return_value="reason"
+        ),
+        patch.object(sdc_sync.wikimedia, "post_commonsdelinker_request") as mock_delink,
+    ):
+        out = sdc_sync._maintain_rename(page, "liveid")
+    # Blocked → original page returned (SDC still syncs in place), error counted,
+    # no CommonsDelinker request.
+    assert out is page
+    fake_tracker.increment.assert_called_once_with(Result.MAINTAIN_RENAME_BLOCKED)
+    mock_delink.assert_not_called()
+
+
+def test_maintain_process_file_renames_before_sync():
+    from ingest_wikimedia.maintain import ResolveResult
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.text = "url=https://x/1"
+    renamed = MagicMock(name="renamed_page")
+    with (
+        patch.object(
+            sdc_sync,
+            "_maintain_resolve",
+            return_value=ResolveResult("liveid", "embedded"),
+        ),
+        patch.object(sdc_sync, "_s3_partner", "digitalnc"),
+        patch.object(sdc_sync, "_maintain_rename", return_value=renamed) as mock_rename,
+        patch.object(
+            sdc_sync, "_maintain_sidecar_payload", return_value={"claims": []}
+        ),
+        patch.object(
+            sdc_sync.wikimedia,
+            "extract_page_ordinal_from_commons_title",
+            return_value=None,
+        ),
+        patch.object(sdc_sync, "_safe_process_one") as mock_sync,
+    ):
+        sdc_sync._maintain_process_file("M1", "liveid", page, "File:X.jpg", tally=None)
+    mock_rename.assert_called_once_with(page, "liveid")
+    # SDC sync lands on the renamed page, not the original.
+    assert mock_sync.call_args.kwargs["file_page"] is renamed

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -5645,3 +5645,55 @@ def test_maintain_process_file_logs_dpla_id_progress_marker(caplog):
     # The status poller (wikimedia_upload_status.py) counts "DPLA ID:" lines
     # for SDC-phase progress; the maintain write path must emit one per file.
     assert any("DPLA ID: liveid" in r.message for r in caplog.records)
+
+
+def test_maintain_canonical_title_none_for_non_string_title():
+    # A non-string staged title (malformed dpla-map) must not reach
+    # get_page_title (which slices/replaces it) — return None instead of
+    # aborting the --cat batch with a TypeError.
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.title.return_value = "X - DPLA - id.jpg"
+    fake_client = MagicMock()
+    fake_client.get_item_metadata.return_value = json.dumps(
+        {"sourceResource": {"title": [{"unexpected": "dict"}]}}
+    )
+    with (
+        patch.object(sdc_sync, "_s3_partner", "digitalnc"),
+        patch.object(sdc_sync, "_s3_client", fake_client),
+    ):
+        assert sdc_sync._maintain_canonical_title(page, "id") is None
+
+
+def test_maintain_rename_transient_error_not_counted_as_blocked():
+    import pywikibot
+
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.title.return_value = "Old - DPLA - deadid.jpg"
+    # A non-occupancy move failure (transient API/auth) — NOT ArticleExists.
+    page.move.side_effect = pywikibot.exceptions.Error("maxlag")
+    fake_tracker = MagicMock()
+    with (
+        patch.object(
+            sdc_sync,
+            "_maintain_canonical_title",
+            return_value="Old - DPLA - liveid.jpg",
+        ),
+        patch.object(sdc_sync, "tracker", fake_tracker),
+        patch.object(sdc_sync, "site", MagicMock(), create=True),
+        patch.object(sdc_sync.wikimedia, "file_has_inbound_usage", return_value=False),
+        patch.object(
+            sdc_sync.wikimedia, "build_title_drift_move_reason", return_value="reason"
+        ),
+        patch.object(sdc_sync.wikimedia, "post_commonsdelinker_request"),
+    ):
+        out = sdc_sync._maintain_rename(page, "liveid")
+    # File left in place for retry; the blocked counter is NOT inflated by a
+    # transient failure (it means "canonical title occupied", not "move erred").
+    assert out is page
+    assert Result.MAINTAIN_RENAME_BLOCKED not in [
+        c.args[0] for c in fake_tracker.increment.call_args_list
+    ]

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -5603,3 +5603,45 @@ def test_maintain_process_file_renames_before_sync():
     mock_rename.assert_called_once_with(page, "liveid")
     # SDC sync lands on the renamed page, not the original.
     assert mock_sync.call_args.kwargs["file_page"] is renamed
+
+
+def test_emit_maintain_summary_calls_notify_with_maintain_flag():
+    from tools import sdc_sync
+
+    fake_tracker = MagicMock()
+    with (
+        patch.object(sdc_sync, "tracker", fake_tracker),
+        patch.object(sdc_sync, "notify_sdc_complete") as mock_notify,
+    ):
+        sdc_sync._emit_maintain_summary("digitalnc", 12.5)
+    # Mirrors _run_partner_mode's terminal block: posts the SDC completion
+    # notice flagged as maintain (so rename counters surface) at workers=1.
+    mock_notify.assert_called_once()
+    kwargs = mock_notify.call_args.kwargs
+    assert kwargs["maintain"] is True
+    assert kwargs["workers"] == 1
+    assert kwargs["partner_label"] == "digitalnc"
+
+
+def test_maintain_process_file_logs_dpla_id_progress_marker(caplog):
+    import logging as _logging
+
+    from ingest_wikimedia.maintain import ResolveResult
+    from tools import sdc_sync
+
+    page = MagicMock()
+    page.text = "url=https://x/1"
+    with (
+        patch.object(
+            sdc_sync,
+            "_maintain_resolve",
+            return_value=ResolveResult("liveid", "embedded"),
+        ),
+        patch.object(sdc_sync, "_s3_partner", None),
+        patch.object(sdc_sync, "_safe_process_one"),
+        caplog.at_level(_logging.INFO),
+    ):
+        sdc_sync._maintain_process_file("M1", "liveid", page, "File:X.jpg", tally=None)
+    # The status poller (wikimedia_upload_status.py) counts "DPLA ID:" lines
+    # for SDC-phase progress; the maintain write path must emit one per file.
+    assert any("DPLA ID: liveid" in r.message for r in caplog.records)

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -610,3 +610,50 @@ def test_notify_upload_complete_clean_retry_still_titled_retry_complete(tmp_path
     assert "Upload Complete" not in captured["header"]
     failed_lines = [s for s in captured["stats_lines"] if s.startswith("FAILED:")]
     assert failed_lines == ["FAILED:        0"]
+
+
+def _capture_sdc_completion(env: dict, tracker_counts: dict, maintain: bool) -> dict:
+    """Run notify_sdc_complete with a mocked Tracker + env, returning the
+    kwargs passed to _post_completion_notice so tests can assert on
+    stats_lines."""
+    tracker = MagicMock(spec=Tracker)
+    tracker.count.side_effect = lambda result: tracker_counts.get(result, 0)
+    captured: dict = {}
+    with (
+        patch.dict(os.environ, env, clear=True),
+        patch("ingest_wikimedia.slack._post_completion_notice") as mock_post,
+    ):
+        mock_post.side_effect = lambda **kwargs: captured.update(kwargs)
+        notify_sdc_complete(
+            tracker=tracker,
+            partner_label="digitalnc",
+            elapsed_seconds=10.0,
+            workers=1,
+            maintain=maintain,
+        )
+    return captured
+
+
+def test_notify_sdc_complete_maintain_reports_rename_counters():
+    captured = _capture_sdc_completion(
+        env={"DPLA_SLACK_BOT_TOKEN": "x"},
+        tracker_counts={
+            Result.MAINTAIN_RENAMED: 7,
+            Result.MAINTAIN_RENAME_BLOCKED: 2,
+        },
+        maintain=True,
+    )
+    lines = captured["stats_lines"]
+    assert any(s.startswith("RENAMED:") and s.endswith("7") for s in lines)
+    assert any(s.startswith("RENAME BLOCKED:") and s.endswith("2") for s in lines)
+
+
+def test_notify_sdc_complete_non_maintain_omits_rename_counters():
+    captured = _capture_sdc_completion(
+        env={"DPLA_SLACK_BOT_TOKEN": "x"},
+        tracker_counts={},
+        maintain=False,
+    )
+    lines = captured["stats_lines"]
+    assert not any(s.startswith("RENAMED:") for s in lines)
+    assert not any(s.startswith("RENAME BLOCKED:") for s in lines)

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -3790,8 +3790,14 @@ def _maintain_canonical_title(file_page, dpla_id):
         get_dict(metadata, SOURCE_RESOURCE_FIELD_NAME), DC_TITLE_FIELD_NAME
     )
     item_title = titles[0] if titles else ""
-    if not item_title:
-        # No source title to build a filename from — leave the name as-is.
+    # No usable source title to build a filename from — leave the name as-is.
+    # The isinstance guard matters because get_page_title slices/replaces the
+    # title (item_title[:181].replace(...)); a non-string staged value would
+    # raise there and abort the whole --cat batch. Don't strip/normalize beyond
+    # the type check: the uploader builds the stored title from the raw
+    # titles[0], so altering it here would break canonical-title parity and
+    # provoke spurious renames.
+    if not isinstance(item_title, str) or not item_title:
         return None
     current = file_page.title(with_ns=False)
     ext = os.path.splitext(current)[1]
@@ -3827,12 +3833,25 @@ def _maintain_rename(file_page, dpla_id):
         file_page.move(
             f"File:{canonical}", reason=reason, movetalk=False, noredirect=False
         )
-    except pywikibot.exceptions.Error as e:
+    except pywikibot.exceptions.ArticleExistsConflictError as e:
+        # The one outcome MAINTAIN_RENAME_BLOCKED is meant to count: MediaWiki
+        # raises this only when the canonical title is occupied by a page that
+        # isn't a redirect back to this file — a genuine collision needing DPLA
+        # follow-up. Leave the file non-canonical; its SDC still syncs in place.
         logging.error(
             f"maintain: could not move [[File:{current}]] ->"
             f" [[File:{canonical}]] ({e}); leaving non-canonical for review."
         )
         tracker.increment(Result.MAINTAIN_RENAME_BLOCKED)
+        return file_page
+    except pywikibot.exceptions.Error as e:
+        # Any other move failure (transient API, auth, invalid-name) is NOT an
+        # occupancy block — don't inflate the blocked counter with it. Log and
+        # continue; a later maintain run retries the rename.
+        logging.error(
+            f"maintain: move failed for [[File:{current}]] ->"
+            f" [[File:{canonical}]] ({e}); continuing without rename."
+        )
         return file_page
     logging.info(f"maintain: renamed [[File:{current}]] -> [[File:{canonical}]]")
     tracker.increment(Result.MAINTAIN_RENAMED)

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -3881,6 +3881,11 @@ def _maintain_process_file(mediaid, embedded_id, file_page, title, tally=None):
             tally["ambiguous"] += 1
         return
 
+    # Emit the per-item marker the status poller (wikimedia_upload_status.py)
+    # counts for SDC-phase progress, so a maintain --cat run advances past
+    # "starting..." like a partner-mode run does.
+    logging.info(f"DPLA ID: {dpla_id}")
+
     if _s3_partner is not None:
         # Title-drift rename (#3): move to the canonical title for the re-linked
         # id before syncing, so SDC + wikitext cleanup land on the final page.
@@ -3925,6 +3930,26 @@ def _report_maintain_tally(tally, total):
     print(f"  {'ambiguous':>12}: {tally['ambiguous']} (multi-hit, not auto-applied)")
     resolved = total - tally["unresolved"]
     print(f"  {'-> resolved':>12}: {resolved}/{total}")
+
+
+def _emit_maintain_summary(label, elapsed_seconds):
+    """Maintain mode's terminal summary, mirroring _run_partner_mode's: log the
+    ``COUNTS:`` marker (which the status poller reads as the SDC-phase
+    completion signal) and post the Slack completion notice with the maintain
+    counters (renames included). Called only on normal loop completion — an
+    aborted run propagates the exception past this point, so (as in partner
+    mode) the shell-level ``notify_pipeline_fail`` handles the failure instead
+    and no spurious ``COUNTS:`` is written.
+    """
+    logging.info("\n" + str(tracker))
+    logging.info(f"{elapsed_seconds} seconds.")
+    notify_sdc_complete(
+        tracker=tracker,
+        partner_label=label,
+        elapsed_seconds=elapsed_seconds,
+        workers=1,
+        maintain=True,
+    )
 
 
 def process_one(mediaid, dpla_id):
@@ -5429,6 +5454,7 @@ def main() -> None:
     _initialize()
 
     count = 0
+    start_time = time.time()
 
     if method == "list":
         ltotal = [i for i in os.listdir(args.lists) if ".txt" in i]
@@ -5494,6 +5520,8 @@ def main() -> None:
                 _safe_process_one(mediaid, embedded_id, file_page=page)
         if tally is not None:
             _report_maintain_tally(tally, count)
+        elif args.maintain:
+            _emit_maintain_summary(_s3_partner or "maintain", time.time() - start_time)
 
     elif args.cat:
         category = pywikibot.Category(site, args.cat)
@@ -5524,6 +5552,8 @@ def main() -> None:
                 break
         if tally is not None:
             _report_maintain_tally(tally, count)
+        elif args.maintain:
+            _emit_maintain_summary(_s3_partner or args.cat, time.time() - start_time)
 
     elif args.partner:
         _ids_file = args.ids_file or os.path.join(args.partner, f"{args.partner}.csv")

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -23,6 +23,8 @@ from ingest_wikimedia.sdc import (
     parse_other_date_template,
 )
 from ingest_wikimedia import legacy_artwork, wikimedia, wikitext_normalize
+from ingest_wikimedia.common import get_dict, get_list
+from ingest_wikimedia.dpla import DC_TITLE_FIELD_NAME, SOURCE_RESOURCE_FIELD_NAME
 from ingest_wikimedia.maintain import resolve_current_dpla_id
 from ingest_wikimedia.slack import notify_phase_start, notify_sdc_complete
 from ingest_wikimedia.tracker import Result, Tracker
@@ -3761,6 +3763,86 @@ def _maintain_sidecar_payload(dpla_id):
         return None
 
 
+def _maintain_canonical_title(file_page, dpla_id):
+    """The canonical Commons title for a maintained file under its (re-linked)
+    ``dpla_id``, or None when it can't be computed.
+
+    Built with the same :func:`get_page_title` authority the uploader uses, so
+    any difference from the file's current title reflects a real
+    current-vs-canonical difference (a drifted embedded id, or an upstream
+    title-text change) — never a fresh normalization rule. Maintain changes
+    neither the bytes nor the page structure, so the extension and page ordinal
+    are taken from the file's own existing title; only the descriptive prefix
+    and the embedded id can move. The descriptive title comes from the item's
+    staged ``dpla-map.json`` (``sourceResource.title``), so this requires
+    ``--from-s3``.
+    """
+    if _s3_partner is None:
+        return None
+    raw = _s3_client.get_item_metadata(_s3_partner, dpla_id)
+    if not raw:
+        return None
+    try:
+        metadata = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    titles = get_list(
+        get_dict(metadata, SOURCE_RESOURCE_FIELD_NAME), DC_TITLE_FIELD_NAME
+    )
+    item_title = titles[0] if titles else ""
+    if not item_title:
+        # No source title to build a filename from — leave the name as-is.
+        return None
+    current = file_page.title(with_ns=False)
+    ext = os.path.splitext(current)[1]
+    page = wikimedia.extract_page_ordinal_from_commons_title(current)
+    return wikimedia.get_page_title(item_title, dpla_id, ext, page=page)
+
+
+def _maintain_rename(file_page, dpla_id):
+    """Maintain mode: move a file to its canonical title when its current title
+    has drifted from it (PR B). Returns the FilePage to SDC-sync against — the
+    moved page on success, or the original file on a no-op or blocked move.
+
+    The move runs only when the canonical title is free or a single-revision
+    redirect back to this same file; MediaWiki permits move-over-redirect only
+    in that case, so a blind move is safe — it cannot clobber another page. When
+    the canonical title is occupied by a different page the move raises, and we
+    log an error for DPLA to resolve and leave the file at its non-canonical
+    title (its SDC still syncs in place). Maintain has no source bytes, so it
+    never inspects hashes or picks a winner. A move never creates a page, so the
+    no-create fence is not at issue.
+    """
+    canonical = _maintain_canonical_title(file_page, dpla_id)
+    current = file_page.title(with_ns=False)
+    if not canonical or canonical == current:
+        return file_page
+    # Gate inbound-usage BEFORE the move, while ``current`` is still the live
+    # file — post-move it is a redirect and the usage query is unreliable.
+    needs_relink = wikimedia.file_has_inbound_usage(site, current)
+    reason = wikimedia.build_title_drift_move_reason(
+        current, canonical, dpla_id, site.user()
+    )
+    try:
+        file_page.move(
+            f"File:{canonical}", reason=reason, movetalk=False, noredirect=False
+        )
+    except pywikibot.exceptions.Error as e:
+        logging.error(
+            f"maintain: could not move [[File:{current}]] ->"
+            f" [[File:{canonical}]] ({e}); leaving non-canonical for review."
+        )
+        tracker.increment(Result.MAINTAIN_RENAME_BLOCKED)
+        return file_page
+    logging.info(f"maintain: renamed [[File:{current}]] -> [[File:{canonical}]]")
+    tracker.increment(Result.MAINTAIN_RENAMED)
+    if needs_relink:
+        wikimedia.post_commonsdelinker_request(
+            site, current, canonical, check_usage=False
+        )
+    return wikimedia.get_page(site, f"File:{canonical}")
+
+
 # Pre-flight sizing (``--count-only``) tally: one bucket per resolver anchor
 # plus ``ambiguous`` (a multi-hit the resolver refused to auto-apply). Order is
 # the ladder order so the printed breakdown reads top-to-bottom.
@@ -3800,6 +3882,12 @@ def _maintain_process_file(mediaid, embedded_id, file_page, title, tally=None):
         return
 
     if _s3_partner is not None:
+        # Title-drift rename (#3): move to the canonical title for the re-linked
+        # id before syncing, so SDC + wikitext cleanup land on the final page.
+        # The MediaInfo entity is keyed by pageid, which a move preserves, so
+        # ``mediaid`` stays valid; the page ordinal is unchanged by the move, so
+        # ``title``'s ordinal still drives P304.
+        file_page = _maintain_rename(file_page, dpla_id)
         payload = _maintain_sidecar_payload(dpla_id)
         if payload is None:
             logging.info(


### PR DESCRIPTION
PR B of the maintain-mode follow-ups (after #330 core, #331 Slack/launcher, #332 A0+sizing+scope). Name-level cleanup plus making maintain runs report through the status surfaces #333/#334 updated.

## #3 — Title-drift rename (name-only)

When a maintained file's current Commons title has drifted from the canonical title for its **re-linked** DPLA id, move it to the canonical title. Maintain has no source bytes, so this is purely about the **filename** — it never inspects file hashes or decides which of two files is "correct" (that's the hash tier, deferred to PR C).

- `_maintain_canonical_title` computes the canonical title with the same `get_page_title` authority the uploader uses (so any difference is a real current-vs-canonical difference, not a new normalization rule), reading the descriptive title from the item's staged `dpla-map.json` and keeping the file's own existing page ordinal + extension.
- `_maintain_rename` moves when the canonical title is **free** or a **single-revision redirect back to this same file** — MediaWiki permits move-over-redirect only in that case, so a blind `.move()` can't clobber another page. When the canonical title is occupied by a **different** page the move raises; we log an error (`MAINTAIN_RENAME_BLOCKED`) for DPLA to resolve later and leave the file non-canonical (its SDC still syncs in place). No tagging, no winner-picking.
- Reuses the pure move helpers (`build_title_drift_move_reason`, `file_has_inbound_usage`, `post_commonsdelinker_request`, `get_page`) — usage gated before the move, CommonsDelinker posted with `check_usage=False`. A move never creates a page, so the no-create fence isn't at issue.

Wired into `_maintain_process_file` before the sidecar sync so SDC + wikitext cleanup land on the final page (pageid-keyed mediaid and the page ordinal both survive the move).

## Status-report cooperation (#333/#334)

Maintain runs the legacy `--cat`/`--file` loop, not `_run_partner_mode`, so they emitted none of the markers the SDC-phase status poller reads and posted no completion summary — a maintain session showed "SDC syncing (starting…)" forever. Fixed by making maintain conform to the existing contract:

- per-file `DPLA ID:` progress line + terminal `COUNTS:` marker (`_emit_maintain_summary`, post-loop on the success path) → the status tool now reads `Generating IDs → SDC syncing (n/total) → SDC complete`.
- `notify_sdc_complete` gains a `maintain` flag that appends `RENAMED` / `RENAME BLOCKED` lines (and it already reported `SKIPPED (no sidecar)`).
- **No change to `wikimedia_upload_status.py`** — maintain now emits the same markers its SDC branch already parses, and the launcher already stages `{label}.csv` for the denominator.

## Notes

- Per the agreed scope, the active hash-based **duplicate resolution** (#5) stays in PR C with the content-hash anchor (#6) and overwrite (#4) — all of which need content identity this PR deliberately doesn't touch.
- First maintain run over a hub may produce a burst of renames if `get_page_title` normalization has advanced since upload; every move is safe (leaves a redirect; blocked → log only), so the volume is bounded and reversible.

Built on `main` after #333/#334; rebased clean. Full suite **878 passing**; ruff + simplify clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR implements two features for the maintain-mode workflow (used in the maintain-mode series):

### 1. Title-Drift Rename Functionality
- Adds `_maintain_canonical_title()` to compute the canonical Commons `File:` title for a file under its relinked DPLA ID by reading the staged `dpla-map.json` from S3 and using the same `get_page_title` authority as the original uploader.
- Preserves the file’s existing page ordinal and extension while canonicalizing the title.
- Adds `_maintain_rename()` to move already-uploaded Commons files to the canonical title when drift is detected.
  - Checks inbound usage before attempting the move.
  - Only proceeds when the target title is free or has a single-revision redirect back to the same file.
  - If the target title is occupied by a different page, the move is blocked, an operator-facing error is logged (`MAINTAIN_RENAME_BLOCKED`), and the file is left at its non-canonical title for manual DPLA resolution.
  - Posts a CommonsDelinker relink request after successful renames.
- Rename operations are performed before sidecar sync so downstream metadata updates land on the canonical page.
- Follow-up hardening: adds a type guard so malformed/non-string `sourceResource.title[0]` in `dpla-map.json` returns `None` instead of aborting; refines exception handling to count blocked renames only for `ArticleExistsConflictError` (avoiding transient API/auth/invalid-name errors).

### 2. Status-Reporting Markers for Maintain Mode
- Updates maintain mode to emit progress/completion markers that match the existing reporting contract so the status poller can track progress (maintain previously could stall with indefinite “SDC syncing (starting…)” output).
- Adds per-file progress logging of `DPLA ID:` in `_maintain_process_file()`.
- Adds `_emit_maintain_summary()` to emit a terminal `COUNTS:` marker and send the completion notice.
- Extends `notify_sdc_complete(...)` with a `maintain: bool = False` flag; when `maintain=True`, it conditionally includes rename counters in the Slack stats lines.
- Adds new maintain-mode counters to the tracker `Result` enum:
  - `MAINTAIN_RENAMED` for successful title moves
  - `MAINTAIN_RENAME_BLOCKED` for blocked renames (title occupied by another page)

### Test Coverage
- Adds/updates unit tests for canonical title computation, rename behavior (including blocked vs transient failure cases), rename-before-sync ordering, maintain completion emission, and Slack stats reporting with/without the `maintain` flag.
- Full test suite passes (880 passing).

### Operational / Compatibility Notes
- No manual pipeline trigger or ECS redeployment is required.
- No environment variables, AWS Secrets Manager keys, database migrations, or shared infrastructure configuration are changed.
- No public-facing API endpoints or response shapes are added/removed.
- The only new external input used is staged `dpla-map.json` from existing S3 partner staging in maintain mode.
- Hash-based duplicate resolution remains deferred to the next PR in the series; renames may appear in bursts on a hub if normalization advanced since the original upload, but moves are safe/reversible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->