### PR TITLE
Maintain mode: default = hash (download + content reconcile); add maintain lite

### DIFF
--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -35,7 +35,11 @@ on:
         type: boolean
         default: false
       maintain:
-        description: "Maintain mode — re-link + SDC-sync EXISTING Commons files of a (possibly no-longer-participating) hub/institution in place; no uploads, no new files"
+        description: "Maintain mode — reconcile EXISTING Commons files of a (possibly no-longer-participating) hub/institution; never creates new files. DEFAULT = hash: download + content re-link/overwrite + SDC. Add 'lite' for the quick no-download sidecar route."
+        type: boolean
+        default: false
+      lite:
+        description: "Lite maintain — quick no-download sidecar route (SDC-in-place + name-drift rename only); requires maintain"
         type: boolean
         default: false
       count_only:
@@ -90,6 +94,7 @@ jobs:
           INPUT_REFRESH_ONLY: ${{ github.event.inputs.refresh_only }}
           INPUT_SDC_ONLY: ${{ github.event.inputs.sdc_only }}
           INPUT_MAINTAIN: ${{ github.event.inputs.maintain }}
+          INPUT_LITE: ${{ github.event.inputs.lite }}
           INPUT_COUNT_ONLY: ${{ github.event.inputs.count_only }}
           INPUT_WORKERS: ${{ github.event.inputs.workers }}
           INPUT_WORKERS_BUDGET: ${{ github.event.inputs.workers_budget }}
@@ -102,6 +107,7 @@ jobs:
             --refresh-only "$INPUT_REFRESH_ONLY" \
             --sdc-only "$INPUT_SDC_ONLY" \
             --maintain "$INPUT_MAINTAIN" \
