### PR TITLE
Throttle {{duplicate}} tags against Category:Duplicate (defer-and-drain)

### DIFF
--- a/ingest_wikimedia/dup_throttle.py
+++ b/ingest_wikimedia/dup_throttle.py
@@ -1,0 +1,142 @@
+"""Throttle emission of ``{{duplicate}}`` tags against the human-maintained
+Category:Duplicate.
+
+A single uploader run over a partner with heavy orphaned-duplicate content can
+try to emit tens of thousands of ``{{duplicate}}`` tags on the Case-2 hash-drift
+path (an existing file's bytes are re-homed to the canonical DPLA-ID title and
+the stranded copy is tagged). Each tag adds a file to Category:Duplicate, which
+Commons volunteers process by hand — flooding it is antisocial and risks the bot
+being blocked. This gate caps how much that path may contribute: at or above
+``threshold`` category members it refuses (defers) further tags until the
+category drains back below ``resume_below`` (hysteresis).
+
+Scope: this gates the hash-drift duplicate-tag path only — the volume source
+behind the flooding it was built to prevent. The trailing-page orphan path
+(``uploader._post_item_orphan_check``) also tags into Category:Duplicate but is
+bounded to truncated trailing pages per item (low volume) and has no defer/drain
+channel, so it is intentionally left un-gated: deferring an orphan tag would
+leave the orphan unresolved with no retry, which is worse than emitting it.
+
+Cost is the design point. The category size is fetched at most once per
+``recheck_cap`` grants, via a cached "headroom" budget — never per upload, and
+never per tag in steady state. Callers consult the gate only on the (rare)
+tag-emitting path, so ordinary uploads pay nothing.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+
+import pywikibot
+
+DEFAULT_THRESHOLD = 1000
+DEFAULT_RESUME_BELOW = 900
+DEFAULT_RECHECK_CAP = 100
+DEFAULT_POLL_SECS = 120
+DUPLICATE_CATEGORY = "Category:Duplicate"
+
+
+class DuplicateCategoryThrottle:
+    """Cap a run's contribution to Category:Duplicate.
+
+    ``try_acquire`` is the non-blocking gate for the main upload pass;
+    ``wait_for_capacity`` is the blocking helper the drain pass uses to wait
+    for the category to fall back below ``resume_below``.
+    """
+
+    def __init__(
+        self,
+        site=None,
+        *,
+        threshold: int = DEFAULT_THRESHOLD,
+        resume_below: int = DEFAULT_RESUME_BELOW,
+        recheck_cap: int = DEFAULT_RECHECK_CAP,
+        poll_secs: float = DEFAULT_POLL_SECS,
+        category: str = DUPLICATE_CATEGORY,
+        size_fn: Callable[[], int] | None = None,
+    ):
+        if resume_below > threshold:
+            raise ValueError("resume_below must be <= threshold")
+        if recheck_cap < 1:
+            raise ValueError("recheck_cap must be >= 1")
+        self._site = site
+        self.threshold = threshold
+        self.resume_below = resume_below
+        self.recheck_cap = recheck_cap
+        self.poll_secs = poll_secs
+        self.category = category
+        # Injectable for tests; defaults to a single pywikibot categoryinfo call.
+        self._size_fn = size_fn
+        # Number of further tags we believe we can emit before the category
+        # could reach ``threshold`` — decremented per grant, refilled (after a
+        # size query) when it hits zero. Starts at 0 so the first grant queries.
+        self._headroom = 0
+
+    def _category_size(self) -> int:
+        if self._size_fn is not None:
+            return self._size_fn()
+        info = pywikibot.Category(self._site, self.category).categoryinfo
+        # ``size`` is total members (files + pages + subcats); for
+        # Category:Duplicate that is effectively the file count. Fall back to
+        # ``files`` if ``size`` is absent.
+        return int(info.get("size", info.get("files", 0)))
+
+    def _headroom_for(self, size: int) -> int:
+        """Tags we may emit before another size query: the room left below
+        ``threshold``, clamped to ``recheck_cap`` (which bounds both how stale
+        the cached size can get and cross-session overshoot). Callers pass a
+        ``size`` already known to be below ``threshold``, so this is >= 1."""
+        return min(self.threshold - size, self.recheck_cap)
+
+    def try_acquire(self) -> bool:
+        """Return ``True`` if a ``{{duplicate}}`` tag may be emitted now
+        (accounting for it), ``False`` if the category is at/over ``threshold``
+        and the tag must be deferred. Never blocks.
+
+        Queries the category size at most once per ``recheck_cap`` grants: while
+        local headroom remains it just decrements a counter (no API call).
+        """
+        if self._headroom > 0:
+            self._headroom -= 1
+            return True
+        # Headroom is exhausted (0), so query the live size to decide.
+        size = self._category_size()
+        if size >= self.threshold:
+            return False  # defer; banks no headroom, so the next attempt re-queries
+        # Refill headroom, consuming one grant for this tag.
+        self._headroom = self._headroom_for(size) - 1
+        return True
+
+    def wait_for_capacity(
+        self,
+        max_wait_secs: float,
+        *,
+        sleep: Callable[[float], None] = time.sleep,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> bool:
+        """Block (polling every ``poll_secs``) until the category is below
+        ``resume_below``, then refill headroom and return ``True``. Return
+        ``False`` if ``max_wait_secs`` elapses first. Used by the drain pass.
+        """
+        deadline = clock() + max_wait_secs
+        while True:
+            size = self._category_size()
+            if size < self.resume_below:
+                self._headroom = self._headroom_for(size)
+                return True
+            now = clock()
+            if now >= deadline:
+                return False
+            # Don't oversleep the deadline: a sub-``poll_secs`` budget remaining
+            # should wake for its final check on time, not ~poll_secs late.
+            nap = min(self.poll_secs, deadline - now)
+            logging.info(
+                "Category:Duplicate at %d (>= resume threshold %d); waiting %ds "
+                "before retrying deferred duplicate-tags.",
+                size,
+                self.resume_below,
+                self.poll_secs,
+            )
+            sleep(nap)

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -623,17 +623,16 @@ def notify_sdc_complete(
 
 
 def notify_dup_drain_incomplete(partner_label: str, remaining: int) -> None:
-    """Warn #tech-alerts that the dup-category drain pass gave up with files
+    """Warn #tech-alerts that the dup-category drain pass exited with files
     still deferred.
 
     The uploader defers ``{{duplicate}}``-tagging uploads while
-    Category:Duplicate is at capacity, then returns to them in a drain pass
-    that waits for the category to drain. If that wait times out (the category
-    stays full longer than the drain budget), the remaining files are left
-    un-uploaded and un-tagged — a human needs to clear the category before a
-    re-run will finish them. This is the only path that leaves intended work
-    undone, so it warrants an explicit operator ping rather than a buried log
-    line.
+    Category:Duplicate is at capacity, then returns to them in a drain pass.
+    If that pass times out (the category stays full past the drain budget) or
+    makes no progress after capacity returns, the remaining files are left
+    un-uploaded and un-tagged — they need operator attention before a re-run
+    will finish them. This is the only path that leaves intended work undone,
+    so it warrants an explicit operator ping rather than a buried log line.
     """
     token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
     if not token:
@@ -644,9 +643,9 @@ def notify_dup_drain_incomplete(partner_label: str, remaining: int) -> None:
     )
     msg = (
         f"⚠️ `{effective_label}`: {remaining:,} file(s) left deferred — "
-        "Category:Duplicate stayed at capacity past the drain window, so their "
-        "uploads + `{{duplicate}}` tags were skipped. Clear the category, then "
-        "re-run the partner to finish them."
+        "the duplicate-category drain pass exited before they could be retried, "
+        "so their uploads + `{{duplicate}}` tags were skipped. Clear "
+        "Category:Duplicate if needed, then re-run the partner to finish them."
     )
     try:
         post_message(token, msg)

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -620,3 +620,37 @@ def notify_sdc_complete(
         plain_text=f"Wikimedia SDC complete: {effective_label}",
         stats_lines=stats_lines,
     )
+
+
+def notify_dup_drain_incomplete(partner_label: str, remaining: int) -> None:
+    """Warn #tech-alerts that the dup-category drain pass gave up with files
+    still deferred.
+
+    The uploader defers ``{{duplicate}}``-tagging uploads while
+    Category:Duplicate is at capacity, then returns to them in a drain pass
+    that waits for the category to drain. If that wait times out (the category
+    stays full longer than the drain budget), the remaining files are left
+    un-uploaded and un-tagged — a human needs to clear the category before a
+    re-run will finish them. This is the only path that leaves intended work
+    undone, so it warrants an explicit operator ping rather than a buried log
+    line.
+    """
+    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
+    if not token:
+        logging.warning("DPLA_SLACK_BOT_TOKEN not set — skipping Slack notification")
+        return
+    effective_label = (
+        f"wikimedia-{os.environ.get('WIKIMEDIA_SESSION_LABEL') or partner_label}"
+    )
+    msg = (
+        f"⚠️ `{effective_label}`: {remaining:,} file(s) left deferred — "
+        "Category:Duplicate stayed at capacity past the drain window, so their "
+        "uploads + `{{duplicate}}` tags were skipped. Clear the category, then "
+        "re-run the partner to finish them."
+    )
+    try:
+        post_message(token, msg)
+    except Exception:
+        logging.warning(
+            "Failed to post dup-drain-incomplete notification to Slack", exc_info=True
+        )

--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -19,6 +19,12 @@ class Result(Enum):
     # core safety invariant of maintain mode — maintenance never emits a new
     # File page — surfaces here so operators can audit that it held.
     UPLOAD_SKIPPED_WOULD_CREATE = auto()
+    # Dup-category throttle: a {{duplicate}}-tagging upload (Case 2 hash-drift)
+    # was deferred because Category:Duplicate was at capacity. Counts each
+    # defer event (a deferred ordinal may be re-attempted — and counted again —
+    # in the drain pass); the number of items still deferred at run end is
+    # logged separately. Not a skip: the work is retried, not abandoned.
+    UPLOAD_DEFERRED_DUP_CATEGORY = auto()
     UPLOADED = auto()
     BYTES = auto()
     ITEM_NOT_PRESENT = auto()

