### PR TITLE
maintain: skip targets with no Commons category AND no existing files (case-2)

### DIFF
--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -7,6 +7,7 @@ GitHub Actions without installing the full ingest_wikimedia package dependencies
 import json
 import re
 import urllib.error
+import urllib.parse
 import urllib.request
 
 # Module-level cache so warm Lambda invocations skip repeated network fetches.
@@ -278,6 +279,64 @@ def resolve_commons_category(qid: str, timeout: int = 10) -> str | None:
                     result = title
                     break
     _commons_category_cache[qid] = result
+    return result
+
+
+# Commons API endpoint for the launcher's case-2 pre-flight (see
+# commons_has_files_for_qid). Same host as commons_site uses, but we go via
+# urllib so this module stays stdlib-only.
+_COMMONS_API_URL = "https://commons.wikimedia.org/w/api.php"
+_commons_files_for_qid_cache: dict[str, bool] = {}
+
+
+def commons_has_files_for_qid(qid: str, timeout: int = 10) -> bool:
+    """True if any Commons File: page carries a P195 (collection) SDC claim
+    pointing at ``qid``.
+
+    Used as the case-2 pre-flight in maintain mode: when an institution has no
+    resolvable Commons category (no P8464 + commonswiki sitelink) AND no file
+    on Commons references its QID, the maintain ``sdc-sync --cat`` step has
+    nothing to walk — the launcher should skip the target gracefully rather
+    than fail it (or eagerly create empty category infrastructure).
+
+    Why P195: every DPLA-bot upload runs through the SDC sync, which posts a
+    P195 ('collection') statement with the institution's QID. So the set of
+    Commons files contributed by an institution is exactly the set with
+    ``haswbstatement:P195=<qid>`` — irrespective of which {{Institution}} /
+    {{DPLA metadata}} template variant the file's wikitext uses. Cirrus's
+    structured-data index makes this a single fast query.
+
+    Fails OPEN (returns True) on any network/parse error so a transient blip
+    doesn't downgrade a real case-1 (files exist) target into a case-2 skip.
+
+    Cached per QID for the life of the process."""
+    if not is_wikidata_id(qid):
+        return False
+    if qid in _commons_files_for_qid_cache:
+        return _commons_files_for_qid_cache[qid]
+    params = {
+        "action": "query",
+        "format": "json",
+        "list": "search",
+        "srsearch": f"haswbstatement:P195={qid}",
+        "srnamespace": "6",
+        "srlimit": "1",
+        "srinfo": "totalhits",
+        "srprop": "",
+    }
+    query = urllib.parse.urlencode(params)
+    url = f"{_COMMONS_API_URL}?{query}"
+    req = urllib.request.Request(url, headers={"User-Agent": _WIKIDATA_UA})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read())
+        total = data.get("query", {}).get("searchinfo", {}).get("totalhits", 0)
+        result = bool(total and total > 0)
+    except (urllib.error.URLError, TimeoutError, ValueError, KeyError):
+        # Fail open: assume files exist so the launcher doesn't silently skip a
+        # target on a transient outage.
+        result = True
+    _commons_files_for_qid_cache[qid] = result
     return result
 
 

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -38,6 +38,7 @@ import requests
 
 from ingest_wikimedia.partners import (
     PARTNER_DIR,
+    commons_has_files_for_qid,
     is_dpla_id,
     is_upload_eligible,
     is_wikidata_id,
@@ -202,8 +203,23 @@ def _maintain_sdc_cat_steps(
     resolving each to its exact Commons category via Wikidata (P8464 →
     commonswiki sitelink — never derived from the display name).
 
-    An institution whose category can't be resolved emits a failing
-    ``echo … >&2; false`` rather than silently widening the write scope.
+    When a category can't be resolved (no P8464 sitelink on the institution's
+    Wikidata item), branch on whether any DPLA-bot uploads exist for the QID:
+
+    * **No files exist on Commons** (case-2): nothing to maintain. Emit an
+      info-log step that exits 0 (``echo … ; true``) so the target succeeds
+      and the batch proceeds — we don't materialise empty category
+      infrastructure pre-emptively, matching the file-driven contract the
+      uploader's ``CategoryEnsurer`` and ``tools/fix_unknown_categories``
+      already follow (don't create a category until there's a file for it).
+    * **Files exist** (case-1, e.g. institution-name drift since the upload):
+      fall through to a per-target failure (``echo … >&2; false``).  The
+      eventual fix is for the launcher to ``CategoryEnsurer.ensure(qid)``
+      before the SDC step in this case, but that path needs a live case to
+      test and isn't merged yet — for now we fail loudly per-target (notify
+      runs, batch continues) instead of silently skipping a target that
+      actually has work.
+
     Shared by the lite and hash maintain routes — both anchor the SDC phase on
     the *live category*, so reconciliation covers every file already on
     Commons, not just a get-ids id list.
