### PR TITLE
worker_slots: add a dedicated uploader priority pool (additive 4 slots)

### DIFF
--- a/ingest_wikimedia/worker_slots.py
+++ b/ingest_wikimedia/worker_slots.py
@@ -13,15 +13,30 @@ a fixed directory of N slot files, each acquired with a non-blocking
 work and releases it on return. When more would-be writers than slots
 exist across all sessions, the excess block until a slot frees.
 
-Both Commons-writing phases draw from the same pool:
+Both Commons-writing phases draw from the slot pool, but with a tier:
 
-  * **SDC sync** — each pool worker (``--workers N``) holds one slot per
-    item it processes.
-  * **Uploader** — single-process (no parallelism), but holds one slot
-    per item too, so it counts as one writer against the shared cap
-    alongside SDC-sync workers. (The downloader is deliberately NOT in
-    the pool: it writes to source sites, not Commons, so it contends for
-    a different resource.)
+  * **Shared pool** (``DEFAULT_SLOT_DIR``) — the box-wide budget every
+    SDC-sync worker contends over. Each pool worker (``--workers N``)
+    holds one slot per item it processes.
+  * **Uploader priority pool** (``UPLOADER_PRIORITY_SLOT_DIR``) — a
+    smaller dedicated pool (``UPLOADER_PRIORITY_SLOTS``) that ONLY
+    uploaders use. The uploader's :class:`WorkerSlotBudget` is wired
+    with the priority pool as primary and the shared pool as
+    ``fallback``, so it acquires from priority first and spills into
+    shared only when all priority slots are held by other simultaneous
+    uploaders. SDC sync constructs no fallback, so it can never lock
+    a priority slot.
+
+    Net effect: an uploader is never blocked by SDC-sync workers as
+    long as fewer than ``UPLOADER_PRIORITY_SLOTS`` uploader items are
+    box-wide in flight. The priority pool is additive (not carved out
+    of the shared budget), trading ~4 more concurrent Commons writers
+    under saturation for guaranteed uploader headroom — a deliberate
+    choice given uploaders are slow-moving and SDC sessions are
+    memory-cheap.
+
+  * **Downloader** is deliberately not in either pool: it writes to
+    source sites, not Commons, so it contends for a different resource.
 
 So the cap bounds the number of DPLA *items* being actively written to
 Commons at once across the whole box — summed over every upload and
@@ -94,6 +109,32 @@ _FLOCK_CONTENDED_ERRNOS = frozenset({errno.EAGAIN, errno.EWOULDBLOCK})
 # clears /tmp also kills every holder, so there's nothing to preserve.
 DEFAULT_SLOT_DIR = "/tmp/sdc-sync-worker-slots"
 
+# Dedicated priority-pool directory for uploader sessions. Smaller pool
+# (UPLOADER_PRIORITY_SLOTS) that ONLY uploaders contend over, kept on a
+# separate path so SDC-sync workers — which never use this directory —
+# can't lock its slots. Uploaders try this pool first per acquisition
+# pass and fall back to ``DEFAULT_SLOT_DIR`` only when all priority
+# slots are held by other uploaders. Net effect: an uploader is never
+# blocked by SDC-sync workers as long as fewer than
+# ``UPLOADER_PRIORITY_SLOTS`` uploader items are simultaneously in
+# flight box-wide.
+UPLOADER_PRIORITY_SLOT_DIR = "/tmp/dpla-uploader-priority-slots"
+
+# Default size of the dedicated uploader priority pool. Sized for
+# typical box concurrency (1–4 uploader sessions, each holding ≤1 slot
+# at any moment): four priority slots fully absorbs the common case
+# without ever queueing behind SDC-sync workers.
+#
+# This pool is ADDITIVE to the shared pool — total writers on the box
+# = shared budget + UPLOADER_PRIORITY_SLOTS — because uploaders are
+# slow-moving (one item per session at a time, big multi-page items
+# hold a slot for many minutes) and SDC sessions are memory-cheap, so
+# carving out of the existing shared budget would shrink SDC concurrency
+# without buying much for uploads. Adding fresh capacity costs ~4 more
+# concurrent Commons writers under saturation, which Commons' parser
+# pool tolerates comfortably.
+UPLOADER_PRIORITY_SLOTS = 4
+
 # Poll interval when every slot is currently held. Slots turn over on
 # the order of seconds (one per-item SDC sync), so a sub-second poll
 # keeps latency low without busy-spinning.