--- a/tests/test_dup_throttle.py
+++ b/tests/test_dup_throttle.py
@@ -1,0 +1,123 @@
+"""Tests for ingest_wikimedia/dup_throttle.py — the cached-headroom gate that
+caps how many ``{{duplicate}}`` tags a single uploader run may add to the
+human-maintained Category:Duplicate.
+
+All tests inject ``size_fn`` so nothing touches pywikibot or the network. The
+key behaviours pinned here:
+
+  * ``try_acquire`` queries the category size at most once per ``recheck_cap``
+    grants (amortized cost — the whole point of the design).
+  * at/over ``threshold`` it defers (returns False) without granting.
+  * ``wait_for_capacity`` polls until the category drains below
+    ``resume_below`` (hysteresis), refills headroom, and times out cleanly.
+"""
+
+from ingest_wikimedia.dup_throttle import DuplicateCategoryThrottle
+
+
+class _Sizes:
+    """Callable returning a scripted sequence of sizes, recording call count.
+
+    The last value sticks once the script is exhausted, so a test can describe
+    just the transitions it cares about.
+    """
+
+    def __init__(self, *values: int):
+        self._values = list(values)
+        self.calls = 0
+
+    def __call__(self) -> int:
+        self.calls += 1
+        idx = min(self.calls - 1, len(self._values) - 1)
+        return self._values[idx]
+
+
+def test_grants_until_threshold_then_defers():
+    sizes = _Sizes(0)
+    t = DuplicateCategoryThrottle(
+        threshold=1000, resume_below=900, recheck_cap=100, size_fn=sizes
+    )
+    # Far below threshold: first call queries, the next 99 ride cached headroom.
+    assert all(t.try_acquire() for _ in range(100))
+    assert sizes.calls == 1
+
+
+def test_requeries_only_after_headroom_exhausted():
+    sizes = _Sizes(0)
+    t = DuplicateCategoryThrottle(
+        threshold=1000, resume_below=900, recheck_cap=100, size_fn=sizes
+    )
+    for _ in range(100):
+        t.try_acquire()
+    assert sizes.calls == 1
+    t.try_acquire()  # 101st grant forces a fresh size query
+    assert sizes.calls == 2
+
+
+def test_defers_at_threshold():
+    sizes = _Sizes(1000)
+    t = DuplicateCategoryThrottle(threshold=1000, resume_below=900, size_fn=sizes)
+    assert t.try_acquire() is False
+    # A deferral does not bank headroom — every subsequent attempt re-queries.
+    assert t.try_acquire() is False
+    assert sizes.calls == 2
+
+
+def test_headroom_capped_near_threshold():
+    # 50 below threshold with a recheck_cap of 100 → only 50 grants before the
+    # next query, so a stale cached size can never let the run overshoot
+    # threshold. Second query shows the category filled to threshold → defer.
+    sizes = _Sizes(950, 1000)
+    t = DuplicateCategoryThrottle(
+        threshold=1000, resume_below=900, recheck_cap=100, size_fn=sizes
+    )
+    assert all(t.try_acquire() for _ in range(50))
+    assert sizes.calls == 1
+    # 51st grant must re-query, and the now-full category forces a defer.
+    assert t.try_acquire() is False
+    assert sizes.calls == 2
+
+
+def test_wait_for_capacity_returns_when_drained():
+    # Full, full, then drained below resume_below.
+    sizes = _Sizes(1000, 950, 880)
+    t = DuplicateCategoryThrottle(
+        threshold=1000, resume_below=900, poll_secs=120, size_fn=sizes
+    )
+    slept: list[float] = []
+    clock = iter([0, 0, 120, 240]).__next__
+    assert t.wait_for_capacity(10_000, sleep=lambda s: slept.append(s), clock=clock)
+    assert slept == [120, 120]
+    # Headroom was refilled, so the next tag rides the cache (no new query).
+    before = sizes.calls
+    assert t.try_acquire() is True
+    assert sizes.calls == before
+
+
+def test_wait_for_capacity_times_out():
+    sizes = _Sizes(1000)  # never drains
+    t = DuplicateCategoryThrottle(
+        threshold=1000, resume_below=900, poll_secs=120, size_fn=sizes
+    )
+    slept: list[float] = []
+    clock = iter([0, 300]).__next__  # second check is past the 100s deadline
+    assert (
+        t.wait_for_capacity(100, sleep=lambda s: slept.append(s), clock=clock) is False
+    )
+    assert slept == []  # deadline hit before any sleep
+
+
+def test_resume_below_must_not_exceed_threshold():
+    try:
+        DuplicateCategoryThrottle(threshold=1000, resume_below=1001)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for resume_below > threshold")
+
+
+def test_recheck_cap_must_be_positive():
+    try:
+        DuplicateCategoryThrottle(threshold=1000, resume_below=900, recheck_cap=0)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for recheck_cap < 1")

--- a/tests/test_dup_throttle.py
+++ b/tests/test_dup_throttle.py
@@ -86,7 +86,8 @@ def test_wait_for_capacity_returns_when_drained():
     )
     slept: list[float] = []
     clock = iter([0, 0, 120, 240]).__next__
-    assert t.wait_for_capacity(10_000, sleep=lambda s: slept.append(s), clock=clock)
+    drained = t.wait_for_capacity(10_000, sleep=lambda s: slept.append(s), clock=clock)
+    assert drained is True
     assert slept == [120, 120]
     # Headroom was refilled, so the next tag rides the cache (no new query).
     before = sizes.calls
@@ -101,9 +102,8 @@ def test_wait_for_capacity_times_out():
     )
     slept: list[float] = []
     clock = iter([0, 300]).__next__  # second check is past the 100s deadline
