### PR TITLE
maintain: fail the target with `false`, not `exit 1` (kept killing the batch)

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -203,7 +203,7 @@ def _maintain_sdc_cat_steps(
     commonswiki sitelink — never derived from the display name).
 
     An institution whose category can't be resolved emits a failing
-    ``echo … >&2; exit 1`` rather than silently widening the write scope.
+    ``echo … >&2; false`` rather than silently widening the write scope.
     Shared by the lite and hash maintain routes — both anchor the SDC phase on
     the *live category*, so reconciliation covers every file already on
     Commons, not just a get-ids id list.
@@ -224,7 +224,18 @@ def _maintain_sdc_cat_steps(
                 f"maintain: could not resolve a Commons category for {who}"
                 " (missing Wikidata QID or P8464 Commons-category link); skipping."
             )
-            steps.append(f"echo {shlex.quote(msg)} >&2; exit 1")
+            # ``false`` (not ``exit 1``): the launcher composes per-target
+            # blocks with a trailing ``|| { notify_fail; }``, expecting
+            # individual targets to fail loudly without taking the rest of
+            # the batch down with them. ``exit 1`` here would terminate the
+            # whole shell — bypassing both the per-target ``||`` notify and
+            # every subsequent target's block — so the first un-resolvable
+            # institution kills the entire batch (observed on a 15-QID
+            # maintain run where target #3 had no P8464 sitelink, leaving
+            # targets #4-15 unrun and Slack silent). ``false`` fails the
+            # ``&&`` chain with exit 1 but stays in the same shell, so the
+            # outer ``||`` runs and the chain proceeds to the next target.
+            steps.append(f"echo {shlex.quote(msg)} >&2; false")
     return steps
 
 
@@ -265,7 +276,9 @@ def _build_maintain_lite_pipeline_steps(
             f"maintain mode does not support {unit} targets; it operates"
             " on a whole hub/institution Commons category."
         )
-        return [f"cd {base}", f"echo {shlex.quote(msg)} >&2; exit 1"]
+        # ``false`` not ``exit 1`` — see the note on the
+        # missing-category branch below; same reasoning applies here.
+        return [f"cd {base}", f"echo {shlex.quote(msg)} >&2; false"]
 
     # count-only and --from-s3 are mutually exclusive: pre-flight sizing only
     # resolves the re-link (no sidecar read, no write), so it skips both the

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -470,10 +470,62 @@ def test_maintain_count_only_ignores_worker_opts():
 
 def test_maintain_rejects_collection_and_single_id_targets():
     coll = _maintain_steps("georgia", (), False, collection="Maps")
-    assert coll[-1].endswith("exit 1")
+    # ``false``, not ``exit 1`` — see test below: ``exit 1`` from inside the
+    # outer ``{ … }`` group kills the whole batch script, not just the target.
+    assert coll[-1].endswith("false")
     assert "does not support" in coll[-1]
     single = _maintain_steps("georgia", (), False, dpla_id="abc123")
-    assert single[-1].endswith("exit 1")
+    assert single[-1].endswith("false")
+
+
+def test_maintain_unresolvable_category_fails_target_not_whole_batch():
+    """If a target can't be resolved to a Commons category, the launcher
+    must fail JUST that target (so the outer ``|| { notify_fail; }`` runs
+    and the next target proceeds), NOT terminate the whole shell.
+
+    The launcher composes per-target blocks as
+    ``{ cd … && step1 && … && <error-step> ; } || { notify_fail; }`` and
+    chains many such blocks with ``;``. ``exit 1`` inside the outer ``{ … }``
+    group kills the whole shell — bypassing both the per-target ``||`` notify
+    AND every subsequent target's block. Observed on a 15-QID maintain run
+    where target #3 (Azalea Regional Library System, Q29094224) had no P8464
+    sitelink: its target block ran through download + uploader, then hit
+    ``exit 1``, leaving targets #4-15 unrun and no Slack failure post
+    (because ``exit`` bypasses ``||``).
+
+    ``false`` is the right primitive here: it fails the ``&&`` chain with
+    exit 1 but stays in the same shell, so the outer ``||`` fires and the
+    chain proceeds to the next target.
+    """
+    import scripts.wikimedia_launch as launch_mod
+
+    # Force "no category resolvable" path: wikidata_qid_for_target returns
+    # None (no QID on the institution at all).
+    with (
+        patch.object(launch_mod, "wikidata_qid_for_target", return_value=None),
+        patch.object(launch_mod, "resolve_commons_category", return_value=None),
+    ):
+        steps = launch_mod._build_maintain_lite_pipeline_steps(
+            "georgia",
+            ("Azalea Regional Library System",),
+            None,
+            None,
+            "/srv/base",
+            "out.csv",
+            count_only=False,
+            worker_opts="",
+        )
+
+    error_step = next(s for s in steps if "could not resolve" in s)
+    # Must NOT use ``exit 1`` — that would kill the whole batch shell.
+    assert "exit 1" not in error_step, (
+        f"error step uses ``exit 1`` which terminates the whole batch shell; "
+        f"must use ``false`` to fail only this target. Got: {error_step!r}"
+    )
+    # Must use ``false`` so the ``&&`` chain fails but the shell survives.
+    assert error_step.endswith("false"), error_step
+    # The diagnostic to stderr must still be present.
+    assert "could not resolve a Commons category" in error_step
 
 
 def test_maintain_mutually_exclusive_with_sdc_only():