@@ -112,11 +153,27 @@ class WorkerSlotBudget:
     ``budget <= 0`` disables the semaphore entirely: :meth:`acquire`
     becomes a no-op context manager. This is the single-process /
     unlimited path — callers don't special-case it.
+
+    Optional ``fallback``: when set, :meth:`acquire` tries this budget
+    first (single non-blocking pass per iteration) and only consults
+    ``fallback`` once the primary pool is fully held. Used for the
+    uploader's two-tier setup: a small dedicated pool (this budget)
+    that the uploader tries first, with the box-wide shared pool
+    (``fallback``) as overflow. The fallback's slots come from a
+    DIFFERENT directory and a DIFFERENT lock-file set, so they're
+    accounted for separately and SDC workers using only the fallback
+    can never lock priority slots.
     """
 
-    def __init__(self, budget: int, slot_dir: str = DEFAULT_SLOT_DIR):
+    def __init__(
+        self,
+        budget: int,
+        slot_dir: str = DEFAULT_SLOT_DIR,
+        fallback: "WorkerSlotBudget | None" = None,
+    ):
         self.budget = budget
         self.slot_dir = slot_dir
+        self.fallback = fallback
         # Cumulative seconds this process spent blocked in acquire() waiting
         # for a free slot. ~0 when the budget isn't contended; grows under
         # saturation. Callers read it to report slot contention.
@@ -170,10 +227,13 @@ class WorkerSlotBudget:
         (also released automatically if this process dies while
         holding it).
 
-        When ``budget <= 0`` the budget is disabled and this yields
-        immediately without touching the filesystem.
+        When ``budget <= 0`` the budget is disabled, AND no fallback is
+        set, this yields immediately without touching the filesystem.
+        When ``budget <= 0`` but a fallback exists, defers to the
+        fallback's normal acquisition — preserving the "primary disabled,
+        still capped by fallback" semantics callers may rely on.
         """
-        if self.budget <= 0:
+        if self.budget <= 0 and self.fallback is None:
             yield
             return
 
@@ -189,36 +249,67 @@ class WorkerSlotBudget:
                 # LOCK_UN needed — close is the documented release.
                 os.close(fd)
 
-    def _acquire_slot_fd(self) -> int:
-        """Block until a slot is free; return the held fd.
+    def _try_acquire_one_pass(self) -> int | None:
+        """One non-blocking scan over this budget's slot files. Returns
+        the held fd on success, ``None`` if every slot is currently held.
 
-        Returns the open file descriptor whose flock this call now
-        holds. Caller owns closing it.
+        Doesn't sleep, doesn't log, doesn't recurse into ``fallback`` —
+        that policy lives in ``_acquire_slot_fd``. A disabled budget
+        (``budget <= 0``) returns ``None`` immediately so callers
+        composing tiers can move on to the next pool.
+        """
+        if self.budget <= 0:
+            return None
+        for i in range(self.budget):
+            path = os.path.join(self.slot_dir, f"slot-{i}")
+            fd = os.open(path, os.O_RDWR | os.O_CREAT, _SLOT_FILE_MODE)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return fd
+            except OSError as e:
+                os.close(fd)
+                if e.errno in _FLOCK_CONTENDED_ERRNOS:
+                    # Slot held by another worker/session — try the
+                    # next one. Any other errno (permission, ENOLCK,
+                    # I/O) is a real fault: re-raise rather than spin
+                    # forever masking it.
+                    continue
+                raise
+        return None
+
+    def _acquire_slot_fd(self) -> int:
+        """Block until a slot is free in this budget or its fallback;
+        return the held fd.
+
+        Tries the primary pool first (single non-blocking pass), then —
+        only if all primary slots are held — the fallback pool. Sleeps
+        and retries when both are saturated. Caller owns closing the
+        returned fd; closing releases the flock regardless of which
+        pool's directory it came from.
+
+        The priority order (primary > fallback) is what makes the
+        uploader's dedicated pool actually a priority pool: the uploader
+        consistently gets a dedicated slot first if any are free, and
+        only spills into the shared pool when its own four slots are
+        exhausted by other simultaneously-running uploaders.
         """
         waited_logged = False
         while True:
-            for i in range(self.budget):
-                path = os.path.join(self.slot_dir, f"slot-{i}")
-                fd = os.open(path, os.O_RDWR | os.O_CREAT, _SLOT_FILE_MODE)
-                try:
-                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fd = self._try_acquire_one_pass()
+            if fd is not None:
+                return fd
+            if self.fallback is not None:
+                fd = self.fallback._try_acquire_one_pass()
+                if fd is not None:
                     return fd
-                except OSError as e:
-                    os.close(fd)
-                    if e.errno in _FLOCK_CONTENDED_ERRNOS:
-                        # Slot held by another worker/session — try the
-                        # next one. Any other errno (permission, ENOLCK,
-                        # I/O) is a real fault: re-raise rather than spin
-                        # forever masking it.
-                        continue
-                    raise
-            # Every slot busy. Log once so an operator watching the log
-            # can see the budget is saturated (expected under heavy
-            # concurrency), then poll.
+            # Every slot busy across primary AND fallback. Log once so an
+            # operator watching the log can see the budget is saturated
+            # (expected under heavy concurrency), then poll.
             if not waited_logged:
+                total = self.budget + (self.fallback.budget if self.fallback else 0)
                 logging.info(
                     " -- All %d %s; waiting for capacity.",
-                    self.budget,
+                    total,
                     SLOTS_BUSY_LOG_MARKER,
                 )
                 waited_logged = True

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1446,25 +1446,32 @@ def test_pageid_refresh_returns_immediately_on_first_success(monkeypatch):
 def test_main_acquires_one_budget_slot_per_item():
     """main() must construct a WorkerSlotBudget from --workers-budget and
     enter its acquire() context exactly once per DPLA item, around the
