### PR TITLE
maintain: resolve de-opted QIDs; de-dupe repeated Slack targets

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -137,7 +137,7 @@ A Wikidata entity identifier (e.g. `Q72380652`). The launch script resolves the 
 
 For a **regular** run, QID resolution drops matches that aren't upload-eligible (hub *and* institution both `upload=false`), so an ineligible QID resolves to nothing. In **maintain** mode that filter is lifted (QID-only gate) — a de-opted (`upload=false`) institution resolves and runs, which is the whole point of maintain. A QID present under multiple hubs then yields one session per hub.
 
-The Lambda handler validates QID format (`^Q\d+$`) and passes QIDs through unchanged; resolution happens in the launch script where `institutions_v2.json` is already cached. A target repeated in the same command (or a QID and its `hub|institution` equivalent) is silently de-duplicated rather than rejected.
+The Lambda handler validates QID format (`^Q\d+$`) and passes QIDs through unchanged; resolution happens in the launch script where `institutions_v2.json` is already cached. A target **repeated verbatim** in the same command is silently de-duplicated (kept once) rather than rejected. A QID and its equivalent `hub|institution` form are *different* raw tokens, so they aren't collapsed there — but they resolve to the same session label, and the launcher skips the duplicate with a warning. Either way the target runs once.
 
 ---
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -135,7 +135,9 @@ A Wikidata entity identifier (e.g. `Q72380652`). The launch script resolves the 
 - If the QID matches an **institution-level** Wikidata field → institution-level run (equivalent to `hub|Institution Name`)
 - If the QID maps to multiple institutions (same or different hubs) → all matching entries run as separate targets
 
-The Lambda handler validates QID format (`^Q\d+$`) and passes QIDs through unchanged; resolution happens in the launch script where `institutions_v2.json` is already cached.
+For a **regular** run, QID resolution drops matches that aren't upload-eligible (hub *and* institution both `upload=false`), so an ineligible QID resolves to nothing. In **maintain** mode that filter is lifted (QID-only gate) — a de-opted (`upload=false`) institution resolves and runs, which is the whole point of maintain. A QID present under multiple hubs then yields one session per hub.
+
+The Lambda handler validates QID format (`^Q\d+$`) and passes QIDs through unchanged; resolution happens in the launch script where `institutions_v2.json` is already cached. A target repeated in the same command (or a QID and its `hub|institution` equivalent) is silently de-duplicated rather than rejected.
 
 ---
 

--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -339,7 +339,9 @@ def canonical_matches_session_component(
     )
 
 
-def resolve_wikidata_id(qid: str, timeout: int = 5) -> list[tuple[str, str | None]]:
+def resolve_wikidata_id(
+    qid: str, timeout: int = 5, *, maintain: bool = False
+) -> list[tuple[str, str | None]]:
     """Return (canonical_slug, institution_or_None) pairs matching a Wikidata QID.
 
     Searches hub-level and institution-level Wikidata fields in
@@ -363,6 +365,15 @@ def resolve_wikidata_id(qid: str, timeout: int = 5) -> list[tuple[str, str | Non
     misleading ``Skipped targets: 'lc'`` error. Filtering here keeps
     eligibility on the QID resolution side, where the data shape is
     available, instead of leaking that knowledge into every caller.
+
+    ``maintain`` drops that filter (QID-only gate): a maintain run
+    reconciles files ALREADY on Commons, so a de-opted (``upload:
+    False``) institution is exactly when it applies — the whole point
+    of maintain. Any hub-/institution-level QID match is returned
+    regardless of the upload flag. A QID present under multiple hubs
+    then resolves to one match per hub, which the launcher groups into
+    one session each (as it does for any cross-hub QID); the same
+    QID-derived Commons category is therefore walked once per hub.
     """
     institutions = _get_institutions(timeout)
     results: list[tuple[str, str | None]] = []
