### PR TITLE
Maintain mode: drop upload-readiness ES filters + write -sdc.log

### DIFF
--- a/tests/test_get_ids_es.py
+++ b/tests/test_get_ids_es.py
@@ -456,3 +456,60 @@ def test_load_eligible_dp_names_maintain_includes_ineligible_with_qid():
     assert normal == ["Active Inst"]
     # Former Inst now included (upload=False but has a QID); No QID Inst never.
     assert sorted(maintain) == ["Active Inst", "Former Inst"]
+
+
+def _filter_terms(query: dict) -> list[dict]:
+    return query["query"]["bool"]["filter"]
+
+
+def test_build_query_default_applies_upload_readiness_filters():
+    from tools import get_ids_es
+
+    filters = _filter_terms(
+        get_ids_es.build_query("Digital Library of Georgia", ["Some Institution"])
+    )
+    # Scoping filters always present.
+    assert {
+        "term": {"provider.name.not_analyzed": "Digital Library of Georgia"}
+    } in filters
+    assert {
+        "terms": {"dataProvider.name.not_analyzed": ["Some Institution"]}
+    } in filters
+    # Upload-readiness gates present in the normal (non-maintain) path.
+    assert {"term": {"rightsCategory": "Unlimited Re-Use"}} in filters
+    assert any("should" in f.get("bool", {}) for f in filters), "asset filter missing"
+
+
+def test_build_query_maintain_drops_rights_and_asset_filters():
+    from tools import get_ids_es
+
+    filters = _filter_terms(
+        get_ids_es.build_query(
+            "Digital Library of Georgia", ["Some Institution"], maintain=True
+        )
+    )
+    # Scoping (hub + QID-bearing institution) still gates the scan.
+    assert {
+        "term": {"provider.name.not_analyzed": "Digital Library of Georgia"}
+    } in filters
+    assert {
+        "terms": {"dataProvider.name.not_analyzed": ["Some Institution"]}
+    } in filters
+    # Upload-readiness gates dropped: maintain syncs files already on Commons,
+    # so items lacking current fetchable media / free rights must not be skipped.
+    assert {"term": {"rightsCategory": "Unlimited Re-Use"}} not in filters
+    assert not any("should" in f.get("bool", {}) for f in filters)
+
+
+def test_build_query_maintain_still_supports_collection_scope():
+    from tools import get_ids_es
+
+    filters = _filter_terms(
+        get_ids_es.build_query(
+            "Digital Library of Georgia",
+            ["Some Institution"],
+            collection="Maps",
+            maintain=True,
+        )
+    )
+    assert {"term": {"sourceResource.collection.title.not_analyzed": "Maps"}} in filters

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -178,28 +178,42 @@ def build_query(
     eligible_dp_names: list[str],
     collection: str | None = None,
     search_after: list | None = None,
+    maintain: bool = False,
 ) -> dict:
-    """Build the Elasticsearch boolean query for a single page."""
-    asset_should = [
-        {"exists": {"field": "mediaMaster"}},
-        {"exists": {"field": "iiifManifest"}},
-        *[
-            {"wildcard": {"isShownAt": pattern}}
-            for pattern in IIIF_DERIVABLE_ISSHOWNAT_PATTERNS
-        ],
-    ]
+    """Build the Elasticsearch boolean query for a single page.
 
+    The ``provider`` + ``dataProvider`` filters always apply: they scope the
+    scan to this hub and to institutions that resolve to a Wikidata QID
+    (``eligible_dp_names`` comes from :func:`load_eligible_dp_names`, which
+    requires a QID). A dataProvider without a QID is correctly excluded — it
+    can't get a P195 institution claim or a Commons category.
+
+    ``maintain`` drops the two *upload-readiness* filters — ``rightsCategory ==
+    "Unlimited Re-Use"`` and the asset-presence check (``mediaMaster`` /
+    ``iiifManifest`` / IIIF-derivable ``isShownAt``). Those gate whether an
+    item's media can be FETCHED for a fresh upload; in maintain the files are
+    already on Commons and the Commons category — not ES — defines the
+    work-set, so applying them would wrongly skip already-uploaded items whose
+    current index doc no longer carries fetchable media or a free rights
+    category (exactly the drift maintain exists to repair: e.g. DLG items that
+    no longer populate ``mediaMaster`` in the current index).
+    """
     filters: list[dict] = [
         {"term": {"provider.name.not_analyzed": provider_name}},
-        {"term": {"rightsCategory": "Unlimited Re-Use"}},
         {"terms": {"dataProvider.name.not_analyzed": eligible_dp_names}},
-        {
-            "bool": {
-                "should": asset_should,
-                "minimum_should_match": 1,
-            }
-        },
     ]