### PR DESCRIPTION
## Summary

The maintain-mode launcher composes a multi-target batch as one long bash script with per-target blocks chained by ``;``:

```bash
{ cd … && get-ids-es … && downloader … && uploader … && sdc-sync --cat … --maintain ; } || { notify_fail; };
{ … next target … } || { … };
…
```

When an institution has **no Wikidata QID or no P8464 Commons-category sitelink**, ``_maintain_sdc_cat_steps`` substituted in this final step instead of an ``sdc-sync --cat`` call:

```bash
echo 'maintain: could not resolve a Commons category for <Name> …; skipping.' >&2; exit 1
```

Same pattern guarded the single-DPLA-id / collection rejection in the lite-route entry.

**``exit 1`` inside the outer ``{ … }`` group terminates the whole shell**, not just the target. That:
- bypasses the per-target ``|| { notify_fail; }`` — no Slack post fires
- never reaches the next target's block — all subsequent QIDs go un-run

## Observed

A maintain run with 15 Georgia institution QIDs:

1. Q57514545 Athens-Clarke County Library — ran fully
2. Q30267984 Augusta-Richmond County Public Library — ran fully
3. **Q29094224 Azalea Regional Library System** — get-ids + downloader + uploader (~30 min) all completed, then hit the missing-category ``exit 1``, killing the shell
4. Q69765977 Calhoun-Gordon County Library — never ran
5. … (11 more QIDs through Q77062603) — never ran

Slack was silent because ``exit`` bypasses the ``||``.

## Fix

Replace both ``exit 1`` instances in [`scripts/wikimedia_launch.py`](https://github.com/dpla/ingest-wikimedia/blob/main/scripts/wikimedia_launch.py) with ``false``. ``false`` returns exit 1 (so the ``&&`` chain fails identically) but stays in the same shell — the outer ``||`` fires for the failing target, the next target's block proceeds. The diagnostic text (``…; skipping.``) is unchanged; it always described per-target skip, the implementation just didn't match.

## Test plan

- [x] New unit test ``test_maintain_unresolvable_category_fails_target_not_whole_batch`` pins the contract: the error step must end in ``false`` and must NOT contain ``exit 1``
- [x] Updated ``test_maintain_rejects_collection_and_single_id_targets`` to match
- [x] Full ``tests/test_wikimedia_launch.py`` passes on EC2 (45 passed)
- [x] ``ruff check`` + ``ruff format`` clean
- [ ] Re-run the original 15-QID maintain batch after merge — expect the 3 no-category targets (Q29094224 Azalea, Q78362427 Columbia County Evans, Q30268035 Live Oak) to fail gracefully with a Slack notification each, and the other 12 to complete in sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the maintain-mode launcher so a single-target failure no longer aborts the entire batch.

- In `scripts/wikimedia_launch.py`, per-target maintain failures now return `false` instead of `exit 1` for:
  - unresolved Commons category lookups
  - unsupported lite-route targets (`--single-id` / collection-scoped)
- Preserved the existing diagnostic/error messages while allowing the outer failure handler to run and the batch to continue with later targets.
- Added/updated tests in `tests/test_wikimedia_launch.py` to verify the generated shell ends with `false` in these failure cases and still emits the expected error text.

No manual pipeline trigger, ECS redeployment, env var/Secrets changes, DB migration, shared infrastructure config changes, API changes, or security-impacting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->