-    process_item call. A spy budget records the constructed budget value
-    and counts context entries."""
+    process_item call. A spy budget records every constructed instance
+    (the uploader now builds two: a priority pool with the shared pool
+    wired as its fallback) and counts context entries on the outer
+    instance the per-item loop actually uses."""
     from click.testing import CliRunner
 
     import tools.uploader as up
 
     acquire_calls = []
-    constructed_budget = {}
+    instances: list = []
 
     class _SpyBudget:
-        def __init__(self, budget):
-            constructed_budget["value"] = budget
+        def __init__(self, budget, slot_dir=None, fallback=None):
+            self.budget = budget
+            self.slot_dir = slot_dir
+            self.fallback = fallback
+            instances.append(self)
 
         def acquire(self):
             from contextlib import contextmanager
 
+            outer = self
+
             @contextmanager
             def _cm():
-                acquire_calls.append(True)
+                acquire_calls.append(outer)
                 yield
 
             return _cm()
@@ -1508,10 +1515,30 @@ def test_main_acquires_one_budget_slot_per_item():
             )
 
     assert result.exit_code == 0, result.output
-    assert constructed_budget["value"] == 16, "budget not built from --workers-budget"
     assert processed == ["id_a", "id_b", "id_c"], "all items must be processed"
+    # The uploader builds two budgets when --workers-budget > 0:
+    #   * a shared-pool instance sized at --workers-budget (16), no fallback
+    #   * a priority-pool instance sized at UPLOADER_PRIORITY_SLOTS, with
+    #     the shared instance wired as its fallback
+    # The per-item loop must acquire on the OUTER (priority) instance so
+    # the priority>fallback acquisition order kicks in.
+    from ingest_wikimedia.worker_slots import (
+        UPLOADER_PRIORITY_SLOT_DIR,
+        UPLOADER_PRIORITY_SLOTS,
+    )
+
+    assert len(instances) == 2, f"expected priority + shared budgets; got {instances}"
+    shared = next(b for b in instances if b.fallback is None)
+    priority = next(b for b in instances if b.fallback is not None)
+    assert shared.budget == 16, "shared pool not sized from --workers-budget"
+    assert priority.budget == UPLOADER_PRIORITY_SLOTS
+    assert priority.slot_dir == UPLOADER_PRIORITY_SLOT_DIR
+    assert priority.fallback is shared, "priority pool must point at shared as fallback"
     assert len(acquire_calls) == 3, (
         f"expected one slot acquire per item; got {len(acquire_calls)}"
+    )
+    assert all(b is priority for b in acquire_calls), (
+        "per-item loop must acquire on the priority (outer) budget, not the shared one"
     )
 
 

