### PR TITLE
maintain: anchor the default (hash) route's SDC phase on the live category

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -300,21 +300,23 @@ Targets use the normal `hub` / `hub|institution` formats. Because the default ro
 
 ### Default route (hash)
 
-`maintain <target>` runs the **full pipeline with the institution gate relaxed and the uploader fenced**:
+`maintain <target>` reconciles **SDC + legacy templates across every file in the live Commons category** (the primary goal) and additionally repairs **content drift** for the media-bearing subset. For a `hub` / `hub|institution` target it runs:
 
 ```text
-get-ids-es … --maintain  →  downloader  →  uploader --no-create  →  sdc-sync --partner
+get-ids-es … --maintain --skip-media-filter  →  downloader  →  uploader --no-create  →  sdc-sync --cat … --maintain --from-s3
 ```
 
-- `get-ids-es --maintain` enumerates the institution's current items (QID-only gate; the per-item rights + media-URL filters **still apply**, because we download).
-- The downloader pulls each current master into S3 (keyed by the item's *current* DPLA id, with its SHA1).
+- `get-ids-es --maintain --skip-media-filter` stages each item's `sdc.json` + `dpla-map.json` for the **whole** QID-bearing scope (QID-only gate, *and* the per-item rights/media-URL filters dropped) — the same broad scan as the lite route, so sidecars exist for the entire category.
+- The downloader pulls each fetchable current master into S3 (keyed by the item's *current* DPLA id, with its SHA1); items with no fetchable master are simply skipped.
 - `uploader --no-create` reuses the existing hash-drift machinery against that fresh S3 set:
   - **Re-link by content (exact SHA1):** an orphaned Commons file whose embedded id is dead but whose bytes match a current item is **moved** to that item's canonical title.
   - **Overwrite on content drift:** a Commons file whose bytes differ from the current master is re-uploaded as a new version at the canonical title.
   - **No-create fence:** an item not already on Commons is skipped (`UPLOAD_SKIPPED_WOULD_CREATE`) — never uploaded fresh.
-- `sdc-sync` then reconciles SDC as in a normal run.
+- `sdc-sync --cat … --maintain` then walks the **live Commons category** and reconciles SDC + legacy templates for *every* file there — not just the items get-ids matched — reading each (re-linked) file's claims from its staged `sdc.json` (`--from-s3`).
 
-Matching is **exact SHA1 only** — no fuzzy/perceptual matching. An item whose master was re-encoded upstream (new bytes) or that has no fetchable media URL is simply not matched, and its orphaned Commons file is left untouched (correctly — see "sidecar skipped" below).
+Anchoring SDC on the category (not the get-ids id list) is deliberate: an institution whose current index docs no longer pass the rights/media filter still has files on Commons, and those must be reconciled. The content-drift repair is the lesser, best-effort benefit layered on top — matching is **exact SHA1 only** (no fuzzy/perceptual matching), so an item whose master was re-encoded upstream or has no fetchable media is simply not re-linked; the SDC `--cat` pass still reconciles its file in place.
+
+> **Single-DPLA-id / collection targets** have no whole category to walk, so they keep the **id-list-anchored** route — `get-ids-es --maintain` (media filter on) → downloader → `uploader --no-create` → `sdc-sync --partner --ids-file` — reconciling exactly the matched items. Use these for targeted drift repair of one item or collection.
 
 ### Lite route
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -316,7 +316,7 @@ get-ids-es … --maintain --skip-media-filter  →  downloader  →  uploader --
 
 Anchoring SDC on the category (not the get-ids id list) is deliberate: an institution whose current index docs no longer pass the rights/media filter still has files on Commons, and those must be reconciled. The content-drift repair is the lesser, best-effort benefit layered on top — matching is **exact SHA1 only** (no fuzzy/perceptual matching), so an item whose master was re-encoded upstream or has no fetchable media is simply not re-linked; the SDC `--cat` pass still reconciles its file in place.
 
-> **Single-DPLA-id / collection targets** have no whole category to walk, so they keep the **id-list-anchored** route — `get-ids-es --maintain` (media filter on) → downloader → `uploader --no-create` → `sdc-sync --partner --ids-file` — reconciling exactly the matched items. Use these for targeted drift repair of one item or collection.
+> **Single-DPLA-id / collection targets** have no whole category to walk, so they keep the **id-list-anchored** route — get-ids → downloader → `uploader --no-create` → `sdc-sync --partner --ids-file` — reconciling exactly the matched items. (A single-id re-stages that one item with `get-ids-es --single-id` — no `--maintain` flag; a collection uses `get-ids-es --collection … --maintain`.) Use these for targeted drift repair of one item or collection.
 
 ### Lite route
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -300,7 +300,7 @@ Targets use the normal `hub` / `hub|institution` formats. Because the default ro
 
 ### Default route (hash)
 
-`maintain <target>` reconciles **SDC + legacy templates across every file in the live Commons category** (the primary goal) and additionally repairs **content drift** for the media-bearing subset. For a `hub` / `hub|institution` target it runs:
+`maintain <target>` reconciles **SDC + legacy templates across every file in the live Commons category** (the primary goal) and additionally repairs **content drift** for the media-bearing subset. For a `hub` / `hub|institution` target it runs (bare-hub `nara` stages via `get-ids-nara` instead of `get-ids-es`, matching the normal pipeline):
 
 ```text
 get-ids-es … --maintain --skip-media-filter  →  downloader  →  uploader --no-create  →  sdc-sync --cat … --maintain --from-s3

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -148,10 +148,12 @@ def _build_get_ids_command(
       collection across every upload-eligible institution in the hub.
 
     ``maintain`` adds ``--maintain`` to the get-ids-es scan (relax the
-    institution upload gate to QID-only) — used by the default hash-maintain
-    pipeline so already-uploaded items of no-longer-opted-in institutions are
-    still enumerated. The per-item media/rights filters still apply (we
-    download), so it is NOT combined with ``--skip-media-filter`` here.
+    institution upload gate to QID-only) so already-uploaded items of
+    no-longer-opted-in institutions are still enumerated. The per-item
+    media/rights filters still apply (we download), so it is NOT combined with
+    ``--skip-media-filter`` here — this builds the id list for the *id-list-
+    anchored* maintain sub-path (single-DPLA-id / collection targets). The
+    category-anchored path stages via :func:`_maintain_stage_cmd` instead.
     """
     if dpla_id is not None:
         return f"get-ids-es {canonical} --single-id {shlex.quote(dpla_id)} > {csv_file}"
@@ -165,6 +167,58 @@ def _build_get_ids_command(
     if maintain:
         cmd += " --maintain"
     return cmd + f" > {csv_file}"
+
+
+def _maintain_stage_cmd(
+    canonical: str, institutions: tuple[str, ...], csv_file: str
+) -> str:
+    """``get-ids-es`` scan that stages each item's ``dpla-map.json`` +
+    ``sdc.json`` for the whole QID-bearing institution scope, with the
+    media/rights item filters dropped (``--skip-media-filter``).
+
+    Maintain reconciles whatever is already on Commons, so staging must not
+    exclude items whose current index doc has lost a fetchable media URL or
+    free-rights category — otherwise their sidecars are absent and the
+    ``--cat`` sync falls back to a live ``api.dp.la`` read per file. Shared by
+    the lite and hash maintain routes.
+    """
+    cmd = f"get-ids-es {canonical}"
+    for inst in institutions:
+        cmd += f" --institution {shlex.quote(inst)}"
+    return cmd + f" --maintain --skip-media-filter > {csv_file}"
+
+
+def _maintain_sdc_cat_steps(
+    canonical: str, institutions: tuple[str, ...], sync_tail: str
+) -> list[str]:
+    """One ``sdc-sync --cat <category> --maintain <sync_tail>`` per institution,
+    resolving each to its exact Commons category via Wikidata (P8464 →
+    commonswiki sitelink — never derived from the display name).
+
+    An institution whose category can't be resolved emits a failing
+    ``echo … >&2; exit 1`` rather than silently widening the write scope.
+    Shared by the lite and hash maintain routes — both anchor the SDC phase on
+    the *live category*, so reconciliation covers every file already on
+    Commons, not just a get-ids id list.
+    """
+    steps: list[str] = []
+    # A bare-hub target (no institutions) is one category-resolution pass with
+    # inst=None; wikidata_qid_for_target and the `who` fallback both accept it.
+    for inst in institutions or (None,):
+        qid = wikidata_qid_for_target(canonical, inst)
+        category = resolve_commons_category(qid) if qid else None
+        if category:
+            steps.append(
+                f"sdc-sync --cat {shlex.quote(category)} --maintain{sync_tail}"
+            )
+        else:
+            who = inst or canonical
+            msg = (
+                f"maintain: could not resolve a Commons category for {who}"
+                " (missing Wikidata QID or P8464 Commons-category link); skipping."
+            )
+            steps.append(f"echo {shlex.quote(msg)} >&2; exit 1")
+    return steps
 
 
 def _build_maintain_lite_pipeline_steps(
@@ -218,28 +272,8 @@ def _build_maintain_lite_pipeline_steps(
     )
     steps = []
     if not count_only:
-        stage_cmd = f"get-ids-es {canonical}"
-        for inst in institutions:
-            stage_cmd += f" --institution {shlex.quote(inst)}"
-        # Lite stages sidecars for the whole QID-bearing institution scope with
-        # the media/rights item filters dropped (--skip-media-filter): it syncs
-        # whatever is already on Commons, so it must not exclude items whose
-        # current index doc lost a fetchable media URL or free-rights category.
-        steps.append(stage_cmd + f" --maintain --skip-media-filter > {csv_file}")
-    for inst in institutions or (None,):
-        qid = wikidata_qid_for_target(canonical, inst)
-        category = resolve_commons_category(qid) if qid else None
-        if category:
-            steps.append(
-                f"sdc-sync --cat {shlex.quote(category)} --maintain{sync_tail}"
-            )
-        else:
-            who = inst or canonical
-            msg = (
-                f"maintain: could not resolve a Commons category for {who}"
-                " (missing Wikidata QID or P8464 Commons-category link); skipping."
-            )
-            steps.append(f"echo {shlex.quote(msg)} >&2; exit 1")
+        steps.append(_maintain_stage_cmd(canonical, institutions, csv_file))
+    steps += _maintain_sdc_cat_steps(canonical, institutions, sync_tail)
     return [f"cd {base}", *steps]
 
 
@@ -256,25 +290,48 @@ def _build_maintain_hash_pipeline_steps(
 ) -> list[str]:
     """Pipeline steps for one DEFAULT (hash) maintain target.
 
-    This is the full upload pipeline with two deltas: the institution upload
-    gate is relaxed (``get-ids-es --maintain`` → QID-only) and the uploader is
-    fenced (``--no-create``). The uploader's existing hash-drift machinery then
-    re-links orphaned files by content (move to the current canonical title)
-    and overwrites byte-drifted files, while the fence guarantees no NEW Commons
-    files are created for these (possibly no-longer-opted-in) institutions. SDC
-    syncs as usual. Item media/rights filters still apply (we download), so
-    items with no fetchable master are simply never pulled and stay untouched.
+    The SDC phase is anchored on the **live Commons category** (``sdc-sync
+    --cat … --maintain``, identical to the lite route), so it reconciles SDC +
+    legacy templates for *every* file already on Commons — the primary maintain
+    goal. Inserted before it, a ``downloader`` + ``uploader --no-create`` pass
+    repairs *content drift* for the media-bearing subset: the uploader's
+    hash-drift machinery re-links orphaned files by content and overwrites
+    byte-drifted ones, fenced (``--no-create``) so no NEW Commons file is ever
+    created for these (possibly no-longer-opted-in) institutions.
+
+    Staging uses the broad ``--skip-media-filter`` scan (same as lite) so the
+    ``--cat`` sync sees the whole category, not just currently-fetchable items;
+    the downloader simply skips items with no fetchable master. This is the
+    delta from lite: lite is stage + ``--cat`` sync only; hash inserts the
+    download + ``--no-create`` upload pass between them.
+
+    A single-DPLA-id or collection-scoped target has no whole category to walk,
+    so it keeps the id-list-anchored route (``sdc-sync --partner --ids-file``):
+    download + ``uploader --no-create`` + SDC over exactly the matched items,
+    for targeted drift repair of one item or collection. Those targets keep the
+    media/rights filter (``get-ids-es --maintain`` without ``--skip-media-
+    filter``) since there's no category to reconcile beyond what's fetched.
     """
-    maintain_get_ids = _build_get_ids_command(
-        canonical, institutions, collection, dpla_id, csv_file, maintain=True
-    )
     dl_age_opt = f"--max-age-days {max_age_days} " if max_age_days is not None else ""
+    if dpla_id is not None or collection is not None:
+        maintain_get_ids = _build_get_ids_command(
+            canonical, institutions, collection, dpla_id, csv_file, maintain=True
+        )
+        return [
+            f"cd {base}",
+            maintain_get_ids,
+            f"downloader {dl_age_opt}{csv_file} {canonical}",
+            f"uploader {csv_file} {canonical} --no-create{upload_opts}",
+            f"sdc-sync --partner {canonical} --ids-file {csv_file}{sdc_opts}",
+        ]
     return [
         f"cd {base}",
-        maintain_get_ids,
+        _maintain_stage_cmd(canonical, institutions, csv_file),
         f"downloader {dl_age_opt}{csv_file} {canonical}",
         f"uploader {csv_file} {canonical} --no-create{upload_opts}",
-        f"sdc-sync --partner {canonical} --ids-file {csv_file}{sdc_opts}",
+        *_maintain_sdc_cat_steps(
+            canonical, institutions, f" --from-s3 {canonical}{sdc_opts}"
+        ),
     ]
 
 

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -182,6 +182,13 @@ def _maintain_stage_cmd(
     ``--cat`` sync falls back to a live ``api.dp.la`` read per file. Shared by
     the lite and hash maintain routes.
     """
+    # Bare-hub NARA stages via its bespoke catalog walk, not get-ids-es —
+    # mirror the routing in _build_get_ids_command so a hub-level NARA maintain
+    # target stages sidecars the same way the normal pipeline does. (Collection
+    # / single-id NARA targets never reach here — they take the id-list-anchored
+    # path in the hash builder.)
+    if canonical == "nara" and not institutions:
+        return f"get-ids-nara > {csv_file}"
     cmd = f"get-ids-es {canonical}"
     for inst in institutions:
         cmd += f" --institution {shlex.quote(inst)}"
@@ -308,9 +315,11 @@ def _build_maintain_hash_pipeline_steps(
     A single-DPLA-id or collection-scoped target has no whole category to walk,
     so it keeps the id-list-anchored route (``sdc-sync --partner --ids-file``):
     download + ``uploader --no-create`` + SDC over exactly the matched items,
-    for targeted drift repair of one item or collection. Those targets keep the
-    media/rights filter (``get-ids-es --maintain`` without ``--skip-media-
-    filter``) since there's no category to reconcile beyond what's fetched.
+    for targeted drift repair of one item or collection. These go through
+    :func:`_build_get_ids_command` — a single-id re-stages that one item with
+    ``--single-id`` (no ``--maintain``); a collection uses ``--collection …
+    --maintain`` — keeping the media/rights filter (no ``--skip-media-filter``),
+    since there's no category to reconcile beyond what's fetched.
     """
     dl_age_opt = f"--max-age-days {max_age_days} " if max_age_days is not None else ""
     if dpla_id is not None or collection is not None:

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -560,9 +560,11 @@ def test_maintain_hash_pipeline_category_anchored_with_download_pass():
 
 def test_maintain_hash_single_id_and_collection_keep_id_list_anchored():
     """A single-DPLA-id or collection-scoped hash target has no whole category
-    to walk, so it keeps the id-list-anchored route: get-ids --maintain (media
-    filter ON — no --skip-media-filter), download, uploader --no-create, and
-    sdc-sync --partner --ids-file."""
+    to walk, so it keeps the id-list-anchored route — download, uploader
+    --no-create, sdc-sync --partner --ids-file — with the media filter on (no
+    --skip-media-filter). Note the get-ids asymmetry: single-id re-stages the
+    one item with --single-id (no --maintain); a collection uses --collection
+    --maintain."""
     import scripts.wikimedia_launch as launch_mod
 
     single = launch_mod._build_maintain_hash_pipeline_steps(
@@ -597,3 +599,22 @@ def test_maintain_hash_single_id_and_collection_keep_id_list_anchored():
     assert coll[1] == "get-ids-es georgia --collection Maps --maintain > out.csv"
     assert not any("--cat" in s for s in coll)
     assert coll[-1].startswith("sdc-sync --partner georgia --ids-file out.csv")
+
+
+def test_maintain_stage_cmd_routes_bare_nara_to_get_ids_nara():
+    """Bare-hub NARA stages via its bespoke catalog walk, mirroring
+    _build_get_ids_command — not `get-ids-es nara`, which can't do NARA's
+    catalog enumeration. A NARA *institution* target still uses get-ids-es."""
+    import scripts.wikimedia_launch as launch_mod
+
+    assert (
+        launch_mod._maintain_stage_cmd("nara", (), "out.csv")
+        == "get-ids-nara > out.csv"
+    )
+    # An institution-scoped NARA target keeps the broad get-ids-es staging.
+    assert launch_mod._maintain_stage_cmd(
+        "nara", ("National Archives at College Park",), "out.csv"
+    ) == (
+        "get-ids-es nara --institution 'National Archives at College Park'"
+        " --maintain --skip-media-filter > out.csv"
+    )

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -514,16 +514,79 @@ def test_maintain_bypasses_upload_eligibility_gate(monkeypatch, capsys):
     assert "not upload-eligible" not in captured.err
 
 
-def test_maintain_hash_pipeline_is_full_download_fenced_no_create():
-    """Default (hash) maintain = full pipeline + relaxed institution gate
-    (get-ids-es --maintain) + uploader --no-create. No --skip-media-filter
-    (it downloads, so media/rights filters apply)."""
+def test_maintain_hash_pipeline_category_anchored_with_download_pass():
+    """Default (hash) maintain for a hub|institution target: broad staging
+    (--skip-media-filter, like lite) so the SDC pass covers the whole live
+    category, plus a download + ``uploader --no-create`` content-drift pass,
+    then ``sdc-sync --cat`` — NOT ``--partner --ids-file``. This is the fix for
+    the regression where an empty get-ids set left the category untouched."""
     import scripts.wikimedia_launch as launch_mod
 
-    steps = launch_mod._build_maintain_hash_pipeline_steps(
+    with (
+        patch.object(launch_mod, "wikidata_qid_for_target", return_value="Q123"),
+        patch.object(
+            launch_mod,
+            "resolve_commons_category",
+            return_value="Category:Media contributed by X",
+        ),
+    ):
+        steps = launch_mod._build_maintain_hash_pipeline_steps(
+            "georgia",
+            ("Southwest Georgia Regional Library",),
+            None,
+            None,
+            "/srv/base",
+            "out.csv",
+            None,
+            " --workers-budget 24",
+            " --workers 6 --workers-budget 24",
+        )
+    assert steps[0] == "cd /srv/base"
+    # Broad staging — same scan as lite, so sidecars exist for the whole category.
+    assert steps[1] == (
+        "get-ids-es georgia --institution 'Southwest Georgia Regional Library'"
+        " --maintain --skip-media-filter > out.csv"
+    )
+    # Content-drift pass: download (skips no-media items) + fenced overwrite.
+    assert any(s.startswith("downloader ") and "out.csv georgia" in s for s in steps)
+    assert "uploader out.csv georgia --no-create --workers-budget 24" in steps
+    # SDC anchored on the live category, NOT the get-ids id list.
+    assert steps[-1] == (
+        "sdc-sync --cat 'Category:Media contributed by X' --maintain"
+        " --from-s3 georgia --workers 6 --workers-budget 24"
+    )
+    assert not any("--partner" in s for s in steps)
+
+
+def test_maintain_hash_single_id_and_collection_keep_id_list_anchored():
+    """A single-DPLA-id or collection-scoped hash target has no whole category
+    to walk, so it keeps the id-list-anchored route: get-ids --maintain (media
+    filter ON — no --skip-media-filter), download, uploader --no-create, and
+    sdc-sync --partner --ids-file."""
+    import scripts.wikimedia_launch as launch_mod
+
+    single = launch_mod._build_maintain_hash_pipeline_steps(
         "georgia",
-        ("Southwest Georgia Regional Library",),
+        (),
         None,
+        "abc123def456",
+        "/srv/base",
+        "out.csv",
+        None,
+        " --workers-budget 24",
+        " --workers 6 --workers-budget 24",
+    )
+    assert single[1] == "get-ids-es georgia --single-id abc123def456 > out.csv"
+    assert not any("--skip-media-filter" in s for s in single)
+    assert not any("--cat" in s for s in single)
+    assert single[-1] == (
+        "sdc-sync --partner georgia --ids-file out.csv --workers 6 --workers-budget 24"
+    )
+
+    coll = launch_mod._build_maintain_hash_pipeline_steps(
+        "georgia",
+        (),
+        "Maps",
         None,
         "/srv/base",
         "out.csv",
@@ -531,14 +594,6 @@ def test_maintain_hash_pipeline_is_full_download_fenced_no_create():
         " --workers-budget 24",
         " --workers 6 --workers-budget 24",
     )
-    assert steps[0] == "cd /srv/base"
-    assert steps[1] == (
-        "get-ids-es georgia --institution 'Southwest Georgia Regional Library'"
-        " --maintain > out.csv"
-    )
-    assert "--skip-media-filter" not in steps[1]
-    assert any(s.startswith("downloader ") and "out.csv georgia" in s for s in steps)
-    assert "uploader out.csv georgia --no-create --workers-budget 24" in steps
-    assert steps[-1] == (
-        "sdc-sync --partner georgia --ids-file out.csv --workers 6 --workers-budget 24"
-    )
+    assert coll[1] == "get-ids-es georgia --collection Maps --maintain > out.csv"
+    assert not any("--cat" in s for s in coll)
+    assert coll[-1].startswith("sdc-sync --partner georgia --ids-file out.csv")


### PR DESCRIPTION
## Problem

The default `maintain` (hash) route anchored its SDC phase on the **get-ids id list** (`sdc-sync --partner --ids-file`). `get-ids-es --maintain` keeps the per-item rights/media-URL filter, so when an institution's current index docs no longer pass it, get-ids returns **0 ids** — and the entire live Commons category goes unreconciled, reported as a bare `0 items` with no category ever walked (not even a "skip").

Observed on Digital Library of Georgia institutions whose index docs have drifted:

| Institution | Index items | Commons files | maintain reported |
|---|---|---|---|
| Calhoun-Gordon County Library | 50,120 | 10,203 | **0** |
| Azalea Regional Library System | 18,508 | (category exists) | **0** |

The SDC + legacy-template reconciliation — the *primary* goal of maintain — never ran on those 10k+ files.

## Fix

Make the SDC phase **category-anchored** in the hash route, matching the lite route: the Commons category is the work-set, not the get-ids result.

For a `hub` / `hub|institution` target the hash route is now:

```text
get-ids-es … --maintain --skip-media-filter  →  downloader  →  uploader --no-create  →  sdc-sync --cat … --maintain --from-s3
```

- Broad staging (`--skip-media-filter`, same scan as lite) so sidecars exist for the whole category.
- The `downloader` + `uploader --no-create` pass still repairs **content drift** for the media-bearing subset (re-link by SHA1, overwrite byte-drift, no-create fence) — the lesser, best-effort benefit, layered on top. The downloader skips items with no fetchable master, so the broad id set is safe.
- `sdc-sync --cat … --maintain` then reconciles SDC + legacy templates for **every** file in the live category.

**Single-DPLA-id / collection targets** have no whole category to walk, so they keep the id-list-anchored route (`sdc-sync --partner --ids-file`) for targeted drift repair of one item or collection.

## Implementation

- Extract `_maintain_stage_cmd` + `_maintain_sdc_cat_steps`, now shared by the lite and hash builders — the only lite-vs-hash difference is the two inserted download/upload steps.
- `tests/test_wikimedia_launch.py`: replaced the old hash test with two — category-anchored hub/institution path, and the preserved id-list-anchored single-id/collection path.
- `docs/operations.md`: rewrote the "Default route (hash)" section.

## Test plan

- [x] `tests/test_wikimedia_launch.py` — 43 passed
- [x] `ruff check` + `ruff format` clean
- [ ] Live verify: re-run `maintain "georgia|Calhoun-Gordon County Library"` and confirm the ~10k-file category is now walked (was 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Maintain Operation Route Refactoring (Default Hash Route)

This PR changes the default (hash) route’s maintain-mode SDC phase to be anchored on the live Commons category (instead of reconciling only the get-ids id list), fixing cases where per-item rights/media filtering in `get-ids` could yield zero results and cause the entire Commons category to be skipped without SDC + legacy-template reconciliation.

### Problem Solved
During maintain operations, `get-ids` could apply per-item rights/media-URL filters. For institutions whose index docs had drifted, this could return zero items—skipping the whole live Commons category (no reconciliation), even when thousands of Commons files existed.

### Solution
For hub / `hub|institution` targets, the workflow is now category-anchored (mirroring lite behavior):

1. `get-ids-es --maintain --skip-media-filter` to stage `sdc.json` + `dpla-map.json` broadly for the QID-bearing scope (dropping per-item media/rights filters)
2. `downloader`
3. fenced `uploader --no-create` to repair content drift for the media-bearing subset (re-linking/overwriting based on refreshed masters via exact SHA1)
4. `sdc-sync --cat ... --maintain --from-s3` to reconcile SDC + legacy-template state for every file in the live Commons category

Single-DPLA-id and collection targets retain the original id-list-anchored route.

### Changes
- **docs/operations.md**
  - Rewrote the “Default route (hash)” maintain documentation to reflect the category-anchored command chain and clarify that single-id/collection targets keep id-list anchoring.
- **scripts/wikimedia_launch.py**
  - Extracted shared helpers:
    - `_maintain_stage_cmd(...)` (includes `--skip-media-filter` staging; routes bare-hub NARA via `get-ids-nara`)
    - `_maintain_sdc_cat_steps(...)` (resolves the authoritative Commons category from Wikidata `P8464`; fails fast if it can’t be resolved)
  - Restructured the default/hash maintain pipeline for hub/institution to:
    - stage broadly → download → fenced `uploader --no-create` → per-institution `sdc-sync --cat ... --maintain --from-s3`
  - Preserved the id-list-anchored path for single-id and collection targets:
    - ends with `sdc-sync --partner ... --ids-file ...` (no `--cat`).
- **tests/test_wikimedia_launch.py**
  - Removed the previous hash hub|institution test expecting id-list-anchored behavior.
  - Added/updated tests to cover:
    - hub|institution category-anchored hash pipeline (includes `downloader`, fenced `uploader --no-create`, ends with `sdc-sync --cat ... --maintain --from-s3`, and does not include `--partner`)
    - single-id + collection targets preserving id-list anchoring
    - `_maintain_stage_cmd` routing for bare-hub NARA vs institution-scoped NARA.

### Deployment Notes
- **Manual pipeline trigger(s) required:** Yes—live verification requires running the relevant maintain pipelines after deploying this code.
- **ECS / CodePipeline / CodeBuild / IAM policy changes:** No changes included.
- **Environment variables / Secrets Manager keys:** No changes included.
- **Database migrations:** None.
- **Public API / endpoints:** None.
- **Security implications:** No auth/credential-handling changes; the workflow adds an external Commons-category resolution step via Wikidata `P8464` as part of command generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->