-    assert (
-        t.wait_for_capacity(100, sleep=lambda s: slept.append(s), clock=clock) is False
-    )
+    timed_out = t.wait_for_capacity(100, sleep=lambda s: slept.append(s), clock=clock)
+    assert timed_out is False
     assert slept == []  # deadline hit before any sleep
 
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -976,7 +976,8 @@ def test_chunk_size_file_exists_small_returns_direct():
 
 def _drain_args(process_item_side_effect):
     """Build the (uploader, throttle, slot_budget) mocks _drain_deferred_dups
-    needs. ``process_item`` returns truthy when an item is (still) deferred."""
+    needs. ``process_item`` returns the count of ordinals still deferred for
+    that item (0 = item fully cleared)."""
     uploader = MagicMock()
     uploader.process_item.side_effect = process_item_side_effect
     throttle = MagicMock()
@@ -986,15 +987,30 @@ def _drain_args(process_item_side_effect):
 
 def test_drain_retries_until_all_emitted():
     # "a" clears on round 1; "b" stays deferred through round 1 and clears on
-    # round 2. Call order: a→done, b→deferred, (round 2) b→done.
-    uploader, throttle, budget = _drain_args([False, True, False])
+    # round 2. Call order: a→0 cleared, b→1 deferred, (round 2) b→0 cleared.
+    uploader, throttle, budget = _drain_args([0, 1, 0])
     throttle.wait_for_capacity.return_value = True
     remaining = _drain_deferred_dups(
-        uploader, throttle, ["a", "b"], {}, "partner", False, False, budget
+        uploader, throttle, {"a": 1, "b": 1}, {}, "partner", False, False, budget
     )
-    assert remaining == []
+    assert remaining == {}
     assert throttle.wait_for_capacity.call_count == 2
     assert uploader.process_item.call_count == 3
+
+
+def test_drain_counts_partial_ordinal_progress_as_progress():
+    # A single multi-page item with 3 deferred ordinals clears 2 on round 1
+    # (3→1) and the last on round 2. Per-item counting would see "still 1 item
+    # deferred" and falsely abort; per-ordinal counting sees real progress.
+    uploader, throttle, budget = _drain_args([1, 0])
+    throttle.wait_for_capacity.return_value = True
+    with patch("tools.uploader.notify_dup_drain_incomplete") as notify:
+        remaining = _drain_deferred_dups(
+            uploader, throttle, {"a": 3}, {}, "partner", False, False, budget
+        )
+    assert remaining == {}
+    assert uploader.process_item.call_count == 2
+    notify.assert_not_called()
 
 
 def test_drain_times_out_and_notifies():
@@ -1002,23 +1018,23 @@ def test_drain_times_out_and_notifies():
     throttle.wait_for_capacity.return_value = False  # category never drains
     with patch("tools.uploader.notify_dup_drain_incomplete") as notify:
         remaining = _drain_deferred_dups(
-            uploader, throttle, ["a", "b"], {}, "partner", False, False, budget
+            uploader, throttle, {"a": 1, "b": 2}, {}, "partner", False, False, budget
         )
-    assert remaining == ["a", "b"]
+    assert remaining == {"a": 1, "b": 2}
     uploader.process_item.assert_not_called()
-    notify.assert_called_once_with("partner", 2)
+    notify.assert_called_once_with("partner", 3)  # total deferred ordinals
 
 
 def test_drain_bails_when_no_progress():
-    # Capacity is available but the re-run clears nothing (category refilling as
-    # fast as we drain): bail rather than spin a hot loop.
-    uploader, throttle, budget = _drain_args([True, True])
+    # Capacity is available but the re-run clears no ordinals (category refilling
+    # as fast as we drain): bail rather than spin a hot loop.
+    uploader, throttle, budget = _drain_args([1, 1])
     throttle.wait_for_capacity.return_value = True
     with patch("tools.uploader.notify_dup_drain_incomplete") as notify:
         remaining = _drain_deferred_dups(
-            uploader, throttle, ["a", "b"], {}, "partner", False, False, budget
+            uploader, throttle, {"a": 1, "b": 1}, {}, "partner", False, False, budget
         )
-    assert remaining == ["a", "b"]
+    assert remaining == {"a": 1, "b": 1}
     assert throttle.wait_for_capacity.call_count == 1
     notify.assert_called_once_with("partner", 2)
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -16,6 +16,7 @@ from tools.uploader import (
     LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES,
     NewFilePageBlocked,
     Uploader,
+    _drain_deferred_dups,
     _post_item_orphan_check,
     _post_upload_touch_new_institutions,
     is_dup_sha1_sibling_at_expected_title,
@@ -965,6 +966,61 @@ def test_chunk_size_file_exists_small_returns_direct():
         force_ignore_warnings=False,
         file_size_bytes=10 * 1024 * 1024,
     ) == (0, True)
+
+
+# --------------------------------------------------------------------------
+# _drain_deferred_dups — the post-upload pass that re-runs items whose
+# {{duplicate}}-tagging upload was deferred while Category:Duplicate was full.
+# --------------------------------------------------------------------------
+
+
+def _drain_args(process_item_side_effect):
+    """Build the (uploader, throttle, slot_budget) mocks _drain_deferred_dups
+    needs. ``process_item`` returns truthy when an item is (still) deferred."""
+    uploader = MagicMock()
+    uploader.process_item.side_effect = process_item_side_effect
+    throttle = MagicMock()
+    # A no-op slot context manager — slot accounting isn't under test here.
+    return uploader, throttle, _DISABLED_BUDGET
+
+
+def test_drain_retries_until_all_emitted():
+    # "a" clears on round 1; "b" stays deferred through round 1 and clears on
+    # round 2. Call order: a→done, b→deferred, (round 2) b→done.
+    uploader, throttle, budget = _drain_args([False, True, False])
+    throttle.wait_for_capacity.return_value = True
+    remaining = _drain_deferred_dups(
+        uploader, throttle, ["a", "b"], {}, "partner", False, False, budget
+    )
+    assert remaining == []
+    assert throttle.wait_for_capacity.call_count == 2
+    assert uploader.process_item.call_count == 3
+
+
+def test_drain_times_out_and_notifies():
+    uploader, throttle, budget = _drain_args([])  # never reached
+    throttle.wait_for_capacity.return_value = False  # category never drains
+    with patch("tools.uploader.notify_dup_drain_incomplete") as notify:
+        remaining = _drain_deferred_dups(
+            uploader, throttle, ["a", "b"], {}, "partner", False, False, budget
+        )
+    assert remaining == ["a", "b"]
+    uploader.process_item.assert_not_called()
+    notify.assert_called_once_with("partner", 2)
+
+
+def test_drain_bails_when_no_progress():
+    # Capacity is available but the re-run clears nothing (category refilling as
+    # fast as we drain): bail rather than spin a hot loop.
+    uploader, throttle, budget = _drain_args([True, True])
+    throttle.wait_for_capacity.return_value = True
+    with patch("tools.uploader.notify_dup_drain_incomplete") as notify:
+        remaining = _drain_deferred_dups(
+            uploader, throttle, ["a", "b"], {}, "partner", False, False, budget
+        )
+    assert remaining == ["a", "b"]
+    assert throttle.wait_for_capacity.call_count == 1
+    notify.assert_called_once_with("partner", 2)
 
 
 def test_chunk_size_force_ignore_warnings_small_returns_direct():

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1525,10 +1525,12 @@ class Uploader:
             # the current truth.
             self._persist_upload_result(partner, dpla_id, ordinal_results, dry_run)
 
-            # Tell main() whether any ordinal was deferred by the dup-category
-            # throttle, so it can re-run this item in the drain pass once
-            # Category:Duplicate has room. (Other exits return None = falsy.)
-            return any(
+            # Return how many ordinals the dup-category throttle deferred, so
+            # main() knows to re-run this item in the drain pass and the drain
+            # loop can measure progress per ordinal (a multi-page item can clear
+            # some deferred ordinals while others remain). 0 = nothing deferred;
+            # other exits return None, also falsy.
+            return sum(
                 r.get("status") == ORDINAL_DEFERRED for r in ordinal_results.values()
             )
 
@@ -1697,22 +1699,24 @@ def main(
 
         dpla_ids = load_ids(ids_file)
 
-        deferred_ids: list[str] = []
+        # Map of dpla_id -> count of ordinals the dup-category throttle deferred.
+        deferred: dict[str, int] = {}
         for dpla_id in tqdm(dpla_ids, desc="Uploading Items", unit="Item", ncols=100):
             with slot_budget.acquire():
-                if uploader.process_item(
+                deferred_count = uploader.process_item(
                     dpla_id, providers_json, partner, verbose, dry_run
-                ):
-                    deferred_ids.append(dpla_id)
+                )
+                if deferred_count:
+                    deferred[dpla_id] = deferred_count
 
         # Any item whose {{duplicate}}-tagging upload was deferred because
         # Category:Duplicate was full: wait for the category to drain, then
         # re-run those items in this same session (not an operator re-run).
-        if deferred_ids:
+        if deferred:
             _drain_deferred_dups(
                 uploader,
                 dup_throttle,
-                deferred_ids,
+                deferred,
                 providers_json,
                 partner,
                 verbose,
@@ -1761,7 +1765,7 @@ _DRAIN_MAX_WAIT_SECS = 4 * 60 * 60  # 4 hours
 def _drain_deferred_dups(
     uploader: "Uploader",
     throttle: DuplicateCategoryThrottle,
-    deferred_ids: list[str],
+    deferred: dict[str, int],
     providers_json,
     partner: str,
     verbose: bool,
@@ -1769,57 +1773,67 @@ def _drain_deferred_dups(
     slot_budget: WorkerSlotBudget,
     *,
     max_wait_secs: float = _DRAIN_MAX_WAIT_SECS,
-) -> list[str]:
+) -> dict[str, int]:
     """Re-run items whose {{duplicate}}-tagging upload was deferred, once
     Category:Duplicate has drained.
 