--- a/tests/test_worker_slots.py
+++ b/tests/test_worker_slots.py
@@ -232,3 +232,133 @@ def test_total_wait_seconds_accumulates_when_blocked(tmp_path):
     t.join(timeout=1)
     assert not t.is_alive(), "worker thread should exit after slot release"
     assert budget.total_wait_seconds > 0.3
+
+
+# ---- Two-tier (uploader priority + shared fallback) behaviour ----
+
+
+def test_two_tier_prefers_priority_pool_over_fallback(tmp_path):
+    """Uploader budget with a priority pool AND a shared fallback must
+    consume a priority slot first whenever one is free, leaving the
+    shared pool entirely untouched. This is the whole point of the
+    dedicated pool — SDC workers using the shared pool must never see
+    an uploader holding one of their slots when there's priority
+    capacity to spare."""
+    priority_dir = tmp_path / "priority"
+    shared_dir = tmp_path / "shared"
+    priority_dir.mkdir()
+    shared_dir.mkdir()
+    shared = WorkerSlotBudget(budget=3, slot_dir=str(shared_dir))
+    uploader = WorkerSlotBudget(budget=2, slot_dir=str(priority_dir), fallback=shared)
+    with uploader.acquire():
+        # Priority pool: slot-0 must be held; shared pool: nothing held.
+        assert _slot_is_held(str(priority_dir), 0), (
+            "uploader should consume a priority slot first"
+        )
+        assert not any(_slot_is_held(str(shared_dir), i) for i in range(3)), (
+            "shared pool must remain untouched while priority capacity is free"
+        )
+
+
+def test_two_tier_falls_back_to_shared_when_priority_saturated(tmp_path):
+    """When every priority slot is held (simulating the uploader's
+    priority pool being fully consumed by other simultaneous uploader
+    sessions), the next uploader acquire MUST fall back to a shared
+    slot rather than block — overflow is the point of the fallback."""
+    priority_dir = tmp_path / "priority"
+    shared_dir = tmp_path / "shared"
+    priority_dir.mkdir()
+    shared_dir.mkdir()
+    shared = WorkerSlotBudget(budget=3, slot_dir=str(shared_dir))
+    uploader = WorkerSlotBudget(budget=2, slot_dir=str(priority_dir), fallback=shared)
+    with (
+        _foreign_flock(str(priority_dir), 0),
+        _foreign_flock(str(priority_dir), 1),
+    ):
+        acquired = []
+
+        def worker():
+            with uploader.acquire():
+                # Priority pool is fully held by foreigners; the
+                # uploader must be in the shared pool now.
+                acquired.append(
+                    any(_slot_is_held(str(shared_dir), i) for i in range(3))
+                )
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=2)
+        assert not t.is_alive(), "uploader must not block when fallback has room"
+        assert acquired == [True], "uploader fallback should have taken a shared slot"
+
+
+def test_two_tier_blocks_only_when_both_pools_saturated(tmp_path):
+    """If both the priority pool AND the shared pool are fully held,
+    the uploader must poll-wait — the two-tier composition shouldn't
+    accidentally bypass the cap. Once any slot in either pool frees,
+    acquisition proceeds."""
+    priority_dir = tmp_path / "priority"
+    shared_dir = tmp_path / "shared"
+    priority_dir.mkdir()
+    shared_dir.mkdir()
+    shared = WorkerSlotBudget(budget=1, slot_dir=str(shared_dir))
+    uploader = WorkerSlotBudget(budget=1, slot_dir=str(priority_dir), fallback=shared)
+    proceeded = threading.Event()
+
+    def worker():
+        with uploader.acquire():
+            proceeded.set()
+
+    stack = contextlib.ExitStack()
+    stack.enter_context(_foreign_flock(str(priority_dir), 0))
+    stack.enter_context(_foreign_flock(str(shared_dir), 0))
+    t = threading.Thread(target=worker)
+    t.start()
+    try:
+        # Both pools fully held → worker must block.
+        assert not proceeded.wait(timeout=0.8)
+    finally:
+        stack.close()  # release both, worker should proceed
+    assert proceeded.wait(timeout=3), "should proceed once any pool frees"
+    t.join(timeout=1)
+    assert not t.is_alive()
+
+
+def test_two_tier_sdc_path_never_touches_priority_pool(tmp_path):
+    """SDC sync constructs its budget with NO fallback, so it can only
+    ever consume shared slots — the priority pool is uploader-only by
+    construction. Pin this so a future refactor doesn't accidentally
+    wire SDC into the priority pool and undo the whole guarantee."""
+    priority_dir = tmp_path / "priority"
+    shared_dir = tmp_path / "shared"
+    priority_dir.mkdir()
+    shared_dir.mkdir()
+    # SDC's budget is plain — no fallback, single pool.
+    sdc = WorkerSlotBudget(budget=2, slot_dir=str(shared_dir))
+    assert sdc.fallback is None
+    with sdc.acquire():
+        assert not any(_slot_is_held(str(priority_dir), i) for i in range(2)), (
+            "SDC sync must not lock priority slots even by accident"
+        )
+
+
+def test_priority_pool_release_does_not_leak_shared_slot(tmp_path):
+    """Closing the acquired fd releases the flock regardless of which
+    pool's directory the slot lives in. Spec-pin so a stray bookkeeping
+    bug can't leak a shared slot when the uploader had been in the
+    priority pool, or vice versa."""
+    priority_dir = tmp_path / "priority"
+    shared_dir = tmp_path / "shared"
+    priority_dir.mkdir()
+    shared_dir.mkdir()
+    shared = WorkerSlotBudget(budget=2, slot_dir=str(shared_dir))
+    uploader = WorkerSlotBudget(budget=2, slot_dir=str(priority_dir), fallback=shared)
+    # Force the fallback path by holding all priority slots.
+    with _foreign_flock(str(priority_dir), 0), _foreign_flock(str(priority_dir), 1):
+        with uploader.acquire():
+            held = [_slot_is_held(str(shared_dir), i) for i in range(2)]
+            assert sum(held) == 1, "exactly one shared slot held during the block"
+    # After the block both shared slots must be free again.
+    assert all(not _slot_is_held(str(shared_dir), i) for i in range(2)), (
+        "shared slot must release when the uploader's with-block exits"
+    )

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -30,7 +30,11 @@ from ingest_wikimedia.s3 import (
 )
 from ingest_wikimedia.tools_context import ToolsContext
 from ingest_wikimedia.tracker import Result, Tracker
