### PR TITLE
uploader: recover pywikibot session on CSRF error; abort run if unrecoverable

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -622,6 +622,45 @@ def notify_sdc_complete(
     )
 
 
+def notify_upload_aborted(
+    tracker: Tracker,
+    partner_label: str,
+    elapsed_seconds: float,
+    reason: str,
+) -> None:
+    """Warn #tech-alerts that the upload phase aborted mid-run.
+
+    Emitted on unrecoverable session-level failures (e.g. pywikibot CSRF
+    token invalidated and recovery ceiling exhausted). The caller
+    suppresses the normal ``notify_upload_complete`` so this message
+    stands on its own.
+    """
+    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
+    if not token:
+        logging.warning("DPLA_SLACK_BOT_TOKEN not set — skipping Slack notification")
+        return
+    effective_label = (
+        f"wikimedia-{os.environ.get('WIKIMEDIA_SESSION_LABEL') or partner_label}"
+    )
+    runtime = _format_runtime(elapsed_seconds)
+    _post_completion_notice(
+        token=token,
+        header=f"🛑 *Wikimedia upload ABORTED: {effective_label}*",
+        plain_text=f"Wikimedia upload aborted: {effective_label}",
+        stats_lines=[
+            f"UPLOADED:      {tracker.count(Result.UPLOADED):,}",
+            f"SKIPPED:       {tracker.count(Result.SKIPPED):,}",
+            f"  not present: {tracker.count(Result.UPLOAD_SKIPPED_NOT_PRESENT):,}",
+            f"  ineligible:  {tracker.count(Result.UPLOAD_SKIPPED_INELIGIBLE):,}",
+            f"FAILED:        {tracker.count(Result.FAILED):,}",
+            f"BYTES:         {_format_bytes(tracker.count(Result.BYTES))}",
+            f"Runtime:       {runtime}",
+            "",
+            f"Reason: {reason}",
+        ],
+    )
+
+
 def notify_dup_drain_incomplete(partner_label: str, remaining: int) -> None:
     """Warn #tech-alerts that the dup-category drain pass exited with files
     still deferred.

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -14,9 +14,13 @@ import pytest
 
 from tools.uploader import (
     LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES,
+    MAX_CSRF_RECOVERIES,
+    CsrfRecoveryFailed,
     NewFilePageBlocked,
     Uploader,
+    _CSRF_TOKEN_ERROR_MARKER,
     _drain_deferred_dups,
+    _is_csrf_token_error,
     _post_item_orphan_check,
     _post_upload_touch_new_institutions,
     is_dup_sha1_sibling_at_expected_title,
@@ -2086,4 +2090,219 @@ def test_process_file_backend_fail_retry_exhaustion_counts_once():
         f"{uploader._safe_upload.call_count} of "
         f"{MAX_UPLOAD_RETRIES} tries. Test isn't exercising the "
         f"removed-increment site."
+    )
+
+
+# ---------------------------------------------------------------------------
+# CSRF token recovery in the retry loop.
+#
+# Pins the contract: (a) recover the session on the first CSRF error,
+# (b) cap total recoveries per run so an unrecoverable state can't loop,
+# (c) escalate to ``CsrfRecoveryFailed`` that propagates past
+# process_file's and process_item's generic ``except Exception`` catches
+# — otherwise the fatal would be swallowed as "one FAILED ordinal" and
+# the main loop would keep going.
+# ---------------------------------------------------------------------------
+
+
+def _csrf_keyerror() -> KeyError:
+    """Build a KeyError whose ``str()`` matches pywikibot's CSRF-invalid
+    TokenWallet message. Uses the production marker constant so the
+    detector and the test data can never drift apart."""
+    return KeyError(
+        f"{_CSRF_TOKEN_ERROR_MARKER} for user 'DPLA bot' on commons:commons wiki."
+    )
+
+
+def test_is_csrf_token_error_matches_pywikibot_shape():
+    """Substring match on ``str(KeyError(...))`` — Python wraps KeyError
+    args in quotes on stringify, so the marker must appear inside those
+    wrapping quotes."""
+    assert _is_csrf_token_error(_csrf_keyerror())
+
+
+def test_is_csrf_token_error_rejects_unrelated_keyerror():
+    """A KeyError from any other code path (e.g. dict miss on 'title')
+    must not be treated as a CSRF error — otherwise a bug elsewhere
+    could accidentally trip the whole session-abort escalation."""
+    assert not _is_csrf_token_error(KeyError("title"))
+    assert not _is_csrf_token_error(KeyError("csrf"))  # bare, no "Invalid token"
+
+
+def test_is_csrf_token_error_rejects_non_keyerror():
+    """A RuntimeError whose message happens to contain the CSRF marker
+    isn't a real CSRF token error — pywikibot only raises this as
+    KeyError. Guard against a false positive from log-string
+    contamination."""
+    assert not _is_csrf_token_error(RuntimeError(_CSRF_TOKEN_ERROR_MARKER))
+
+
+def _csrf_retry_loop_uploader(tracker: Tracker) -> Uploader:
+    """Mirrors ``_process_file_uploader`` but wires up the extra mocks
+    needed to reach the retry loop (the CSRF handling site) rather than
+    landing in the pre-loop outer catch."""
+    uploader = Uploader(
+        tracker=tracker,
+        local_fs=MagicMock(),
+        s3_client=MagicMock(),
+        dpla=MagicMock(),
+        site=MagicMock(),
+        category_ensurer=None,
+    )
+    uploader.s3_client.get_media_s3_path.return_value = "p/a/t/h/abc/1_abc"
+    uploader.s3_client.s3_file_exists.return_value = True
+    fake_s3_object = MagicMock()
+    fake_s3_object.content_length = 100
+    fake_s3_object.metadata = {"sha1": "deadbeef" * 5}
+    fake_s3_object.content_type = "image/jpeg"
+    uploader.s3_client.get_s3.return_value.Object.return_value = fake_s3_object
+    return uploader
+
+
+def _csrf_process_file(uploader: Uploader):
+    """Drive execution into the retry loop with all pre-retry mocks
+    patched in. Returns the tuple ``(fake_page, result_or_exc)`` where
+    the latter is the process_file return value or ``None`` if an
+    exception was raised (caught outside this helper)."""
+    fake_page = MagicMock()
+    fake_page.exists.return_value = False
+    fake_page.isRedirectPage.return_value = False
+    fake_page.title.return_value = (
+        "File:X - DPLA - abcdef1234567890abcdef1234567890 (page 1).jpg"
+    )
+    fake_page.pageid = 0
+    with (
+        patch("tools.uploader.get_wiki_text", return_value="wt"),
+        patch("tools.uploader.find_file_by_hash", return_value=None),
+        patch(
+            "tools.uploader.get_page_title",
+            return_value=(
+                "File:X - DPLA - abcdef1234567890abcdef1234567890 (page 1).jpg"
+            ),
+        ),
+        patch("tools.uploader.get_page", return_value=fake_page),
+        patch("tools.uploader.time.sleep"),
+    ):
+        return uploader.process_file(
+            dpla_id="abc",
+            title="X",
+            item_metadata={},
+            provider={},
+            data_provider={},
+            ordinal=1,
+            partner="nara",
+            page_label="",
+            verbose=False,
+            dry_run=False,
+        )
+
+
+def test_csrf_error_triggers_session_recovery_and_retry():
+    """First CSRF error → ``_recover_commons_session`` fires and the
+    retry loop advances to the next attempt. Verifies the recovery +
+    re-attempt contract only — the second attempt is arranged to fail
+    with a non-CSRF error so the test doesn't have to fake the
+    post-upload FilePage refresh."""
+    tracker = Tracker()
+    uploader = _csrf_retry_loop_uploader(tracker)
+    # First upload attempt raises CSRF KeyError; second raises a
+    # non-CSRF error so the retry loop exits without exercising the
+    # post-upload machinery. The point of this test is the RE-ATTEMPT
+    # after recovery, not what happens on the second attempt.
+    uploader._safe_upload = MagicMock(
+        side_effect=[_csrf_keyerror(), RuntimeError("second attempt marker")]
+    )
+    with patch("tools.uploader._recover_commons_session") as recover_mock:
+        _csrf_process_file(uploader)
+    recover_mock.assert_called_once_with(uploader.site)
+    assert uploader._safe_upload.call_count == 2, (
+        f"retry loop did not re-attempt after CSRF recovery — "
+        f"_safe_upload called {uploader._safe_upload.call_count} time(s), "
+        f"expected 2. If this is 1, the recovery path returned instead "
+        f"of continuing the loop."
+    )
+    assert uploader._csrf_recoveries_used == 1
+
+
+def test_csrf_errors_beyond_cap_raise_csrf_recovery_failed():
+    """Once ``MAX_CSRF_RECOVERIES`` is reached, the next CSRF error
+    raises ``CsrfRecoveryFailed`` — the exception must not be silently
+    counted as FAILED. Bounded abort under a persistently invalid
+    session."""
+    tracker = Tracker()
+    uploader = _csrf_retry_loop_uploader(tracker)
+    # Pre-consume the cap so the very next CSRF error escalates. This is
+    # a cleaner test than driving through many attempts (each of which
+    # would exhaust MAX_UPLOAD_RETRIES per ordinal) and pins the cap
+    # behavior specifically.
+    uploader._csrf_recoveries_used = MAX_CSRF_RECOVERIES
+    uploader._safe_upload = MagicMock(side_effect=_csrf_keyerror())
+    with patch("tools.uploader._recover_commons_session") as recover_mock:
+        with pytest.raises(CsrfRecoveryFailed):
+            _csrf_process_file(uploader)
+    # Recovery must NOT have been attempted — the cap was already at the
+    # ceiling, so trying again would just loop the same failure.
+    recover_mock.assert_not_called()
+    # And nothing was silently counted as FAILED — the exception
+    # propagates past process_file's outer catch (the whole point).
+    assert tracker.count(Result.FAILED) == 0, (
+        "CsrfRecoveryFailed must propagate past process_file's outer "
+        "``except Exception`` — if this is nonzero, the generic catch "
+        "swallowed the session-fatal escalation and the run would keep "
+        "going, defeating the abort."
+    )
+
+
+def test_csrf_recovery_that_throws_escalates_to_csrf_recovery_failed():
+    """If ``_recover_commons_session`` itself throws (network down,
+    credentials rotated, etc.), escalate to ``CsrfRecoveryFailed``
+    immediately rather than looping recovery attempts against an
+    unreachable auth endpoint."""
+    tracker = Tracker()
+    uploader = _csrf_retry_loop_uploader(tracker)
+    uploader._safe_upload = MagicMock(side_effect=_csrf_keyerror())
+    with patch(
+        "tools.uploader._recover_commons_session",
+        side_effect=RuntimeError("network unreachable"),
+    ):
+        with pytest.raises(CsrfRecoveryFailed):
+            _csrf_process_file(uploader)
+    assert tracker.count(Result.FAILED) == 0
+
+
+def test_csrf_recovery_failed_propagates_past_process_item_outer_catch():
+    """process_item wraps its body in an outer ``except Exception`` that
+    increments FAILED. Without an explicit ``except CsrfRecoveryFailed:
+    raise`` before it, the fatal would be swallowed as a per-ordinal
+    FAILED and the main() loop would move on to the next item — every
+    one of which would hit the same broken session. This test pins that
+    CsrfRecoveryFailed propagates all the way out of process_item, so
+    main() sees it and aborts the run.
+
+    Raises CsrfRecoveryFailed from the very first call inside the try
+    (``get_item_metadata``) — the propagation contract is about outer
+    handler ordering (specific-before-generic), which is testable at
+    the boundary without driving through the full ordinal pipeline.
+    """
+    tracker = Tracker()
+    uploader = _csrf_retry_loop_uploader(tracker)
+    uploader.s3_client.get_item_metadata.side_effect = CsrfRecoveryFailed(
+        "session unrecoverable"
+    )
+    with pytest.raises(CsrfRecoveryFailed):
+        uploader.process_item(
+            dpla_id="abc",
+            providers_json={},
+            partner="nara",
+            verbose=False,
+            dry_run=False,
+        )
+    # The fatal must not have been counted as a plain FAILED — that
+    # counter is reserved for per-ordinal failures the generic outer
+    # catch legitimately owns after PR #349.
+    assert tracker.count(Result.FAILED) == 0, (
+        "CsrfRecoveryFailed was caught by process_item's generic "
+        "``except Exception`` and counted as FAILED. Add an explicit "
+        "``except CsrfRecoveryFailed: raise`` before the generic "
+        "handler so the run aborts instead of looping the next item."
     )

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -758,7 +758,15 @@ class Uploader:
                 # Use try/finally to guarantee shutdown(wait=False) on all paths.
                 executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                 try:
-                    for attempt in range(1, MAX_UPLOAD_RETRIES + 1):
+                    # ``attempt`` is managed manually rather than via
+                    # ``for attempt in range(...)`` so a CSRF-recovery
+                    # continue can re-loop WITHOUT consuming an attempt
+                    # slot — the recovered session deserves a fresh try
+                    # of the same call. Only real per-ordinal errors
+                    # (backend-fail retries, unrecoverable exceptions)
+                    # advance ``attempt``.
+                    attempt = 1
+                    while attempt <= MAX_UPLOAD_RETRIES:
                         future = None
                         try:
                             future = executor.submit(
@@ -824,6 +832,10 @@ class Uploader:
                                 self._csrf_recoveries_used += 1
                                 del future
                                 gc.collect()
+                                # Do NOT advance ``attempt``: the previous call
+                                # failed on session state, not on anything
+                                # ordinal-specific — the recovered session
+                                # gets a fresh attempt slot.
                                 continue
                             if is_backend_fail and attempt < MAX_UPLOAD_RETRIES:
                                 delay = min(
@@ -845,6 +857,8 @@ class Uploader:
                                 del future
                                 gc.collect()
                                 time.sleep(delay)
+                                attempt += 1
+                                continue
                             else:
                                 # Don't increment FAILED here — the ``raise``
                                 # propagates to the generic ``except Exception``
@@ -1836,10 +1850,28 @@ def main(
                     )
                     if deferred_count:
                         deferred[dpla_id] = deferred_count
+
+            # Any item whose {{duplicate}}-tagging upload was deferred because
+            # Category:Duplicate was full: wait for the category to drain, then
+            # re-run those items in this same session (not an operator re-run).
+            # Inside the same try so a CSRF-fatal from the drain pass also
+            # routes to the notify_upload_aborted + re-raise path below.
+            if deferred:
+                _drain_deferred_dups(
+                    uploader,
+                    dup_throttle,
+                    deferred,
+                    providers_json,
+                    partner,
+                    verbose,
+                    dry_run,
+                    slot_budget,
+                )
         except CsrfRecoveryFailed as ex:
             # Session's auth is broken and unrecoverable. Abort — do NOT
             # continue to remaining items (every one would hit the same
-            # error). The drain pass below is skipped for the same reason.
+            # error). Re-raise after notifying so the process exits
+            # non-zero and the tmux `&&` chain doesn't proceed to sdc-sync.
             session_aborted = True
             logging.error("Aborting upload: %s", ex)
             notify_upload_aborted(
@@ -1848,42 +1880,31 @@ def main(
                 elapsed_seconds=time.time() - start_time,
                 reason=str(ex),
             )
-
-        # Any item whose {{duplicate}}-tagging upload was deferred because
-        # Category:Duplicate was full: wait for the category to drain, then
-        # re-run those items in this same session (not an operator re-run).
-        if deferred and not session_aborted:
-            _drain_deferred_dups(
-                uploader,
-                dup_throttle,
-                deferred,
-                providers_json,
-                partner,
-                verbose,
-                dry_run,
-                slot_budget,
-            )
+            raise
 
     finally:
         elapsed = time.time() - start_time
         logging.info("\n" + str(tracker))
         logging.info(f"{elapsed} seconds.")
         local_fs.cleanup_temp_dir()
-        # Touch files for any institutions we set up this session.  Closes the
-        # Wikidata-replication-lag race that lands first-batch files in the
-        # "unknown institution" category; without this we rely on a periodic
-        # run of fix-unknown-categories to clean up after the fact.  The 10s
-        # pause is a cheap belt-and-suspenders against very-late ensure()
-        # calls — for typical runs replication has settled long before this.
-        #
-        # Passes the slot budget through: these touches are Commons writes,
-        # so the helper holds a slot around them (see its docstring).
-        _post_upload_touch_new_institutions(
-            commons_site, category_ensurer, dry_run, slot_budget
-        )
         # On a session-aborted run ``notify_upload_aborted`` already
-        # posted the failure message; skip the "Upload Complete" summary.
+        # posted the failure message; skip the "Upload Complete" summary
+        # AND the Commons-writing touch helper, since the auth state is
+        # broken and further writes would fail noisily (potentially
+        # masking the original CSRF-fatal in logs).
         if not session_aborted:
+            # Touch files for any institutions we set up this session.  Closes the
+            # Wikidata-replication-lag race that lands first-batch files in the
+            # "unknown institution" category; without this we rely on a periodic
+            # run of fix-unknown-categories to clean up after the fact.  The 10s
+            # pause is a cheap belt-and-suspenders against very-late ensure()
+            # calls — for typical runs replication has settled long before this.
+            #
+            # Passes the slot budget through: these touches are Commons writes,
+            # so the helper holds a slot around them (see its docstring).
+            _post_upload_touch_new_institutions(
+                commons_site, category_ensurer, dry_run, slot_budget
+            )
             notify_upload_complete(
                 # Bare partner slug, not "wikimedia-<partner>" — notify_upload_complete
                 # always prepends "wikimedia-" itself (matching the bare-label

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -45,7 +45,11 @@ from ingest_wikimedia.dpla import (
     WIKIDATA_FIELD_NAME,
     DPLA,
 )
-from ingest_wikimedia.slack import notify_dup_drain_incomplete, notify_upload_complete
+from ingest_wikimedia.slack import (
+    notify_dup_drain_incomplete,
+    notify_upload_aborted,
+    notify_upload_complete,
+)
 from ingest_wikimedia.wikimedia import (
     WMC_UPLOAD_CHUNK_SIZE,
     IGNORE_WIKIMEDIA_WARNINGS,
@@ -205,6 +209,45 @@ class NewFilePageBlocked(RuntimeError):
     """
 
 