+    ``deferred`` maps each item's dpla_id to its count of deferred ordinals.
     Each round waits (via the throttle) for the category to fall below its
     resume threshold, then re-processes the still-deferred items. Re-processing
     may itself defer again if the category refills mid-drain, so it loops until
     nothing remains, no progress is made, or the wait budget is exhausted.
-    Returns the ids still deferred at exit (empty on full success).
+    Returns the {id: count} still deferred at exit (empty on full success).
+
+    Progress is measured by total deferred *ordinals*, not items: a single
+    multi-page item can clear some ordinals while others remain, which is real
+    progress and must not read as a stall.
     """
-    remaining = list(deferred_ids)
+    remaining = dict(deferred)
     deadline = time.monotonic() + max_wait_secs
     logging.info(
-        "Drain pass: %d item(s) deferred while Category:Duplicate was at "
-        "capacity; waiting for it to drain, then retrying their uploads.",
+        "Drain pass: %d file(s) across %d item(s) deferred while "
+        "Category:Duplicate was at capacity; waiting for it to drain, then "
+        "retrying their uploads.",
+        sum(remaining.values()),
         len(remaining),
     )
     while remaining:
         budget = deadline - time.monotonic()
         if budget <= 0 or not throttle.wait_for_capacity(budget):
+            still = sum(remaining.values())
             logging.error(
-                "Drain pass timed out with %d item(s) still deferred; their "
+                "Drain pass timed out with %d file(s) still deferred; their "
                 "uploads + {{duplicate}} tags were NOT emitted. Clear "
                 "Category:Duplicate, then re-run the partner to finish them.",
-                len(remaining),
+                still,
             )
-            notify_dup_drain_incomplete(partner, len(remaining))
+            notify_dup_drain_incomplete(partner, still)
             return remaining
 
-        still_deferred: list[str] = []
+        still_deferred: dict[str, int] = {}
         for dpla_id in remaining:
             with slot_budget.acquire():
-                if uploader.process_item(
+                count = uploader.process_item(
                     dpla_id, providers_json, partner, verbose, dry_run
-                ):
-                    still_deferred.append(dpla_id)
+                )
+                if count:
+                    still_deferred[dpla_id] = count
 
         # A batch larger than the throttle's headroom (recheck_cap) legitimately
         # takes several rounds — each round re-queries and clears up to a cap's
         # worth, so partial progress is normal, not a stall. But if a round that
-        # began with confirmed capacity clears NOTHING, the category is refilling
-        # as fast as we drain (or another mechanism keeps deferring) — bail
-        # rather than spin a hot loop re-querying the category every iteration.
-        if len(still_deferred) >= len(remaining):
+        # began with confirmed capacity cleared NO ordinals, the category is
+        # refilling as fast as we drain (or another mechanism keeps deferring) —
+        # bail rather than spin a hot loop re-querying the category every round.
+        if sum(still_deferred.values()) >= sum(remaining.values()):
+            still = sum(still_deferred.values())
             logging.error(
                 "Drain pass made no progress despite available capacity (%d "
-                "still deferred); aborting drain. Clear Category:Duplicate, "
-                "then re-run the partner to finish them.",
-                len(still_deferred),
+                "file(s) still deferred); aborting drain. Clear "
+                "Category:Duplicate, then re-run the partner to finish them.",
+                still,
             )
-            notify_dup_drain_incomplete(partner, len(still_deferred))
+            notify_dup_drain_incomplete(partner, still)
             return still_deferred
         remaining = still_deferred
 

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -14,6 +14,7 @@ from pywikibot.site import BaseSite
 
 from tqdm import tqdm
 
+from ingest_wikimedia.dup_throttle import DuplicateCategoryThrottle
 from ingest_wikimedia.common import (
     get_list,
     get_dict,
@@ -44,7 +45,7 @@ from ingest_wikimedia.dpla import (
     WIKIDATA_FIELD_NAME,
     DPLA,
 )
-from ingest_wikimedia.slack import notify_upload_complete
+from ingest_wikimedia.slack import notify_dup_drain_incomplete, notify_upload_complete
 from ingest_wikimedia.wikimedia import (
     WMC_UPLOAD_CHUNK_SIZE,
     IGNORE_WIKIMEDIA_WARNINGS,
@@ -176,6 +177,9 @@ ORDINAL_NOT_PRESENT = "NOT_PRESENT"  # no S3 asset to upload (downloader gap)
 ORDINAL_INELIGIBLE = "INELIGIBLE"  # S3 asset present but uploader chose not
 # to upload (bad MIME, download-only, unguessable extension, etc.)
 ORDINAL_FAILED = "FAILED"  # upload attempted, raised, did not land
+ORDINAL_DEFERRED = (
+    "DEFERRED"  # {{duplicate}}-tagging upload deferred: Category:Duplicate at capacity
+)
 
 
 class UploadTimeoutError(RuntimeError):
@@ -211,6 +215,7 @@ class Uploader:
         site: BaseSite,
         category_ensurer: CategoryEnsurer | None = None,
         no_create: bool = False,
+        dup_throttle: DuplicateCategoryThrottle | None = None,
     ):
         self.tracker = tracker
         self.local_fs = local_fs
@@ -222,6 +227,10 @@ class Uploader:
         # write to a File page that does not already exist, so no run can
         # create a new Commons file. Defaults False (normal upload behaviour).
         self.no_create = no_create
+        # dup_throttle: gate on the Case-2 hash-drift tag-emitting path so a
+        # run can't flood the human-maintained Category:Duplicate. None disables
+        # the gate (standalone / unit-test construction); main() injects one.
+        self.dup_throttle = dup_throttle
 
     def _safe_upload(self, *, filepage, **kwargs):
         """Sole sanctioned wrapper around ``site.upload`` — every upload in