-from ingest_wikimedia.worker_slots import WorkerSlotBudget
+from ingest_wikimedia.worker_slots import (
+    UPLOADER_PRIORITY_SLOT_DIR,
+    UPLOADER_PRIORITY_SLOTS,
+    WorkerSlotBudget,
+)
 from ingest_wikimedia.categories import CategoryEnsurer, touch_institution_files
 from ingest_wikimedia.dpla import (
     SOURCE_RESOURCE_FIELD_NAME,
@@ -1591,17 +1595,36 @@ def main(
 
     dpla.check_partner(partner)
 
-    # Box-wide Commons-write budget, shared with the SDC-sync phase
-    # (same flock slot dir). The uploader is single-process, so it holds
-    # exactly one slot while working an item — counting as one writer
-    # against the shared cap so concurrent upload + SDC-sync sessions
+    # Box-wide Commons-write budget. The uploader is single-process, so
+    # it holds exactly one slot while working an item — counting as one
+    # writer against the cap so concurrent upload + SDC-sync sessions
     # across the host don't collectively overrun Commons' maxlag
     # threshold. Per-item acquire (not whole-run) so the uploader doesn't
     # stall at startup holding a slot through its S3 reads when the pool
     # is momentarily full, and briefly frees the slot between items.
-    # budget <= 0 disables it (no-op). Built before the try so the
-    # post-upload touch in the finally can reuse it.
-    slot_budget = WorkerSlotBudget(workers_budget)
+    #
+    # Two-tier: primary = dedicated uploader priority pool, fallback =
+    # the box-wide shared pool the SDC workers contend over. The
+    # uploader's per-item ``slot_budget.acquire()`` tries the priority
+    # pool first and only spills into the shared pool when fewer than
+    # ``UPLOADER_PRIORITY_SLOTS`` uploader items would otherwise be
+    # serviced — which means an uploader is never blocked by SDC
+    # workers as long as box-wide uploader concurrency stays within the
+    # priority pool's size. See ``ingest_wikimedia.worker_slots`` for
+    # the rationale (additive, not carved out of the shared budget).
+    #
+    # ``workers_budget <= 0`` disables both pools (standalone run).
+    # Built before the try so the post-upload touch in the finally can
+    # reuse it.
+    if workers_budget > 0:
+        shared_budget = WorkerSlotBudget(workers_budget)
+        slot_budget = WorkerSlotBudget(
+            UPLOADER_PRIORITY_SLOTS,
+            slot_dir=UPLOADER_PRIORITY_SLOT_DIR,
+            fallback=shared_budget,
+        )
+    else:
+        slot_budget = WorkerSlotBudget(0)
 
     try:
         local_fs.setup_temp_dir()


### PR DESCRIPTION
## Summary

Adds a small dedicated slot pool that only the uploader ever consults, so an uploader is never blocked by SDC-sync workers as long as fewer than 4 uploader items are in flight box-wide.

| | Pool | Size | Who uses it |
|---|---|---|---|
| Primary (new) | ``/tmp/dpla-uploader-priority-slots/`` | ``UPLOADER_PRIORITY_SLOTS = 4`` | Uploader only |
| Fallback (existing) | ``/tmp/sdc-sync-worker-slots/`` | ``--workers-budget`` (e.g. 24) | SDC-sync + uploader overflow |

Acquisition order: priority first per non-blocking pass; spill into the shared pool only if every priority slot is currently held by *another* uploader. SDC-sync's ``WorkerSlotBudget`` is constructed with **no fallback**, so it can never lock a priority slot.

## Why additive, not carved out of the shared budget

Per your sizing guidance:

* SDC sessions are memory-cheap — carving 4 slots out of the shared 24 to give uploaders priority would shrink overall SDC throughput without much upload benefit
* Uploaders are slow-moving (one item per session at a time, big multi-page items hold a slot for many minutes) — 4 extra concurrent writers under worst-case saturation won't materially move Commons' parser-pool replag

So the total box-wide writer cap goes from 24 → 28 only when uploaders genuinely need it. In the common case (fewer than 4 uploader items in flight) SDC's 24 are untouched.

## How acquisition composes

```python
# Uploader (when --workers-budget > 0):
shared = WorkerSlotBudget(workers_budget)                       # no fallback
slot_budget = WorkerSlotBudget(                                  # primary
    UPLOADER_PRIORITY_SLOTS,
    slot_dir=UPLOADER_PRIORITY_SLOT_DIR,
    fallback=shared,
)
# Per-item, unchanged:
with slot_budget.acquire():
    uploader.process_item(...)
```

``_acquire_slot_fd`` now does ``priority single-pass → fallback single-pass → sleep → retry``. Neither side can starve. ``workers_budget <= 0`` still fully disables both pools (standalone-run path, unchanged).

## Test plan

- [x] ``test_two_tier_prefers_priority_pool_over_fallback`` — priority slot taken first; shared pool untouched
- [x] ``test_two_tier_falls_back_to_shared_when_priority_saturated`` — foreigners hold all priority slots → uploader takes a shared slot
- [x] ``test_two_tier_blocks_only_when_both_pools_saturated`` — both fully held → poll-wait → proceed once any frees
- [x] ``test_two_tier_sdc_path_never_touches_priority_pool`` — SDC budget has ``fallback is None``; SDC's acquire leaves priority slots free
- [x] ``test_priority_pool_release_does_not_leak_shared_slot`` — uploader-via-fallback releases the shared slot cleanly on context exit
- [x] ``test_main_acquires_one_budget_slot_per_item`` updated for the two-instance construction
- [x] Full ``tests/test_worker_slots.py`` + ``tests/test_uploader.py`` passes on EC2 (75 passed)
- [x] ``ruff check`` + ``ruff format`` clean
- [ ] Live verify: deploy + watch ``/wikimedia-status`` — uploader sessions should stop reporting ``⏸ waiting on slots`` while SDC is at capacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added a two-tier worker-slot scheme for Wikimedia ingest uploads.

- Introduced an uploader-only dedicated priority slot pool with 4 additive slots (UPLOADER_PRIORITY_*).
- Updated slot acquisition so uploaders try the priority pool first, then fall back to the existing shared box-wide SDC-sync worker-slot pool only when all priority slots are occupied.
- Kept SDC-sync workers isolated to the shared pool only; they cannot acquire priority slots.
- Preserved the existing `workers_budget <= 0` no-budget behavior.
- Extended tests to cover priority acquisition, fallback when priority is saturated, blocking only when both pools are saturated, correct release/freeing behavior, and SDC isolation.

No manual pipeline trigger, redeployment, env var/Secrets Manager changes, database migration, shared infrastructure configuration changes, API response shape/endpoint changes, or security/auth changes were indicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->