+class CsrfRecoveryFailed(RuntimeError):
+    """Raised when the pywikibot session's CSRF token cannot be recovered.
+
+    Routed AROUND the per-ordinal generic FAILED-counter catch so a
+    session-level fatal aborts the run instead of looping the same
+    error against every remaining item.
+    """
+
+
+# Session-scoped ceiling on CSRF recoveries per run; exceeding it raises
+# ``CsrfRecoveryFailed``. This is the hard guardrail against unbounded
+# looping on a persistently invalid session.
+MAX_CSRF_RECOVERIES = 3
+
+_CSRF_TOKEN_ERROR_MARKER = "Invalid token 'csrf'"
+
+
+def _is_csrf_token_error(ex: BaseException) -> bool:
+    """True if ``ex`` is the pywikibot ``KeyError`` from ``TokenWallet``
+    whose message signals an invalidated CSRF token — narrowed on the
+    marker so unrelated ``KeyError``s don't trigger session recovery."""
+    return isinstance(ex, KeyError) and _CSRF_TOKEN_ERROR_MARKER in str(ex)
+
+
+def _recover_commons_session(site) -> None:
+    """Drop the current pywikibot session, re-authenticate, and clear
+    the cached TokenWallet so the next ``site.tokens['csrf']`` refetches.
+
+    ``site.logout()`` is required first: ``site.login()`` on an
+    already-"logged-in" site is a no-op in pywikibot's default flow, so
+    clearing tokens alone would just re-fetch against the same bad
+    session.
+    """
+    logging.info("Recovering Commons session: logout + login + token-wallet clear")
+    site.logout()
+    site.login()
+    site.tokens.clear()
+
+
 class Uploader:
     def __init__(
         self,
@@ -231,6 +274,9 @@ class Uploader:
         # run can't flood the human-maintained Category:Duplicate. None disables
         # the gate (standalone / unit-test construction); main() injects one.
         self.dup_throttle = dup_throttle
+        # Capped at :data:`MAX_CSRF_RECOVERIES`; once exhausted the next
+        # CSRF error raises :class:`CsrfRecoveryFailed` and aborts the run.
+        self._csrf_recoveries_used = 0
 
     def _safe_upload(self, *, filepage, **kwargs):
         """Sole sanctioned wrapper around ``site.upload`` — every upload in
@@ -741,6 +787,44 @@ class Uploader:
                             break
                         except Exception as ex:
                             is_backend_fail = ERROR_BACKEND_FAIL in str(ex)
+                            is_csrf_error = _is_csrf_token_error(ex)
+                            if is_csrf_error:
+                                # Session was invalidated — every subsequent
+                                # upload will hit the same KeyError until
+                                # we re-authenticate. Retrying the same call
+                                # can't help; refresh the session instead.
+                                # Session cap or recovery failure → fatal.
+                                if self._csrf_recoveries_used >= MAX_CSRF_RECOVERIES:
+                                    raise CsrfRecoveryFailed(
+                                        f"Commons session invalidated: CSRF"
+                                        f" token still invalid after"
+                                        f" {self._csrf_recoveries_used}"
+                                        f" recovery attempts; aborting run."
+                                    ) from ex
+                                logging.warning(
+                                    "CSRF token invalidated (attempt"
+                                    " %d/%d for %s ordinal %d); refreshing"
+                                    " Commons session (recovery %d/%d)",
+                                    attempt,
+                                    MAX_UPLOAD_RETRIES,
+                                    dpla_id,
+                                    ordinal,
+                                    self._csrf_recoveries_used + 1,
+                                    MAX_CSRF_RECOVERIES,
+                                )
+                                try:
+                                    _recover_commons_session(self.site)
+                                except Exception as recover_ex:
+                                    raise CsrfRecoveryFailed(
+                                        f"Commons session recovery threw"
+                                        f" ({recover_ex!r}); aborting rather"
+                                        f" than looping unrecoverable auth"
+                                        f" errors."
+                                    ) from recover_ex
+                                self._csrf_recoveries_used += 1
+                                del future
+                                gc.collect()
+                                continue
                             if is_backend_fail and attempt < MAX_UPLOAD_RETRIES:
                                 delay = min(
                                     UPLOAD_RETRY_BASE_DELAY_SECS * (2 ** (attempt - 1)),
@@ -856,12 +940,19 @@ class Uploader:
             # ordinals aren't attempted — a stuck Commons job queue won't
             # magically un-stick mid-item.
             raise
+        except CsrfRecoveryFailed:
+            # Session-level fatal — propagates to main() so the whole run
+            # aborts. Not a per-ordinal FAILED (the auth state is broken
+            # for every subsequent write, not just this ordinal).
+            raise
         except Exception as ex:
             # Single source of truth for the per-ordinal FAILED counter on
-            # every non-timeout exception path — includes pywikibot API
-            # errors like the CSRF ``KeyError`` from an invalidated session,
-            # backend-fail retries exhausted, "file linked to another
-            # page" ID drift, and anything else that reaches this catch.
+            # every non-timeout, non-session-fatal exception path — includes
+            # pywikibot API errors like a *recoverable* CSRF ``KeyError``
+            # that we couldn't recover from within this attempt (post the
+            # session-recovery branch in the retry loop above), backend-fail
+            # retries exhausted, "file linked to another page" ID drift, and
+            # anything else that reaches this catch.
             # Pre-fix, ``handle_upload_exception`` logged the ``Failed:
             # <reason>`` line but never bumped the counter, so a whole
             # class of upload failures were silently absent from
@@ -1557,6 +1648,12 @@ class Uploader:
                 r.get("status") == ORDINAL_DEFERRED for r in ordinal_results.values()
             )
 
+        except CsrfRecoveryFailed:
+            # Session-level fatal — propagates to main() so the run
+            # aborts. Explicit re-raise ordering: the generic catch
+            # below is for per-item transient errors and would swallow
+            # this into a FAILED bump.
+            raise
         except Exception as ex:
             # Intentionally NOT writing upload-result.json on the catch-all
             # exception path. The failure may be transient (S3 hiccup,
@@ -1706,6 +1803,11 @@ def main(
     else:
         slot_budget = WorkerSlotBudget(0)
 
+    # Suppresses the "Upload Complete" Slack notification in the finally
+    # when the run aborted mid-loop. Defined *before* the outer try so
+    # it's in scope for the finally even if an early setup step raises.
+    session_aborted = False
+
     try:
         local_fs.setup_temp_dir()
         setup_logging(partner, "upload", logging.INFO)
@@ -1724,18 +1826,33 @@ def main(
 
         # Map of dpla_id -> count of ordinals the dup-category throttle deferred.
         deferred: dict[str, int] = {}
-        for dpla_id in tqdm(dpla_ids, desc="Uploading Items", unit="Item", ncols=100):
-            with slot_budget.acquire():
-                deferred_count = uploader.process_item(
-                    dpla_id, providers_json, partner, verbose, dry_run
-                )
-                if deferred_count:
-                    deferred[dpla_id] = deferred_count
+        try:
+            for dpla_id in tqdm(
+                dpla_ids, desc="Uploading Items", unit="Item", ncols=100
+            ):
+                with slot_budget.acquire():
+                    deferred_count = uploader.process_item(
+                        dpla_id, providers_json, partner, verbose, dry_run
+                    )
+                    if deferred_count:
+                        deferred[dpla_id] = deferred_count
+        except CsrfRecoveryFailed as ex:
+            # Session's auth is broken and unrecoverable. Abort — do NOT
+            # continue to remaining items (every one would hit the same
+            # error). The drain pass below is skipped for the same reason.
+            session_aborted = True
+            logging.error("Aborting upload: %s", ex)
+            notify_upload_aborted(
+                tracker=tracker,
+                partner_label=partner,
+                elapsed_seconds=time.time() - start_time,
+                reason=str(ex),
+            )
 
         # Any item whose {{duplicate}}-tagging upload was deferred because
         # Category:Duplicate was full: wait for the category to drain, then
         # re-run those items in this same session (not an operator re-run).
-        if deferred:
+        if deferred and not session_aborted:
             _drain_deferred_dups(
                 uploader,
                 dup_throttle,
@@ -1764,17 +1881,20 @@ def main(
         _post_upload_touch_new_institutions(
             commons_site, category_ensurer, dry_run, slot_budget
         )
-        notify_upload_complete(
-            # Bare partner slug, not "wikimedia-<partner>" — notify_upload_complete
-            # always prepends "wikimedia-" itself (matching the bare-label
-            # convention notify_phase_start and notify_download_complete use).
-            # Passing the pre-prefixed form yielded "wikimedia-wikimedia-<partner>"
-            # in standalone runs after PR #199 refactored these helpers.
-            tracker=tracker,
-            partner_label=partner,
-            elapsed_seconds=elapsed,
-            dry_run=dry_run,
-        )
+        # On a session-aborted run ``notify_upload_aborted`` already
+        # posted the failure message; skip the "Upload Complete" summary.
+        if not session_aborted:
+            notify_upload_complete(
+                # Bare partner slug, not "wikimedia-<partner>" — notify_upload_complete
+                # always prepends "wikimedia-" itself (matching the bare-label
+                # convention notify_phase_start and notify_download_complete use).
+                # Passing the pre-prefixed form yielded "wikimedia-wikimedia-<partner>"
+                # in standalone runs after PR #199 refactored these helpers.
+                tracker=tracker,
+                partner_label=partner,
+                elapsed_seconds=elapsed,
+                dry_run=dry_run,
+            )
 
 
 # Upper bound on how long the drain pass will wait for Category:Duplicate to


### PR DESCRIPTION
## Summary

- Detect the pywikibot `KeyError: Invalid token 'csrf'` inside the retry loop and refresh the Commons session (`logout()` + `login()` + `tokens.clear()`) instead of burning through the per-ordinal retry budget on an error that isn't item-specific.
- Cap session recoveries per run at `MAX_CSRF_RECOVERIES = 3`; exceeding the cap or a recovery that itself throws raises `CsrfRecoveryFailed`, which propagates past process_file's and process_item's generic `except Exception` handlers up to `main()`. main() posts a `notify_upload_aborted` Slack message, suppresses the normal `notify_upload_complete`, skips the deferred-dup drain, and exits — so the tmux `&&` chain doesn't proceed to sdc-sync.
- Motivating incident: a NARA run logged **22,572 identical CSRF errors + 22,712 `Failed: Unknown` tracebacks over ~8 days** before the CSV exhausted. Worst-case with this fix: **~4 CSRF errors** before the run aborts.

## Design notes

- CSRF recovery consumes a `MAX_UPLOAD_RETRIES` attempt slot per ordinal (same shape as backend-fail retries). The session-level `MAX_CSRF_RECOVERIES` cap is the real guardrail against unbounded loops across items.
- `CsrfRecoveryFailed` deliberately routes **around** the generic `except Exception` catches — those own the per-ordinal FAILED counter (per #349), which is the wrong owner for a session-level fatal.
- `_is_csrf_token_error` narrows on both `isinstance(ex, KeyError)` and the marker substring `Invalid token 'csrf'` so unrelated `KeyError`s (dict misses, etc.) don't trigger session refresh.
- The abort path only fires when the session is genuinely stuck. Transient failures continue to flow through the existing retry-then-FAILED path.

## Test plan

- [x] 8 new pytest cases in `tests/test_uploader.py`: detector matches/rejects, recovery + retry, cap exhaustion, recovery-itself-throws, propagation past process_item's outer catch.
- [x] Full suite: 502 passed on EC2 (Python 3.13, pywikibot installed).
- [x] `ruff check` + `ruff format` clean on all three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR makes Wikimedia uploads recover from pywikibot CSRF token invalidation instead of failing item-by-item.

- Detects the pywikibot `KeyError: Invalid token 'csrf'` in the upload retry loop.
- Recovers the Commons session by calling `logout()`, `login()`, and clearing the token cache (`site.tokens`), and then retries the same ordinal attempt without consuming the remaining per-item retry budget.
- Caps CSRF recoveries at `MAX_CSRF_RECOVERIES = 3`; once the cap is exceeded (or session recovery fails), raises `CsrfRecoveryFailed` to abort the run rather than falling back to misleading downstream behavior.
- Updates `main()` to treat `CsrfRecoveryFailed` as an unrecoverable abort: sends a new Slack alert via `notify_upload_aborted(...)`, suppresses the normal completion notification, skips the deferred-duplicate drain, and exits so the `tmux && sdc-sync` chain does not continue.
- Adds tests covering CSRF detection, recovery + retry behavior, cap exhaustion, recovery failure, and propagation past outer exception handlers.

Security note: this changes session handling by actively re-authenticating to recover from invalid CSRF tokens; Slack notifications remain gated on `DPLA_SLACK_BOT_TOKEN` being set (no new env vars/secrets or credential-handling surfaces were introduced).

No infrastructure changes (no manual pipeline trigger/ECS redeploy requirement, no CodePipeline/CodeBuild/ECS/IAM/Secrets Manager changes) and no API response/endpoints or database migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->