### PR TITLE
DPLA.check_partner: honor maintain mode (partner-level twin of #342)

### DIFF
--- a/ingest_wikimedia/dpla.py
+++ b/ingest_wikimedia/dpla.py
@@ -34,7 +34,7 @@ class DPLA:
         self.iiif = iiif
 
     @staticmethod
-    def check_partner(partner: str) -> None:
+    def check_partner(partner: str, *, maintain: bool = False) -> None:
         """Raise ValueError if `partner` is not an upload-eligible DPLA hub.
 
         Eligibility is driven entirely by institutions_v2.json — the file
@@ -43,10 +43,21 @@ class DPLA:
         institutions_v2.json marks it (or any of its institutions) as
         `upload: True` is accepted here. No code change is required to
         add a new partner.
+
+        ``maintain`` drops the upload-eligibility check (keeps the
+        slug-recognition check). Maintain mode reconciles files ALREADY
+        on Commons, which is exactly when an un-opted-in hub is in
+        scope: a hub with zero opted-in institutions but real prior
+        uploads (e.g. ``digitalnc`` in the user's Q5312898 Duke
+        Libraries case) needs its existing files maintained even
+        though no new uploads should land. Pre-fix this raised
+        ``ValueError`` → ``click.BadParameter`` (exit 2) at every CLI
+        entry point — the partner-level twin of the bug PR #342 fixed
+        for :func:`resolve_wikidata_id`.
         """
         if partner not in PARTNER_HUBS:
             raise ValueError(f"Unrecognized partner: {partner}")
-        if not is_upload_eligible(partner):
+        if not maintain and not is_upload_eligible(partner):
             raise ValueError(
                 f"Hub {partner!r} has no upload-eligible institutions in "
                 f"institutions_v2.json — edit that file to opt in"

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -422,6 +422,14 @@ def _build_maintain_hash_pipeline_steps(
     since there's no category to reconcile beyond what's fetched.
     """
     dl_age_opt = f"--max-age-days {max_age_days} " if max_age_days is not None else ""
+    # ``--maintain`` on the downloader bypasses its
+    # ``DPLA.check_partner`` upload-eligibility precheck, so a hub like
+    # ``digitalnc`` (no opted-in institutions but real prior uploads)
+    # can still run the hash-drift download pass. Behaviour is otherwise
+    # unchanged — items the CSV passes through are downloaded the same.
+    # The uploader gets the same effect via its existing ``--no-create``
+    # flag (the launcher's maintain pipelines already pass it), so no
+    # extra flag there.
     if dpla_id is not None or collection is not None:
         maintain_get_ids = _build_get_ids_command(
             canonical, institutions, collection, dpla_id, csv_file, maintain=True
@@ -429,14 +437,14 @@ def _build_maintain_hash_pipeline_steps(
         return [
             f"cd {base}",
             maintain_get_ids,
-            f"downloader {dl_age_opt}{csv_file} {canonical}",
+            f"downloader --maintain {dl_age_opt}{csv_file} {canonical}",
             f"uploader {csv_file} {canonical} --no-create{upload_opts}",
             f"sdc-sync --partner {canonical} --ids-file {csv_file}{sdc_opts}",
         ]
     return [
         f"cd {base}",
         _maintain_stage_cmd(canonical, institutions, csv_file),
-        f"downloader {dl_age_opt}{csv_file} {canonical}",
+        f"downloader --maintain {dl_age_opt}{csv_file} {canonical}",
         f"uploader {csv_file} {canonical} --no-create{upload_opts}",
         *_maintain_sdc_cat_steps(
             canonical, institutions, f" --from-s3 {canonical}{sdc_opts}"

--- a/tests/test_dpla.py
+++ b/tests/test_dpla.py
@@ -89,6 +89,40 @@ def test_check_partner_rejects_hub_with_no_upload_eligible_institutions(
             dpla.check_partner("bpl")
 
 
+def test_check_partner_maintain_mode_accepts_de_opted_hub(dpla: DPLA):
+    """Maintain mode reconciles files ALREADY on Commons for de-opted
+    institutions, so a hub with zero ``upload: True`` institutions must
+    still pass the precheck when ``maintain=True``. This is the
+    digitalnc-class case from the user's Q5312898 Duke Libraries run:
+    the launcher correctly resolved the QID to three hubs (one of which,
+    NCDH, has no opted-in institutions), and the maintain pipeline
+    needs to process each — but pre-fix, ``DPLA.check_partner`` raised
+    ``ValueError`` → ``click.BadParameter`` (exit 2) at every CLI
+    entry point before maintain mode could rescue.
+
+    The partner-level twin of the bug PR #342 fixed for
+    :func:`resolve_wikidata_id`.
+    """
+    with patch("ingest_wikimedia.dpla.is_upload_eligible", return_value=False):
+        # No exception when maintain=True, even though the hub fails
+        # the eligibility check.
+        dpla.check_partner("bpl", maintain=True)
+    # And the eligibility check is still skipped — not even called.
+    with patch("ingest_wikimedia.dpla.is_upload_eligible") as mock_eligible:
+        dpla.check_partner("bpl", maintain=True)
+        mock_eligible.assert_not_called()
+
+
+def test_check_partner_maintain_mode_still_rejects_unknown_slug(dpla: DPLA):
+    """Maintain mode drops ONLY the upload-eligibility check. A slug
+    not in ``PARTNER_HUBS`` is still a real bug (typo / unsupported
+    hub) and must fail loudly even in maintain mode — otherwise the
+    downstream tools would dereference ``PARTNER_HUBS[partner]`` and
+    KeyError obscurely."""
+    with pytest.raises(ValueError, match="Unrecognized partner"):
+        dpla.check_partner("nope-not-a-real-slug", maintain=True)
+
+
 def test_check_record_partner_valid(dpla: DPLA):
     partner = "bpl"
     item_metadata = {"provider": {"name": "Digital Commonwealth"}}

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -843,6 +843,64 @@ def test_maintain_hash_single_id_and_collection_keep_id_list_anchored():
     assert coll[-1].startswith("sdc-sync --partner georgia --ids-file out.csv")
 
 
+def test_maintain_hash_pipeline_passes_maintain_flag_to_downloader():
+    """The downloader's ``--maintain`` flag bypasses its
+    ``DPLA.check_partner`` upload-eligibility precheck. Without it, a
+    maintain run on a hub with no opted-in institutions (e.g.
+    ``digitalnc`` in the Q5312898 Duke Libraries case) would die at
+    the downloader step with ``click.BadParameter`` → exit 2, even
+    after PR #346 made the failure message readable.
+
+    Pin both the institution-scoped (hub|institution) AND the
+    single-id / collection branches: both call paths build the
+    ``downloader`` step from the same template, so a regression would
+    drop the flag from both. The uploader uses its existing
+    ``--no-create`` as the maintain signal (no extra flag here).
+    """
+    import scripts.wikimedia_launch as launch_mod
+
+    with (
+        patch.object(launch_mod, "wikidata_qid_for_target", return_value="Q123"),
+        patch.object(
+            launch_mod,
+            "resolve_commons_category",
+            return_value="Category:Media contributed by X",
+        ),
+    ):
+        inst_steps = launch_mod._build_maintain_hash_pipeline_steps(
+            "digitalnc",
+            ("Duke University Libraries",),
+            None,
+            None,
+            "/srv/base",
+            "out.csv",
+            None,
+            " --workers-budget 24",
+            " --workers 6 --workers-budget 24",
+        )
+    dl_step = next(s for s in inst_steps if s.startswith("downloader "))
+    assert "--maintain" in dl_step, (
+        "maintain pipeline must pass --maintain to the downloader so its"
+        " check_partner precheck doesn't reject a de-opted hub"
+    )
+    assert "out.csv digitalnc" in dl_step
+
+    # Same for the single-id route.
+    single = launch_mod._build_maintain_hash_pipeline_steps(
+        "digitalnc",
+        (),
+        None,
+        "abc123def456",
+        "/srv/base",
+        "out.csv",
+        None,
+        " --workers-budget 24",
+        " --workers 6 --workers-budget 24",
+    )
+    dl_step = next(s for s in single if s.startswith("downloader "))
+    assert "--maintain" in dl_step
+
+
 def test_maintain_stage_cmd_routes_bare_nara_to_get_ids_nara():
     """Bare-hub NARA stages via its bespoke catalog walk, mirroring
     _build_get_ids_command — not `get-ids-es nara`, which can't do NARA's

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -592,6 +592,18 @@ class Downloader:
     is_flag=True,
     help="Post a download-complete summary to Slack when finished (used for refresh runs).",
 )
+@click.option(
+    "--maintain",
+    is_flag=True,
+    help=(
+        "Bypass the partner upload-eligibility precheck so a maintain run"
+        " can process a hub whose institutions are all de-opted (``upload:"
+        " false``). Matches the same ``--maintain`` semantics in get-ids-es"
+        " and the uploader's ``--no-create`` fence. Has no other behavioural"
+        " effect on the downloader itself — items the CSV passes through"
+        " are downloaded the same way."
+    ),
+)
 def main(
     ids_file: IO,
     partner: str,
@@ -601,6 +613,7 @@ def main(
     sleep: float,
     max_age_days: int | None,
     notify_complete: bool,
+    maintain: bool,
 ):
     setup_logging(partner, "download", logging.INFO)
     start_time = time.time()
@@ -622,7 +635,7 @@ def main(
     dpla = tools_context.get_dpla()
     tracker = tools_context.get_tracker()
 
-    dpla.check_partner(partner)
+    dpla.check_partner(partner, maintain=maintain)
     notify_phase_start(partner, "download")
     logging.info(f"Starting download for {partner}")
 

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -349,7 +349,13 @@ def main(
         # the hub. Some DPLA collections span multiple institutions.
 
     try:
-        DPLA.check_partner(partner)
+        # Maintain mode operates on hubs whose upload flag is off
+        # (the whole point — reconcile already-on-Commons files for
+        # de-opted institutions), so the eligibility precheck must
+        # honor ``--maintain``. Mirrors the same flag honoring
+        # ``load_eligible_dp_names`` already does for the
+        # institution-level gate below.
+        DPLA.check_partner(partner, maintain=maintain)
     except ValueError as e:
         raise click.BadParameter(str(e)) from e
 

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1593,7 +1593,12 @@ def main(
     local_fs = tools_context.get_local_fs()
     tracker = tools_context.get_tracker()
 
-    dpla.check_partner(partner)
+    # ``--no-create`` is the uploader's maintain signal — it gates the
+    # no-create fence inside the per-item loop and is exactly what the
+    # launcher passes in maintain mode. Reusing it as the maintain
+    # flag for ``check_partner`` keeps the CLI surface unchanged (no
+    # new ``--maintain`` flag here, unlike the downloader).
+    dpla.check_partner(partner, maintain=no_create)
 
     # Box-wide Commons-write budget. The uploader is single-process, so
     # it holds exactly one slot while working an item — counting as one


### PR DESCRIPTION
## Summary

PR [#342](https://github.com/dpla/ingest-wikimedia/pull/342) added ``maintain=True`` to ``resolve_wikidata_id`` so a maintain QID resolves to one target per hub. The partner-level twin of that bug lived in ``DPLA.check_partner`` — called unconditionally at the top of ``get-ids-es``, ``downloader``, and ``uploader`` — and was the ``digitalnc`` failure in your Q5312898 Duke Libraries run:

> Error: Invalid value: Hub 'digitalnc' has no upload-eligible institutions in institutions_v2.json — edit that file to opt in

NCDH has zero institutions with ``upload: True``, which is correct for the regular upload path but wrong for maintain — that's the one mode that needs to process exactly those hubs (to reconcile prior uploads that predate the de-opt).

## Changes

| File | Change |
|---|---|
| ``ingest_wikimedia/dpla.py`` | ``check_partner`` gains kw-only ``maintain: bool = False``; when True, drops the ``is_upload_eligible`` check but keeps the ``PARTNER_HUBS`` slug-recognition check |
| ``tools/get_ids_es.py`` | passes existing ``--maintain`` to ``check_partner`` |
| ``tools/downloader.py`` | new ``--maintain`` flag (bypass precheck only — no other behavioural effect) |
| ``tools/uploader.py`` | reuses existing ``--no-create`` as the maintain signal for ``check_partner`` |
| ``scripts/wikimedia_launch.py`` | maintain hash pipeline emits ``downloader --maintain`` in both institution and single-id/collection routes |

Other ``check_partner`` callers (``get_ids_api``, ``nuke``, ``remimer``, ``retirer``, ``sign``) deliberately left alone — none are part of the maintain pipeline.

## Why ``maintain=True`` keeps the slug check

The slug-recognition check (``partner not in PARTNER_HUBS``) is preserved either way. An unknown slug is still a real bug (typo / unsupported hub) that must fail loudly so downstream ``PARTNER_HUBS[partner]`` dereferences don't KeyError obscurely. Maintain mode only relaxes the upload-eligibility gate — which is the one thing data-driven and supposed to be permissive in this context.

## With the chain complete

Together with PRs [#342](https://github.com/dpla/ingest-wikimedia/pull/342) / [#344](https://github.com/dpla/ingest-wikimedia/pull/344) / [#346](https://github.com/dpla/ingest-wikimedia/pull/346), a maintain QID run for an institution under one or more de-opted hubs now:
1. Resolves the QID to one target per hub (#342)
2. Skips targets with no Commons category + no existing files (#344)
3. Tells the operator clearly which step failed with the actual stderr (#346)
4. Doesn't fail at the partner precheck for de-opted hubs (this PR)

## Test plan

- [x] ``test_check_partner_maintain_mode_accepts_de_opted_hub`` — bypass works
- [x] ``test_check_partner_maintain_mode_still_rejects_unknown_slug`` — slug check preserved
- [x] ``test_maintain_hash_pipeline_passes_maintain_flag_to_downloader`` — launcher threads the flag through both routes
- [x] Existing ``test_check_partner_rejects_*`` tests unchanged — non-maintain path preserved
- [x] Full ``tests/test_dpla.py`` + ``tests/test_wikimedia_launch.py`` + ``tests/test_uploader.py`` pass on EC2 (131 passed)
- [x] ``ruff check`` + ``ruff format`` clean
- [ ] Live verify: re-run ``/wikimedia-upload maintain Q5312898`` and watch all three Duke targets (georgia / ia / digitalnc) complete cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated maintain-mode handling for partner checks so existing content can be reconciled without requiring upload-eligibility approval, while still rejecting unrecognized partner slugs.

- `DPLA.check_partner` now accepts `maintain: bool = False` and skips the upload-eligibility check only in maintain mode.
- Threaded maintain mode through the workflow:
  - `tools/get_ids_es.py` passes `--maintain` into partner checks
  - `tools/downloader.py` adds `--maintain` and forwards it to `check_partner`
  - `tools/uploader.py` reuses `--no-create` as the maintain signal
  - `scripts/wikimedia_launch.py` passes `--maintain` to downloader in maintain hash routes
- Added tests covering maintain-mode partner acceptance, slug validation, and downloader flag propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->