### PR TITLE
downloader: log per-item marker on no-media skip + recognize it in status

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -338,7 +338,11 @@ def get_phase_and_progress(
                 f"{_DOWNLOAD_COMPLETE_PREFIX} ({dpla_id_count:,} / {total:,} items)",
                 log_mtime,
             )
-        if "Downloading" in tail or "Key already in S3" in tail:
+        if (
+            "Downloading" in tail
+            or "Key already in S3" in tail
+            or "No media; skipping." in tail
+        ):
             return (
                 f"Downloading ({dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%){stale_suffix}",
                 log_mtime,

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -1213,6 +1213,39 @@ def test_total_ordinals_awk_counts_universal_downloading_marker():
     assert "Item [a-f0-9]+: [0-9]+ ordinals" not in main_cmd, main_cmd
 
 
+def test_download_phase_classifies_no_media_skip_marker_as_active():
+    """All-no-media partners — e.g. a maintain-mode pass over a hub whose
+    items have no eligible media — emit the per-item ``No media;
+    skipping.`` marker added at ``tools/downloader.py:484``. The status
+    script must treat that marker as evidence the downloader is
+    actively iterating, not classify the run as ``Stalled``. Without
+    this branch in the tail-check, the prior tests asserting ``Stalled``
+    only on truly missing markers would mask the calhoun-style
+    misclassification."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_phase(
+        log_filename="20260623-200436-georgia+calhoun-gordon-county-library-download.log",
+        awk_counts=[42311, 0, 0, 0, 0],  # 42,311 items iterated, no COUNTS yet
+        csv_total=50120,
+        tail="[INFO] 16:50:00: No media; skipping.",
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-georgia+calhoun-gordon-county-library",
+            hub="georgia",
+            label="georgia+calhoun-gordon-county-library",
+        )
+    assert phase is not None
+    assert phase.startswith("Downloading"), phase
+    assert "Stalled" not in phase, phase
+    assert "42,311 / 50,120 items" in phase, phase
+    assert "~84.4%" in phase, phase
+
+
 def test_fetch_position_annotation_for_multi_label_batch():
     """Multi-label batch sessions get a `[<pos>/<total>]` suffix on the
     active label, replacing the prior `(+N more)` form. Lets the

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -482,6 +482,17 @@ class Downloader:
 
             else:
                 # item metadata has neither media_master nor IIIF manifest field
+                # — emit a per-item marker so the silent-skip path leaves an
+                # activity trail in the log. Without this, an all-no-media
+                # partner (e.g. maintain-mode passes over a hub whose items
+                # have no eligible media) produces only ``DPLA ID:`` lines per
+                # item and no other downloader markers, which makes
+                # ``wikimedia_upload_status`` misclassify the active phase
+                # as ``Stalled``. This branch didn't matter before maintain
+                # mode existed — most pre-maintain partners had at least
+                # ``mediaMaster`` or an IIIF manifest, so the silent path
+                # was rarely hit at scale.
+                logging.info("No media; skipping.")
                 self.tracker.increment(Result.SKIPPED)
                 return
 


### PR DESCRIPTION
## Summary

Fixes the ``Stalled`` misclassification you saw on the georgia+calhoun-gordon-county-library session today. The downloader was actively iterating items at ~13/sec the whole time — every one of the 50,120 items has staged metadata with neither ``mediaMaster`` nor an IIIF manifest, so they all hit the silent-skip branch at [`tools/downloader.py:484`](https://github.com/dpla/ingest-wikimedia/blob/main/tools/downloader.py#L484) which only ``tracker.increment(Result.SKIPPED)`` + ``return`` with no log line. The download log contained only ``[INFO] HH:MM:SS: DPLA ID: <id>`` lines plus the terminal ``COUNTS: SKIPPED: 50120`` block — no ``Downloading``, no ``Key already in S3``.

The status script's download-phase classifier at [`scripts/wikimedia_upload_status.py:341`](https://github.com/dpla/ingest-wikimedia/blob/main/scripts/wikimedia_upload_status.py#L341) looks for ``Downloading`` or ``Key already in S3`` in the recent tail. Both absent → falls through to ``Stalled (…)`` — a phase label that **replaces** the phase name (vs the ``⚠ idle`` *suffix* used by upload/SDC). Net effect: the user-facing status read ``Stalled (42,311 / 50,120 items, ~84.4%)`` for a phase that was emitting items in real time and went on to complete a minute later.

Pre-maintain-mode this branch was rarely hit at scale because most partners had ``mediaMaster`` or an IIIF manifest on every item. Maintain mode + hubs with broad item lists (NARA, calhoun, etc.) hit it constantly.

## Fix

Two narrow edits:

1. **downloader** — emit ``logging.info(\"No media; skipping.\")`` at the silent-skip branch so the path leaves a recognizable per-item marker.
2. **wikimedia_upload_status** — accept that marker as evidence of active downloader work, alongside ``Downloading`` and ``Key already in S3``.

The ``Stalled`` label now requires the originally-intended case: log exists, no terminal ``COUNTS``, and no activity marker in the tail (i.e., genuinely crashed mid-flight).

## Not in scope (separate, but related)

- The terminology mismatch you flagged — ``Stalled`` *replaces* the phase name while ``⚠ idle Nm`` *suffixes* it. After this PR, the harsh label fires only in the crashed case where the swap is more justified, but the inconsistency still exists for the truly-crashed path. Worth a follow-up if you want them normalized.
- The other silent-skip log lines (line 440 warning, the bare ``Bad rights category`` / ``Bad asset`` info-info in the **uploader**) — not touched here; the calhoun case was specifically about the downloader's no-media branch.

## Test plan

- [x] New unit test ``test_download_phase_classifies_no_media_skip_marker_as_active`` reproduces calhoun's exact numbers (42,311 / 50,120) and asserts the phase is ``Downloading``, not ``Stalled``
- [x] Full ``tests/test_wikimedia_upload_status.py`` passes on EC2 (43 passed)
- [x] ``ruff check`` + ``ruff format`` clean
- [ ] Live verify: re-run ``/wikimedia-status`` against the calhoun session after this lands. (Now that the session has moved to the upload phase, the live verify will need a partner about to start a fresh no-media pass.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated downloader logging so no-media items now emit a `No media; skipping.` marker before being skipped, and taught the status checker to treat that marker as active download progress alongside `Downloading` and `Key already in S3`. Added a regression test to ensure no-media runs are classified as `Downloading` rather than `Stalled`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->