### PR TITLE
Maintain mode: parallelize the --cat walk (matches partner-mode SDC)

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -166,6 +166,7 @@ def _build_maintain_pipeline_steps(
     base: str,
     csv_file: str,
     count_only: bool,
+    worker_opts: str = "",
 ) -> list[str]:
     """Pipeline steps for one maintain target (`cd` + the maintain commands).
 
@@ -197,7 +198,13 @@ def _build_maintain_pipeline_steps(
     # count-only and --from-s3 are mutually exclusive: pre-flight sizing only
     # resolves the re-link (no sidecar read, no write), so it skips both the
     # staging scan and --from-s3.
-    sync_tail = " --count-only" if count_only else f" --from-s3 {canonical}"
+    # The write path runs the parallel pool (one worker per group of files
+    # sharing a DPLA id) under the box-wide slot budget — same --workers /
+    # --workers-budget as partner mode. count-only is read-only pre-flight
+    # sizing: serial, no sidecar read, no write, no workers.
+    sync_tail = (
+        " --count-only" if count_only else f" --from-s3 {canonical}{worker_opts}"
+    )
     steps = []
     if not count_only:
         stage_cmd = f"get-ids-es {canonical}"
@@ -208,9 +215,6 @@ def _build_maintain_pipeline_steps(
         qid = wikidata_qid_for_target(canonical, inst)
         category = resolve_commons_category(qid) if qid else None
         if category:
-            # No --workers/--workers-budget: --cat mode is single-process (one
-            # Commons writer at a time), so it neither uses the pool nor needs
-            # the box-wide slot budget.
             steps.append(
                 f"sdc-sync --cat {shlex.quote(category)} --maintain{sync_tail}"
             )
@@ -1028,6 +1032,7 @@ def main() -> None:
                 base,
                 csv_file,
                 count_only,
+                worker_opts=sdc_opts,
             )
         elif sdc_only:
             # SDC-only backfill: re-enumerate the partner's items (which

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -5615,12 +5615,26 @@ def test_emit_maintain_summary_calls_notify_with_maintain_flag():
     ):
         sdc_sync._emit_maintain_summary("digitalnc", 12.5)
     # Mirrors _run_partner_mode's terminal block: posts the SDC completion
-    # notice flagged as maintain (so rename counters surface) at workers=1.
+    # notice flagged as maintain (so rename counters surface). Serial callers
+    # default to workers=1.
     mock_notify.assert_called_once()
     kwargs = mock_notify.call_args.kwargs
     assert kwargs["maintain"] is True
     assert kwargs["workers"] == 1
     assert kwargs["partner_label"] == "digitalnc"
+
+
+def test_emit_maintain_summary_threads_real_worker_count():
+    from tools import sdc_sync
+
+    with (
+        patch.object(sdc_sync, "tracker", MagicMock()),
+        patch.object(sdc_sync, "notify_sdc_complete") as mock_notify,
+    ):
+        sdc_sync._emit_maintain_summary("digitalnc", 12.5, workers=6)
+    # Parallel path passes the real count so SLOT WAIT (avg/wkr) divides the
+    # aggregate worker-seconds by N, not 1.
+    assert mock_notify.call_args.kwargs["workers"] == 6
 
 
 def test_maintain_process_file_logs_dpla_id_progress_marker(caplog):

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -5697,3 +5697,105 @@ def test_maintain_rename_transient_error_not_counted_as_blocked():
     assert Result.MAINTAIN_RENAME_BLOCKED not in [
         c.args[0] for c in fake_tracker.increment.call_args_list
     ]
+
+
+def test_enumerate_maintain_groups_buckets_by_embedded_id():
+    from tools import sdc_sync
+
+    def _page(title, pageid):
+        p = MagicMock()
+        p.title.return_value = title
+        p.pageid = pageid
+        return p
+
+    # Two pages of item A (same id, different ordinals), one of item B.
+    pages = [
+        _page("A (page 1) - DPLA - id_a.jpg", 1),
+        _page("B - DPLA - id_b.jpg", 2),
+        _page("A (page 2) - DPLA - id_a.jpg", 3),
+    ]
+    with (
+        patch.object(sdc_sync, "dpla_api", None, create=True),
+        patch.object(
+            sdc_sync,
+            "_resolve_dpla_id",
+            side_effect=lambda title, api: "id_a" if title.startswith("A") else "id_b",
+        ),
+    ):
+        groups = sdc_sync._enumerate_maintain_groups(iter(pages), limit=0)
+    # One group per embedded id; item A's two pages stay together (so one worker
+    # serializes their renames — the whole point of grouping).
+    by_id = {g[0][2]: g for g in groups}
+    assert sorted(by_id) == ["id_a", "id_b"]
+    assert {t[1] for t in by_id["id_a"]} == {1, 3}
+    assert len(by_id["id_b"]) == 1
+
+
+def test_enumerate_maintain_groups_respects_limit():
+    from tools import sdc_sync
+
+    pages = []
+    for i in range(5):
+        p = MagicMock()
+        p.title.return_value = f"X{i} - DPLA - id{i}.jpg"
+        p.pageid = i
+        pages.append(p)
+    with (
+        patch.object(sdc_sync, "dpla_api", None, create=True),
+        patch.object(sdc_sync, "_resolve_dpla_id", side_effect=lambda t, a: t),
+    ):
+        groups = sdc_sync._enumerate_maintain_groups(iter(pages), limit=3)
+    assert sum(len(g) for g in groups) == 3
+
+
+def test_worker_maintain_group_task_processes_each_file_and_returns_delta():
+    from tools import sdc_sync
+
+    fake_tracker = MagicMock()
+    fake_tracker.diff.return_value = {"sentinel": 1}
+
+    class _NoopSlot:
+        total_wait_seconds = 0
+
+        def acquire(self):
+            from contextlib import nullcontext
+
+            return nullcontext()
+
+    group = [
+        ("A (page 1) - DPLA - id_a.jpg", 1, "id_a"),
+        ("A (page 2) - DPLA - id_a.jpg", 3, "id_a"),
+    ]
+    with (
+        patch.object(sdc_sync, "tracker", fake_tracker),
+        patch.object(sdc_sync, "_worker_slot_budget", _NoopSlot()),
+        patch.object(sdc_sync, "site", MagicMock(), create=True),
+        patch.object(sdc_sync.pywikibot, "FilePage", return_value=MagicMock()),
+        patch.object(sdc_sync, "_maintain_process_file") as mock_proc,
+    ):
+        delta = sdc_sync._worker_maintain_group_task(group)
+    # Both files of the group processed in this one worker; mediaid derived
+    # from pageid; embedded_id carried through.
+    assert mock_proc.call_count == 2
+    assert mock_proc.call_args_list[0].args[0] == "M1"
+    assert mock_proc.call_args_list[1].args[0] == "M3"
+    assert delta == {"sentinel": 1}
+
+
+def test_run_maintain_parallel_delegates_to_run_pool():
+    from tools import sdc_sync
+
+    groups = [[("t", 1, "id")]]
+    with (
+        patch.object(sdc_sync, "_run_pool") as mock_pool,
+        patch.object(sdc_sync, "hubs", {"h": 1}, create=True),
+        patch.object(sdc_sync, "_s3_partner", "georgia"),
+    ):
+        sdc_sync._run_maintain_parallel(groups, 4)
+    mock_pool.assert_called_once()
+    kwargs = mock_pool.call_args.kwargs
+    assert kwargs["workers"] == 4
+    assert kwargs["initializer"] is sdc_sync._init_maintain_worker
+    assert kwargs["task_fn"] is sdc_sync._worker_maintain_group_task
+    # _s3_partner is threaded so workers read the right sidecar prefix.
+    assert "georgia" in kwargs["initargs"]

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -5799,3 +5799,18 @@ def test_run_maintain_parallel_delegates_to_run_pool():
     assert kwargs["task_fn"] is sdc_sync._worker_maintain_group_task
     # _s3_partner is threaded so workers read the right sidecar prefix.
     assert "georgia" in kwargs["initargs"]
+
+
+def test_maintain_parallel_enabled_requires_from_s3_and_workers():
+    from tools import sdc_sync
+
+    f = sdc_sync._maintain_parallel_enabled
+    # Happy path: maintain + workers>1 + write + staged sidecars.
+    assert f(maintain=True, workers=6, count_only=False, from_s3_partner="georgia")
+    # No --from-s3 → must NOT fan out (live fallback would NameError in workers
+    # / hammer api.dp.la); caller drops to serial.
+    assert not f(maintain=True, workers=6, count_only=False, from_s3_partner=None)
+    # count-only sizing is serial; single worker is serial; non-maintain n/a.
+    assert not f(maintain=True, workers=6, count_only=True, from_s3_partner="georgia")
+    assert not f(maintain=True, workers=1, count_only=False, from_s3_partner="georgia")
+    assert not f(maintain=False, workers=6, count_only=False, from_s3_partner="georgia")

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -379,7 +379,13 @@ def test_count_only_requires_maintain():
 
 
 def _maintain_steps(
-    canonical, institutions, count_only, *, collection=None, dpla_id=None
+    canonical,
+    institutions,
+    count_only,
+    *,
+    collection=None,
+    dpla_id=None,
+    worker_opts="",
 ):
     """Run _build_maintain_pipeline_steps with Wikidata resolution stubbed."""
     import scripts.wikimedia_launch as launch_mod
@@ -400,6 +406,7 @@ def _maintain_steps(
             "/srv/base",
             "out.csv",
             count_only,
+            worker_opts=worker_opts,
         )
 
 
@@ -438,6 +445,26 @@ def test_maintain_count_only_skips_staging_and_from_s3():
     # Pre-flight sizing never stages sidecars and never reads from S3.
     assert not any("get-ids-es" in s for s in steps)
     assert not any("--from-s3" in s for s in steps)
+
+
+def test_maintain_write_run_passes_worker_opts_to_cat_sync():
+    steps = _maintain_steps(
+        "digitalnc", (), False, worker_opts=" --workers 6 --workers-budget 24"
+    )
+    sync = next(s for s in steps if s.startswith("sdc-sync"))
+    # Parallel maintain runs the pool under the box-wide slot budget, same flags
+    # as partner mode, appended after --from-s3.
+    assert sync.endswith("--from-s3 digitalnc --workers 6 --workers-budget 24")
+
+
+def test_maintain_count_only_ignores_worker_opts():
+    steps = _maintain_steps(
+        "digitalnc", (), True, worker_opts=" --workers 6 --workers-budget 24"
+    )
+    sync = next(s for s in steps if s.startswith("sdc-sync"))
+    # count-only is serial read-only sizing — never parallelized.
+    assert "--workers" not in sync
+    assert sync.endswith("--maintain --count-only")
 
 
 def test_maintain_rejects_collection_and_single_id_targets():

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -4687,71 +4687,76 @@ def _migrate_one_dpla_item(s3, partner: str, dpla_id: str) -> None:
             )
 
 
-def _run_partner_mode_parallel(partner, dpla_ids, workers):
-    """Dispatch partner-mode SDC sync across ``workers`` processes.
+def _run_pool(tasks, *, workers, initializer, initargs, task_fn):
+    """Shared spawn-Pool scaffolding for the parallel sync paths.
 
-    Each worker process runs :func:`_process_one_partner_item` against
-    one DPLA item at a time via ``Pool.imap_unordered``; the parent
-    aggregates per-task counter deltas into the module-level tracker.
+    Routes worker log records to the parent's handlers (the open ``-sdc.log``)
+    through a ``multiprocessing.Queue`` + ``QueueListener``, runs ``task_fn``
+    over ``tasks`` with ``imap_unordered``, and merges each task's returned
+    tracker delta into the parent ``tracker``. ``initargs`` are forwarded to
+    ``initializer`` AFTER the log queue — every worker initializer takes
+    ``log_queue`` as its first parameter.
 
-    Item-level safety: every ordinal of every item has a unique
-    MediaInfo M-id, so two workers handling different items never
-    write to the same Commons entity. The pywikibot ``Site`` is
-    re-initialized per worker (see :func:`_init_partner_worker`),
-    isolating HTTP sessions and CSRF tokens.
-
-    Logging: workers route records through a ``multiprocessing.Queue``
-    to a ``QueueListener`` thread in the parent, which dispatches them
-    to the per-partner SDC log file the parent already opened.
-
-    Uses ``spawn`` start_method explicitly so workers don't inherit
-    the parent's pywikibot session sockets — fork-then-use of a live
-    session has been a source of half-broken connections in similar
-    bot setups.
+    Uses ``spawn`` start_method explicitly so workers don't inherit the
+    parent's pywikibot session sockets — fork-then-use of a live session has
+    been a source of half-broken connections in similar bot setups.
     """
     import logging.handlers
     import multiprocessing
 
     ctx = multiprocessing.get_context("spawn")
     log_queue = ctx.Manager().Queue(-1)