+            --lite "$INPUT_LITE" \
             --count-only "$INPUT_COUNT_ONLY" \
             --workers "$INPUT_WORKERS" \
             --workers-budget "$INPUT_WORKERS_BUDGET"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -13,12 +13,13 @@ This guide covers running, monitoring, and troubleshooting the DPLA Wikimedia up
 4. [Partner hub registry](#partner-hub-registry)
 5. [Upload eligibility](#upload-eligibility)
 6. [Pipeline phases](#pipeline-phases)
-7. [Session naming and chaining](#session-naming-and-chaining)
-8. [GitHub Actions workflows](#github-actions-workflows)
-9. [Lambda dispatch mechanism](#lambda-dispatch-mechanism)
-10. [EC2 infrastructure](#ec2-infrastructure)
-11. [Monitoring](#monitoring)
-12. [Troubleshooting](#troubleshooting)
+7. [Maintain mode](#maintain-mode)
+8. [Session naming and chaining](#session-naming-and-chaining)
+9. [GitHub Actions workflows](#github-actions-workflows)
+10. [Lambda dispatch mechanism](#lambda-dispatch-mechanism)
+11. [EC2 infrastructure](#ec2-infrastructure)
+12. [Monitoring](#monitoring)
+13. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -85,6 +86,10 @@ Stops one or more running pipeline sessions. Use any `+`-delimited component of 
 ```
 
 Result posts to **#tech-alerts**.
+
+### `/wikimedia-upload maintain [lite|count] <target> [<target> ...]`
+
+Reconciles files already on Commons for a hub/institution (incl. no-longer-opted-in institutions); never creates new files. Default downloads + content-reconciles (re-link by hash + overwrite changed bytes + SDC); `lite` is the quick no-download SDC-in-place + rename route; `count` is a read-only pre-flight sizing pass. See [Maintain mode](#maintain-mode) for the full behavior.
 
 ### `/wikimedia-status`
 
@@ -276,6 +281,62 @@ The `wikimedia-launch.yml` workflow accepts two boolean inputs that swap the def
 - **`sdc_only=true`** — runs `get-ids-es → sdc-sync` only (no downloader, no uploader). For backfilling or refreshing SDC on items that were uploaded in a prior session, including picking up changes to ingestion3's `institutions_v2.json` / `subjects.json` mappings. The `get-ids-es` step re-stages each item's `sdc.json` from current ingestion3 data; `sdc-sync` then reconciles Commons against that.
   - **Targets without sdc.json re-staging**: single-item DPLA IDs (which use `resolve-dpla-ids` + `printf`) and NARA hub-level targets (which use `get-ids-nara`) do **not** re-stage `sdc.json`. For these, `sdc-sync` replays whatever sidecar the original upload run wrote. The launcher prints a stderr warning when this combination is detected. Useful for re-running fixed sdc-sync logic against a specific item; not useful for picking up upstream mapping changes.
   - `max_age_days` is ignored in `sdc_only` mode (no download phase runs).
+
+---
+
+## Maintain mode
+
+Maintain mode **reconciles files that are already on Commons** for a hub or institution — including institutions that are no longer authorized for *new* uploads (`upload=false` in `institutions_v2.json`). The only institution gate is a **Wikidata QID** (needed for the P195 institution claim and the Commons category); the `upload` flag is ignored. The safety guarantee is the uploader/sync **no-create fence**: maintain never creates a new Commons File page — it only edits, moves, or overwrites files that already exist.
+
+Trigger from Slack:
+
+```text
+/wikimedia-upload maintain <target> [<target> ...]          # default: hash route
+/wikimedia-upload maintain lite <target> [<target> ...]     # quick no-download route
+/wikimedia-upload maintain count <target> [<target> ...]    # pre-flight sizing, writes nothing
+```
+
+Targets use the normal `hub` / `hub|institution` formats. Because the default route downloads media, in practice you'll usually run at **`hub|institution`** granularity to bound how much is fetched (a whole service hub can be enormous).
+
+### Default route (hash)
+
+`maintain <target>` runs the **full pipeline with the institution gate relaxed and the uploader fenced**:
+
+```text
+get-ids-es … --maintain  →  downloader  →  uploader --no-create  →  sdc-sync --partner
+```
+
+- `get-ids-es --maintain` enumerates the institution's current items (QID-only gate; the per-item rights + media-URL filters **still apply**, because we download).
+- The downloader pulls each current master into S3 (keyed by the item's *current* DPLA id, with its SHA1).
+- `uploader --no-create` reuses the existing hash-drift machinery against that fresh S3 set:
+  - **Re-link by content (exact SHA1):** an orphaned Commons file whose embedded id is dead but whose bytes match a current item is **moved** to that item's canonical title.
+  - **Overwrite on content drift:** a Commons file whose bytes differ from the current master is re-uploaded as a new version at the canonical title.
+  - **No-create fence:** an item not already on Commons is skipped (`UPLOAD_SKIPPED_WOULD_CREATE`) — never uploaded fresh.
+- `sdc-sync` then reconciles SDC as in a normal run.
+
+Matching is **exact SHA1 only** — no fuzzy/perceptual matching. An item whose master was re-encoded upstream (new bytes) or that has no fetchable media URL is simply not matched, and its orphaned Commons file is left untouched (correctly — see "sidecar skipped" below).
+
+### Lite route
+
+`maintain lite <target>` is the quick, **no-download** sidecar route. It walks the institution's Commons category and, per file:
+
+- re-links the DPLA id via the URL ladder (embedded id still live → exact `isShownAt` → institution-scoped wildcard);
+- **renames** a title-drifted file to its canonical title when that title is free or a redirect back to the file (else logs `MAINTAIN_RENAME_BLOCKED`);
+- syncs SDC in place from the precomputed `sdc.json` sidecar (`--from-s3`).
+
+`get-ids-es` here adds `--skip-media-filter` (drops the rights + media-URL item filters): lite touches whatever is already on Commons, so it must not exclude items whose current index doc lost a media URL or free-rights category. Lite runs under the same `--workers` / `--workers-budget` pool as a partner-mode SDC sync (files are grouped by DPLA id so an item's pages stay on one worker). It cannot re-link or overwrite by content (no download) — use it for routine SDC refresh + cheap name-drift fixes.
+
+### Count route (pre-flight sizing)
+
+`maintain count <target>` is a read-only lite pre-flight: it walks the category and resolves how each file *would* re-link (embedded / isShownAt / wildcard / unresolved), prints a per-anchor breakdown, and writes nothing. Run it first to size a maintain job and spot a scope that re-links poorly.
+
+### Reading the result
+
+Maintain reports through the same surfaces as a normal SDC run — the per-target `…-sdc.log` and the `/wikimedia-status` poller (`Generating IDs → SDC syncing (n/total) → SDC complete`), plus a `#tech-alerts` completion summary. In the COUNTS summary:
+
+- **`SDC_ITEMS_SKIPPED_NO_SIDECAR`** (lite) / a file left untouched (hash): the re-link found no current match — the item left the index, or (hash route) its bytes/media URL changed so no exact match exists. This is expected and safe, not an error; flagged for human review.
+- **`MAINTAIN_RENAMED` / `MAINTAIN_RENAME_BLOCKED`** (lite): title-drift renames applied / left for follow-up.
+- **`UPLOAD_SKIPPED_WOULD_CREATE`** (hash): items not already on Commons — correctly not created.
 
 ---
 

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -455,22 +455,33 @@ def handler(event, context):
         # upload, no new File pages — so upload-ineligible targets are allowed.
         if tokens[0] == "maintain":
             maintain_tokens = tokens[1:]
-            # `maintain count <target> ...` is the pre-flight sizing variant:
-            # resolve how each file would re-link and report a per-anchor
-            # breakdown without writing anything.
-            count_only = bool(maintain_tokens) and maintain_tokens[0] == "count"
-            if count_only:
+            # An optional mode modifier follows `maintain`:
+            #   count — pre-flight sizing (lite re-link, writes nothing)
+            #   lite  — quick no-download sidecar route (SDC-in-place + rename)
+            #   (none) — DEFAULT hash route: download + content reconcile + SDC
+            mode = (
+                maintain_tokens[0]
+                if maintain_tokens and maintain_tokens[0] in ("count", "lite")
+                else None
+            )
+            if mode:
                 maintain_tokens = maintain_tokens[1:]
+            count_only = mode == "count"
+            lite = mode == "lite"
             if not maintain_tokens:
                 return _slack_reply(
-                    "Usage: `/wikimedia-upload maintain [count] <target> [<target> ...]`\n"
-                    "Re-links + SDC-syncs files already on Commons for a hub or"
-                    " institution, in place (no uploads, no new files). Works for"
-                    " hubs no longer participating in uploads.\n"
-                    "Add `count` to size the re-link without writing anything.\n"
-                    "Example: `/wikimedia-upload maintain digitalnc`\n"
-                    "Example: `/wikimedia-upload maintain count digitalnc`\n"
-                    'Example: `/wikimedia-upload maintain "georgia|Atlanta History Center"`',
+                    "Usage: `/wikimedia-upload maintain [lite|count] <target> [<target> ...]`\n"
+                    "Reconciles files already on Commons for a hub or institution"
+                    " (never creates new files); works for hubs no longer"
+                    " participating in uploads.\n"
+                    "Default (hash): downloads media and content-reconciles —"
+                    " re-links drifted files + overwrites changed bytes + SDC.\n"
+                    "`lite`: quick no-download route — SDC-in-place + name-drift"
+                    " rename only.\n"
+                    "`count`: size the re-link without writing anything.\n"
+                    'Example: `/wikimedia-upload maintain "georgia|Atlanta History Center"`\n'
+                    "Example: `/wikimedia-upload maintain lite digitalnc`\n"
+                    "Example: `/wikimedia-upload maintain count digitalnc`",
                     ephemeral=True,
                 )
             maintain_targets, err = _validate_launch_targets(maintain_tokens)
@@ -479,11 +490,14 @@ def handler(event, context):
             inputs = {"maintain": "true"}
             if count_only:
                 inputs["count_only"] = "true"
-            action = (
-                "maintain pre-flight sizing (count-only, writes nothing)"
-                if count_only
-                else "maintain (re-link + SDC sync, no uploads)"
-            )
+            if lite:
+                inputs["lite"] = "true"
+            if count_only:
+                action = "maintain pre-flight sizing (count-only, writes nothing)"
+            elif lite:
+                action = "lite maintain (SDC-in-place + rename, no download)"
+            else:
+                action = "maintain (download + content reconcile + SDC)"
             return _launch_with_targets(
                 gh_token,
                 repo,

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -131,6 +131,7 @@ def _build_get_ids_command(
     collection: str | None,
     dpla_id: str | None,
     csv_file: str,
+    maintain: bool = False,
 ) -> str:
     """Build the get-ids command that stages the ID CSV for one target.
 
@@ -145,6 +146,12 @@ def _build_get_ids_command(
       resolved name (ORed in the ES dataProvider filter) and adding
       ``--collection`` when set. Omitting ``--institution`` matches the
       collection across every upload-eligible institution in the hub.
+
+    ``maintain`` adds ``--maintain`` to the get-ids-es scan (relax the
+    institution upload gate to QID-only) — used by the default hash-maintain
+    pipeline so already-uploaded items of no-longer-opted-in institutions are
+    still enumerated. The per-item media/rights filters still apply (we
+    download), so it is NOT combined with ``--skip-media-filter`` here.
     """
     if dpla_id is not None:
         return f"get-ids-es {canonical} --single-id {shlex.quote(dpla_id)} > {csv_file}"
@@ -155,10 +162,12 @@ def _build_get_ids_command(
         cmd += f" --institution {shlex.quote(inst)}"
     if collection is not None:
         cmd += f" --collection {shlex.quote(collection)}"
+    if maintain:
+        cmd += " --maintain"
     return cmd + f" > {csv_file}"
 
 
-def _build_maintain_pipeline_steps(
+def _build_maintain_lite_pipeline_steps(
     canonical: str,
     institutions: tuple[str, ...],
     collection: str | None,
@@ -168,9 +177,11 @@ def _build_maintain_pipeline_steps(
     count_only: bool,
     worker_opts: str = "",
 ) -> list[str]:
-    """Pipeline steps for one maintain target (`cd` + the maintain commands).
+    """Pipeline steps for one LITE maintain target (`cd` + the maintain
+    commands). Lite = the quick, no-download sidecar route (the default
+    hash-maintain path runs the full download+uploader pipeline instead).
 
-    Maintain re-links + SDC-syncs the EXISTING Commons files for this scope in
+    Lite re-links + SDC-syncs the EXISTING Commons files for this scope in
     place: no download, no upload, no new File pages. Each hub/institution is
     resolved to its exact Commons category via Wikidata (P8464 → commonswiki
     sitelink — authoritative, never derived from the display name) and walked
@@ -210,7 +221,11 @@ def _build_maintain_pipeline_steps(
         stage_cmd = f"get-ids-es {canonical}"
         for inst in institutions:
             stage_cmd += f" --institution {shlex.quote(inst)}"
-        steps.append(stage_cmd + f" --maintain > {csv_file}")
+        # Lite stages sidecars for the whole QID-bearing institution scope with
+        # the media/rights item filters dropped (--skip-media-filter): it syncs
+        # whatever is already on Commons, so it must not exclude items whose
+        # current index doc lost a fetchable media URL or free-rights category.
+        steps.append(stage_cmd + f" --maintain --skip-media-filter > {csv_file}")
     for inst in institutions or (None,):
         qid = wikidata_qid_for_target(canonical, inst)
         category = resolve_commons_category(qid) if qid else None
@@ -226,6 +241,41 @@ def _build_maintain_pipeline_steps(
             )
             steps.append(f"echo {shlex.quote(msg)} >&2; exit 1")
     return [f"cd {base}", *steps]
+
+
+def _build_maintain_hash_pipeline_steps(
+    canonical: str,
+    institutions: tuple[str, ...],
+    collection: str | None,
+    dpla_id: str | None,
+    base: str,
+    csv_file: str,
+    max_age_days: int | None,
+    upload_opts: str,
+    sdc_opts: str,
+) -> list[str]:
+    """Pipeline steps for one DEFAULT (hash) maintain target.
+
+    This is the full upload pipeline with two deltas: the institution upload
+    gate is relaxed (``get-ids-es --maintain`` → QID-only) and the uploader is
+    fenced (``--no-create``). The uploader's existing hash-drift machinery then
+    re-links orphaned files by content (move to the current canonical title)
+    and overwrites byte-drifted files, while the fence guarantees no NEW Commons
+    files are created for these (possibly no-longer-opted-in) institutions. SDC
+    syncs as usual. Item media/rights filters still apply (we download), so
+    items with no fetchable master are simply never pulled and stay untouched.
+    """
+    maintain_get_ids = _build_get_ids_command(
+        canonical, institutions, collection, dpla_id, csv_file, maintain=True
+    )
+    dl_age_opt = f"--max-age-days {max_age_days} " if max_age_days is not None else ""
+    return [
+        f"cd {base}",
+        maintain_get_ids,
+        f"downloader {dl_age_opt}{csv_file} {canonical}",
+        f"uploader {csv_file} {canonical} --no-create{upload_opts}",
+        f"sdc-sync --partner {canonical} --ids-file {csv_file}{sdc_opts}",
+    ]
 
 
 def _target_label(
@@ -260,6 +310,7 @@ def main() -> None:
     parser.add_argument("--refresh-only", default="false")
     parser.add_argument("--sdc-only", default="false")
     parser.add_argument("--maintain", default="false")
+    parser.add_argument("--lite", default="false")
     parser.add_argument("--count-only", default="false")
     # Keep in sync with .github/workflows/wikimedia-launch.yml inputs.workers
     # / inputs.workers_budget (currently 6 / 24), which the workflow always
@@ -275,6 +326,10 @@ def main() -> None:
     sdc_only = _parse_bool(args.sdc_only)
     maintain = _parse_bool(args.maintain)
     count_only = _parse_bool(args.count_only)
+    # Lite = the quick no-download sidecar route. count-only is a lite-only
+    # pre-flight (re-link sizing), so it forces lite. Default maintain (lite
+    # False) is the hash route: full download + uploader --no-create.
+    lite = _parse_bool(args.lite) or count_only
 
     # Normalize the response_url first so the mutual-exclusion check below
     # can use the validated value rather than re-implementing the same
@@ -300,6 +355,15 @@ def main() -> None:
             response_url,
             "--count-only is a maintain-mode pre-flight (it sizes the re-link"
             " without writing); it has no meaning outside --maintain.",
+        )
+    # Guard on the RAW --lite flag, not the derived ``lite`` above: ``lite`` is
+    # also True under --count-only, so using it here would wrongly reject a bare
+    # ``--count-only`` (which is validated separately just above).
+    if _parse_bool(args.lite) and not maintain:
+        _slack_fail(
+            response_url,
+            "--lite selects the quick no-download maintain route; it has no"
+            " meaning outside --maintain.",
         )
     max_age_days: int | None = None
     if args.max_age_days.strip():
@@ -1023,8 +1087,8 @@ def main() -> None:
         # overrun maxlag. Only the budget — no --workers (no upload
         # parallelism).
         upload_opts = f" --workers-budget {sdc_workers_budget}"
-        if maintain:
-            pipeline_steps = _build_maintain_pipeline_steps(
+        if maintain and lite:
+            pipeline_steps = _build_maintain_lite_pipeline_steps(
                 canonical,
                 institutions,
                 collection,
@@ -1033,6 +1097,18 @@ def main() -> None:
                 csv_file,
                 count_only,
                 worker_opts=sdc_opts,
+            )
+        elif maintain:
+            pipeline_steps = _build_maintain_hash_pipeline_steps(
+                canonical,
+                institutions,
+                collection,
+                dpla_id,
+                base,
+                csv_file,
+                max_age_days,
+                upload_opts,
+                sdc_opts,
             )
         elif sdc_only:
             # SDC-only backfill: re-enumerate the partner's items (which
@@ -1105,10 +1181,19 @@ def main() -> None:
             if refresh_only:
                 msg = f"▶ Launching `{session_name}` refresh: {', '.join(batch_labels)}{refresh_suffix}."
             elif maintain:
+                if lite:
+                    detail = (
+                        "re-linking + SDC-syncing existing Commons files in place"
+                        " (lite: no download)"
+                    )
+                else:
+                    detail = (
+                        "download + content-reconcile (hash re-link + overwrite) +"
+                        " SDC on existing Commons files (no new files)"
+                    )
                 msg = (
                     f"▶ Launching `{session_name}` maintain:"
-                    f" {', '.join(batch_labels)} — re-linking + SDC-syncing existing"
-                    " Commons files in place (no uploads, no new files)."
+                    f" {', '.join(batch_labels)} — {detail}."
                 )
             elif sdc_only:
                 msg = (

--- a/tests/test_get_ids_es.py
+++ b/tests/test_get_ids_es.py
@@ -480,12 +480,12 @@ def test_build_query_default_applies_upload_readiness_filters():
     assert any("should" in f.get("bool", {}) for f in filters), "asset filter missing"
 
 
-def test_build_query_maintain_drops_rights_and_asset_filters():
+def test_build_query_skip_media_filter_drops_rights_and_asset_filters():
     from tools import get_ids_es
 
     filters = _filter_terms(
         get_ids_es.build_query(
-            "Digital Library of Georgia", ["Some Institution"], maintain=True
+            "Digital Library of Georgia", ["Some Institution"], skip_media_filter=True
         )
     )
     # Scoping (hub + QID-bearing institution) still gates the scan.
@@ -501,7 +501,7 @@ def test_build_query_maintain_drops_rights_and_asset_filters():
     assert not any("should" in f.get("bool", {}) for f in filters)
 
 
-def test_build_query_maintain_still_supports_collection_scope():
+def test_build_query_skip_media_filter_still_supports_collection_scope():
     from tools import get_ids_es
 
     filters = _filter_terms(
@@ -509,7 +509,7 @@ def test_build_query_maintain_still_supports_collection_scope():
             "Digital Library of Georgia",
             ["Some Institution"],
             collection="Maps",
-            maintain=True,
+            skip_media_filter=True,
         )
     )
     assert {"term": {"sourceResource.collection.title.not_analyzed": "Maps"}} in filters

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -259,12 +259,33 @@ def test_maintain_subcommand_dispatches_launch_with_maintain_true(
     call = dispatched[0]
     assert call["workflow"] == "wikimedia-launch.yml"
     assert call["inputs"]["maintain"] == "true"
+    # Bare `maintain` is the DEFAULT hash route — not lite, not count-only.
+    assert "lite" not in call["inputs"]
+    assert "count_only" not in call["inputs"]
     # Maintain is its own run mode — must never set the others.
     assert "sdc_only" not in call["inputs"]
     assert "refresh_only" not in call["inputs"]
     assert call["inputs"]["partner"] == "digitalnc"
     assert len(call["inputs"]["concurrency_key"]) == 16
     assert "maintain" in _decode_reply(reply)["text"].lower()
+
+
+def test_maintain_lite_subcommand_dispatches_with_lite_true(
+    monkeypatch, handler_module
+):
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(_make_event("maintain lite digitalnc"), None)
+
+    assert reply["statusCode"] == 200
+    assert len(dispatched) == 1
+    inputs = dispatched[0]["inputs"]
+    assert inputs["maintain"] == "true"
+    assert inputs["lite"] == "true"
+    assert "count_only" not in inputs
+    assert inputs["partner"] == "digitalnc"
+    assert "lite" in _decode_reply(reply)["text"].lower()
 
 
 def test_maintain_subcommand_with_no_targets_returns_usage(monkeypatch, handler_module):

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -5637,6 +5637,63 @@ def test_emit_maintain_summary_threads_real_worker_count():
     assert mock_notify.call_args.kwargs["workers"] == 6
 
 
+def _drive_main_cat_maintain(monkeypatch, *, count_only):
+    """Drive ``sdc_sync.main()`` down the ``--cat`` maintain branch on an EMPTY
+    category, returning the patched ``notify_phase_start`` mock.
+
+    ``main()`` is gated behind module-level argparse globals normally set by
+    ``_initialize()``; we stub those so the dispatch reaches the maintain block
+    without a live Commons login or category walk. The empty generator means
+    the per-file loop body never runs — we exercise only the dispatch and the
+    phase-start announcement.
+    """
+    import argparse
+
+    from tools import sdc_sync
+
+    args = argparse.Namespace(
+        maintain=True,
+        count_only=count_only,
+        cat="Category:Test",
+        files=None,
+        lists=None,
+        recurse=False,
+        limit=0,
+    )
+    monkeypatch.setattr(sdc_sync, "_initialize", lambda: None)
+    monkeypatch.setattr(sdc_sync, "args", args, raising=False)
+    monkeypatch.setattr(sdc_sync, "method", "cat", raising=False)
+    monkeypatch.setattr(sdc_sync, "_s3_partner", None, raising=False)
+    monkeypatch.setattr(sdc_sync, "site", MagicMock(name="site"), raising=False)
+    monkeypatch.setattr(sdc_sync, "setup_logging", lambda *a, **k: None)
+    monkeypatch.setattr(sdc_sync, "_emit_maintain_summary", lambda *a, **k: None)
+    monkeypatch.setattr(sdc_sync, "_report_maintain_tally", lambda *a, **k: None)
+    monkeypatch.setattr(sdc_sync.pywikibot, "Category", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(
+        sdc_sync.pagegenerators, "CategorizedPageGenerator", lambda *a, **k: iter(())
+    )
+    mock_phase = MagicMock()
+    monkeypatch.setattr(sdc_sync, "notify_phase_start", mock_phase)
+
+    sdc_sync.main()
+    return mock_phase
+
+
+def test_main_cat_maintain_announces_sdc_phase_start(monkeypatch):
+    # A launched maintain --cat run must announce the SDC phase (like
+    # _run_partner_mode does at its start) so Slack isn't silent between the
+    # launcher's ack and the final summary — which on a long run is hours away.
+    mock_phase = _drive_main_cat_maintain(monkeypatch, count_only=False)
+    mock_phase.assert_called_once_with("maintain", "sdc-sync")
+
+
+def test_main_cat_maintain_count_only_stays_silent(monkeypatch):
+    # Count-only is a read-only sizing pre-flight — no SDC writes happen, so it
+    # must NOT post a phase-start (that would falsely signal sync had begun).
+    mock_phase = _drive_main_cat_maintain(monkeypatch, count_only=True)
+    mock_phase.assert_not_called()
+
+
 def test_maintain_process_file_logs_dpla_id_progress_marker(caplog):
     import logging as _logging
 

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -398,7 +398,7 @@ def _maintain_steps(
             return_value="Category:Media contributed by X",
         ),
     ):
-        return launch_mod._build_maintain_pipeline_steps(
+        return launch_mod._build_maintain_lite_pipeline_steps(
             canonical,
             institutions,
             collection,
@@ -414,7 +414,7 @@ def test_maintain_real_run_stages_sidecars_then_syncs_from_s3():
     steps = _maintain_steps("digitalnc", (), count_only=False)
     # One ES scan stages sdc.json sidecars, then the category walk reads them.
     assert steps[0] == "cd /srv/base"
-    assert steps[1] == "get-ids-es digitalnc --maintain > out.csv"
+    assert steps[1] == "get-ids-es digitalnc --maintain --skip-media-filter > out.csv"
     assert steps[2] == (
         "sdc-sync --cat 'Category:Media contributed by X' --maintain"
         " --from-s3 digitalnc"
@@ -428,7 +428,8 @@ def test_maintain_per_institution_get_ids_repeats_institution_flags():
     )
     assert steps[1] == (
         "get-ids-es georgia --institution 'Athens-Clarke County Library'"
-        " --institution 'Atlanta History Center' --maintain > out.csv"
+        " --institution 'Atlanta History Center' --maintain --skip-media-filter"
+        " > out.csv"
     )
     # One --cat sync per institution category, all reading from S3.
     syncs = [s for s in steps if s.startswith("sdc-sync")]
@@ -511,3 +512,33 @@ def test_maintain_bypasses_upload_eligibility_gate(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "mutually exclusive" not in captured.err
     assert "not upload-eligible" not in captured.err
+
+
+def test_maintain_hash_pipeline_is_full_download_fenced_no_create():
+    """Default (hash) maintain = full pipeline + relaxed institution gate
+    (get-ids-es --maintain) + uploader --no-create. No --skip-media-filter
+    (it downloads, so media/rights filters apply)."""
+    import scripts.wikimedia_launch as launch_mod
+
+    steps = launch_mod._build_maintain_hash_pipeline_steps(
+        "georgia",
+        ("Southwest Georgia Regional Library",),
+        None,
+        None,
+        "/srv/base",
+        "out.csv",
+        None,
+        " --workers-budget 24",
+        " --workers 6 --workers-budget 24",
+    )
+    assert steps[0] == "cd /srv/base"
+    assert steps[1] == (
+        "get-ids-es georgia --institution 'Southwest Georgia Regional Library'"
+        " --maintain > out.csv"
+    )
+    assert "--skip-media-filter" not in steps[1]
+    assert any(s.startswith("downloader ") and "out.csv georgia" in s for s in steps)
+    assert "uploader out.csv georgia --no-create --workers-budget 24" in steps
+    assert steps[-1] == (
+        "sdc-sync --partner georgia --ids-file out.csv --workers 6 --workers-budget 24"
+    )

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -178,7 +178,7 @@ def build_query(
     eligible_dp_names: list[str],
     collection: str | None = None,
     search_after: list | None = None,
-    maintain: bool = False,
+    skip_media_filter: bool = False,
 ) -> dict:
     """Build the Elasticsearch boolean query for a single page.
 
@@ -188,22 +188,26 @@ def build_query(
     requires a QID). A dataProvider without a QID is correctly excluded — it
     can't get a P195 institution claim or a Commons category.
 
-    ``maintain`` drops the two *upload-readiness* filters — ``rightsCategory ==
-    "Unlimited Re-Use"`` and the asset-presence check (``mediaMaster`` /
-    ``iiifManifest`` / IIIF-derivable ``isShownAt``). Those gate whether an
-    item's media can be FETCHED for a fresh upload; in maintain the files are
-    already on Commons and the Commons category — not ES — defines the
-    work-set, so applying them would wrongly skip already-uploaded items whose
-    current index doc no longer carries fetchable media or a free rights
-    category (exactly the drift maintain exists to repair: e.g. DLG items that
-    no longer populate ``mediaMaster`` in the current index).
+    ``skip_media_filter`` drops the two *upload-readiness* item filters —
+    ``rightsCategory == "Unlimited Re-Use"`` and the asset-presence check
+    (``mediaMaster`` / ``iiifManifest`` / IIIF-derivable ``isShownAt``). Those
+    gate whether an item's media can be FETCHED. It is set only by **lite
+    maintain** (``sdc-sync --cat``), which downloads nothing and operates on the
+    files already on Commons — so applying them would wrongly skip
+    already-uploaded items whose current index doc no longer carries fetchable
+    media or a free rights category (e.g. DLG items that no longer populate
+    ``mediaMaster``). The DEFAULT (hash) maintain path DOWNLOADS media, so it
+    keeps these filters (``skip_media_filter=False``) — only downloadable,
+    free-rights items can be hash-reconciled. Distinct from ``--maintain``,
+    which relaxes the *institution* upload gate (see ``load_eligible_dp_names``)
+    and applies to BOTH maintain routes.
     """
     filters: list[dict] = [
         {"term": {"provider.name.not_analyzed": provider_name}},
         {"terms": {"dataProvider.name.not_analyzed": eligible_dp_names}},
     ]
 
-    if not maintain:
+    if not skip_media_filter:
         asset_should = [
             {"exists": {"field": "mediaMaster"}},
             {"exists": {"field": "iiifManifest"}},
@@ -285,7 +289,20 @@ def build_query(
         " (QID still required), so IDs + sdc.json are generated for already-"
         "uploaded files of institutions no longer authorized for new uploads."
         " New-upload prevention is enforced by the uploader's --no-create"
-        " fence, not by this worklist."
+        " fence, not by this worklist. Relaxes only the INSTITUTION gate; item"
+        " media/rights filters still apply unless --skip-media-filter is given."
+    ),
+)
+@click.option(
+    "--skip-media-filter",
+    is_flag=True,
+    help=(
+        "Drop the per-item upload-readiness filters (rightsCategory +"
+        " mediaMaster/iiifManifest/IIIF-derivable isShownAt). Used only by LITE"
+        " maintain (sdc-sync --cat), which downloads nothing and maintains the"
+        " files already on Commons regardless of current media/rights. The"
+        " default (hash) maintain path downloads media, so it keeps these"
+        " filters (omit this flag)."
     ),
 )
 def main(
@@ -294,6 +311,7 @@ def main(
     collection: str | None,
     single_id: str | None,
     maintain: bool,
+    skip_media_filter: bool,
 ) -> None:
     """Print wiki-eligible DPLA IDs for PARTNER to stdout, one per line.
 
@@ -426,7 +444,7 @@ def main(
                     eligible_dp_names,
                     collection,
                     search_after,
-                    maintain=maintain,
+                    skip_media_filter=skip_media_filter,
                 )
             response = post_es(query)
             response.raise_for_status()

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -5633,6 +5633,13 @@ def main() -> None:
     # run reports through the identical status surface as a partner-mode run.
     if args.maintain:
         setup_logging(_s3_partner or "maintain", "sdc", logging.INFO)
+        # Announce the SDC phase (as _run_partner_mode does) so a launched
+        # maintain run surfaces in Slack instead of going silent until the
+        # final summary. The lite --cat/--file path is the only one that
+        # reached SDC work without this. Count-only is a read-only sizing
+        # pre-flight, so it stays quiet.
+        if not args.count_only:
+            notify_phase_start(_s3_partner or "maintain", "sdc-sync")
 
     count = 0
     start_time = time.time()


### PR DESCRIPTION
Final piece of the maintain-mode work. Makes the **content-reconciling (hash) route the default** `maintain` behavior and the quick no-download sidecar route opt-in via **`lite`**. The goal is reconciling prior uploads of institutions that are **no longer opted in** (`upload=false`) — the only institution gate is a Wikidata QID, and the **no-create fence** guarantees it never uploads a new file.

## The hash route is the existing pipeline + two deltas

No new content-hash / sha1-index code — it reuses the uploader's hash-drift machinery (and the `--no-create` fence #330 built for exactly this):

```
get-ids-es --maintain  →  downloader  →  uploader --no-create  →  sdc-sync --partner
```

- **Re-link by content (exact SHA1):** an orphaned Commons file whose embedded id is dead but whose bytes match a current item is **moved** to that item's canonical title.
- **Overwrite on content drift:** a Commons file whose bytes differ from the current master is re-uploaded as a new version.
- **No-create fence:** items not already on Commons are skipped (`UPLOAD_SKIPPED_WOULD_CREATE`).
- Exact SHA1 only — no fuzzy/perceptual matching. Items with no fetchable master or re-encoded bytes are simply not matched and left untouched (correctly — the kind of orphan that should be left for human review).

## Eligibility decoupled (reverses part of #336)

`get-ids-es --maintain` previously relaxed the institution gate **and** dropped the per-item rights/media filters under one flag. Those are now separate:

| Route | Institution gate | Item rights/media filters |
|---|---|---|
| `maintain` (default, hash) | QID only (`--maintain`) | **applied** — it downloads |
| `maintain lite` | QID only (`--maintain`) | **dropped** (`--skip-media-filter`) — no download |

So the hash route only reconciles downloadable, free-rights items; lite touches whatever is already on Commons.

## Slack

```
/wikimedia-upload maintain <target>          # default: hash route
/wikimedia-upload maintain lite <target>     # quick no-download sidecar route
/wikimedia-upload maintain count <target>    # read-only pre-flight sizing
```
In practice, run the default at **`hub|institution`** granularity to bound the download.

## Changes

- **get_ids_es:** `build_query` param `maintain` → `skip_media_filter`; new `--skip-media-filter` CLI flag; `--maintain` stays the institution gate.
- **launcher:** `_build_maintain_hash_pipeline_steps` (default) + `_build_maintain_lite_pipeline_steps` (renamed; its get-ids-es gains `--skip-media-filter`); `_build_get_ids_command` `maintain` param; `--lite` flag (count-only implies lite); hash-vs-lite Slack message.
- **lambda:** `maintain [lite|count] <targets>` → `maintain`/`lite`/`count_only` inputs.
- **workflow yml:** `lite` input.
- **docs/operations.md:** new **Maintain mode** section (both routes, the no-create fence, reading COUNTS / "sidecar skipped"), the Slack command, TOC.

Tests: `build_query` skip-media-filter; hash pipeline builder (get-ids `--maintain`, `uploader --no-create`, `sdc-sync --partner`, no `--skip-media-filter`); lambda default/lite/count dispatch. Full suite **893 passing**; ruff + simplify clean.

Builds on #337 (already merged). This completes the planned maintain-mode work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Maintain Mode Feature: Hash and Lite Routes

This PR adds a dual-route “Maintain” mode to the Wikimedia upload pipeline to reconcile prior Commons files for institutions that are no longer opted in (`upload=false`) using only a Wikidata QID gate, with a safety fence that prevents creating new Commons files.

It introduces three Slack command variants:
- `/wikimedia-upload maintain <target>`: default **hash** route (download + exact SHA1 reconciliation + SDC sync; no-create fence)
- `/wikimedia-upload maintain lite <target>`: **lite** route (quick no-download sidecar; SDC sync + rename without downloading; skips per-item media/rights filters)
- `/wikimedia-upload maintain count <target>`: pre-flight sizing (read-only)

### Key Changes

#### Workflow & Dispatch
- Updated `.github/workflows/wikimedia-launch.yml`:
  - Added `workflow_dispatch` boolean input `lite`
  - Extended workflow job environment to pass `${{ github.event.inputs.lite }}` as `INPUT_LITE`
  - Launch step forwards it to `python scripts/wikimedia_launch.py` as `--lite "$INPUT_LITE"`
- Updated Slack dispatch parsing to support `maintain [lite|count] <target>` and improved confirmation text to distinguish default (download+reconcile) vs `lite` vs `count_only`.

#### Default Hash Route (Maintain / Default)
- Reuses the existing upload/reconcile pipeline with two reconciliation additions:
  - Re-links orphaned Commons files by **exact SHA1 content match** to current items’ canonical titles
  - **Overwrites** Commons files when bytes differ from the master version
- Applies a **`--no-create`** fence so items not already present on Commons are skipped (unmatched items remain untouched).
- Uses per-item eligibility filters (because this route downloads content).

#### Lite Route (Maintain Lite / No-Download Sidecar)
- Performs a faster reconcile flow that only touches **existing** Commons files (no downloads).
- Drops per-item media/rights gating via a new query behavior:
  - Uses `get-ids-es --skip-media-filter` to bypass download-related media/rights filters while still keeping institution eligibility checks.
- Includes the “SDC-in-place + rename” behavior and then runs `sdc-sync` (without creating new files).

#### Decoupled Eligibility Gates
- `--maintain` now relaxes **only the institution upload gate** (QID-only check).
- A new `--skip-media-filter` flag independently controls dropping per-item rights/media filters (used by the lite route; hash route keeps filters).

### Code Changes
- `scripts/wikimedia_launch.py`
  - Added `--lite` CLI support with guards (lite only allowed when maintain is enabled)
  - Added maintain hash pipeline builder (`_build_maintain_hash_pipeline_steps`)
  - Kept/extended maintain pipeline branching between hash (default) and lite
- `lambda/wikimedia-slack-dispatch/handler.py`
  - Added `maintain lite` and `maintain count` subcommand modifier parsing
  - Updated Slack confirmation messaging
- `tools/get_ids_es.py`
  - Introduced `--skip-media-filter` / `skip_media_filter` parameter to control item eligibility filters in ES query building (replacing maintain-based item-filter behavior)
- `docs/operations.md`
  - Added full “Maintain mode” documentation, including safety/no-create behavior and Slack command syntax.

### Testing
- Updated and extended unit tests to cover:
  - `maintain lite` dispatch and dispatch flags
  - `skip_media_filter` query behavior
  - Hash pipeline construction correctness (including the `--no-create` fence)

### Deployment & Infrastructure / Compatibility Checks
- **Requires redeploy of the Slack/Lambda dispatcher code** for the new parsing behavior (`maintain lite` / `maintain count`) to be active.
- **No manual ECS/CodePipeline/CodeBuild redeployment is required** for the feature logic to take effect.
- **GitHub Actions workflow update** (`wikimedia-launch.yml`) is consumed automatically on the next workflow run after merge.
- **No environment variable changes or AWS Secrets Manager key changes** beyond workflow-level `INPUT_LITE` wiring; existing AWS credential/Slack token usage remains unchanged.
- **No database migrations**.
- **No public API endpoints** or response-shapes were changed.
- **Security implications:** no auth model changes; this is limited to command parsing and eligibility/query behavior for reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->