+
+    if not maintain:
+        asset_should = [
+            {"exists": {"field": "mediaMaster"}},
+            {"exists": {"field": "iiifManifest"}},
+            *[
+                {"wildcard": {"isShownAt": pattern}}
+                for pattern in IIIF_DERIVABLE_ISSHOWNAT_PATTERNS
+            ],
+        ]
+        filters.append({"term": {"rightsCategory": "Unlimited Re-Use"}})
+        filters.append({"bool": {"should": asset_should, "minimum_should_match": 1}})
 
     if collection is not None:
         filters.append(
@@ -408,7 +422,11 @@ def main(
                 query = {"query": {"term": {"id": single_id}}, "size": 2}
             else:
                 query = build_query(
-                    provider_name, eligible_dp_names, collection, search_after
+                    provider_name,
+                    eligible_dp_names,
+                    collection,
+                    search_after,
+                    maintain=maintain,
                 )
             response = post_es(query)
             response.raise_for_status()

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -5472,6 +5472,15 @@ def main() -> None:
     """
     _initialize()
 
+    # Maintain runs through the legacy --cat/--file dispatch, which (unlike
+    # _run_partner_mode) never set up file logging — so a launched maintain
+    # session wrote no `-sdc.log`, leaving the status poller
+    # (wikimedia_upload_status.py) and the terminal COUNTS:/DPLA ID: markers
+    # with nothing to read. Set up the same "sdc"-phase log here so a maintain
+    # run reports through the identical status surface as a partner-mode run.
+    if args.maintain:
+        setup_logging(_s3_partner or "maintain", "sdc", logging.INFO)
+
     count = 0
     start_time = time.time()
 


### PR DESCRIPTION
Fixes two bugs found in the first live maintain run (`maintain "georgia|Southwest Georgia Regional Library"`), which synced **nothing** — every file reported "sidecar skipped."

## Root cause: get-ids-es staged 0 sidecars

`get-ids-es` `build_query` applied the full **fresh-upload eligibility filters** even in `--maintain`:
- `rightsCategory == "Unlimited Re-Use"`, **and**
- asset-presence: `mediaMaster` OR `iiifManifest` OR a CONTENTdm-style `isShownAt`.

`--maintain` only dropped the upload-*flag* gate (in `load_eligible_dp_names`), not these. But those filters gate whether an item's media can be **fetched for a fresh upload** — irrelevant in maintain, where the files are already on Commons and the **Commons category, not ES, defines the work-set**. Verified against the live index: the items have `rightsCategory = Unlimited Re-Use` but **no `mediaMaster`/`iiifManifest`**, and DLG `isShownAt` isn't CONTENTdm — so every DLG item failed the asset filter → nothing enumerated → nothing staged → universal "sidecar skipped" (and, downstream, no template migration, since that runs *inside* the sync that never happened). The one file that still moved did so because title-drift rename re-links against ES directly, independent of the staged sidecars.

**Fix:** `build_query` gains a `maintain` param; when set it omits the `rightsCategory` and asset-presence filters, keeping only `provider` + `dataProvider` scoping. The `dataProvider` scoping stays a **hard gate by design**: `eligible_dp_names` requires a Wikidata QID, and an institution with no QID can't get a P195 claim or a Commons category — so excluding it is correct, not a gap.

## Second bug: maintain wrote no `-sdc.log`

The legacy `--cat`/`--file` dispatch never called `setup_logging` (only `_run_partner_mode` did), so a launched maintain run produced **no `-sdc.log`** — leaving the status poller (`wikimedia_upload_status.py`) and the #335 terminal `COUNTS:`/`DPLA ID:` markers with nothing to read. `main()` now calls `setup_logging(_s3_partner or "maintain", "sdc")` under `--maintain`, mirroring partner mode, so maintain reports through the identical status surface.

## Tests / notes

- `build_query`: default applies the upload-readiness gates; `maintain=True` drops rights + asset filters while keeping provider/dataProvider scoping and collection support. Full suite **883 passing**.
- The one-line logging call in `main()` isn't unit-tested — `main()` overwrites globals via `_initialize()` and isn't cleanly mockable; it'll be verified by the next live run producing a `-sdc.log`.

Built on `main` after #335. No `wikimedia_upload_status.py` change needed — maintain now emits the markers its SDC branch already parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes two bugs discovered during the first live maintain run for "georgia|Southwest Georgia Regional Library" that resulted in no files being synced because every file reported "sidecar skipped."

### Bug Fixes

**Bug 1: Incorrect Query Filters in Maintain Mode**

The `get-ids-es` tool's `build_query` function was applying fresh-upload eligibility filters even in maintain mode. These filters required items to have `rightsCategory == "Unlimited Re-Use"` AND possess media assets (`mediaMaster`, `iiifManifest`, or CONTENTdm-style `isShownAt`). In maintain mode, these filters are inappropriate because files are already on Commons and the work-set is defined by the Commons category, not the Elasticsearch index. DLG items lacked the required asset properties and failed these checks, preventing any sidecars from being staged.

The fix adds a `maintain: bool = False` parameter to `build_query`. When enabled, it omits the `rightsCategory` and asset-presence filters while retaining provider and dataProvider scoping filters. The dataProvider filter remains as a hard gate by design, since eligible institution names require a Wikidata QID—institutions without a QID cannot obtain a P195 claim or Commons category.

**Bug 2: Missing Logging in Maintain Mode**

The legacy maintain mode dispatch code paths (`--maintain`, `--cat`, `--file`) never called `setup_logging`, unlike the partner mode path. This meant maintain runs produced no `-sdc.log` file, leaving the status poller and terminal status markers with no data to read.

The fix calls `setup_logging(_s3_partner or "maintain", "sdc", logging.INFO)` in `main()` under maintain mode, mirroring the partner mode behavior so maintain mode reports through the same status surface.

### Code Changes

- **tools/get_ids_es.py**: Updated `build_query` signature to accept `maintain: bool = False`; conditionally drops upload-readiness filters when maintain is enabled while preserving provider/dataProvider scoping and collection support
- **tools/sdc_sync.py**: Added `setup_logging` call in maintain mode within `main()` to enable `-sdc.log` output
- **tests/test_get_ids_es.py**: Added three new unit tests validating that `build_query` includes upload-readiness gates in default mode, drops them in maintain mode while preserving scoping filters, and still supports collection filtering in maintain mode

### Testing

The full test suite has 883 passing tests. The fix has been verified to ensure `build_query` defaults to applying upload-readiness gates, with maintain mode properly dropping rights and asset filters while preserving provider/dataProvider scoping and collection support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->