@@ -218,24 +234,27 @@ def _maintain_sdc_cat_steps(
             steps.append(
                 f"sdc-sync --cat {shlex.quote(category)} --maintain{sync_tail}"
             )
-        else:
-            who = inst or canonical
+            continue
+        who = inst or canonical
+        if qid and not commons_has_files_for_qid(qid):
+            # Case 2: live institution, brand-new — no Commons category and
+            # no files referencing the QID. Maintain pass is a no-op for this
+            # target; succeed it and continue.
             msg = (
-                f"maintain: could not resolve a Commons category for {who}"
-                " (missing Wikidata QID or P8464 Commons-category link); skipping."
+                f"maintain: no Commons category and no existing files for {who}"
+                f" ({qid}); nothing to maintain — skipping."
             )
-            # ``false`` (not ``exit 1``): the launcher composes per-target
-            # blocks with a trailing ``|| { notify_fail; }``, expecting
-            # individual targets to fail loudly without taking the rest of
-            # the batch down with them. ``exit 1`` here would terminate the
-            # whole shell — bypassing both the per-target ``||`` notify and
-            # every subsequent target's block — so the first un-resolvable
-            # institution kills the entire batch (observed on a 15-QID
-            # maintain run where target #3 had no P8464 sitelink, leaving
-            # targets #4-15 unrun and Slack silent). ``false`` fails the
-            # ``&&`` chain with exit 1 but stays in the same shell, so the
-            # outer ``||`` runs and the chain proceeds to the next target.
-            steps.append(f"echo {shlex.quote(msg)} >&2; false")
+            steps.append(f"echo {shlex.quote(msg)} >&2; true")
+            continue
+        # Case 1 (files exist, no category yet) OR QID-less target — fall
+        # through to per-target failure. ``false`` (not ``exit 1``) so only
+        # this target fails; the outer ``|| { notify_fail; }`` runs and the
+        # batch proceeds. ``exit 1`` would terminate the whole shell (PR #343).
+        msg = (
+            f"maintain: could not resolve a Commons category for {who}"
+            " (missing Wikidata QID or P8464 Commons-category link); skipping."
+        )
+        steps.append(f"echo {shlex.quote(msg)} >&2; false")
     return steps
 
 

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -12,10 +12,12 @@ The fix is to filter results by ``upload`` at resolution time so
 non-eligible matches never leak to the launcher.
 """
 
-from unittest.mock import patch
+import json
+from unittest.mock import MagicMock, patch
 
 from ingest_wikimedia import partners
 from ingest_wikimedia.partners import (
+    commons_has_files_for_qid,
     resolve_commons_category,
     resolve_wikidata_id,
     wikidata_qid_for_target,
@@ -297,3 +299,64 @@ def test_resolve_commons_category_rejects_non_qid():
     with patch.object(partners, "_fetch_wikidata_entity") as fetch:
         assert resolve_commons_category("georgia") is None
         fetch.assert_not_called()
+
+
+def _fake_commons_search_response(totalhits: int) -> bytes:
+    """Shape a Cirrus list=search response so urlopen().read() can hand it
+    straight to ``commons_has_files_for_qid``."""
+    return json.dumps(
+        {"query": {"searchinfo": {"totalhits": totalhits}, "search": []}}
+    ).encode()
+
+
+def test_commons_has_files_for_qid_true_when_p195_hits():
+    """One or more files carry P195=<qid> in SDC: maintain has work to do."""
+    fake_resp = MagicMock()
+    fake_resp.__enter__.return_value.read.return_value = _fake_commons_search_response(
+        42
+    )
+    with (
+        patch.object(partners, "_commons_files_for_qid_cache", {}),
+        patch.object(partners.urllib.request, "urlopen", return_value=fake_resp),
+    ):
+        assert commons_has_files_for_qid("Q12345") is True
+
+
+def test_commons_has_files_for_qid_false_when_no_hits():
+    """Zero P195=<qid> hits: case-2 — the launcher should skip the
+    target's SDC step gracefully (see
+    ``test_maintain_no_category_no_files_skips_target_gracefully``)."""
+    fake_resp = MagicMock()
+    fake_resp.__enter__.return_value.read.return_value = _fake_commons_search_response(
+        0
+    )
+    with (
+        patch.object(partners, "_commons_files_for_qid_cache", {}),
+        patch.object(partners.urllib.request, "urlopen", return_value=fake_resp),
+    ):
+        assert commons_has_files_for_qid("Q12345") is False
+
+
+def test_commons_has_files_for_qid_fails_open_on_network_error():
+    """A transient Commons API outage must NOT silently downgrade a real
+    case-1 (files exist) target to case-2 (skipped). Return True on any
+    network/parse error so the launcher errs on the side of running the
+    SDC step rather than dropping a target."""
+    import urllib.error as _ue
+
+    with (
+        patch.object(partners, "_commons_files_for_qid_cache", {}),
+        patch.object(
+            partners.urllib.request,
+            "urlopen",
+            side_effect=_ue.URLError("boom"),
+        ),
+    ):
+        assert commons_has_files_for_qid("Q12345") is True
+
+
+def test_commons_has_files_for_qid_rejects_non_qid_without_network():
+    """No QID → no network call; just return False."""
+    with patch.object(partners.urllib.request, "urlopen") as urlopen:
+        assert commons_has_files_for_qid("not-a-qid") is False
+        urlopen.assert_not_called()

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -499,11 +499,13 @@ def test_maintain_unresolvable_category_fails_target_not_whole_batch():
     """
     import scripts.wikimedia_launch as launch_mod
 