@@ -522,6 +531,32 @@ class Uploader:
                                 "pageid": existing_file.pageid,
                             }
                         elif drift_action == "upload_and_tag":
+                            # This ordinal would upload its bytes to the
+                            # canonical title AND tag the stranded sha1-sibling
+                            # {{duplicate}}. If Category:Duplicate is at
+                            # capacity, defer the WHOLE op — not just the tag —
+                            # so we never upload the duplicating bytes and leave
+                            # an untagged duplicate behind. The drain pass
+                            # re-runs this item once the category drains. The
+                            # gate is consulted only here (the rare tag path),
+                            # so ordinary uploads are unaffected.
+                            if (
+                                self.dup_throttle is not None
+                                and not self.dup_throttle.try_acquire()
+                            ):
+                                logging.info(
+                                    f"Deferring {dpla_id} {ordinal}: "
+                                    f"Category:Duplicate at capacity; will retry "
+                                    f"upload + duplicate-tag in the drain pass."
+                                )
+                                self.tracker.increment(
+                                    Result.UPLOAD_DEFERRED_DUP_CATEGORY
+                                )
+                                return {
+                                    "status": ORDINAL_DEFERRED,
+                                    "title": page_title,
+                                    "pageid": None,
+                                }
                             drift_old_filename = existing_file.title(with_ns=False)
                             force_ignore_warnings = True
                         else:  # "upload_only"