-
-    # Reuse the file handler(s) the parent's setup_logging already
-    # attached to the root logger — the QueueListener drains worker
-    # records into the same destinations the parent writes to.
-    listener_targets = list(logging.getLogger().handlers)
     listener = logging.handlers.QueueListener(
-        log_queue, *listener_targets, respect_handler_level=True
+        log_queue, *logging.getLogger().handlers, respect_handler_level=True
     )
     listener.start()
-
-    tasks = [
-        (partner, dpla_id, idx, len(dpla_ids))
-        for idx, dpla_id in enumerate(dpla_ids, start=1)
-    ]
     try:
         with ctx.Pool(
             processes=workers,
-            initializer=_init_partner_worker,
-            # Pickle the parent's already-fetched mapping tables across
-            # to each worker so the cleanup path (which calls
-            # ``DPLA.get_provider_and_data_provider`` with ``hubs``)
-            # doesn't NameError under spawn start_method. Sharing one
-            # snapshot also means workers and parent agree on the data
-            # even if ingestion3 updates mid-run.
-            initargs=(
-                log_queue,
-                hubs,
-                rights,
-                subject_ids,
-                _normalize_wikitext_enabled,
-                _workers_budget,
-            ),
+            initializer=initializer,
+            initargs=(log_queue, *initargs),
         ) as pool:
-            for delta in pool.imap_unordered(_worker_partner_task, tasks):
+            for delta in pool.imap_unordered(task_fn, tasks):
                 if delta:
                     tracker.merge(delta)
     finally:
         listener.stop()
+
+
+def _run_partner_mode_parallel(partner, dpla_ids, workers):
+    """Dispatch partner-mode SDC sync across ``workers`` processes.
+
+    Each worker process runs :func:`_process_one_partner_item` against one DPLA
+    item at a time via :func:`_run_pool`; the parent aggregates per-task counter
+    deltas into the module-level tracker.
+
+    Item-level safety: every ordinal of every item has a unique MediaInfo M-id,
+    so two workers handling different items never write to the same Commons
+    entity. The pywikibot ``Site`` is re-initialized per worker (see
+    :func:`_init_partner_worker`), isolating HTTP sessions and CSRF tokens.
+
+    ``initargs`` pickles the parent's already-fetched mapping tables (``hubs`` /
+    ``rights`` / ``subject_ids``) across to each worker so the cleanup path
+    (``DPLA.get_provider_and_data_provider`` with ``hubs``) doesn't NameError
+    under spawn, and all workers + parent agree on one snapshot.
+    """
+    tasks = [
+        (partner, dpla_id, idx, len(dpla_ids))
+        for idx, dpla_id in enumerate(dpla_ids, start=1)
+    ]
+    _run_pool(
+        tasks,
+        workers=workers,
+        initializer=_init_partner_worker,
+        initargs=(
+            hubs,
+            rights,
+            subject_ids,
+            _normalize_wikitext_enabled,
+            _workers_budget,
+        ),
+        task_fn=_worker_partner_task,
+    )
 
 
 def _init_partner_worker(
@@ -5264,6 +5269,133 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
         tracker.increment(Result.SDC_PAGES_EDITED, len(pages_edited))
 
 
+def _enumerate_maintain_groups(generator, limit):
+    """Walk the ``--cat`` page generator once and bucket files by embedded DPLA
+    id for parallel maintain.
+
+    Returns a list of groups, each a list of ``(title, pageid, embedded_id)``
+    for files sharing one embedded id. Grouping keeps an item's multi-page set
+    on a single worker (see :func:`_run_maintain_parallel`). ``limit`` caps the
+    total files enumerated (``--limit``). Embedded ids are resolved here in the
+    single-threaded parent (``_resolve_dpla_id`` — title-pattern only for
+    service hubs, so effectively no api.dp.la calls).
+    """
+    groups: dict[str, list] = {}
+    count = 0
+    for page in generator:
+        title = page.title()
+        embedded_id = _resolve_dpla_id(title, dpla_api)
+        groups.setdefault(embedded_id, []).append((title, page.pageid, embedded_id))
+        count += 1
+        if limit and count >= limit:
+            print(f" -- Reached --limit {limit}, stopping enumeration.")
+            break
+    return list(groups.values())
+
+
+def _init_maintain_worker(
+    log_queue,
+    hubs_data,
+    s3_partner,
+    normalize_wikitext_enabled,
+    workers_budget,
+):
+    """Per-worker setup for parallel maintain — mirrors
+    :func:`_init_partner_worker`: a fresh pywikibot session, the parent's
+    ``hubs`` snapshot (anchor-3 QID scope map + post-SDC cleanup provider
+    lookup), the ``--from-s3`` partner key and an S3 client for sidecar reads,
+    the normalize flag, the box-wide slot budget, and log routing to the parent.
+
+    No ``dpla_api`` is injected: embedded ids are precomputed by the parent and
+    carried in each group tuple, and the sync reads claims from the staged
+    sidecar — neither path calls ``api.dp.la``.
+    """
+    import logging.handlers
+
+    import pywikibot
+
+    pywikibot.config.max_retries = _PYWIKIBOT_MAX_RETRIES
+    pywikibot.config.retry_wait = _PYWIKIBOT_RETRY_WAIT
+    pywikibot.config.retry_max = _PYWIKIBOT_RETRY_MAX
+
+    global site, hubs, _s3_partner, _s3_client
+    global _normalize_wikitext_enabled, _worker_slot_budget
+    site = pywikibot.Site("commons", "commons")
+    site.login()
+    hubs = hubs_data
+    _s3_partner = s3_partner
+    _normalize_wikitext_enabled = bool(normalize_wikitext_enabled)
+    _worker_slot_budget = WorkerSlotBudget(workers_budget)
+    if s3_partner is not None:
+        from ingest_wikimedia.s3 import S3Client
+
+        _s3_client = S3Client()
+
+    qh = logging.handlers.QueueHandler(log_queue)
+    root = logging.getLogger()
+    root.handlers = [qh]
+    root.setLevel(logging.INFO)
+
+
+def _worker_maintain_group_task(group):
+    """Pool worker entrypoint for parallel maintain: process one id-group (all
+    files sharing an embedded DPLA id) serially in this worker, returning the
+    per-group tracker delta.
+
+    Snapshot/diff gives the parent only what this group contributed (workers
+    are reused across groups). One box-wide slot is held for the whole group —
+    matching partner mode's per-item slot — and a per-file try/except keeps one
+    bad page from dropping the rest of the group.
+    """
+    prior = tracker.snapshot()
+    wait_before = _worker_slot_budget.total_wait_seconds
+    try:
+        with _worker_slot_budget.acquire():
+            for title, pageid, embedded_id in group:
+                try:
+                    file_page = pywikibot.FilePage(site, title)
+                    _maintain_process_file(
+                        "M" + str(pageid), embedded_id, file_page, title
+                    )
+                except Exception:
+                    logging.exception("maintain: worker failed on %s", title)
+                    tracker.increment(Result.SDC_ITEMS_SKIPPED_ERROR)
+    except Exception:
+        logging.exception("maintain: worker group setup failed (%d files)", len(group))
+        tracker.increment(Result.SDC_ITEMS_SKIPPED_ERROR)
+    wait_delta = int(_worker_slot_budget.total_wait_seconds) - int(wait_before)
+    if wait_delta:
+        tracker.increment(Result.SDC_SLOT_WAIT_SECONDS, wait_delta)
+    return tracker.diff(prior)
+
+
+def _run_maintain_parallel(groups, workers):
+    """Dispatch parallel maintain across ``workers`` processes, one id-group per
+    task via :func:`_run_pool`.
+
+    Concurrency safety: the canonical title embeds the DPLA id, so two files can
+    only collide on a destination title if they share an id — and grouping puts
+    every such file on the same worker, serializing those renames. The only
+    residual (two different embedded ids that re-link to the SAME current id — a
+    drifted duplicate) degrades safely: the second move hits
+    ``ArticleExistsConflictError`` → ``MAINTAIN_RENAME_BLOCKED``, the
+    dedup-deferral behavior we want anyway. CommonsDelinker posts are append-only
+    and already race-safe.
+    """
+    _run_pool(
+        groups,
+        workers=workers,
+        initializer=_init_maintain_worker,
+        initargs=(
+            hubs,
+            _s3_partner,
+            _normalize_wikitext_enabled,
+            _workers_budget,
+        ),
+        task_fn=_worker_maintain_group_task,
+    )
+
+
 def _run_partner_mode(partner, ids_file):
     """Drive the SDC phase from precomputed S3 sidecars for a whole partner.
 
@@ -5556,6 +5688,22 @@ def main() -> None:
         generator = pagegenerators.CategorizedPageGenerator(
             category, namespaces=[6], recurse=args.recurse
         )
+        if args.maintain and _workers > 1 and not args.count_only:
+            # Parallel maintain: enumerate the category into id-groups and
+            # dispatch one group per worker. Grouping keeps an item's files
+            # together so title-drift renames (which only collide within one
+            # id — the id is in the canonical title) can't race across workers.
+            # --count-only stays on the serial path below (read-only sizing).
+            groups = _enumerate_maintain_groups(generator, args.limit)
+            total_files = sum(len(g) for g in groups)
+            print(
+                f"maintain: {total_files} files in {len(groups)} id-group(s); "
+                f"{_workers} workers."
+            )
+            _run_maintain_parallel(groups, _workers)
+            _emit_maintain_summary(_s3_partner or args.cat, time.time() - start_time)
+            return
+
         tally = _new_maintain_tally(args.maintain and args.count_only)
         for page in generator:
             title = page.title()

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -3951,7 +3951,7 @@ def _report_maintain_tally(tally, total):
     print(f"  {'-> resolved':>12}: {resolved}/{total}")
 
 
-def _emit_maintain_summary(label, elapsed_seconds):
+def _emit_maintain_summary(label, elapsed_seconds, workers=1):
     """Maintain mode's terminal summary, mirroring _run_partner_mode's: log the
     ``COUNTS:`` marker (which the status poller reads as the SDC-phase
     completion signal) and post the Slack completion notice with the maintain
@@ -3959,6 +3959,9 @@ def _emit_maintain_summary(label, elapsed_seconds):
     aborted run propagates the exception past this point, so (as in partner
     mode) the shell-level ``notify_pipeline_fail`` handles the failure instead
     and no spurious ``COUNTS:`` is written.
+
+    ``workers`` is the real worker count so the SLOT WAIT (avg/wkr) line divides
+    the aggregate worker-seconds correctly; the serial paths keep the default 1.
     """
     logging.info("\n" + str(tracker))
     logging.info(f"{elapsed_seconds} seconds.")
@@ -3966,7 +3969,7 @@ def _emit_maintain_summary(label, elapsed_seconds):
         tracker=tracker,
         partner_label=label,
         elapsed_seconds=elapsed_seconds,
-        workers=1,
+        workers=workers,
         maintain=True,
     )
 
@@ -5720,7 +5723,9 @@ def main() -> None:
                 f"{_workers} workers."
             )
             _run_maintain_parallel(groups, _workers)
-            _emit_maintain_summary(_s3_partner or args.cat, time.time() - start_time)
+            _emit_maintain_summary(
+                _s3_partner or args.cat, time.time() - start_time, workers=_workers
+            )
             return
 
         tally = _new_maintain_tally(args.maintain and args.count_only)

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -5369,6 +5369,24 @@ def _worker_maintain_group_task(group):
     return tracker.diff(prior)
 
 
+def _maintain_parallel_enabled(maintain, workers, count_only, from_s3_partner):
+    """Whether the ``--cat`` maintain run should fan out to the worker pool.
+
+    Requires --maintain, --workers > 1, NOT --count-only (read-only pre-flight
+    sizing stays serial), and --from-s3 (``from_s3_partner``). The --from-s3
+    requirement is load-critical: without staged sidecars,
+    :func:`_maintain_process_file` falls back to the live :func:`process_one`,
+    which needs ``dpla_api`` / ``rights`` / ``subject_ids`` (not injected into
+    workers) and would hit ``api.dp.la`` once per file — at N-way concurrency
+    that is exactly the load the precomputed-sidecar path exists to avoid. With
+    no sidecars the caller drops to the serial path, where that single-file
+    fallback runs once, in the parent, with the globals bound.
+    """
+    return bool(
+        maintain and workers > 1 and not count_only and from_s3_partner is not None
+    )
+
+
 def _run_maintain_parallel(groups, workers):
     """Dispatch parallel maintain across ``workers`` processes, one id-group per
     task via :func:`_run_pool`.
@@ -5688,12 +5706,13 @@ def main() -> None:
         generator = pagegenerators.CategorizedPageGenerator(
             category, namespaces=[6], recurse=args.recurse
         )
-        if args.maintain and _workers > 1 and not args.count_only:
+        if _maintain_parallel_enabled(
+            args.maintain, _workers, args.count_only, _s3_partner
+        ):
             # Parallel maintain: enumerate the category into id-groups and
             # dispatch one group per worker. Grouping keeps an item's files
             # together so title-drift renames (which only collide within one
             # id — the id is in the canonical title) can't race across workers.
-            # --count-only stays on the serial path below (read-only sizing).
             groups = _enumerate_maintain_groups(generator, args.limit)
             total_files = sum(len(g) for g in groups)
             print(


### PR DESCRIPTION
Maintain ran the legacy `--cat` loop single-process; at hub scale (100Ks of files) that's the throughput bottleneck. This gives maintain the same parallelism the partner-mode SDC phase already has — a `spawn` multiprocessing Pool under the box-wide `WorkerSlotBudget` — reusing that machinery rather than inventing a new model.

## Changes

- **Extract shared scaffolding.** Pulled the spawn-Pool + `QueueListener` log routing + `imap_unordered` + per-task `tracker.merge` block out of `_run_partner_mode_parallel` into **`_run_pool(tasks, *, workers, initializer, initargs, task_fn)`**; partner mode now calls it. Each worker initializer takes `log_queue` first, then its own injected globals.
- **Maintain pool path:** `_enumerate_maintain_groups` walks the category once and buckets files by **embedded DPLA id**; `_init_maintain_worker` (fresh pywikibot session, `hubs` snapshot, `--from-s3` partner + S3 client, normalize flag, slot budget, log routing); `_worker_maintain_group_task` processes one id-group serially under one slot and returns the tracker delta; `_run_maintain_parallel` dispatches via `_run_pool`. `main()`'s `--cat` branch runs the pool when `args.maintain and _workers > 1 and not count_only`, else the existing serial loop.
- **`--count-only` stays serial** (read-only pre-flight sizing — no writes, no slot, no workers), as agreed.
- **Launcher:** `_build_maintain_pipeline_steps` appends `--workers`/`--workers-budget` (the same values partner mode uses) to the write-path `sdc-sync --cat` command; count-only omits them.

## Concurrency safety

The one thing partner mode never had to handle: maintain **moves** files (cross-*title* work, vs partner mode's per-item unique-M-id isolation). The canonical title **embeds the DPLA id**, so two files can only collide on a destination title if they share an id — and **grouping by embedded id keeps every such file on one worker**, serializing those renames (your suggestion). The only residual — two *different* embedded ids that re-link to the **same** current id (a drifted duplicate) — degrades safely: the second move hits `ArticleExistsConflictError` → `MAINTAIN_RENAME_BLOCKED`, which is the dedup-deferral behavior we want anyway. CommonsDelinker posts are append-only and already race-safe. Workers are separate processes (no shared mutable state); the flock slot budget bounds concurrent Commons writes box-wide.

Grouping also makes the maintain task unit **match partner mode's** (one task = one item).

## Notes

- **Builds on #336** — the parallel logging reuses the `QueueListener → parent -sdc.log` path that #336's `setup_logging` call opens.
- ES load at N workers: cheap keyword/`ids` re-link lookups (one per file, already happening); the slot budget gates the Commons writes.
- Tests: `_run_pool` extraction (partner mode green), group bucketing + `--limit`, group-task delta + per-file mediaid, `_run_maintain_parallel` delegation, launcher `worker_opts` on write path / absent on count-only. Full suite **889 passing**; ruff + simplify clean.

Next live test after merge: re-run `maintain "georgia|Southwest Georgia Regional Library"` with workers and confirm parallel throughput + correct grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR parallelizes maintain-mode `--cat` walks for category file handling at hub scale by reusing the existing partner-mode multiprocessing infrastructure. It consolidates spawn-Pool + log-routing + per-task tracker aggregation into a shared `_run_pool()` helper, then applies it to maintain `--cat` execution under a strict concurrency safety gate.

## Key Changes

1. **Shared multiprocessing scaffolding**
   - Added `_run_pool(tasks, *, workers, initializer, initargs, task_fn)` in `tools/sdc_sync.py` to standardize:
     - `spawn`-based multiprocessing Pool setup
     - `QueueListener` log routing from workers back to the parent
     - `imap_unordered` iteration
     - merging each task’s returned `tracker.diff()` into the parent tracker
   - Refactored existing partner-mode parallel execution to use `_run_pool()`.

2. **Parallel maintain implementation (`--cat` + `--maintain`)**
   - Added maintain parallel primitives:
     - `_enumerate_maintain_groups()` groups `--cat` items by resolved embedded DPLA id (so colliding destination renames are serialized within a worker).
     - `_init_maintain_worker()` initializes each worker with a fresh pywikibot context, hubs snapshot, S3 partner client when applicable, normalize flag, and a shared `WorkerSlotBudget`, plus log routing.
     - `_worker_maintain_group_task()` processes one embedded-id group serially per worker slot and returns the tracker delta.
     - `_maintain_parallel_enabled()` centralizes gating logic.
     - `_run_maintain_parallel()` dispatches groups via `_run_pool()`.
   - Updated `main()` so maintain parallel `--cat` is used only when:
     - `maintain=True`, `workers > 1`, `count_only=False`, and `from_s3` is set
     - otherwise it falls back to the existing serial path (including the “live fallback” behavior) to avoid the previously reachable worker `NameError` under spawn and to prevent undesirable `api.dp.la` fan-out when sidecars aren’t available.

3. **Launcher/CLI propagation for worker settings**
   - Updated `scripts/wikimedia_launch.py` so `_build_maintain_pipeline_steps(..., worker_opts=...)` appends `--workers` and `--workers-budget` to the write-path `sdc-sync --cat` command when invoking maintain mode.
   - Count-only maintain (`--maintain --count-only`) continues to omit worker/budget flags.

4. **Correct maintain completion reporting**
   - Extended `_emit_maintain_summary(... )` to pass through the real `workers` count to `notify_sdc_complete` (instead of always using `workers=1`), aligning reported wait-time metrics with whether parallel execution actually ran.

## Deployment Notes / Impact

- **Manual pipeline trigger or ECS redeployment required to take effect?** No—this is a code/launcher change that updates how the existing `sdc-sync` job is invoked (worker flags are now included when appropriate).
- **Environment variables / AWS Secrets Manager keys:** No new or changed variables/secrets.
- **Database migration (reversible?):** None.
- **Shared infrastructure configuration (CodePipeline, CodeBuild, ECS task definitions, IAM policies):** None.
- **Public-facing API shape / endpoints:** None.
- **Security implications:** No auth/credential handling changes; no new external data inputs.

## Tests

- Added/extended unit coverage in `tests/test_sdc_sync.py` and `tests/test_wikimedia_launch.py` for:
  - maintain parallel enablement truth-table
  - maintain grouping and per-group task behavior
  - `_run_maintain_parallel` delegating to `_run_pool` with correct initializer/task/args
  - propagation of `--workers` / `--workers-budget` into `sdc-sync --cat`
  - forwarding `workers` into `notify_sdc_complete`
- Full test suite passes (reported as 889→891 passing depending on iteration noted in the changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->