-    # Force "no category resolvable" path: wikidata_qid_for_target returns
-    # None (no QID on the institution at all).
+    # Force the no-QID, no-category path (case-1 / QID-less). The case-2
+    # branch (which would emit ``true``) needs a real QID; with qid=None
+    # the launcher falls straight through to the loud-failure step.
     with (
         patch.object(launch_mod, "wikidata_qid_for_target", return_value=None),
         patch.object(launch_mod, "resolve_commons_category", return_value=None),
+        patch.object(launch_mod, "commons_has_files_for_qid", return_value=True),
     ):
         steps = launch_mod._build_maintain_lite_pipeline_steps(
             "georgia",
@@ -526,6 +528,85 @@ def test_maintain_unresolvable_category_fails_target_not_whole_batch():
     assert error_step.endswith("false"), error_step
     # The diagnostic to stderr must still be present.
     assert "could not resolve a Commons category" in error_step
+
+
+def test_maintain_no_category_no_files_skips_target_gracefully():
+    """Case-2: institution has a QID but no Commons category yet AND no
+    existing files on Commons reference the QID. There's nothing to
+    maintain; the launcher must succeed the target (``true``) with an
+    info-log line, not fail it.
+
+    Observed live on Azalea Regional Library System (Q29094224),
+    Columbia County Library (Q78362427), and Live Oak Public Libraries
+    (Q30268035) — all three have institutions_v2.json entries with
+    Wikidata QIDs but no P8464 sitelink and zero Commons files carrying
+    P195=<qid>. PR #343 stopped these from killing the batch; this
+    completes the fix by making the per-target outcome a graceful skip
+    instead of a failure notification.
+    """
+    import scripts.wikimedia_launch as launch_mod
+
+    with (
+        patch.object(launch_mod, "wikidata_qid_for_target", return_value="Q29094224"),
+        patch.object(launch_mod, "resolve_commons_category", return_value=None),
+        patch.object(launch_mod, "commons_has_files_for_qid", return_value=False),
+    ):
+        steps = launch_mod._build_maintain_lite_pipeline_steps(
+            "georgia",
+            ("Azalea Regional Library System",),
+            None,
+            None,
+            "/srv/base",
+            "out.csv",
+            count_only=False,
+            worker_opts="",
+        )
+
+    skip_step = next(s for s in steps if "nothing to maintain" in s)
+    # Must succeed the target (``true``) so the outer ``;`` proceeds to the
+    # next target's block; must NOT use ``false`` (would trigger
+    # notify_pipeline_fail for a non-failure) or ``exit 1`` (would kill the
+    # whole batch).
+    assert skip_step.endswith("true"), skip_step
+    assert "false" not in skip_step.split(";")[-1], skip_step
+    assert "exit 1" not in skip_step, skip_step
+    # The diagnostic should name the institution and the QID so the operator
+    # can identify the skipped target in the tmux log.
+    assert "Azalea Regional Library System" in skip_step
+    assert "Q29094224" in skip_step
+
+
+def test_maintain_no_category_but_files_exist_still_fails_target():
+    """Case-1: no Commons category yet, BUT files exist on Commons
+    referencing the QID. The eventual fix is to call
+    ``CategoryEnsurer.ensure(qid)`` before the SDC step so the category
+    materialises and the sync can walk it — but that path needs a live
+    test case and isn't merged yet. For now we must fail the target
+    LOUDLY (``false`` → notify_pipeline_fail) so the operator sees there's
+    real work being skipped, instead of silently downgrading to the
+    case-2 ``true`` path.
+    """
+    import scripts.wikimedia_launch as launch_mod
+
+    with (
+        patch.object(launch_mod, "wikidata_qid_for_target", return_value="Q12345"),
+        patch.object(launch_mod, "resolve_commons_category", return_value=None),
+        patch.object(launch_mod, "commons_has_files_for_qid", return_value=True),
+    ):
+        steps = launch_mod._build_maintain_lite_pipeline_steps(
+            "georgia",
+            ("Some Existing-Files Institution",),
+            None,
+            None,
+            "/srv/base",
+            "out.csv",
+            count_only=False,
+            worker_opts="",
+        )
+
+    step = next(s for s in steps if "could not resolve" in s)
+    assert step.endswith("false"), step
+    assert "true" not in step.split(";")[-1], step
 
 
 def test_maintain_mutually_exclusive_with_sdc_only():


### PR DESCRIPTION
## Summary

Follow-up to [#343](https://github.com/dpla/ingest-wikimedia/pull/343). That PR stopped a missing-category target from killing the whole batch (``exit 1`` → ``false``), but the target still failed *loudly* even when there was genuinely nothing to do. This PR distinguishes two sub-cases and handles the harmless one gracefully:

| State | After #343 | After this PR |
|---|---|---|
| Category exists | Run ``sdc-sync --cat`` | Run ``sdc-sync --cat`` (unchanged) |
| No category, no files (**case-2**) | Per-target *failure* + Slack notify | **Graceful skip**, target succeeds, no notify |
| No category, files exist (**case-1**) | Per-target *failure* + Slack notify | Per-target *failure* + Slack notify (unchanged) |

## Why case-2 should be a graceful skip, not a failure

We don't want to materialise empty Commons category infrastructure pre-emptively. The codebase's existing flows are file-driven: [`tools/uploader.py:1342`](https://github.com/dpla/ingest-wikimedia/blob/main/tools/uploader.py#L1342) calls ``CategoryEnsurer.ensure()`` per-eligible-item, and [`tools/fix_unknown_categories.py:106`](https://github.com/dpla/ingest-wikimedia/blob/main/tools/fix_unknown_categories.py#L106) calls it per-file-found-in-the-unknown-institution-category. Neither creates infrastructure on the basis of an institution being *listed*; both require a concrete file as evidence. The maintain launcher should follow the same contract.

## Concrete trio that motivated this

| QID | Institution | DPLA items | Eligible for upload | Files on Commons w/ P195=qid | Outcome |
|---|---|---|---|---|---|
| Q29094224 | Azalea Regional Library System | 18,508 | 0 (all "Bad asset") | 0 | now: graceful skip |
| Q78362427 | Columbia County Library | 200 | 0 (all "Bad asset") | 0 | now: graceful skip |
| Q30268035 | Live Oak Public Libraries | 288 | 0 (all "Bad asset") | 0 | now: graceful skip |

All three: in [`institutions_v2.json`](https://github.com/dpla/ingestion3/blob/main/src/main/resources/wiki/institutions_v2.json) with QIDs, no P8464 sitelink, no Commons category page, no existing DPLA-bot uploads.

## How case-2 is detected

New [``commons_has_files_for_qid(qid)``](https://github.com/dpla/ingest-wikimedia/blob/fix/maintain-skip-empty-targets/ingest_wikimedia/partners.py) helper: single Cirrus ``haswbstatement:P195=<qid>`` query against the Commons API. Every DPLA-bot upload runs through the SDC sync, which posts a P195 ('collection') statement with the institution's QID — so this matches exactly the set of files contributed by the institution, irrespective of which template variant the wikitext uses. Cached per-QID for the run. **Fails open** (returns True) on any network/parse error so a transient Commons outage doesn't silently downgrade a real case-1 target to case-2.

## Case-1 left for a live test case

Case-1 (QID exists, no category, files DO reference the QID — e.g. institution-name drift since upload) stays on the loud per-target failure path. The right fix is to call ``CategoryEnsurer.ensure(qid)`` before the SDC step so the category materialises mid-batch — but that path needs a live case-1 example to test against before merging. For now we fail loudly so the operator sees there's real work being skipped, rather than silently downgrading to a ``true``.

## Test plan

- [x] New ``test_maintain_no_category_no_files_skips_target_gracefully`` (asserts step ends in ``true``, includes institution name + QID in diagnostic)
- [x] New ``test_maintain_no_category_but_files_exist_still_fails_target`` (case-1 pinned on the ``false`` path until a live case lands)
- [x] Updated PR #343 test to be explicit about which branch it covers
- [x] New ``test_commons_has_files_for_qid_*`` (4 tests: hits, no hits, network fail-open, non-QID input)
- [x] Full ``tests/test_wikimedia_launch.py`` + ``tests/test_partners.py`` passes on EC2 (62 passed)
- [x] ``ruff check`` + ``ruff format`` clean
- [ ] Live verify: re-run the original 15-QID maintain batch after merge — expect the 3 Azalea/Columbia/Live Oak targets to skip gracefully (no Slack notify), the other 12 to complete normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated the Wikimedia maintain flow to distinguish between two “missing Commons category” cases:

- If a QID has Commons files but no resolvable category, the target still fails and triggers the existing notification path.
- If the QID has no Commons category and no Commons files, the target now skips gracefully so the batch can continue.

Added a cached `commons_has_files_for_qid(qid)` helper that checks Commons via Cirrus search on `P195=<qid>` and fails open on request/parse errors to avoid turning transient Commons issues into false skips.

## Tests

Expanded coverage for:
- graceful skip when no category and no Commons files exist,
- failure when files exist but the category is missing,
- Commons file-detection helper behavior,
- the prior missing-category branch from PR `#343`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->