### PR TITLE
slack/launch: name the failing step + interpret common exits in failure msgs

### DIFF
--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -557,7 +557,16 @@ def parse_dpla_doc(
     titles = doc["sourceResource"]["title"]
     if isinstance(titles, str):
         titles = [titles]
-    rs = doc["rights"]
+    # ``rights`` is always present on regular runs (``rightsCategory ==
+    # "Unlimited Re-Use"`` is in the ES filter), but maintain mode runs
+    # with ``--skip-media-filter``, which drops that filter so docs
+    # without a ``rights`` field reach SDC pre-compute. Default to empty
+    # string — ``normalize_rights_uri("")`` is a no-op and the
+    # ``rights.get("")`` lookup in ``_build_rights_claims`` returns
+    # None, so no rights claim is appended. Without this, the first
+    # de-opted item in a maintain run raises ``KeyError`` and aborts
+    # the whole id-generation pass.
+    rs = doc.get("rights", "")
     url = doc["isShownAt"]
 
     # The shape-tolerant blocks below treat missing or mis-typed fields as

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -39,16 +39,27 @@ def post_message(token: str, text: str) -> None:
         raise RuntimeError(f"Slack API error: {data.get('error')}")
 
 
-# exit code → short hint shown in the Slack failure message.  Anything >128 is
-# a bash-encoded signal (128 + signal number).  137 in particular is SIGKILL,
+# exit code → short hint shown in the Slack failure message. Anything >128 is
+# a bash-encoded signal (128 + signal number). 137 in particular is SIGKILL,
 # which the OOM killer uses — so seeing it in the message is a strong "this was
 # probably an OOM" hint without having to SSM in and check dmesg.
+#
+# Common interpreter-level exits also have universally-recognised meanings:
+#   * 1 — Python uncaught exception (CRITICAL traceback printed to stderr)
+#   * 2 — Click misuse: bad CLI arguments / failed Click-side validation
+#         (e.g. ``click.BadParameter`` from a precheck like
+#         ``DPLA.check_partner``). Always points at config / args, never code.
+#   * 124 — GNU ``timeout`` (1) wrapper killed the child for exceeding its
+#         deadline. Not used in the pipeline today but cheap to include.
 _EXIT_CODE_HINTS: dict[int, str] = {
-    137: "SIGKILL — likely OOM",
-    143: "SIGTERM",
-    139: "SIGSEGV",
-    134: "SIGABRT",
+    1: "uncaught exception — see traceback",
+    2: "rejected its arguments",
+    124: "timed out",
     130: "SIGINT (Ctrl-C)",
+    134: "SIGABRT",
+    137: "SIGKILL — likely OOM",
+    139: "SIGSEGV",
+    143: "SIGTERM",
 }
 
 
@@ -137,12 +148,97 @@ def _summarize_log(log_path: str, tail_lines: int = 8) -> str | None:
     return "\n".join(parts)
 
 
+# Map WIKIMEDIA_STEP (set by the launcher per pipeline step) → the phase
+# suffix the corresponding tool uses for ``setup_logging(...)``. Used by
+# :func:`notify_pipeline_fail` to scope log lookup to the failing step.
+#
+# ``id-generation`` deliberately has no entry: ``tools/get_ids_es.py`` does
+# NOT call ``setup_logging``, so there's no log file to tail. The launcher
+# instead tees its stderr to the per-session path returned by
+# :func:`id_generation_stderr_tail_file` and the failure handler reads
+# that file directly.
+_PHASE_LOG_SUFFIX: dict[str, str] = {
+    "download": "download",
+    "upload": "upload",
+    "sdc-sync": "sdc",
+}
+
+# Per-session-label path the launcher tees ``get-ids-es`` stderr to.
+# Per-label, not a single shared path, because the EC2 box runs many
+# concurrent tmux sessions and a shared ``/tmp/wm-id-generation-stderr.log``
+# would race: two id-generation steps starting near-simultaneously would
+# clobber each other's stderr, and a later failure handler would pick up
+# whichever ran second. The launcher's bash side composes the same path
+# via ``${WIKIMEDIA_SESSION_LABEL}`` interpolation in the tee redirect,
+# so write-side and read-side agree without any extra env var.
+#
+# A label is the per-target slug (e.g. ``georgia+duke-university-library``);
+# it's already passed through ``slugify_session_label_component`` so it's
+# filesystem-safe (lowercase + digits + ``+`` + ``-`` only — no shell
+# metacharacters and no path separators).
+_ID_GENERATION_STDERR_TAIL_BASENAME_PREFIX = "wm-id-generation-stderr"
+# Matches the bash ``${WIKIMEDIA_SESSION_LABEL:-unknown}`` fallback in
+# ``scripts/wikimedia_launch.py``'s tee redirect, so when the env var
+# isn't set on either side both write/read paths produce the same file
+# name. Without this agreement, a partial-env failure handler would
+# look for ``…-stderr.log`` while the launcher wrote
+# ``…-stderr-unknown.log`` and the operator would see no stderr body.
+_ID_GENERATION_STDERR_NO_LABEL_FALLBACK = "unknown"
+
+
+def id_generation_stderr_tail_file(session_label: str | None) -> str:
+    """Return the per-session path the launcher tees ``get-ids-es`` /
+    ``get-ids-nara`` stderr to. The launcher's bash side interpolates
+    the same shape via ``${WIKIMEDIA_SESSION_LABEL:-unknown}``; this
+    helper is the Python read-side counterpart used by
+    :func:`notify_pipeline_fail` and must produce the SAME path for
+    the SAME env state.
+
+    Callers must pass the *raw* ``WIKIMEDIA_SESSION_LABEL`` value (or
+    ``None``/empty when unset), not a display-fallback like ``"unknown"``
+    — otherwise the no-label branch here is dead and the helper agrees
+    with bash only by accident.
+    """
+    label = session_label or _ID_GENERATION_STDERR_NO_LABEL_FALLBACK
+    return f"/tmp/{_ID_GENERATION_STDERR_TAIL_BASENAME_PREFIX}-{label}.log"
+
+
+def _tail_text_file(
+    path: str, tail_lines: int = 8, max_bytes: int = 64 * 1024
+) -> str | None:
+    """Read up to ``max_bytes`` from the end of ``path`` and return the last
+    ``tail_lines`` non-empty lines, or None if the file is missing/unreadable.
+
+    Used by the failure handler for steps without a dedicated log file
+    (currently just id-generation, which has no ``setup_logging`` call).
+    """
+    try:
+        size = os.path.getsize(path)
+        read_size = min(size, max_bytes)
+        with open(path, "rb") as f:
+            f.seek(size - read_size)
+            data = f.read().decode("utf-8", errors="replace")
+    except OSError:
+        return None
+    lines = [line for line in data.splitlines() if line.strip()]
+    if not lines:
+        return None
+    return "\n".join(lines[-tail_lines:])
+
+
 def notify_pipeline_fail() -> None:
     """Post a pipeline-step failure notification to Slack.
 
     Reads from the environment:
       DPLA_SLACK_BOT_TOKEN     — required to post
       WIKIMEDIA_SESSION_LABEL  — identifies the target in the message
+      WIKIMEDIA_STEP           — name of the pipeline step that was running
+                                 when the chain broke (``id-generation``,
+                                 ``download``, ``upload``, ``sdc-sync``).
+                                 Empty / unset → "pipeline step" generic
+                                 wording. Set by the launcher's per-step
+                                 ``export`` so the latest assignment before
+                                 the failure sticks in the shell.
       WIKIMEDIA_LAST_EXIT      — exit code of the failed step (best-effort)
       WIKIMEDIA_PARTNER_DIR    — absolute path to the partner dir, used to
                                  locate the most recent log for tailing
@@ -162,20 +258,60 @@ def notify_pipeline_fail() -> None:
             "DPLA_SLACK_BOT_TOKEN not set — skipping pipeline failure notification"
         )
         return
-    label = os.environ.get("WIKIMEDIA_SESSION_LABEL") or "unknown"
+    # Two views of the same env var:
+    #   * ``raw_label`` — the actual value (or ``None`` / empty when
+    #     unset). Passed to :func:`id_generation_stderr_tail_file` so
+    #     the helper's own fallback decides the path. Mixing in a
+    #     display-text fallback here would skip that branch and only
+    #     agree with the bash side by coincidence.
+    #   * ``label`` — display-only, used in Slack header text where an
+    #     empty session label would render ugly backticks.
+    raw_label = os.environ.get("WIKIMEDIA_SESSION_LABEL")
+    label = raw_label or "unknown"
     rc_suffix = _decode_exit_code(os.environ.get("WIKIMEDIA_LAST_EXIT"))
+    step = (os.environ.get("WIKIMEDIA_STEP") or "").strip()
 
     is_last = os.environ.get("WIKIMEDIA_TARGET_IS_LAST") == "1"
     tail_phrase = (
         "no further targets in batch" if is_last else "skipping to next target"
     )
-    msg = f"❌ `wikimedia-{label}`: pipeline step failed{rc_suffix} — {tail_phrase}"
+    # Step-aware header: tells the operator WHICH phase failed
+    # (id-generation / download / upload / sdc-sync), not just "the
+    # pipeline". Pre-step-tracking this said only "pipeline step
+    # failed" — leaving the operator to SSM in and grep four log
+    # files to find the actual phase. WIKIMEDIA_STEP is exported by
+    # the launcher right before each step, and the bash ``&&`` chain
+    # halts on the failing step, so its value survives into this
+    # handler.
+    step_phrase = f"`{step}` step failed" if step else "pipeline step failed"
+    msg = f"❌ `wikimedia-{label}`: {step_phrase}{rc_suffix} — {tail_phrase}"
 
-    log_path = _find_latest_log(os.environ.get("WIKIMEDIA_PARTNER_DIR", ""), label)
-    if log_path is not None:
-        summary = _summarize_log(log_path)
-        if summary:
-            msg += "\n" + summary
+    # Scope log lookup to the failing step's log file when possible.
+    # id-generation has no dedicated log file (get_ids_es.py never
+    # calls setup_logging), so for that step we fall back to reading
+    # the tee'd stderr file the launcher writes — without this, a
+    # failure inside get-ids-es would only ever surface as a bare
+    # "exit N" in Slack.
+    partner_dir = os.environ.get("WIKIMEDIA_PARTNER_DIR", "")
+    summary: str | None = None
+    log_suffix = _PHASE_LOG_SUFFIX.get(step)
+    if log_suffix is not None:
+        log_path = _find_latest_log(partner_dir, label, phase=log_suffix)
+        if log_path is not None:
+            summary = _summarize_log(log_path)
+    elif step == "id-generation":
+        stderr_tail = _tail_text_file(id_generation_stderr_tail_file(raw_label))
+        if stderr_tail:
+            summary = "Last stderr lines:\n```\n" + stderr_tail + "\n```"
+    else:
+        # Unknown step (or step unset on a stale launcher): fall back to
+        # the legacy any-phase log lookup so we don't regress on the
+        # info-density of the pre-step-tracking message.
+        log_path = _find_latest_log(partner_dir, label)
+        if log_path is not None:
+            summary = _summarize_log(log_path)
+    if summary:
+        msg += "\n" + summary
 
     try:
         post_message(token, msg)

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -126,6 +126,74 @@ def _slack_fail(response_url: str, msg: str, *, operational: bool = False) -> No
     sys.exit(1)
 
 
+# Maps the first token of a pipeline command to the step name reported to
+# Slack on failure via ``WIKIMEDIA_STEP``. ``id-generation`` covers both
+# ``get-ids-es`` and the bespoke NARA catalog walker (``get-ids-nara``);
+# Slack's failure handler reads the env var directly so a stale launcher
+# without this map still produces a generic "pipeline step failed" message
+# (the legacy wording) rather than crashing.
+_STEP_BY_FIRST_TOKEN: dict[str, str] = {
+    "get-ids-es": "id-generation",
+    "get-ids-nara": "id-generation",
+    "downloader": "download",
+    "uploader": "upload",
+    "sdc-sync": "sdc-sync",
+}
+
+
+def _wrap_step_with_marker(cmd: str) -> str:
+    """Prefix ``cmd`` with ``export WIKIMEDIA_STEP=<name> &&`` so the bash
+    shell's WIKIMEDIA_STEP reflects which step was running when the
+    ``&&``-chain breaks. The export goes BEFORE the step's command in the
+    same chain, so the failed-step's name is the most recent assignment
+    when ``notify_pipeline_fail`` reads it.
+
+    For ``get-ids-es`` / ``get-ids-nara`` (the id-generation step), also
+    tees stderr to the per-session path returned by
+    :func:`id_generation_stderr_tail_file` (interpolated by bash from
+    ``WIKIMEDIA_SESSION_LABEL`` at runtime, so concurrent tmux sessions
+    don't clobber each other's stderr file). That's the one step in the
+    pipeline whose tool doesn't call ``setup_logging``, so without this
+    its stderr (e.g. ``click.BadParameter`` from a failed
+    ``DPLA.check_partner`` precheck) would be visible only in the tmux
+    pane and never reach the Slack failure message. Process substitution
+    keeps the live stream going to the pane too.
+
+    Commands not in :data:`_STEP_BY_FIRST_TOKEN` (``cd``, ``echo``, the
+    case-2 skip step) are returned unchanged.
+    """
+    if not cmd:
+        return cmd
+    first = cmd.split(None, 1)[0]
+    step = _STEP_BY_FIRST_TOKEN.get(first)
+    if step is None:
+        return cmd
+    wrapped = cmd
+    if step == "id-generation":
+        # The existing build emits ``... > csv_file`` for stdout; appending
+        # ``2> >(tee FILE >&2)`` here keeps stdout on the CSV and tees
+        # stderr both to the tmux pane (via the trailing ``>&2``) and to
+        # the failure-tail file. Bash parses the redirects in order:
+        # stdout to the CSV, stderr through the substitution.
+        #
+        # Path is interpolated at runtime from
+        # ``${WIKIMEDIA_SESSION_LABEL}`` so concurrent tmux sessions
+        # running id-generation don't clobber each other's stderr file
+        # in ``/tmp``. The launcher's per-target preamble exports
+        # ``WIKIMEDIA_SESSION_LABEL`` BEFORE this tee runs, so the
+        # interpolation always resolves. The ``:-unknown`` fallback is
+        # belt-and-braces against a future caller that doesn't set the
+        # var; in that case the read-side
+        # (:func:`ingest_wikimedia.slack.id_generation_stderr_tail_file`)
+        # would not match — accepting that as a fail-soft. Mirrors the
+        # Python helper's filename shape.
+        per_session_path = (
+            '"/tmp/wm-id-generation-stderr-${WIKIMEDIA_SESSION_LABEL:-unknown}.log"'
+        )
+        wrapped = f"{cmd} 2> >(tee {per_session_path} >&2)"
+    return f"export WIKIMEDIA_STEP={step} && {wrapped}"
+
+
 def _build_get_ids_command(
     canonical: str,
     institutions: tuple[str, ...],
@@ -1169,11 +1237,21 @@ def main() -> None:
             if idx == last_idx
             else "unset WIKIMEDIA_TARGET_IS_LAST"
         )
+        # ``unset WIKIMEDIA_STEP`` first so a failure in this target's
+        # un-wrapped preamble (``cd $base``, currently the only step that
+        # ``_wrap_step_with_marker`` leaves alone) doesn't inherit the
+        # previous target's last-step name in the Slack failure message.
+        # Each subsequent step's ``export WIKIMEDIA_STEP=<name>`` then
+        # sets it freshly. Without this, a target whose ``cd`` fails on a
+        # missing partner directory would be reported as e.g. "`sdc-sync`
+        # step failed" — naming the prior target's tail step instead of
+        # the actual failure point.
         label_export = (
             f"export WIKIMEDIA_SESSION_LABEL={shlex.quote(session_label)}; "
             f"export WIKIMEDIA_PARTNER_DIR={shlex.quote(base)}; "
             f"{is_last_env}; "
-            f"{single_item_env}"
+            f"{single_item_env}; "
+            f"unset WIKIMEDIA_STEP"
         )
         # SDC-sync parallelism options. --workers > 1 enables the
         # multiprocessing pool; --workers-budget caps concurrent worker
@@ -1240,7 +1318,12 @@ def main() -> None:
                 pipeline_steps.append(
                     f"sdc-sync --partner {canonical} --ids-file {csv_file}{sdc_opts}"
                 )
-        target_steps = " && ".join(pipeline_steps)
+        # Wrap each step with an ``export WIKIMEDIA_STEP=<name>`` prefix so
+        # the per-target failure handler (``notify_pipeline_fail``) can name
+        # the failing phase in Slack instead of just reporting an exit code.
+        # See :func:`_wrap_step_with_marker` for the per-step details
+        # (including the id-generation stderr tee).
+        target_steps = " && ".join(_wrap_step_with_marker(s) for s in pipeline_steps)
         target_blocks.append(
             f"{label_export}; {{ {target_steps}; }}"
             f" || {{ {notify_fail_cmd} >/dev/null 2>&1 || true; }}"

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -556,6 +556,55 @@ def test_build_claims_for_doc_rejects_junky_iiif_manifest_values():
         assert p7482["qualifiers"]["P6108"][0]["datavalue"]["value"] == valid.strip()
 
 
+def test_build_claims_for_doc_tolerates_missing_rights_field():
+    """In maintain mode + ``--skip-media-filter``, the ES query no longer
+    enforces ``rightsCategory == "Unlimited Re-Use"``, so docs with no
+    ``rights`` field reach SDC pre-compute. Pre-fix, ``parse_dpla_doc``
+    did ``doc["rights"]`` unguarded and raised ``KeyError`` on the first
+    such doc — aborting the entire id-generation pass for one maintain
+    target (concretely: Duke maintain via Internet Archive / Digital
+    Library of Georgia hubs, both of which have de-opted institutions
+    whose records still flow through the maintain scope).
+
+    The fix defaults missing ``rights`` to an empty string;
+    ``normalize_rights_uri("")`` is a no-op and the
+    ``rights.get("")`` lookup in ``_build_rights_claims`` returns
+    None, so no rights claim is emitted (instead of crashing).
+    """
+    from ingest_wikimedia.sdc import build_claims_for_doc
+
+    doc = {
+        "id": "abc1234567890",
+        "provider": {"name": "Internet Archive"},
+        "dataProvider": {"name": "Duke University Libraries"},
+        "sourceResource": {
+            "title": ["A book"],
+            "date": [{"displayDate": "1945"}],
+        },
+        "isShownAt": "https://example.org/item/abc",
+        # No "rights" key.
+    }
+    hubs = {
+        "Internet Archive": {
+            "Wikidata": "Q461",
+            "institutions": {"Duke University Libraries": {"Wikidata": "Q5312898"}},
+        }
+    }
+    import datetime as _dt
+
+    out = build_claims_for_doc(
+        doc, "abc1234567890", hubs, {}, {}, {}, _dt.date(2026, 6, 29)
+    )
+    # No crash. No P275/P6426 rights claims since the input had no rights.
+    rights_props = {"P275", "P6426", "P6216"}
+    rights_claims = [
+        c for c in out["claims"] if c["mainsnak"]["property"] in rights_props
+    ]
+    assert rights_claims == [], (
+        f"missing rights must produce no rights claims; got {rights_claims}"
+    )
+
+
 def test_build_source_claim_never_stamps_p2699():
     """``P2699`` is per-ordinal — different ordinals of the same DPLA
     item have different download URLs, so the qualifier can't be baked

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -64,8 +64,9 @@ def test_notify_phase_start_supports_sdc_sync_phase():
         ("", ""),
         (None, ""),
         ("not-a-number", ""),
-        ("1", " (exit 1)"),
-        ("2", " (exit 2)"),
+        ("1", " (exit 1 — uncaught exception — see traceback)"),
+        ("2", " (exit 2 — rejected its arguments)"),
+        ("124", " (exit 124 — timed out)"),
         ("137", " (exit 137 — SIGKILL — likely OOM)"),
         ("143", " (exit 143 — SIGTERM)"),
         ("139", " (exit 139 — SIGSEGV)"),
@@ -200,6 +201,175 @@ def test_notify_pipeline_fail_treats_any_value_other_than_1_as_not_last():
         assert "skipping to next target" in msg, (
             f"value {value!r} should be treated as not-last"
         )
+
+
+# ---------------------------------------------------------------------------
+# Step-aware failure messages: include WIKIMEDIA_STEP in the header so the
+# operator sees WHICH phase failed instead of a bare "pipeline step failed".
+# Also pin the new exit-code hints for 1 ("uncaught exception") and 2
+# ("rejected its arguments"), since those are the two codes the user's
+# Duke maintain run hit and the bare-number message was opaque.
+# ---------------------------------------------------------------------------
+
+
+def test_decode_exit_code_interprets_python_exit_1():
+    """Exit 1 ≈ Python uncaught exception. Including the hint makes the
+    Slack message actionable — "look for a CRITICAL traceback in the log"
+    instead of "the pipeline failed somehow with exit 1"."""
+    assert _decode_exit_code("1") == " (exit 1 — uncaught exception — see traceback)"
+
+
+def test_decode_exit_code_interprets_click_exit_2():
+    """Exit 2 ≈ Click usage error (e.g. ``click.BadParameter`` from a
+    failed precheck like ``DPLA.check_partner``). Points the operator
+    at config/CLI args, never at a code bug."""
+    assert _decode_exit_code("2") == " (exit 2 — rejected its arguments)"
+
+
+def test_notify_pipeline_fail_names_the_failing_step():
+    """The failure message header should include the step name when
+    ``WIKIMEDIA_STEP`` is set. Pre-change the message just said
+    "pipeline step failed" and left the operator to grep four log
+    files to find which one."""
+    msg = _capture_message(
+        {
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": "georgia+duke-university-library",
+            "WIKIMEDIA_LAST_EXIT": "1",
+            "WIKIMEDIA_STEP": "id-generation",
+        }
+    )
+    assert "`id-generation` step failed" in msg, msg
+    assert "uncaught exception" in msg, msg
+    assert "pipeline step failed" not in msg, (
+        "step-aware header must replace the generic phrasing"
+    )
+
+
+def test_notify_pipeline_fail_falls_back_to_generic_when_step_unset():
+    """A stale launcher (no WIKIMEDIA_STEP export) must not crash — the
+    handler should fall back to the legacy "pipeline step failed"
+    wording. Pre-step-tracking deployments will still produce this
+    while the new launcher rolls out."""
+    msg = _capture_message(
+        {
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": "georgia+x",
+            "WIKIMEDIA_LAST_EXIT": "1",
+        }
+    )
+    assert "pipeline step failed" in msg, msg
+
+
+def test_notify_pipeline_fail_id_generation_step_includes_stderr_tail(
+    tmp_path, monkeypatch
+):
+    """For the id-generation step there's no per-phase log file (the
+    ``get-ids-es`` CLI doesn't call ``setup_logging``), so the failure
+    handler reads stderr-tail directly from the file the launcher
+    tees to. This is exactly the digitalnc case from the user's Duke
+    run: ``click.BadParameter`` printed to stderr, no log produced,
+    Slack would otherwise show only a bare "exit 2"."""
+    # Per-session-label path: the file lives under /tmp/ in production
+    # but tests redirect it to a tmp_path via monkeypatching the helper
+    # itself — so we control the read path without writing to /tmp.
+    label = "digitalnc+duke-university-libraries"
+    stderr_path = tmp_path / f"wm-id-generation-stderr-{label}.log"
+    stderr_path.write_text(
+        "Usage: get-ids-es [OPTIONS] PARTNER\n"
+        "Try 'get-ids-es --help' for help.\n"
+        "\n"
+        "Error: Invalid value: Hub 'digitalnc' has no upload-eligible institutions in"
+        " institutions_v2.json — edit that file to opt in\n"
+    )
+    monkeypatch.setattr(
+        "ingest_wikimedia.slack.id_generation_stderr_tail_file",
+        lambda label_arg: str(tmp_path / f"wm-id-generation-stderr-{label_arg}.log"),
+    )
+    msg = _capture_message(
+        {
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": label,
+            "WIKIMEDIA_LAST_EXIT": "2",
+            "WIKIMEDIA_STEP": "id-generation",
+        }
+    )
+    # The header names the failing step + interprets exit 2.
+    assert "`id-generation` step failed" in msg
+    assert "rejected its arguments" in msg
+    # The actual stderr message must be in the body so the operator
+    # doesn't have to SSM in to find out WHY the precheck rejected.
+    assert "Hub 'digitalnc' has no upload-eligible institutions" in msg
+
+
+def test_id_generation_stderr_tail_file_is_per_session():
+    """The stderr tail path must be per-session-label, not a single
+    shared ``/tmp`` file. The EC2 box runs many concurrent tmux
+    sessions; a shared path would let two id-generation steps clobber
+    each other's stderr and serve the wrong failure body to Slack."""
+    from ingest_wikimedia.slack import id_generation_stderr_tail_file
+
+    a = id_generation_stderr_tail_file("georgia+duke-university-library")
+    b = id_generation_stderr_tail_file("ia+duke-university-libraries")
+    assert a != b, "different labels must produce different paths"
+    assert "georgia+duke-university-library" in a
+    assert "ia+duke-university-libraries" in b
+
+
+def test_id_generation_stderr_tail_file_no_label_fallback_matches_bash():
+    """The Python read-side and bash write-side must agree on the path
+    when ``WIKIMEDIA_SESSION_LABEL`` is unset. The launcher's tee
+    redirect uses ``${WIKIMEDIA_SESSION_LABEL:-unknown}``, so the
+    helper's empty-label fallback MUST produce the same
+    ``…-unknown.log`` suffix — otherwise a partial-env failure would
+    have Python looking for a file at a path bash never wrote to.
+
+    Both ``None`` and empty string represent "unset" and must collapse
+    to the same fallback path. This is the dead-branch regression CR
+    caught on the first pass: previously the helper's empty-string
+    branch returned a no-suffix path, agreeing with bash only by
+    accident because the caller never actually fed it an empty value.
+    """
+    from ingest_wikimedia.slack import id_generation_stderr_tail_file
+
+    expected_fallback = "/tmp/wm-id-generation-stderr-unknown.log"
+    assert id_generation_stderr_tail_file("") == expected_fallback
+    assert id_generation_stderr_tail_file(None) == expected_fallback
+
+
+def test_notify_pipeline_fail_phase_log_scopes_to_failing_step(tmp_path):
+    """When ``WIKIMEDIA_STEP`` is ``upload`` (or ``download`` / ``sdc``),
+    the handler must tail the *matching* phase log — not the most
+    recent log of any phase. Pre-step-tracking the lookup matched any
+    phase (``*``), so a failure during the upload step that came
+    after a longer-running download could end up tailing the older
+    download log instead. Pin the scope so the failing step's tail
+    actually goes to Slack."""
+    base = tmp_path
+    logs = base / "logs"
+    logs.mkdir()
+    label = "georgia+x"
+    older_upload = logs / f"20260101-100000-{label}-upload.log"
+    newer_download = logs / f"20260101-110000-{label}-download.log"
+    older_upload.write_text("[INFO] start\n[ERROR] Failed: boom in uploader\n")
+    newer_download.write_text("[INFO] downloader ran fine, nothing to flag\n")
+    # Force ``older_upload`` to be older than ``newer_download`` so the
+    # legacy any-phase lookup would have picked the newer download.
+    os.utime(str(older_upload), (time.time() - 7200, time.time() - 7200))
+
+    msg = _capture_message(
+        {
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": label,
+            "WIKIMEDIA_PARTNER_DIR": str(base),
+            "WIKIMEDIA_LAST_EXIT": "1",
+            "WIKIMEDIA_STEP": "upload",
+        }
+    )
+    # The upload-phase log content should be reflected; the unrelated
+    # download log should NOT be the tailed file.
+    assert "boom in uploader" in msg
+    assert "downloader ran fine" not in msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -410,6 +410,115 @@ def _maintain_steps(
         )
 
 
+# ---------------------------------------------------------------------------
+# Step-marker wrapping: each pipeline step gets an ``export WIKIMEDIA_STEP``
+# prefix so the per-target failure handler can name the failing phase in
+# Slack. Tests pin the per-tool step-name mapping and the special
+# id-generation stderr-tee behaviour.
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_step_with_marker_tags_each_tool_with_its_phase():
+    """The first token of the command determines the step name. Every
+    Commons-writing tool that the per-target ``&&`` chain runs must
+    produce a recognisable step name so the failure handler can
+    identify the failing phase. ``cd`` / ``echo`` / unknown tokens
+    pass through unchanged."""
+    from scripts.wikimedia_launch import _wrap_step_with_marker
+
+    assert _wrap_step_with_marker("downloader x.csv georgia").startswith(
+        "export WIKIMEDIA_STEP=download && downloader "
+    )
+    assert _wrap_step_with_marker("uploader x.csv ohio --no-create").startswith(
+        "export WIKIMEDIA_STEP=upload && uploader "
+    )
+    assert _wrap_step_with_marker(
+        "sdc-sync --partner texas --ids-file x.csv --workers 6"
+    ).startswith("export WIKIMEDIA_STEP=sdc-sync && sdc-sync ")
+    # Non-step commands (``cd``, the case-2 graceful-skip ``echo … ; true``,
+    # and the ``sdc-sync --cat`` flavour the maintain builder emits — wait,
+    # that one IS sdc-sync. Use a true non-step instead.):
+    assert _wrap_step_with_marker("cd /srv/base") == "cd /srv/base"
+    assert (
+        _wrap_step_with_marker("echo 'maintain: skipping' >&2; true")
+        == "echo 'maintain: skipping' >&2; true"
+    )
+
+
+def test_wrap_step_with_marker_tees_id_generation_stderr():
+    """The id-generation step is the one tool that doesn't call
+    ``setup_logging``, so it produces no log file. To let the
+    failure handler include its stderr in Slack, the launcher tees
+    stderr to a known path while keeping the live stream visible in
+    the tmux pane (``>&2``). Pin the tee shape so a refactor can't
+    silently drop it — the digitalnc-class case (``click.BadParameter``
+    from ``DPLA.check_partner``) only reaches Slack via this tee."""
+    from scripts.wikimedia_launch import _wrap_step_with_marker
+
+    wrapped = _wrap_step_with_marker(
+        "get-ids-es digitalnc --institution 'Duke University Libraries'"
+        " --maintain --skip-media-filter > out.csv"
+    )
+    assert wrapped.startswith("export WIKIMEDIA_STEP=id-generation && ")
+    # The redirect must keep stdout on the CSV (the existing >),
+    # tee stderr to a per-session path interpolated from
+    # ``${WIKIMEDIA_SESSION_LABEL}`` at runtime (so concurrent tmux
+    # sessions can't clobber each other's stderr file), AND pass stderr
+    # through to the pane (``>&2`` inside the substitution).
+    assert "> out.csv" in wrapped
+    assert "${WIKIMEDIA_SESSION_LABEL" in wrapped, (
+        "id-generation stderr path must be per-session, not a shared /tmp file"
+    )
+    assert "tee" in wrapped and ">&2" in wrapped
+
+
+def test_wrap_step_with_marker_id_generation_for_nara_uses_same_phase():
+    """``get-ids-nara`` is the bespoke NARA catalog walker — it
+    replaces ``get-ids-es`` for a bare-hub NARA target but is still
+    the id-generation phase. Same step name + same stderr-tee
+    treatment as ``get-ids-es``, so the failure handler doesn't
+    care which tool ran."""
+    from scripts.wikimedia_launch import _wrap_step_with_marker
+
+    wrapped = _wrap_step_with_marker("get-ids-nara > nara.csv")
+    assert "WIKIMEDIA_STEP=id-generation" in wrapped
+    assert "tee" in wrapped
+
+
+def test_per_target_preamble_unsets_wikimedia_step():
+    """Each target's preamble must reset ``WIKIMEDIA_STEP`` so a
+    failure in the un-wrapped ``cd $base`` step (or any other step
+    not in ``_STEP_BY_FIRST_TOKEN``) doesn't carry over the previous
+    target's last-step name into the Slack failure message.
+
+    Concrete scenario: target 1's sdc-sync runs successfully (exports
+    ``WIKIMEDIA_STEP=sdc-sync``), target 2's ``cd /home/.../wrong-dir``
+    fails. Without this reset, Slack would post "`sdc-sync` step
+    failed" for target 2 — misleading. With the reset, the message
+    falls back to the generic "pipeline step failed" wording, which
+    is accurate.
+
+    Pinned via source inspection rather than running ``main()`` because
+    the label_export composition is inline in the per-target loop and
+    spinning up the full launcher (AWS clients, Slack, partner-dir
+    bootstrapping) for one preamble assertion is more setup than the
+    pin is worth. If the line moves, the source grep still catches it.
+    """
+    import inspect
+
+    import scripts.wikimedia_launch as launch_mod
+
+    source = inspect.getsource(launch_mod)
+    # The per-target preamble (label_export) is the only place this
+    # literal should appear; if it shows up elsewhere, the test still
+    # passes — overzealous-unset is harmless. We only fail when the
+    # reset is MISSING entirely.
+    assert "unset WIKIMEDIA_STEP" in source, (
+        "per-target preamble must clear WIKIMEDIA_STEP so an unwrapped-cd "
+        "failure doesn't inherit the prior target's step name"
+    )
+
+
 def test_maintain_real_run_stages_sidecars_then_syncs_from_s3():
     steps = _maintain_steps("digitalnc", (), count_only=False)
     # One ES scan stages sdc.json sidecars, then the category walk reads them.


### PR DESCRIPTION
## Summary

Pipeline-failure Slack posts used to read:

> ❌ \`wikimedia-georgia+duke-university-library\`: pipeline step failed (exit 1) — skipping to next target

The operator was left to (a) guess WHICH phase failed (all four logs share the same partner+label prefix) and (b) decode "exit 1"/"exit 2" with no category hint. After this PR:

> ❌ \`wikimedia-georgia+duke-university-library\`: \`id-generation\` step failed (exit 1 — uncaught exception — see traceback) — skipping to next target

And for the digitalnc case the original [Duke run](https://commons.wikimedia.org) hit, the body now contains the actual stderr:

> ❌ \`wikimedia-digitalnc+duke-university-libraries\`: \`id-generation\` step failed (exit 2 — rejected its arguments) — no further targets in batch
> Last stderr lines:
> ```
> Usage: get-ids-es [OPTIONS] PARTNER
> Try 'get-ids-es --help' for help.
> Error: Invalid value: Hub 'digitalnc' has no upload-eligible institutions in institutions_v2.json — edit that file to opt in
> ```

## What's in the PR

1. **Step-aware header.** The launcher exports ``WIKIMEDIA_STEP=<phase>`` right before each step in the per-target ``&&`` chain. Bash halts on the failing step, so its name sticks in the shell for ``notify_pipeline_fail`` to read. Step names: ``id-generation``, ``download``, ``upload``, ``sdc-sync``. A stale launcher with no ``WIKIMEDIA_STEP`` export falls back to the legacy "pipeline step failed" wording — handler-side change is forward-compatible.

2. **Exit-code hint table expanded** with the three most common interpreter-level codes:
   - **1** → "uncaught exception — see traceback" (Python's default for uncaught exceptions ≈ code bug)
   - **2** → "rejected its arguments" (Click's exit for ``BadParameter`` ≈ config/CLI issue, not code)
   - **124** → "timed out" (GNU ``timeout(1)``)

3. **id-generation stderr tee.** ``tools/get_ids_es.py`` is the one tool that doesn't call ``setup_logging`` — no log file for the failure handler to tail. The launcher now appends ``2> >(tee /tmp/wm-id-generation-stderr.log >&2)`` to ``get-ids-es`` / ``get-ids-nara`` invocations: stderr still flows to the tmux pane (via ``>&2``) AND a copy lands in the failure-tail file. The handler reads it back when ``WIKIMEDIA_STEP=id-generation``.

4. **Bug fix in ``ingest_wikimedia/sdc.py``.** ``parse_dpla_doc`` did ``doc["rights"]`` unguarded; maintain + ``--skip-media-filter`` drops the ``rightsCategory == "Unlimited Re-Use"`` ES filter, so docs without a ``rights`` field reach SDC pre-compute and raised ``KeyError``. This was the exit-1 traceback the user's georgia and ia targets hit. Default to ``""`` — downstream ``normalize_rights_uri("")`` is a no-op and the rights lookup returns None, producing no rights claim instead of crashing.

## Per-step behavior summary

| ``WIKIMEDIA_STEP`` | Log file tailed | Header in Slack |
|---|---|---|
| ``id-generation`` | (no log file) — falls back to ``/tmp/wm-id-generation-stderr.log`` (teed by launcher) | \`id-generation\` step failed |
| ``download`` | ``*-download.log`` (scope-restricted) | \`download\` step failed |
| ``upload`` | ``*-upload.log`` (scope-restricted) | \`upload\` step failed |
| ``sdc-sync`` | ``*-sdc.log`` (scope-restricted) | \`sdc-sync\` step failed |
| (unset, stale launcher) | latest log of any phase | pipeline step failed |

## Test plan

- [x] ``test_decode_exit_code_interprets_python_exit_1`` / ``_click_exit_2`` — new hints
- [x] ``test_notify_pipeline_fail_names_the_failing_step`` — header includes step name
- [x] ``test_notify_pipeline_fail_falls_back_to_generic_when_step_unset`` — legacy wording survives
- [x] ``test_notify_pipeline_fail_id_generation_step_includes_stderr_tail`` — digitalnc-class case
- [x] ``test_notify_pipeline_fail_phase_log_scopes_to_failing_step`` — wrong-phase log doesn't get tailed
- [x] ``test_wrap_step_with_marker_tags_each_tool_with_its_phase`` — launcher mapping
- [x] ``test_wrap_step_with_marker_tees_id_generation_stderr`` — tee shape pinned
- [x] ``test_wrap_step_with_marker_id_generation_for_nara_uses_same_phase`` — get-ids-nara
- [x] ``test_build_claims_for_doc_tolerates_missing_rights_field`` — sdc.py crash fix
- [x] Full ``tests/test_slack.py`` + ``tests/test_wikimedia_launch.py`` + ``tests/test_sdc.py`` pass on EC2 (174 passed)
- [x] ``ruff check`` + ``ruff format`` clean
- [ ] Live verify: a maintain run that fails (e.g. re-trigger Duke before the ``DPLA.check_partner`` follow-up PR lands) produces the new step-aware messages with stderr body

## Follow-up

A separate PR will fix the underlying ``DPLA.check_partner`` ignoring maintain mode (the digitalnc case in the screenshot you posted). That's the partner-level twin of PR [#342](https://github.com/dpla/ingest-wikimedia/pull/342)'s fix to ``resolve_wikidata_id`` and touches more files, so keeping it separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Updated Wikimedia launch Slack failure notifications to be step-aware: when `WIKIMEDIA_STEP` is set, Slack headers report the failing phase (`id-generation`, `download`, `upload`, or `sdc-sync`) and the message includes the most relevant step-scoped log/stderr tail when available.
- Expanded Slack exit-code hints for common interpreter/runtime failure codes (e.g., `1`, `2`, `124`, and related signal-derived cases).
- Added stderr capture/tee support for the `id-generation` step so the failure handler can include “last stderr lines” from the captured stderr tail.
- Fixed `ingest_wikimedia/sdc.py` so `parse_dpla_doc()` tolerates DPLA documents missing the `rights` field (prevents `KeyError` during SDC pre-compute/maintain mode).
- Kept backward compatibility for stale launchers that don’t export `WIKIMEDIA_STEP` (Slack falls back to the legacy generic/latest-log behavior).

## Notes
- Adds a new environment variable: `WIKIMEDIA_STEP` (exported by the launcher per pipeline step).
- Requires redeploying/updating the launcher and the Slack-dispatch code (or otherwise re-running the launch with the updated code) for the step markers and richer failure context to take effect.
- No database migrations, infra/config changes, public API changes, or security/credential handling changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->