@@ -1490,6 +1525,13 @@ class Uploader:
             # the current truth.
             self._persist_upload_result(partner, dpla_id, ordinal_results, dry_run)
 
+            # Tell main() whether any ordinal was deferred by the dup-category
+            # throttle, so it can re-run this item in the drain pass once
+            # Category:Duplicate has room. (Other exits return None = falsy.)
+            return any(
+                r.get("status") == ORDINAL_DEFERRED for r in ordinal_results.values()
+            )
+
         except Exception as ex:
             # Intentionally NOT writing upload-result.json on the catch-all
             # exception path. The failure may be transient (S3 hiccup,
@@ -1579,6 +1621,13 @@ def main(
     commons_site = get_site()
     category_ensurer = CategoryEnsurer(commons_site, dry_run=dry_run)
 
+    # Caps how many files this run may add to the human-maintained
+    # Category:Duplicate (via {{duplicate}} tags on Case-2 hash-drift uploads).
+    # Consulted only on that rare tag-emitting path; ordinary uploads never
+    # touch it and it queries the category size at most once per ~100 tags.
+    # A dry run never tags, so the throttle is simply never consulted.
+    dup_throttle = DuplicateCategoryThrottle(commons_site)
+
     uploader = Uploader(
         tools_context.get_tracker(),
         tools_context.get_local_fs(),
@@ -1587,6 +1636,7 @@ def main(
         commons_site,
         category_ensurer,
         no_create=no_create,
+        dup_throttle=dup_throttle,
     )
 
     dpla = tools_context.get_dpla()
@@ -1647,11 +1697,28 @@ def main(
 
         dpla_ids = load_ids(ids_file)
 
+        deferred_ids: list[str] = []
         for dpla_id in tqdm(dpla_ids, desc="Uploading Items", unit="Item", ncols=100):
             with slot_budget.acquire():
-                uploader.process_item(
+                if uploader.process_item(
                     dpla_id, providers_json, partner, verbose, dry_run
-                )
+                ):
+                    deferred_ids.append(dpla_id)
+
+        # Any item whose {{duplicate}}-tagging upload was deferred because
+        # Category:Duplicate was full: wait for the category to drain, then
+        # re-run those items in this same session (not an operator re-run).
+        if deferred_ids:
+            _drain_deferred_dups(
+                uploader,
+                dup_throttle,
+                deferred_ids,
+                providers_json,
+                partner,
+                verbose,
+                dry_run,
+                slot_budget,
+            )
 
     finally:
         elapsed = time.time() - start_time
@@ -1681,6 +1748,83 @@ def main(
             elapsed_seconds=elapsed,
             dry_run=dry_run,
         )
+
+
+# Upper bound on how long the drain pass will wait for Category:Duplicate to
+# fall back below the throttle's resume threshold. Volunteers clear the
+# category on human timescales, so give it real headroom — but cap it so a
+# session never hangs indefinitely. On timeout the remaining files are left
+# un-uploaded and the operator is pinged to re-run after the category drains.
+_DRAIN_MAX_WAIT_SECS = 4 * 60 * 60  # 4 hours
+
+
+def _drain_deferred_dups(
+    uploader: "Uploader",
+    throttle: DuplicateCategoryThrottle,
+    deferred_ids: list[str],
+    providers_json,
+    partner: str,
+    verbose: bool,
+    dry_run: bool,
+    slot_budget: WorkerSlotBudget,
+    *,
+    max_wait_secs: float = _DRAIN_MAX_WAIT_SECS,
+) -> list[str]:
+    """Re-run items whose {{duplicate}}-tagging upload was deferred, once
+    Category:Duplicate has drained.
+
+    Each round waits (via the throttle) for the category to fall below its
+    resume threshold, then re-processes the still-deferred items. Re-processing
+    may itself defer again if the category refills mid-drain, so it loops until
+    nothing remains, no progress is made, or the wait budget is exhausted.
+    Returns the ids still deferred at exit (empty on full success).
+    """
+    remaining = list(deferred_ids)
+    deadline = time.monotonic() + max_wait_secs
+    logging.info(
+        "Drain pass: %d item(s) deferred while Category:Duplicate was at "
+        "capacity; waiting for it to drain, then retrying their uploads.",
+        len(remaining),
+    )
+    while remaining:
+        budget = deadline - time.monotonic()
+        if budget <= 0 or not throttle.wait_for_capacity(budget):
+            logging.error(
+                "Drain pass timed out with %d item(s) still deferred; their "
+                "uploads + {{duplicate}} tags were NOT emitted. Clear "
+                "Category:Duplicate, then re-run the partner to finish them.",
+                len(remaining),
+            )
+            notify_dup_drain_incomplete(partner, len(remaining))
+            return remaining
+
+        still_deferred: list[str] = []
+        for dpla_id in remaining:
+            with slot_budget.acquire():
+                if uploader.process_item(
+                    dpla_id, providers_json, partner, verbose, dry_run
+                ):
+                    still_deferred.append(dpla_id)
+
+        # A batch larger than the throttle's headroom (recheck_cap) legitimately
+        # takes several rounds — each round re-queries and clears up to a cap's
+        # worth, so partial progress is normal, not a stall. But if a round that
+        # began with confirmed capacity clears NOTHING, the category is refilling
+        # as fast as we drain (or another mechanism keeps deferring) — bail
+        # rather than spin a hot loop re-querying the category every iteration.
+        if len(still_deferred) >= len(remaining):
+            logging.error(
+                "Drain pass made no progress despite available capacity (%d "
+                "still deferred); aborting drain. Clear Category:Duplicate, "
+                "then re-run the partner to finish them.",
+                len(still_deferred),
+            )
+            notify_dup_drain_incomplete(partner, len(still_deferred))
+            return still_deferred
+        remaining = still_deferred
+
+    logging.info("Drain pass complete: all deferred uploads + duplicate-tags emitted.")
+    return remaining
 
 
 # Wait between the last ensure() and the first touch.  Wikidata→Commons


### PR DESCRIPTION
## Problem

A single uploader run over a partner with heavy orphaned-duplicate content (e.g. the Minnesota / Hennepin County Library session) can emit **tens of thousands** of `{{duplicate}}` tags on the Case-2 hash-drift path — where an existing Commons file's bytes are re-homed to the canonical DPLA-ID title and the stranded copy is tagged. Each tag adds a file to **`Category:Duplicate`**, which Commons volunteers clear **by hand**. Flooding it is antisocial and risks the bot being blocked.

## Approach — defer-and-drain

Add `DuplicateCategoryThrottle`, a cached-headroom (token-bucket-style) gate consulted **only** at the hash-drift tag-emitting point:

- **try_acquire()** — when the category is at/over `threshold` (default 1000), defer; otherwise grant. Category size is fetched at most **once per ~`recheck_cap` (100) grants** via a cached "headroom" budget, with tighter rechecks near the cap. Ordinary uploads never consult it and pay nothing.
- **Defer the whole op, not just the tag.** The Case-2 decision is made pre-download, so the gate sits before the upload — we never upload the duplicating bytes only to leave an untagged duplicate behind.
- **Same-session drain pass.** `process_item` signals deferral up to `main()`, which collects deferred ids and, after the main pass, waits (hysteresis: resume below `resume_below`, default 900) and **re-runs the deferred items in the same session** — not an operator re-run. Re-running a whole item is idempotent (already-uploaded ordinals short-circuit on hash).
- **Bounded.** If the category stays full past `_DRAIN_MAX_WAIT_SECS` (4h), or a round with confirmed capacity clears nothing, the drain bails and pings `#tech-alerts` (`notify_dup_drain_incomplete`) so an operator can clear the category and re-run.

A new `DEFERRED` ordinal status is recorded; it's automatically excluded from SDC eligibility (the allowlist only admits `UPLOADED`/`SKIPPED`).

## Scope

Gates the **hash-drift duplicate-tag path only** — the volume source behind the flooding. The trailing-page orphan path (`_post_item_orphan_check`) also tags into `Category:Duplicate` but is bounded to truncated trailing pages per item (low volume) and has no defer/drain channel, so it is intentionally left un-gated (deferring an orphan tag would strand it unresolved). This is documented in the throttle's module docstring.

## Tests

- `tests/test_dup_throttle.py` — headroom amortization (one query per 100 grants), defer at threshold, near-threshold cap, `wait_for_capacity` hysteresis + timeout, constructor validation.
- `tests/test_uploader.py` — `_drain_deferred_dups` retries to completion, times out + notifies, and bails on no-progress.

Pre-commit: ruff check/format clean, `simplify` skill run (4 agents) with fixes applied, lessons.md reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Throttle `{{duplicate}}` tagging against `Category:Duplicate` on the hash-drift (Case-2) path using a defer-and-drain flow.

- Added `DuplicateCategoryThrottle` to cache `Category:Duplicate` headroom and limit category-size rechecks; when the category is at/above `threshold`, the uploader defers the entire upload/tag operation rather than partially proceeding, resuming after the category drains below `resume_below`.
- Updated the uploader to:
  - emit a new per-ordinal `DEFERRED` status (for duplicate-category throttling only) and return deferred-ordinal counts from `process_item`
  - collect deferred ordinals during the main pass and repeatedly re-run them in a post-pass drain loop until cleared, the category doesn’t drain within a timeout, or no forward progress occurs
  - count “no progress” and timeout/abort conditions based on per-ordinal deferred progress (so partially cleared multi-page items don’t trigger false aborts)
- Added `notify_dup_drain_incomplete` to post an operator alert to `#tech-alerts` when the drain loop exits with remaining deferred ordinals.
- Introduced `DEFERRED` and ensured SDC only processes ordinals whose upload-result `status` is `UPLOADED` or `SKIPPED` (so deferred ordinals are excluded).
- Left the trailing-page orphan duplicate-tagging path intentionally ungated (no defer/drain), as it’s bounded and should not be deferred.

Tests:
- Added `tests/test_dup_throttle.py` for throttle headroom caching, threshold/deferral behavior, and drain/wait timeout behavior.
- Extended uploader tests to validate the defer-and-drain control flow, including ordinal-based progress/no-progress and correct alerting.

Pipeline/infra/ops notes:
- No code changes to pipeline triggers, ECS/container definitions, IAM/SSM setup, database migrations, or public API endpoints.
- No new environment variables or secrets added; notifications rely on existing `DPLA_SLACK_BOT_TOKEN` and `WIKIMEDIA_SESSION_LABEL`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->