@@ -371,7 +382,7 @@ def resolve_wikidata_id(qid: str, timeout: int = 5) -> list[tuple[str, str | Non
         if canonical is None:
             continue
         hub_upload = bool(hub_data.get("upload"))
-        if hub_data.get("Wikidata") == qid and hub_upload:
+        if hub_data.get("Wikidata") == qid and (maintain or hub_upload):
             results.append((canonical, None))
         # Don't ``continue`` on a hub-level QID match — if the same
         # QID is also used by an institution within this hub, that
@@ -381,6 +392,6 @@ def resolve_wikidata_id(qid: str, timeout: int = 5) -> list[tuple[str, str | Non
         for inst_name, inst_data in hub_data.get("institutions", {}).items():
             if inst_data.get("Wikidata") != qid:
                 continue
-            if hub_upload or bool(inst_data.get("upload")):
+            if maintain or hub_upload or bool(inst_data.get("upload")):
                 results.append((canonical, inst_name))
     return results

--- a/lambda/wikimedia-slack-dispatch/handler.py
+++ b/lambda/wikimedia-slack-dispatch/handler.py
@@ -216,25 +216,26 @@ def _validate_launch_targets(
     Validate a list of target tokens (hub slugs, DPLA IDs, QIDs, pipe-separated).
     Returns (launch_targets, None) on success, or ([], error_reply) on the first
     invalid token.
+
+    A target repeated in the same command is silently de-duplicated (kept once,
+    in first-seen order) rather than rejected: the operator's intent is
+    unambiguous, and running it once is risk-free. Only genuinely invalid tokens
+    (unknown hub, bad syntax) abort the launch.
     """
     seen_tokens: set[str] = set()
     launch_targets: list[str] = []
+
+    def _add(target: str) -> None:
+        # De-dupe a repeated target: keep the first occurrence, preserve order.
+        if target not in seen_tokens:
+            seen_tokens.add(target)
+            launch_targets.append(target)
+
     for token in tokens:
         if is_wikidata_id(token):
-            if token in seen_tokens:
-                return [], _slack_reply(
-                    f"Target `{token}` appears more than once.", ephemeral=True
-                )
-            seen_tokens.add(token)
-            launch_targets.append(token)
+            _add(token)
         elif is_dpla_id(token):
-            normalised = token.lower()
-            if normalised in seen_tokens:
-                return [], _slack_reply(
-                    f"Target `{normalised}` appears more than once.", ephemeral=True
-                )
-            seen_tokens.add(normalised)
-            launch_targets.append(normalised)
+            _add(token.lower())
         else:
             pipe_count = token.count("|")
             if pipe_count > 2:
@@ -264,12 +265,7 @@ def _validate_launch_targets(
                 target_str = f"{canonical}|{institution}"
             else:
                 target_str = canonical
-            if target_str in seen_tokens:
-                return [], _slack_reply(
-                    f"Target `{target_str}` appears more than once.", ephemeral=True
-                )
-            seen_tokens.add(target_str)
-            launch_targets.append(target_str)
+            _add(target_str)
     return launch_targets, None
 
 

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -627,7 +627,7 @@ def main() -> None:
 
     for token in target_tokens:
         if is_wikidata_id(token):
-            resolved = resolve_wikidata_id(token)
+            resolved = resolve_wikidata_id(token, maintain=maintain)
             if not resolved:
                 skipped_warnings.append(
                     f"Wikidata ID {token!r}: not found in institutions_v2.json."

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -337,3 +337,35 @@ def test_plain_maintain_does_not_set_count_only(monkeypatch, handler_module):
 
     assert reply["statusCode"] == 200
     assert "count_only" not in dispatched[0]["inputs"]
+
+
+def test_duplicate_targets_are_deduped_not_rejected(monkeypatch, handler_module):
+    """A target repeated in one command is silently de-duped and still
+    launches — the operator's intent is unambiguous and running it once is
+    risk-free. Pins the fix for the loud 'appears more than once' rejection."""
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(_make_event("maintain Q77062489 Q77062489"), None)
+
+    assert reply["statusCode"] == 200
+    assert len(dispatched) == 1, "a duplicate target must not abort the launch"
+    text = _decode_reply(reply)["text"]
+    assert "appears more than once" not in text
+    # The QID survives exactly once in the dispatched partner string.
+    assert dispatched[0]["inputs"]["partner"].count("Q77062489") == 1
+
+
+def test_duplicate_hub_slug_deduped_across_mixed_targets(monkeypatch, handler_module):
+    """De-dupe is by resolved target, preserving first-seen order and keeping
+    distinct targets. `bpl pa bpl` → `bpl pa` (one each)."""
+    dispatched: list[dict] = []
+    _setup_env_and_stubs(monkeypatch, handler_module, dispatched)
+
+    reply = handler_module.handler(_make_event("bpl pa bpl"), None)
+
+    assert reply["statusCode"] == 200
+    assert len(dispatched) == 1
+    partner = dispatched[0]["inputs"]["partner"]
+    assert partner.count("bpl") == 1
+    assert "pa" in partner

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -212,7 +212,19 @@ def test_resolve_wikidata_id_maintain_keeps_de_opted_matches_across_hubs():
             },
         },
     }
-    with _mock_institutions(data):
+    # Pin the slug map locally so the test exercises only the maintain-mode
+    # filter, not the real registry (a slug rename shouldn't break it).
+    with (
+        _mock_institutions(data),
+        patch.dict(
+            "ingest_wikimedia.partners._SLUG_BY_HUB_NAME",
+            {
+                "digital library of georgia": "georgia",
+                "internet archive": "ia",
+                "north carolina digital heritage center": "digitalnc",
+            },
+        ),
+    ):
         default = resolve_wikidata_id("Q5312898")
         maintained = resolve_wikidata_id("Q5312898", maintain=True)
     # The default (upload-gated) path drops all three — the reported bug.

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -182,6 +182,49 @@ def test_resolve_wikidata_id_same_hub_overlap_picks_up_eligible_institution():
     assert results == [("overlap-hub", "Self-listed Institution")]
 
 
+def test_resolve_wikidata_id_maintain_keeps_de_opted_matches_across_hubs():
+    """In maintain mode the upload-eligibility filter is dropped (QID-only
+    gate): a de-opted (upload=false) institution still resolves, because
+    maintain reconciles files ALREADY on Commons — exactly when it applies. A
+    QID present under multiple hubs resolves to one match per hub. Mirrors the
+    reported Duke (Q5312898) case, which the default filter wrongly returned
+    empty for (→ misleading "not found in institutions_v2.json")."""
+    data = {
+        "Digital Library of Georgia": {
+            "Wikidata": "Qhub-ga",
+            "upload": False,
+            "institutions": {
+                "Duke University. Library": {"Wikidata": "Q5312898", "upload": False},
+            },
+        },
+        "Internet Archive": {
+            "Wikidata": "Qhub-ia",
+            "upload": False,
+            "institutions": {
+                "Duke University Libraries": {"Wikidata": "Q5312898", "upload": False},
+            },
+        },
+        "North Carolina Digital Heritage Center": {
+            "Wikidata": "Qhub-nc",
+            "upload": False,
+            "institutions": {
+                "Duke University Libraries": {"Wikidata": "Q5312898", "upload": False},
+            },
+        },
+    }
+    with _mock_institutions(data):
+        default = resolve_wikidata_id("Q5312898")
+        maintained = resolve_wikidata_id("Q5312898", maintain=True)
+    # The default (upload-gated) path drops all three — the reported bug.
+    assert default == []
+    # Maintain keeps every match, one per hub (launcher groups → one session each).
+    assert set(maintained) == {
+        ("georgia", "Duke University. Library"),
+        ("ia", "Duke University Libraries"),
+        ("digitalnc", "Duke University Libraries"),
+    }
+
+
 # --- maintain mode: slug/target -> QID -> exact Commons category -------------
 
 


### PR DESCRIPTION
Two maintain-mode Slack operator-UX fixes (related: both are launch-target handling at the front door).

## 1. Bare-QID maintain targets for de-opted institutions

`/wikimedia-upload maintain Q5312898` failed with `Wikidata ID 'Q5312898': not found in institutions_v2.json` — but it **is** in the JSON. `Q5312898` (Duke University Libraries) appears as an institution under 3 hubs (georgia, ia, digitalnc), all `upload=false`. `resolve_wikidata_id` filters out matches where neither hub nor institution is upload-eligible, so all three were dropped → empty → misleading "not found."

This is the launcher front-door analogue of the get-ids institution gate that maintain already relaxes. Maintain exists to reconcile **de-opted** institutions' files, so its QID resolution must honor the same QID-only gate.

**Fix:** `resolve_wikidata_id(qid, *, maintain=False)` — when `maintain`, drop the upload filter (any hub/institution QID match resolves). `wikimedia_launch.py` passes `maintain=maintain` at its one call site. A cross-hub QID resolves to one session per hub (consistent with existing cross-hub QID behavior); each walks the same QID-derived Commons category once.

## 2. Duplicate targets shouldn't kill a launch

`maintain Q77062489 Q77062489` aborted with `Target Q77062489 appears more than once.` The intent is unambiguous and a duplicate run is risk-free, so `_validate_launch_targets` now **silently de-dupes** (keep first, preserve order) instead of rejecting. Only genuinely invalid tokens (unknown hub, bad syntax) still abort. The launcher's session-label collision check remains the downstream safety net. The three identical dedup tails are collapsed into one nested helper.

## Tests
- `test_partners.py`: maintain keeps de-opted matches across all 3 hubs; default still filters them (regression guard).
- `test_lambda_handler.py`: repeated QID / repeated hub slug de-duped and dispatched once, not rejected.
- Full suite green (71 passed); ruff clean.
- `docs/operations.md`: QID-resolution note for both behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated maintain-mode QID resolution so de-opted institutions can still be launched even when their hub/institution entries are `upload=false`, while normal runs keep the existing eligibility filtering. Also changed Slack launch target validation to silently de-duplicate repeated valid targets in a single command instead of aborting, preserving order and first occurrence.

Added tests for maintain-mode QID resolution across de-opted hubs and for duplicate target de-duplication, and documented the QID-resolution behavior in `docs/operations.md`.

Deployment note: Lambda/launcher code changes require redeploying the affected runtime to take effect; no environment variables/secrets, DB migrations, shared infrastructure configuration, endpoint/public response shapes, or auth/security behavior were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->