### PR TITLE
sdc-match: widen Wikitext↔SDC comparators to catch near-duplicate values

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -34,7 +34,12 @@ from urllib.parse import urlencode
 
 import mwparserfromhell
 
-from ingest_wikimedia.sdc import parse_date_range, parse_dpla_date
+from ingest_wikimedia.sdc import (
+    casefold_for_compare,
+    dates_semantically_equal,
+    parse_date_range,
+    parse_dpla_date,
+)
 
 # DPLA's Commons-bot account names. Revisions authored by these accounts
 # are treated as DPLA-originated for the purpose of provenance
@@ -325,11 +330,18 @@ def plan_migration(
 
     for key, value in wikitext_params.items():
         canonical_value = _canonical_value_for_key(canonical_params, key)
-        if classified.get(key) == "community" and value != canonical_value:
+        if classified.get(key) == "community" and not _value_equivalent_to_canonical(
+            key, value, canonical_value
+        ):
             # Only import community values that *differ* from canonical
             # — a community editor restating DPLA's title verbatim is
             # not an import we want to record (it's redundant). Same
             # invariant as Goal 1: if it matches, it's strip-eligible.
+            # Equivalence is checked semantically for the ``date`` key
+            # (via :func:`dates_semantically_equal`) and via casefold +
+            # punctuation-trim for the display-string keys — so a
+            # community edit that reformatted DPLA's own value is not
+            # imported as a spurious community contribution.
             community_imports[key] = value
         else:
             dpla_originated[key] = value
@@ -341,6 +353,46 @@ def plan_migration(
         dpla_originated_params=dpla_originated,
         artwork_template_name=_template_name(legacy_template),
     )
+
+
+_CASEFOLD_COMPARE_KEYS = frozenset(
+    {
+        "title",
+        "description",
+        "date",
+        "permission",
+        "creator",
+    }
+)
+
+
+def _value_equivalent_to_canonical(key: str, value: str, canonical: str) -> bool:
+    """Return True when ``value`` (from wikitext) and ``canonical`` (from
+    DPLA) are the same fact for the purpose of migration-planning.
+
+    Exact string equality is the primary check. For the display-string
+    keys (``title``/``description``/``date``/``permission``/``creator``)
+    a casefold + leading/trailing-punctuation-trim comparator widens
+    the tolerance so a community edit whose only difference from
+    canonical is punctuation or case is not imported as a spurious
+    community contribution. For the ``date`` key specifically the
+    semantic date-equivalence check runs first — an override like
+    ``19 November 1902`` collapses cleanly against ``1902-11-19``.
+
+    Keys outside the display-string set (opaque identifiers,
+    sub-template shapes) fall back to strict equality: a case change in
+    an identifier is a genuinely different value.
+    """
+    if value == canonical:
+        return True
+    if key == "date" and dates_semantically_equal(value, canonical):
+        return True
+    if key in _CASEFOLD_COMPARE_KEYS:
+        folded_value = casefold_for_compare(value)
+        folded_canonical = casefold_for_compare(canonical)
+        if folded_value and folded_value == folded_canonical:
+            return True
+    return False
 
 
 def _canonical_value_for_key(canonical_params: dict, key: str) -> str:

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -36,6 +36,7 @@ from urllib.parse import urlencode
 import mwparserfromhell
 
 from ingest_wikimedia.sdc import (
+    CASEFOLD_COMPARE_KEYS,
     casefold_for_compare,
     dates_semantically_equal,
     parse_date_range,
@@ -356,17 +357,6 @@ def plan_migration(
     )
 
 
-_CASEFOLD_COMPARE_KEYS = frozenset(
-    {
-        "title",
-        "description",
-        "date",
-        "permission",
-        "creator",
-    }
-)
-
-
 # Matches a bare ``{{Institution|wikidata=Q...}}`` sub-template value.
 # Case-insensitive on the template name and param key so hand-typed
 # variants (``institution`` / ``Institution``, ``Wikidata`` / ``wikidata``)
@@ -434,7 +424,7 @@ def _value_equivalent_to_canonical(key: str, value: str, canonical: str) -> bool
         canon_qid = _extract_institution_qid(canonical) or canonical.strip()
         if wiki_qid and wiki_qid == canon_qid:
             return True
-    if key in _CASEFOLD_COMPARE_KEYS:
+    if key in CASEFOLD_COMPARE_KEYS:
         folded_value = casefold_for_compare(value)
         folded_canonical = casefold_for_compare(canonical)
         if folded_value and folded_value == folded_canonical:

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import re
 from dataclasses import dataclass, field
 from typing import Iterable
 from urllib.parse import urlencode
@@ -366,6 +367,39 @@ _CASEFOLD_COMPARE_KEYS = frozenset(
 )
 
 
+# Matches a bare ``{{Institution|wikidata=Q...}}`` sub-template value.
+# Case-insensitive on the template name and param key so hand-typed
+# variants (``institution`` / ``Institution``, ``Wikidata`` / ``wikidata``)
+# both parse cleanly to the inner Q-ID.
+_INSTITUTION_SUBTEMPLATE_RE = re.compile(
+    r"^\s*\{\{\s*Institution\s*\|\s*wikidata\s*=\s*(Q\d+)\s*\}\}\s*$",
+    re.IGNORECASE,
+)
+
+
+def _extract_institution_qid(value: str) -> str | None:
+    """Return the inner Q-ID from a wikitext ``institution`` param
+    value, or ``None`` if the value isn't a bare Q-ID or an
+    ``{{Institution|wikidata=Q...}}`` sub-template.
+
+    The legacy ``{{Artwork}}`` shape wraps the Q-ID in a sub-template
+    (``| Institution = {{Institution|wikidata=Q59661041}}``); the flat
+    ``{{DPLA metadata}}`` shape stores it as a bare Q-ID (``| institution
+    = Q59661041``). This helper normalises both so the migration
+    planner's equivalence check works regardless of which shape the
+    legacy wikitext carried.
+    """
+    if not value:
+        return None
+    stripped = value.strip()
+    m = _INSTITUTION_SUBTEMPLATE_RE.match(stripped)
+    if m:
+        return m.group(1)
+    if re.fullmatch(r"Q\d+", stripped):
+        return stripped
+    return None
+
+
 def _value_equivalent_to_canonical(key: str, value: str, canonical: str) -> bool:
     """Return True when ``value`` (from wikitext) and ``canonical`` (from
     DPLA) are the same fact for the purpose of migration-planning.
@@ -379,14 +413,27 @@ def _value_equivalent_to_canonical(key: str, value: str, canonical: str) -> bool
     semantic date-equivalence check runs first — an override like
     ``19 November 1902`` collapses cleanly against ``1902-11-19``.
 
-    Keys outside the display-string set (opaque identifiers,
-    sub-template shapes) fall back to strict equality: a case change in
-    an identifier is a genuinely different value.
+    For ``institution`` the wikitext value may be a bare Q-ID (flat
+    ``{{DPLA metadata}}`` shape) or the legacy sub-template
+    ``{{Institution|wikidata=Q...}}`` shape; both extract to a plain
+    Q-ID that is byte-compared to the canonical DPLA institution Q-ID.
+    This closes the case where a legacy NARA file's ``Institution``
+    sub-template holds the (custodial-unit) Q-ID that DPLA now emits as
+    ``institution`` in canonical params, but where a wrap difference
+    prevents plain equality from firing.
+
+    Keys outside those sets (other sub-template shapes) fall back to
+    strict equality.
     """
     if value == canonical:
         return True
     if key == "date" and dates_semantically_equal(value, canonical):
         return True
+    if key == "institution":
+        wiki_qid = _extract_institution_qid(value)
+        canon_qid = _extract_institution_qid(canonical) or canonical.strip()
+        if wiki_qid and wiki_qid == canon_qid:
+            return True
     if key in _CASEFOLD_COMPARE_KEYS:
         folded_value = casefold_for_compare(value)
         folded_canonical = casefold_for_compare(canonical)
@@ -398,15 +445,16 @@ def _value_equivalent_to_canonical(key: str, value: str, canonical: str) -> bool
 def _canonical_value_for_key(canonical_params: dict, key: str) -> str:
     """Pull the comparable canonical value for a key.
 
-    title/description/date/permission/creator are all scalar strings in
-    ``dpla_metadata_params``'s output — creator included (it comes from
-    ``extract_strings``, not an ``{{InFi|Creator|...}}`` sub-template dict).
-    Source, institution, etc. are sub-template valued and not handled in
-    Phase 3a's scalar mapping — return empty so the equality check
-    classifies them as "different" and they fall through to community-import
-    or dpla-originated based on provenance only.
+    title/description/date/permission/creator/institution are all scalar
+    strings in ``dpla_metadata_params``'s output — institution is a bare
+    Q-ID (``data_provider_wiki_q``), the rest come from
+    ``extract_strings``.  Other sub-template-valued keys (``source``,
+    etc.) are not handled in Phase 3a's scalar mapping — return empty
+    so the equality check classifies them as "different" and they fall
+    through to community-import or dpla-originated based on provenance
+    only.
     """
-    if key in ("title", "description", "date", "permission", "creator"):
+    if key in ("title", "description", "date", "permission", "creator", "institution"):
         return str(canonical_params.get(key, ""))
     return ""
 

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1143,6 +1143,24 @@ _TRAILING_TRIM_RE = re.compile(rf"[{_TRIM_PUNCT_CHARS}]+$")
 _INTERNAL_WS_RE = re.compile(r"\s+")
 
 
+# Canonical-params keys where a casefold + leading/trailing-punctuation
+# strip is a safe equivalence-widening fallback. Excludes opaque
+# identifier / URL / hub keys: a case change in a Q-ID, DPLA ID, URL, or
+# hub identifier is a genuinely different value, not a display variant.
+# Imported by both :mod:`ingest_wikimedia.legacy_artwork` (pre-write
+# migration equivalence) and :mod:`ingest_wikimedia.wikitext_normalize`
+# (post-write template-arg strip) so the allowlist can't drift.
+CASEFOLD_COMPARE_KEYS: frozenset[str] = frozenset(
+    {
+        "title",
+        "description",
+        "date",
+        "permission",
+        "creator",
+    }
+)
+
+
 def casefold_for_compare(s: str) -> str:
     """Fold ``s`` to a comparable form for equivalence checks against
     another display string. Strips leading/trailing whitespace and

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1064,6 +1064,124 @@ _YEAR_MONTH = re.compile(r"^(\d{1,4})-(\d{1,2})$")
 _DECADE = re.compile(r"^(\d{1,4})s$")
 _YEAR_ONLY = re.compile(r"^(\d{1,4})$")
 
+# English month-name lookup for the natural-language forms the DPLA API
+# occasionally emits (and that community editors routinely type into
+# ``{{DPLA metadata}}`` ``date`` overrides). Recognised spellings include
+# every 3-letter abbreviation plus the two common 4-letter one
+# (``Sept``). The lookup key is casefold-stripped-of-trailing-period so
+# ``September``, ``sept``, ``Sept.``, ``SEPT`` all collapse to the same
+# integer.
+_MONTH_NAMES = {
+    "jan": 1,
+    "january": 1,
+    "feb": 2,
+    "february": 2,
+    "mar": 3,
+    "march": 3,
+    "apr": 4,
+    "april": 4,
+    "may": 5,
+    "jun": 6,
+    "june": 6,
+    "jul": 7,
+    "july": 7,
+    "aug": 8,
+    "august": 8,
+    "sep": 9,
+    "sept": 9,
+    "september": 9,
+    "oct": 10,
+    "october": 10,
+    "nov": 11,
+    "november": 11,
+    "dec": 12,
+    "december": 12,
+}
+_MONTH_NAME_RE = (
+    r"(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?"
+    r"|aug(?:ust)?|sept?(?:ember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)"
+)
+# ``November 1902`` / ``Nov 1902`` / ``Sept. 1902`` → month + year precision.
+_MONTH_YEAR = re.compile(rf"^{_MONTH_NAME_RE}\.?\s+(\d{{3,4}})$", re.IGNORECASE)
+# ``November 19, 1902`` / ``Nov 19 1902`` / ``November 19 1902`` → day precision.
+# Comma between day and year is optional; whitespace is required.
+_MONTH_DAY_YEAR = re.compile(
+    rf"^{_MONTH_NAME_RE}\.?\s+(\d{{1,2}}),?\s+(\d{{3,4}})$", re.IGNORECASE
+)
+# ``19 November 1902`` / ``19 Nov. 1902`` → day precision (British / scholarly form).
+_DAY_MONTH_YEAR = re.compile(
+    rf"^(\d{{1,2}})\s+{_MONTH_NAME_RE}\.?\s+(\d{{3,4}})$", re.IGNORECASE
+)
+# ``11/19/1902`` — US slash-form with day precision. Deliberately requires
+# the trailing 3-4-digit year to avoid gluing to unrelated slash-shaped
+# strings; ambiguous with DD/MM/YYYY is left unrecognised (both forms
+# would need a heuristic we don't want in a value-preserving parser).
+_US_SLASH_DATE = re.compile(r"^(\d{1,2})/(\d{1,2})/(\d{3,4})$")
+
+# Unicode punctuation categories used by ``casefold_for_compare``'s
+# leading/trailing strip. ``\W`` in Python's re without ``re.ASCII`` covers
+# most Unicode punctuation; the explicit character class here spells out
+# the ASCII/Unicode punctuation that matters in practice so the intent is
+# reviewable and the behaviour is predictable regardless of locale.
+_TRIM_PUNCT_CHARS = (
+    r" \t\r\n"
+    r".,;:!?"
+    r"\"'`‘’“”"  # curly quotes
+    r"()\[\]{}<>"
+    r"\-‐‑‒–—"  # hyphens/en-dash/em-dash
+    r"…"  # ellipsis
+    r"/\\|"
+)
+_LEADING_TRIM_RE = re.compile(rf"^[{_TRIM_PUNCT_CHARS}]+")
+_TRAILING_TRIM_RE = re.compile(rf"[{_TRIM_PUNCT_CHARS}]+$")
+_INTERNAL_WS_RE = re.compile(r"\s+")
+
+
+def casefold_for_compare(s: str) -> str:
+    """Fold ``s`` to a comparable form for equivalence checks against
+    another display string. Strips leading/trailing whitespace and
+    punctuation, collapses internal whitespace runs, and casefolds.
+
+    Used ONLY as a comparator key — never to rewrite stored or rendered
+    values. DPLA-authored SDC and rendered wikitext must continue to
+    match byte-for-byte (case and punctuation intact); this helper only
+    widens the tolerance of "is this DPLA claim + this community claim
+    the same fact?" checks.
+
+    Non-string / falsy input returns an empty string, so a caller
+    comparing two folded keys treats both as equal only when both are
+    empty-like — deliberate: two None-shaped claims should not
+    accidentally dedup against each other.
+    """
+    if not isinstance(s, str) or not s:
+        return ""
+    s = _LEADING_TRIM_RE.sub("", s)
+    s = _TRAILING_TRIM_RE.sub("", s)
+    s = _INTERNAL_WS_RE.sub(" ", s)
+    return s.casefold()
+
+
+def dates_semantically_equal(a: str, b: str) -> bool:
+    """True iff ``a`` and ``b`` are date display strings that parse
+    (via :func:`parse_dpla_date`) to the same Wikibase time value,
+    precision, and circa-flag.
+
+    Returns False when either side fails to parse or the parses
+    disagree — never widens a match beyond structured equivalence. Used
+    by the wikitext-normalize equivalence check (for ``date =``
+    overrides in ``{{DPLA metadata}}``) and by the legacy-Artwork
+    migration planner's community-vs-canonical comparator.
+    """
+    if not a or not b:
+        return False
+    pa = parse_dpla_date(a)
+    pb = parse_dpla_date(b)
+    if pa is None or pb is None:
+        return False
+    if bool(pa.get("approximate")) != bool(pb.get("approximate")):
+        return False
+    return pa.get("value") == pb.get("value")
+
 
 def _wikibase_time(time_str: str, precision: int) -> dict:
     """Construct the canonical ``value`` payload for a Wikibase time
@@ -1127,21 +1245,30 @@ def parse_dpla_date(date_string: str) -> dict | None:
 
     Recognised single-date shapes (after decorator stripping):
 
-      * ``YYYY-MM-DD``   → precision 11 (day)
-      * ``YYYY-MM``      → precision 10 (month)
-      * ``YYYYs``        → precision 8 (decade), accepted only when the
-                            year is decade-aligned (e.g. ``1940s``, not
-                            ``1945s``)
-      * ``YYYY``         → precision 9 (year)
+      * ``YYYY-MM-DD``            → precision 11 (day)
+      * ``MM/DD/YYYY``            → precision 11 (US slash-form)
+      * ``Month D, YYYY`` /
+        ``Month D YYYY``          → precision 11
+      * ``D Month YYYY``          → precision 11 (British / scholarly)
+      * ``YYYY-MM``               → precision 10 (month)
+      * ``Month YYYY``            → precision 10 (English month name)
+      * ``YYYYs``                 → precision 8 (decade), accepted only
+                                    when the year is decade-aligned
+                                    (e.g. ``1940s``, not ``1945s``)
+      * ``YYYY``                  → precision 9 (year)
+
+    Month names accept every 3-letter abbreviation plus the common
+    4-letter ``Sept``; case is folded and an optional trailing period is
+    tolerated (``Nov``, ``Nov.``, ``November``, ``NOV``). Comma between
+    day and year is optional in the ``Month D YYYY`` shapes.
 
     Returns None for ranges (``1945-1950``), BC dates (``500 BC``), free
     prose (``During the Gilded Age``), era markers (``1945 AD``),
-    parenthesised forms (``(1945)``), month names (``January 1945``),
-    "before"/"after"/"between" prefixes, or any other shape that
-    leaves unrecognised text in the residue after decorator stripping
-    — the builder falls back to ``somevalue + P1932 stated-as`` for
-    those, so the original DPLA string is preserved verbatim
-    regardless of parse outcome.
+    parenthesised forms (``(1945)``), "before"/"after"/"between"
+    prefixes, or any other shape that leaves unrecognised text in the
+    residue after decorator stripping — the builder falls back to
+    ``somevalue + P1932 stated-as`` for those, so the original DPLA
+    string is preserved verbatim regardless of parse outcome.
 
     Conservative-fallback contract: every regex above is anchored
     (``^…$``), so ANY non-date text adjacent to a recognised pattern
@@ -1183,10 +1310,67 @@ def parse_dpla_date(date_string: str) -> dict | None:
                 _wikibase_time(f"+{y:04d}-{mo:02d}-{d:02d}T00:00:00Z", _PRECISION_DAY)
             )
 
+    m = _US_SLASH_DATE.match(s)
+    if m:
+        mo, d, y = int(m[1]), int(m[2]), int(m[3])
+        if y != 0:
+            try:
+                datetime.date(y, mo, d)
+            except ValueError:
+                pass
+            else:
+                return _ok(
+                    _wikibase_time(
+                        f"+{y:04d}-{mo:02d}-{d:02d}T00:00:00Z", _PRECISION_DAY
+                    )
+                )
+
+    m = _MONTH_DAY_YEAR.match(s)
+    if m:
+        mo = _MONTH_NAMES[m[1].casefold()]
+        d, y = int(m[2]), int(m[3])
+        if y != 0:
+            try:
+                datetime.date(y, mo, d)
+            except ValueError:
+                pass
+            else:
+                return _ok(
+                    _wikibase_time(
+                        f"+{y:04d}-{mo:02d}-{d:02d}T00:00:00Z", _PRECISION_DAY
+                    )
+                )
+
+    m = _DAY_MONTH_YEAR.match(s)
+    if m:
+        d = int(m[1])
+        mo = _MONTH_NAMES[m[2].casefold()]
+        y = int(m[3])
+        if y != 0:
+            try:
+                datetime.date(y, mo, d)
+            except ValueError:
+                pass
+            else:
+                return _ok(
+                    _wikibase_time(
+                        f"+{y:04d}-{mo:02d}-{d:02d}T00:00:00Z", _PRECISION_DAY
+                    )
+                )
+
     m = _YEAR_MONTH.match(s)
     if m:
         y, mo = int(m[1]), int(m[2])
         if y != 0 and 1 <= mo <= 12:
+            return _ok(
+                _wikibase_time(f"+{y:04d}-{mo:02d}-01T00:00:00Z", _PRECISION_MONTH)
+            )
+
+    m = _MONTH_YEAR.match(s)
+    if m:
+        mo = _MONTH_NAMES[m[1].casefold()]
+        y = int(m[2])
+        if y != 0:
             return _ok(
                 _wikibase_time(f"+{y:04d}-{mo:02d}-01T00:00:00Z", _PRECISION_MONTH)
             )

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1147,6 +1147,17 @@ _INTERNAL_WS_RE = re.compile(r"\s+")
 # strip is a safe equivalence-widening fallback. Excludes opaque
 # identifier / URL / hub keys: a case change in a Q-ID, DPLA ID, URL, or
 # hub identifier is a genuinely different value, not a display variant.
+#
+# ``date`` is deliberately EXCLUDED. ``casefold_for_compare`` trims ``[``,
+# ``]``, ``(``, ``)``, ``?`` — the same characters ``_strip_date_decorators``
+# treats as approximate/uncertain markers — so ``[1902]``, ``(1902)``, and
+# ``1902?`` would all fold to ``1902`` and spuriously match a bare
+# canonical ``1902``. That would silently strip an archival "supplied/
+# uncertain date" override, losing the uncertainty annotation.
+# :func:`dates_semantically_equal` is the ONLY comparator dates need —
+# it already handles month-name/slash-form format variance AND respects
+# the approximate-flag distinction the decorator markers encode.
+#
 # Imported by both :mod:`ingest_wikimedia.legacy_artwork` (pre-write
 # migration equivalence) and :mod:`ingest_wikimedia.wikitext_normalize`
 # (post-write template-arg strip) so the allowlist can't drift.
@@ -1154,7 +1165,6 @@ CASEFOLD_COMPARE_KEYS: frozenset[str] = frozenset(
     {
         "title",
         "description",
-        "date",
         "permission",
         "creator",
     }
@@ -1246,6 +1256,22 @@ def _strip_date_decorators(s: str) -> tuple[str, bool]:
     return s.strip(), stripped
 
 
+def _day_precision_value(y: int, mo: int, d: int) -> dict | None:
+    """Return a day-precision Wikibase time-datavalue value dict for
+    ``(y, mo, d)``, or ``None`` if the tuple isn't a real Gregorian
+    date. Encapsulates the year-zero guard + ``datetime.date`` calendar
+    check + ``_wikibase_time`` construction shared by every day-
+    precision branch of :func:`parse_dpla_date`.
+    """
+    if y == 0:
+        return None
+    try:
+        datetime.date(y, mo, d)
+    except ValueError:
+        return None
+    return _wikibase_time(f"+{y:04d}-{mo:02d}-{d:02d}T00:00:00Z", _PRECISION_DAY)
+
+
 def parse_dpla_date(date_string: str) -> dict | None:
     """Parse a DPLA display-date string into a structured representation,
     or ``None`` when the input is too messy to commit to a Wikibase
@@ -1322,65 +1348,27 @@ def parse_dpla_date(date_string: str) -> dict | None:
 
     m = _ISO_DATE.match(s)
     if m:
-        y, mo, d = int(m[1]), int(m[2]), int(m[3])
-        if y == 0:
-            return None
-        try:
-            datetime.date(y, mo, d)
-        except ValueError:
-            pass
-        else:
-            return _ok(
-                _wikibase_time(f"+{y:04d}-{mo:02d}-{d:02d}T00:00:00Z", _PRECISION_DAY)
-            )
+        v = _day_precision_value(int(m[1]), int(m[2]), int(m[3]))
+        if v is not None:
+            return _ok(v)
 
     m = _US_SLASH_DATE.match(s)
     if m:
-        mo, d, y = int(m[1]), int(m[2]), int(m[3])
-        if y != 0:
-            try:
-                datetime.date(y, mo, d)
-            except ValueError:
-                pass
-            else:
-                return _ok(
-                    _wikibase_time(
-                        f"+{y:04d}-{mo:02d}-{d:02d}T00:00:00Z", _PRECISION_DAY
-                    )
-                )
+        v = _day_precision_value(int(m[3]), int(m[1]), int(m[2]))
+        if v is not None:
+            return _ok(v)
 
     m = _MONTH_DAY_YEAR.match(s)
     if m:
-        mo = _MONTH_NAMES[m[1].casefold()]
-        d, y = int(m[2]), int(m[3])
-        if y != 0:
-            try:
-                datetime.date(y, mo, d)
-            except ValueError:
-                pass
-            else:
-                return _ok(
-                    _wikibase_time(
-                        f"+{y:04d}-{mo:02d}-{d:02d}T00:00:00Z", _PRECISION_DAY
-                    )
-                )
+        v = _day_precision_value(int(m[3]), _MONTH_NAMES[m[1].casefold()], int(m[2]))
+        if v is not None:
+            return _ok(v)
 
     m = _DAY_MONTH_YEAR.match(s)
     if m:
-        d = int(m[1])
-        mo = _MONTH_NAMES[m[2].casefold()]
-        y = int(m[3])
-        if y != 0:
-            try:
-                datetime.date(y, mo, d)
-            except ValueError:
-                pass
-            else:
-                return _ok(
-                    _wikibase_time(
-                        f"+{y:04d}-{mo:02d}-{d:02d}T00:00:00Z", _PRECISION_DAY
-                    )
-                )
+        v = _day_precision_value(int(m[3]), _MONTH_NAMES[m[2].casefold()], int(m[1]))
+        if v is not None:
+            return _ok(v)
 
     m = _YEAR_MONTH.match(s)
     if m:

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1112,10 +1112,16 @@ _MONTH_DAY_YEAR = re.compile(
 _DAY_MONTH_YEAR = re.compile(
     rf"^(\d{{1,2}})\s+{_MONTH_NAME_RE}\.?\s+(\d{{3,4}})$", re.IGNORECASE
 )
-# ``11/19/1902`` — US slash-form with day precision. Deliberately requires
-# the trailing 3-4-digit year to avoid gluing to unrelated slash-shaped
-# strings; ambiguous with DD/MM/YYYY is left unrecognised (both forms
-# would need a heuristic we don't want in a value-preserving parser).
+# ``11/19/1902`` — US slash-form with day precision. Always interpreted
+# as MM/DD/YYYY; when the day component is <= 12 this is genuinely
+# ambiguous with DD/MM/YYYY and a non-US-formatted date will be silently
+# mis-parsed rather than rejected. Acceptable trade-off in this
+# codebase: ``parse_dpla_date``'s callers are (a) the reconciler's
+# comparator — where a mis-parse is self-correcting, since both sides
+# just fail to match and the override survives unstripped — and (b)
+# ``_build_date_claim`` on unambiguously US-formatted DPLA sources.
+# Requires a 3-4-digit trailing year so unrelated slash-shaped strings
+# can't glue.
 _US_SLASH_DATE = re.compile(r"^(\d{1,2})/(\d{1,2})/(\d{3,4})$")
 
 # Unicode punctuation categories used by ``casefold_for_compare``'s

--- a/ingest_wikimedia/wikitext_normalize.py
+++ b/ingest_wikimedia/wikitext_normalize.py
@@ -26,6 +26,8 @@ import re
 
 import mwparserfromhell
 
+from ingest_wikimedia.sdc import casefold_for_compare, dates_semantically_equal
+
 # Pattern that identifies the family of Commons single-language wrapper
 # templates ({{en|...}}, {{es|...}}, {{de|...}}, {{pt-br|...}}, …).
 # Used solely to *recognise* a wrapper so we can decide whether stripping
@@ -95,7 +97,11 @@ def _canonical_value(value: str) -> str:
 
 
 def _value_matches(
-    wikitext_value: str, expected: str, languages: frozenset[str] | set[str]
+    wikitext_value: str,
+    expected: str,
+    languages: frozenset[str] | set[str],
+    *,
+    param_name: str | None = None,
 ) -> bool:
     """Compare a wikitext value to its canonical-DPLA expectation.
 
@@ -116,6 +122,23 @@ def _value_matches(
     an English item, ``{{es|A Title}}`` survives even when the inner
     text byte-matches the canonical English (the ``es`` tag is editor-
     contributed translation metadata, not a redundant wrapper).
+
+    Two tolerance widenings run AFTER the byte-exact and language-
+    wrapper paths fail:
+
+      * For ``param_name == "date"`` the two values are compared via
+        :func:`ingest_wikimedia.sdc.dates_semantically_equal` — so an
+        override like ``| date = 19 November 1902`` collapses cleanly
+        against a canonical ``1902-11-19``.
+      * For every scalar key, a casefold-and-trim comparator
+        (:func:`ingest_wikimedia.sdc.casefold_for_compare`) folds both
+        sides through the same normaliser used by the SDC dedup
+        comparator, so a description differing only by a trailing
+        period, wrapping brackets, or an editor's case change strips
+        cleanly. Codepoint identifiers (``hub``, ``institution``,
+        ``dpla_id``, ``url``, ``local_id``) are excluded from the
+        casefold path — those are opaque tokens where a case change
+        genuinely represents a different value.
 
     Other template-wrapped values (``{{LangSwitch|...}}``, an Information
     sub-template, a citation) are conservatively a mismatch — they
@@ -138,7 +161,23 @@ def _value_matches(
         lang = _language_wrapper_code(tpl)
         if lang is not None and lang in languages:
             inner = str(tpl.get(1).value)
-            return _canonical_value(inner) == _canonical_value(expected)
+            if _canonical_value(inner) == _canonical_value(expected):
+                return True
+            # Fall through to the tolerance-widening checks below on the
+            # unwrapped inner value — a bracketed / trailing-period /
+            # cased variant inside ``{{en|…}}`` still deserves to dedup.
+            wikitext_value = inner
+
+    if param_name == "date" and dates_semantically_equal(
+        _canonical_value(wikitext_value), _canonical_value(expected)
+    ):
+        return True
+
+    if param_name in _CASEFOLD_COMPARE_KEYS:
+        folded_wiki = casefold_for_compare(_canonical_value(wikitext_value))
+        folded_expected = casefold_for_compare(_canonical_value(expected))
+        if folded_wiki and folded_wiki == folded_expected:
+            return True
 
     return False
 
@@ -159,6 +198,20 @@ _SCALAR_PARAMS = (
     "url",
     "dpla_id",
     "local_id",
+)
+
+# Scalar keys where a casefold + leading/trailing-punctuation strip
+# fallback is safe (see :func:`_value_matches`). Excludes opaque
+# identifier / URL keys: a case change in a Q-ID, DPLA ID, or URL is a
+# genuinely different value, not a display variant.
+_CASEFOLD_COMPARE_KEYS = frozenset(
+    {
+        "title",
+        "description",
+        "date",
+        "permission",
+        "creator",
+    }
 )
 
 # Legacy param shapes that an older upload (pre-flat-shape) may carry.
@@ -260,7 +313,9 @@ def normalize(wikitext: str, expected_params: dict) -> tuple[str, list[str]]:
         param = _find_param(template, param_name)
         if param is None:
             continue
-        if _value_matches(str(param.value), expected_value, languages):
+        if _value_matches(
+            str(param.value), expected_value, languages, param_name=param_name
+        ):
             template.remove(param, keep_field=False)
             stripped.append(param_name)
 

--- a/ingest_wikimedia/wikitext_normalize.py
+++ b/ingest_wikimedia/wikitext_normalize.py
@@ -26,7 +26,11 @@ import re
 
 import mwparserfromhell
 
-from ingest_wikimedia.sdc import casefold_for_compare, dates_semantically_equal
+from ingest_wikimedia.sdc import (
+    CASEFOLD_COMPARE_KEYS,
+    casefold_for_compare,
+    dates_semantically_equal,
+)
 
 # Pattern that identifies the family of Commons single-language wrapper
 # templates ({{en|...}}, {{es|...}}, {{de|...}}, {{pt-br|...}}, …).
@@ -173,7 +177,7 @@ def _value_matches(
     ):
         return True
 
-    if param_name in _CASEFOLD_COMPARE_KEYS:
+    if param_name in CASEFOLD_COMPARE_KEYS:
         folded_wiki = casefold_for_compare(_canonical_value(wikitext_value))
         folded_expected = casefold_for_compare(_canonical_value(expected))
         if folded_wiki and folded_wiki == folded_expected:
@@ -198,20 +202,6 @@ _SCALAR_PARAMS = (
     "url",
     "dpla_id",
     "local_id",
-)
-
-# Scalar keys where a casefold + leading/trailing-punctuation strip
-# fallback is safe (see :func:`_value_matches`). Excludes opaque
-# identifier / URL keys: a case change in a Q-ID, DPLA ID, or URL is a
-# genuinely different value, not a display variant.
-_CASEFOLD_COMPARE_KEYS = frozenset(
-    {
-        "title",
-        "description",
-        "date",
-        "permission",
-        "creator",
-    }
 )
 
 # Legacy param shapes that an older upload (pre-flat-shape) may carry.

--- a/ingest_wikimedia/wikitext_normalize.py
+++ b/ingest_wikimedia/wikitext_normalize.py
@@ -163,14 +163,29 @@ def _value_matches(
         if _template_name(tpl) == _LANGSWITCH_NAME:
             return False
         lang = _language_wrapper_code(tpl)
-        if lang is not None and lang in languages:
-            inner = str(tpl.get(1).value)
-            if _canonical_value(inner) == _canonical_value(expected):
-                return True
-            # Fall through to the tolerance-widening checks below on the
-            # unwrapped inner value — a bracketed / trailing-period /
-            # cased variant inside ``{{en|…}}`` still deserves to dedup.
-            wikitext_value = inner
+        if lang is None or lang not in languages:
+            # Any non-language-wrapper template ({{Cite|…}},
+            # {{Institution|…}}, {{PD-USGov}}, {{Cc-zero}}, an arbitrary
+            # citation) is deliberate editor structure. Falling through
+            # to the casefold widening would let ``casefold_for_compare``
+            # strip the leading/trailing braces and compare the residue
+            # against a bare canonical scalar — a false-match risk on
+            # display-string keys and a semantic-loss risk on structural
+            # keys. Exit here so template-wrapped values only ever match
+            # via exact string equality above.
+            return False
+        inner = str(tpl.get(1).value)
+        if _canonical_value(inner) == _canonical_value(expected):
+            return True
+        # Fall through to the tolerance-widening checks below on the
+        # unwrapped inner value — a bracketed / trailing-period / cased
+        # variant inside ``{{en|…}}`` still deserves to dedup.
+        wikitext_value = inner
+    elif templates:
+        # Multiple templates (or nested-template soup) is by definition
+        # editor-added structure. Same reasoning as the single non-lang
+        # case above; skip the tolerance widening.
+        return False
 
     if param_name == "date" and dates_semantically_equal(
         _canonical_value(wikitext_value), _canonical_value(expected)

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1654,3 +1654,70 @@ def test_plan_migration_still_imports_substantively_different_title():
     plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
     assert plan is not None
     assert plan.community_imports == {"title": "A Completely Different Title"}
+
+
+# ---------------------------------------------------------------------------
+# plan_migration — institution Q-ID equivalence (this commit).
+# For NARA files in particular, the legacy `{{Artwork}}` template wrote
+# the data-provider as a nested `{{Institution|wikidata=Q...}}` sub-
+# template, while `dpla_metadata_params` now emits it as a bare Q-ID.
+# A byte-wise inequality shouldn't lead to a spurious inferred-from-
+# Wikitext import when both sides carry the same Q-ID.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_migration_skips_institution_subtemplate_matching_canonical_qid():
+    """Legacy `{{Institution|wikidata=Q59661041}}` sub-template value in
+    a community-authored revision must NOT import as inferred-from-
+    Wikitext when the canonical DPLA `institution` param is the same
+    Q-ID. Motivating example: NARA custodial-unit files whose legacy
+    `Institution =` field held the same custodial-unit Q-ID that DPLA
+    now writes as canonical."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|institution=Q59661041}}"),
+        (2, "Editor1", "{{Artwork|institution={{Institution|wikidata=Q59661041}}}}"),
+    )
+    plan = plan_migration(
+        "File:Foo.jpg", revs, _canonical_params(institution="Q59661041")
+    )
+    assert plan is not None
+    assert plan.community_imports == {}, (
+        f"expected `{{Institution|wikidata=Q59661041}}` to be recognised "
+        f"as equivalent to canonical `Q59661041`; got "
+        f"community_imports={plan.community_imports}"
+    )
+
+
+def test_plan_migration_still_imports_institution_that_differs():
+    """Q-ID mismatch is real — the community pointed the file at a
+    different institution and that override must be preserved."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|institution=Q59661041}}"),
+        (2, "Editor1", "{{Artwork|institution={{Institution|wikidata=Q77777777}}}}"),
+    )
+    plan = plan_migration(
+        "File:Foo.jpg", revs, _canonical_params(institution="Q59661041")
+    )
+    assert plan is not None
+    assert "institution" in plan.community_imports
+
+
+def test_plan_migration_extract_institution_qid_handles_flat_bare_qid():
+    """The flat `{{DPLA metadata|institution=Q123}}` shape stores the
+    Q-ID bare — the extractor recognises both shapes so migration off
+    an already-partially-modernised page still equates cleanly."""
+    from ingest_wikimedia.legacy_artwork import _extract_institution_qid
+
+    assert _extract_institution_qid("Q59661041") == "Q59661041"
+    assert _extract_institution_qid("{{Institution|wikidata=Q59661041}}") == "Q59661041"
+    # Case-insensitive on the template name + key.
+    assert _extract_institution_qid("{{institution|Wikidata=Q123}}") == "Q123"
+    # Whitespace-tolerant.
+    assert _extract_institution_qid("  {{ Institution | wikidata = Q123 }} ") == "Q123"
+    # Non-matching shapes return None (so the caller can fall through
+    # to the byte-equality / casefold branches without wrongly claiming
+    # a Q-ID equivalence).
+    assert _extract_institution_qid("") is None
+    assert _extract_institution_qid("Not a Q-ID") is None
+    assert _extract_institution_qid("Q") is None  # no digits
+    assert _extract_institution_qid("Q59661041x") is None  # trailing junk

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1721,3 +1721,33 @@ def test_plan_migration_extract_institution_qid_handles_flat_bare_qid():
     assert _extract_institution_qid("Not a Q-ID") is None
     assert _extract_institution_qid("Q") is None  # no digits
     assert _extract_institution_qid("Q59661041x") is None  # trailing junk
+
+
+def test_plan_migration_preserves_bracketed_date_override():
+    """Regression guard (CR flagged on PR #351): a community editor's
+    ``date = [1902]`` (archival supplied-date convention) carries an
+    approximate-flag semantic distinct from the bare canonical ``1902``.
+    Must be preserved as a community import, not classified as
+    dpla-originated on a casefold false-match.
+    """
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|date=1902}}"),
+        (2, "Editor1", "{{Artwork|date=[1902]}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params(date="1902"))
+    assert plan is not None
+    assert plan.community_imports == {"date": "[1902]"}, (
+        f"expected `[1902]` to be preserved as a community import; "
+        f"got community_imports={plan.community_imports}"
+    )
+
+
+def test_plan_migration_preserves_question_marked_date_override():
+    """Same shape as above but with the ``1902?`` uncertain-marker."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|date=1902}}"),
+        (2, "Editor1", "{{Artwork|date=1902?}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params(date="1902"))
+    assert plan is not None
+    assert plan.community_imports == {"date": "1902?"}

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1578,3 +1578,79 @@ def test_migrate_legacy_file_strips_params_matching_sdc_in_one_edit():
     assert "{{DPLA metadata}}" in saved
     # And only one save was issued.
     assert page.save.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# plan_migration — community-vs-canonical equivalence widening (this PR).
+# A community edit that reformatted DPLA's own value (case, punctuation,
+# or date format) is NOT a community contribution and must not be
+# imported as an inferred-from-Wikitext SDC claim. The equivalence
+# function :func:`_value_equivalent_to_canonical` widens the previous
+# byte-equality check to cover these editor-reformat cases.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_migration_skips_semantically_equal_date():
+    """Editor reformatted DPLA's `1900` as `January 1, 1900` (or
+    similar). Same year+month+day at same precision — no import."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|date=1900-06-15}}"),
+        (2, "Editor1", "{{Artwork|date=15 June 1900}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params(date="1900-06-15"))
+    assert plan is not None
+    assert plan.community_imports == {}, (
+        f"expected `15 June 1900` == `1900-06-15` semantically; "
+        f"got community_imports={plan.community_imports}"
+    )
+    assert plan.dpla_originated_params.get("date") == "15 June 1900"
+
+
+def test_plan_migration_skips_case_only_title_change():
+    """Editor retyped title in uppercase — no factual change, no
+    import. Casefold widening applies to display-string keys."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=A Title}}"),
+        (2, "Editor1", "{{Artwork|title=A TITLE}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert plan.community_imports == {}
+
+
+def test_plan_migration_skips_trailing_period_description_change():
+    """Editor stripped a trailing period from DPLA's description —
+    still the same fact, no import."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|description=A description.}}"),
+        (2, "Editor1", "{{Artwork|description=A description}}"),
+    )
+    plan = plan_migration(
+        "File:Foo.jpg", revs, _canonical_params(description="A description.")
+    )
+    assert plan is not None
+    assert plan.community_imports == {}
+
+
+def test_plan_migration_still_imports_substantively_different_date():
+    """Widening must not lose real differences — an editor supplied a
+    different date, we import."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|date=1900}}"),
+        (2, "Editor1", "{{Artwork|date=1950}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params(date="1900"))
+    assert plan is not None
+    assert plan.community_imports == {"date": "1950"}
+
+
+def test_plan_migration_still_imports_substantively_different_title():
+    """Guard against overshoot — a title that differs by more than
+    case/punctuation still imports."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=A Title}}"),
+        (2, "Editor1", "{{Artwork|title=A Completely Different Title}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert plan.community_imports == {"title": "A Completely Different Title"}

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -347,9 +347,9 @@ def test_parse_falls_back_when_residue_has_unrecognised_text():
         "before 1945",
         "after 1945",
         "between 1945 and 1950",
-        # Month-name prefixes / season markers — not stripped.
-        "January 1945",
-        "Jan 1945",
+        # Season markers — not stripped. Month names ARE now handled
+        # separately (see test_parse_month_name_forms) so they are
+        # correctly excluded from the fall-back list.
         "Spring 1945",
         "summer 1945",
         # Parenthesised forms — parens not in the decorator list.
@@ -453,6 +453,217 @@ def test_build_date_claim_returns_none_for_empty_input():
 
     assert _build_date_claim("", "abc123", _dt.date(2026, 6, 7)) is None
     assert _build_date_claim("   ", "abc123", _dt.date(2026, 6, 7)) is None
+
+
+# ---------------------------------------------------------------------------
+# parse_dpla_date — natural-language month/year and slash-form
+# extensions. Motivating example: M174777532 (indiana partner) has a
+# DPLA-attributed P571 stored as ``somevalue + P1932="June 1959"``, whose
+# comparable key would not match the inferred-from-Wikitext value-typed
+# time claim for the same date until parse_dpla_date learned month
+# names.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_month_name_year_forms():
+    """``Month YYYY`` variants → month precision (10)."""
+    for src in (
+        "June 1959",
+        "june 1959",
+        "Jun 1959",
+        "JUN 1959",
+        "Sept 1912",
+        "sept. 1912",
+        "September 1912",
+        "May 1900",
+    ):
+        r = parse_dpla_date(src)
+        assert r is not None, f"{src!r} should now parse to a structured month"
+        v = r["value"]
+        assert v["precision"] == 10, f"{src!r} → wrong precision {v['precision']}"
+        assert not r["approximate"]
+        # Time string always +YYYY-MM-01T00:00:00Z
+        assert v["time"].endswith("-01T00:00:00Z"), f"{src!r} time={v['time']}"
+
+
+def test_parse_month_day_year_forms():
+    """``Month D, YYYY`` and ``Month D YYYY`` → day precision (11)."""
+    for src in (
+        "November 19, 1902",
+        "November 19 1902",
+        "Nov 19, 1902",
+        "nov. 19 1902",
+        "March 3, 1900",
+    ):
+        r = parse_dpla_date(src)
+        assert r is not None, f"{src!r} should now parse to a structured day"
+        v = r["value"]
+        assert v["precision"] == 11, f"{src!r} → wrong precision"
+        assert not r["approximate"]
+
+
+def test_parse_day_month_year_forms():
+    """``D Month YYYY`` (British / scholarly) → day precision (11).
+    Motivating example: M105419621's ``| date = 19 November 1902``
+    override must parse to the same time as DPLA's ``1902-11-19``."""
+    r = parse_dpla_date("19 November 1902")
+    assert r is not None
+    assert r["value"]["precision"] == 11
+    assert r["value"]["time"] == "+1902-11-19T00:00:00Z"
+
+
+def test_parse_us_slash_date_form():
+    """``MM/DD/YYYY`` → day precision. Common in US-hub-supplied dates."""
+    r = parse_dpla_date("11/19/1902")
+    assert r is not None
+    assert r["value"]["precision"] == 11
+    assert r["value"]["time"] == "+1902-11-19T00:00:00Z"
+
+
+def test_parse_month_name_forms_reject_invalid_calendar_dates():
+    """``February 30, 1902`` etc. must NOT silently parse — the
+    calendar check runs on every day-precision path so a phantom
+    date can't sneak through."""
+    for src in ("February 30, 1902", "13/40/1900", "November 31 1902"):
+        assert parse_dpla_date(src) is None, f"{src!r} should not parse"
+
+
+def test_parse_month_name_forms_reject_year_zero():
+    """Year zero is invalid in the proleptic Gregorian calendar; the
+    month-name paths honour the same guard as the existing regexes."""
+    for src in ("June 0", "November 19, 0", "19 November 0"):
+        assert parse_dpla_date(src) is None
+
+
+def test_parse_month_name_forms_reject_adjacent_text():
+    """A recognised month + year must not silently absorb trailing
+    prose. Regex is fully anchored so the parser refuses anything
+    outside the exact shape."""
+    for src in (
+        "January 1945 or 1946",
+        "Jan 1945 AD",
+        "circa Jan 1945 (uncertain)",
+        "November 19, 1902 (approximately)",
+    ):
+        assert parse_dpla_date(src) is None, f"{src!r} should NOT parse"
+
+
+def test_parse_month_name_forms_carry_approximate_flag():
+    """Circa / bracket / question-mark decorators around a
+    month-name date correctly propagate the approximate flag."""
+    r = parse_dpla_date("circa June 1959")
+    assert r is not None and r["approximate"] is True
+    r = parse_dpla_date("[19 November 1902]")
+    assert r is not None and r["approximate"] is True
+
+
+# ---------------------------------------------------------------------------
+# casefold_for_compare — comparator-only text normaliser. Motivating
+# examples: M114630785 (trailing "." on DPLA-side description) and
+# M100761231 (wrapping "[…]" brackets on DPLA-side title).
+# ---------------------------------------------------------------------------
+
+
+def test_casefold_for_compare_trims_leading_and_trailing_punctuation():
+    """Wrapping brackets / parens / quotes on either side collapse."""
+    from ingest_wikimedia.sdc import casefold_for_compare
+
+    # Trailing period (M114630785 case).
+    assert casefold_for_compare(
+        "A.D. Abbott, Hancock N.H. L.M. Stearns Collection."
+    ) == casefold_for_compare("A.D. Abbott, Hancock N.H. L.M. Stearns Collection")
+    # Wrapping brackets (M100761231 case).
+    assert casefold_for_compare(
+        "[Promissory note for Thomas Love]"
+    ) == casefold_for_compare("Promissory note for Thomas Love")
+    # Curly-quote wrappers and paren wrappers.
+    assert casefold_for_compare("“A title”") == casefold_for_compare("A title")
+    assert casefold_for_compare("(1902)") == casefold_for_compare("1902")
+
+
+def test_casefold_for_compare_folds_case_but_not_internal_punctuation():
+    """Case-fold turns ``ABC`` == ``abc``, but internal punctuation is
+    preserved — so ``"A.D. Abbott"`` and ``"A D Abbott"`` do NOT
+    collapse. Rationale: the reconciler is one-way (removes inferred
+    claims only), but conservative internal-punctuation handling still
+    protects the rare case where internal punctuation is meaningful
+    (e.g. a stringy inventory number)."""
+    from ingest_wikimedia.sdc import casefold_for_compare
+
+    assert casefold_for_compare("ABC def") == casefold_for_compare("abc DEF")
+    # Internal punctuation NOT collapsed.
+    assert casefold_for_compare("A.D. Abbott") != casefold_for_compare("A D Abbott")
+
+
+def test_casefold_for_compare_collapses_internal_whitespace():
+    """Runs of whitespace fold to a single space — an editor's
+    accidental double-space or newline in a wikitext value doesn't
+    survive as a mismatch."""
+    from ingest_wikimedia.sdc import casefold_for_compare
+
+    assert casefold_for_compare("A  B  C") == casefold_for_compare("A B C")
+    assert casefold_for_compare("A\tB\nC") == casefold_for_compare("A B C")
+
+
+def test_casefold_for_compare_handles_falsy_input():
+    """Non-string / empty input returns an empty string — callers that
+    compare two folded keys treat that as unequal-to-any-real-value
+    (an empty key from a malformed claim should never accidentally
+    dedup against another empty)."""
+    from ingest_wikimedia.sdc import casefold_for_compare
+
+    assert casefold_for_compare("") == ""
+    assert casefold_for_compare(None) == ""  # type: ignore[arg-type]
+    assert casefold_for_compare("   .,  ") == ""
+
+
+# ---------------------------------------------------------------------------
+# dates_semantically_equal — semantic date equivalence for
+# ``{{DPLA metadata}}`` ``date =`` overrides that reformat DPLA's own
+# supplied date. Motivating example: M105419621 with
+# ``| date = 19 November 1902`` alongside canonical ``1902-11-19``.
+# ---------------------------------------------------------------------------
+
+
+def test_dates_semantically_equal_matches_across_formats():
+    """Cross-format equivalence: month-name day form, US slash form,
+    and canonical ISO all fold to the same time+precision."""
+    from ingest_wikimedia.sdc import dates_semantically_equal
+
+    assert dates_semantically_equal("19 November 1902", "1902-11-19")
+    assert dates_semantically_equal("November 19, 1902", "1902-11-19")
+    assert dates_semantically_equal("11/19/1902", "1902-11-19")
+    assert dates_semantically_equal("June 1959", "1959-06")
+
+
+def test_dates_semantically_equal_rejects_different_precisions():
+    """Same year but different precisions must NOT match — a P571
+    claim at year precision and one at day precision are different
+    facts even when the day one falls inside the year."""
+    from ingest_wikimedia.sdc import dates_semantically_equal
+
+    assert not dates_semantically_equal("1902", "1902-11-19")
+    assert not dates_semantically_equal("1902-11", "1902-11-19")
+
+
+def test_dates_semantically_equal_respects_circa_flag():
+    """A circa-decorated date and a plain date at the same time are
+    NOT semantically equal — the circa flag drives the P1480
+    qualifier and represents a distinct uncertainty semantic."""
+    from ingest_wikimedia.sdc import dates_semantically_equal
+
+    assert not dates_semantically_equal("circa 1902-11-19", "1902-11-19")
+    assert dates_semantically_equal("circa 1902-11-19", "circa November 19, 1902")
+
+
+def test_dates_semantically_equal_returns_false_on_unparseable():
+    """Anything the parser can't structure returns False — never a
+    false positive from two None-returns colliding."""
+    from ingest_wikimedia.sdc import dates_semantically_equal
+
+    assert not dates_semantically_equal("some date", "another date")
+    assert not dates_semantically_equal("", "1902-11-19")
+    assert not dates_semantically_equal("1902-11-19", "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -5885,3 +5885,248 @@ def test_maintain_parallel_enabled_requires_from_s3_and_workers():
     assert not f(maintain=True, workers=6, count_only=True, from_s3_partner="georgia")
     assert not f(maintain=True, workers=1, count_only=False, from_s3_partner="georgia")
     assert not f(maintain=False, workers=6, count_only=False, from_s3_partner="georgia")
+
+
+# ---------------------------------------------------------------------------
+# Wikitext ↔ SDC match tolerance (this PR). Covers the four in-the-wild
+# mismatch shapes surfaced during PR authoring — all now dedup after
+# extending parse_dpla_date + adding casefold_for_compare to the
+# comparator's text-shape branches.
+#
+# Each test builds a minimal DPLA-attributed + inferred-from-Wikitext
+# pair and asserts the inferred side is queued for removal.
+# ---------------------------------------------------------------------------
+
+
+def _p571_value_typed_time(stmt_id, time_str, precision, references=None):
+    """Build a value-typed P571 statement at the given time/precision.
+    Uses the pinned before/after/timezone/calendarmodel that
+    ``_wikibase_time`` produces so the fixture matches what real
+    upload paths write.
+
+    Not routed through ``_stmt`` because that helper's value-typed
+    branch is written for wikibase-entityid / string props, and a
+    time datavalue has neither shape."""
+    return {
+        "id": stmt_id,
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P571",
+            "datavalue": {
+                "type": "time",
+                "value": {
+                    "time": time_str,
+                    "precision": precision,
+                    "before": 0,
+                    "after": 0,
+                    "timezone": 0,
+                    "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
+                },
+            },
+        },
+        "references": references or [],
+    }
+
+
+def _monolingual_claim(stmt_id, prop, text, language, references=None, p459=False):
+    """Build a monolingualtext-mainsnak statement, optionally with the
+    P459 = Q61848113 (heuristic-determination) DPLA marker qualifier."""
+    quals = {"P459": _dpla_p459()} if p459 else None
+    return {
+        "id": stmt_id,
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": prop,
+            "datavalue": {
+                "type": "monolingualtext",
+                "value": {"text": text, "language": language},
+            },
+        },
+        **({"qualifiers": quals} if quals is not None else {}),
+        "references": references or [],
+    }
+
+
+def test_inferred_dupe_cleanup_removes_month_name_year_when_dpla_is_somevalue():
+    """M174777532 (indiana) repro: DPLA P571 = somevalue+P1932="June 1959"
+    and an inferred-from-Wikitext P571 value-typed +1959-06-01|P10.
+    Before this PR the DPLA-side comparable was ('p1932-string', 'June
+    1959') because parse_dpla_date returned None for the month-name
+    form — the two comparables disagreed on shape_tag and the dedup
+    never fired. Extending the parser closes the shape mismatch."""
+    from tools import sdc_sync
+
+    dpla_claim = _p571_somevalue_with_p1932(
+        "M174$DPLA", "June 1959", references=[_dpla_reference()]
+    )
+    inferred_claim = _p571_value_typed_time(
+        "M174$INFERRED",
+        "+1959-06-01T00:00:00Z",
+        10,
+        references=[_inferred_from_wikitext_reference()],
+    )
+    entity = {"pageid": 174, "statements": {"P571": [dpla_claim, inferred_claim]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M174")
+    assert sdc_sync.removals == ["M174$INFERRED"]
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_dupe_cleanup_removes_monolingual_text_with_trailing_period():
+    """M114630785 (bpl) repro: DPLA P10358 description carries a
+    trailing '.'; the inferred-from-Wikitext copy has no trailing
+    period. Byte comparison of the monolingualtext text failed;
+    casefold_for_compare's trailing-punctuation trim collapses them."""
+    from tools import sdc_sync
+
+    dpla_claim = _monolingual_claim(
+        "M114$DPLA",
+        "P10358",
+        "A.D. Abbott, Hancock N.H. L.M. Stearns Collection.",
+        "en",
+        references=[_dpla_reference()],
+        p459=True,
+    )
+    inferred_claim = _monolingual_claim(
+        "M114$INFERRED",
+        "P10358",
+        "A.D. Abbott, Hancock N.H. L.M. Stearns Collection",
+        "en",
+        references=[_inferred_from_wikitext_reference()],
+    )
+    entity = {"pageid": 114, "statements": {"P10358": [dpla_claim, inferred_claim]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M114")
+    assert sdc_sync.removals == ["M114$INFERRED"]
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_dupe_cleanup_removes_monolingual_text_wrapped_in_brackets():
+    """M100761231 (bpl) repro: DPLA P1476 title wraps a supplied title
+    in ``[…]`` per archival convention; the inferred copy strips the
+    brackets. Both fold to the same normaliser key, dedup fires,
+    inferred claim removed. DPLA's bracketed form survives on the
+    file — archival convention preserved."""
+    from tools import sdc_sync
+
+    dpla_claim = _monolingual_claim(
+        "M100$DPLA",
+        "P1476",
+        "[Promissory note for Thomas Love]",
+        "en",
+        references=[_dpla_reference()],
+        p459=True,
+    )
+    inferred_claim = _monolingual_claim(
+        "M100$INFERRED",
+        "P1476",
+        "Promissory note for Thomas Love",
+        "en",
+        references=[_inferred_from_wikitext_reference()],
+    )
+    entity = {"pageid": 100, "statements": {"P1476": [dpla_claim, inferred_claim]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M100")
+    assert sdc_sync.removals == ["M100$INFERRED"]
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_dupe_cleanup_removes_monolingual_text_case_only_difference():
+    """Casefold protection: an editor who retyped a DPLA title in
+    different case (``AN OLD MAP`` vs canonical ``An Old Map``) still
+    dedups — the case difference carries no factual distinction."""
+    from tools import sdc_sync
+
+    dpla_claim = _monolingual_claim(
+        "M001$DPLA",
+        "P1476",
+        "An Old Map",
+        "en",
+        references=[_dpla_reference()],
+        p459=True,
+    )
+    inferred_claim = _monolingual_claim(
+        "M001$INFERRED",
+        "P1476",
+        "an old map",
+        "en",
+        references=[_inferred_from_wikitext_reference()],
+    )
+    entity = {"pageid": 1, "statements": {"P1476": [dpla_claim, inferred_claim]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M001")
+    assert sdc_sync.removals == ["M001$INFERRED"]
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_dupe_cleanup_preserves_language_mismatch():
+    """Two monolingualtext claims with the SAME text but different
+    languages must NOT dedup — the language field is a separate
+    identity axis. The comparator preserves it distinct from the
+    folded text."""
+    from tools import sdc_sync
+
+    dpla_claim = _monolingual_claim(
+        "M002$DPLA",
+        "P1476",
+        "An Old Map",
+        "en",
+        references=[_dpla_reference()],
+        p459=True,
+    )
+    inferred_claim = _monolingual_claim(
+        "M002$INFERRED",
+        "P1476",
+        "An Old Map",
+        "es",
+        references=[_inferred_from_wikitext_reference()],
+    )
+    entity = {"pageid": 2, "statements": {"P1476": [dpla_claim, inferred_claim]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M002")
+    assert sdc_sync.removals == []
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_dupe_cleanup_preserves_substantively_different_text():
+    """Punctuation-only tolerance must NOT widen to substantively
+    different text. Two inventory-number claims that differ by more
+    than punctuation stay separate."""
+    from tools import sdc_sync
+
+    dpla_claim = _monolingual_claim(
+        "M003$DPLA",
+        "P1476",
+        "A Title About Cats",
+        "en",
+        references=[_dpla_reference()],
+        p459=True,
+    )
+    inferred_claim = _monolingual_claim(
+        "M003$INFERRED",
+        "P1476",
+        "A Title About Dogs",
+        "en",
+        references=[_inferred_from_wikitext_reference()],
+    )
+    entity = {"pageid": 3, "statements": {"P1476": [dpla_claim, inferred_claim]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_dupes("M003")
+    assert sdc_sync.removals == []
+    sdc_sync._reset_per_file_accumulators()

--- a/tests/test_wikitext_normalize.py
+++ b/tests/test_wikitext_normalize.py
@@ -613,3 +613,135 @@ def test_canonicalize_returns_input_unchanged_when_no_dpla_metadata_template():
     job upstream."""
     untouched = "Just some prose.\n{{Artwork|title=Foo}}\n[[Category:Foo]]"
     assert canonicalize(untouched) == untouched
+
+
+# ---------------------------------------------------------------------------
+# Tolerance widenings on `_value_matches` (this PR).
+# * `date` key gets semantic-equivalence via parse_dpla_date.
+# * display-string keys get casefold + leading/trailing-punctuation
+#   trim as a byte-equality fallback.
+# Identifier keys (hub, dpla_id, url, local_id, institution) do NOT
+# get the casefold path — a case change there is a distinct value.
+# ---------------------------------------------------------------------------
+
+
+def _item_with_date(display_date: str, dpla_id: str = "abc") -> dict:
+    return {
+        "rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+        "isShownAt": "https://example.org/item/123",
+        "sourceResource": {
+            "creator": ["A Creator"],
+            "title": ["A Title"],
+            "description": ["A description"],
+            "date": [{"displayDate": display_date}],
+            "identifier": [dpla_id],
+        },
+    }
+
+
+def test_normalize_strips_semantically_equal_date_override():
+    """M105419621 repro: canonical ``1902-11-19`` DPLA-supplied date;
+    editor added ``| date = 19 November 1902`` inside ``{{DPLA
+    metadata}}``. The two parse to the same time+precision, so the
+    override strips cleanly. Extends the existing byte-equality strip
+    contract."""
+    item = _item_with_date("1902-11-19")
+    expected = dpla_metadata_params("abc", item, _PROVIDER, _DATA_PROVIDER)
+    wikitext = (
+        "== {{int:filedesc}} ==\n\n"
+        "{{DPLA metadata\n| hub = Q72380652\n| date = 19 November 1902\n}}\n"
+    )
+    normalized, stripped = normalize(wikitext, expected)
+    assert "date" in stripped, (
+        f"expected `date` override to strip; stripped={stripped}. "
+        f"If missing, either parse_dpla_date doesn't recognise "
+        f"`19 November 1902` or _value_matches skipped the semantic-"
+        f"equivalence path."
+    )
+    assert "19 November 1902" not in normalized
+
+
+def test_normalize_preserves_date_override_that_disagrees_semantically():
+    """A community edit that changes the date to a different year is
+    real information — must NOT strip even under the widened
+    tolerance. Semantic equivalence is strict about precision+time."""
+    item = _item_with_date("1902-11-19")
+    expected = dpla_metadata_params("abc", item, _PROVIDER, _DATA_PROVIDER)
+    wikitext = "{{DPLA metadata\n| hub = Q72380652\n| date = 15 November 1903\n}}\n"
+    _, stripped = normalize(wikitext, expected)
+    assert "date" not in stripped
+
+
+def test_normalize_strips_description_with_trailing_period():
+    """M114630785 shape: canonical description ends with a period;
+    editor's copy in wikitext drops the trailing period. Casefold-
+    with-punctuation-trim strips the override cleanly."""
+    item = _item_with_date("1902")
+    item["sourceResource"]["description"] = [
+        "A.D. Abbott, Hancock N.H. L.M. Stearns Collection."
+    ]
+    expected = dpla_metadata_params("abc", item, _PROVIDER, _DATA_PROVIDER)
+    wikitext = (
+        "{{DPLA metadata\n"
+        "| description = A.D. Abbott, Hancock N.H. L.M. Stearns Collection\n"
+        "}}\n"
+    )
+    _, stripped = normalize(wikitext, expected)
+    assert "description" in stripped
+
+
+def test_normalize_strips_title_with_wrapping_brackets():
+    """M100761231 shape: canonical title is bracketed (supplied-title
+    convention); editor's copy drops the brackets. Casefold-with-
+    punctuation-trim on both sides folds to the same key and the
+    override strips."""
+    item = _item_with_date("1902")
+    item["sourceResource"]["title"] = ["[Promissory note for Thomas Love]"]
+    expected = dpla_metadata_params("abc", item, _PROVIDER, _DATA_PROVIDER)
+    wikitext = "{{DPLA metadata\n| title = Promissory note for Thomas Love\n}}\n"
+    _, stripped = normalize(wikitext, expected)
+    assert "title" in stripped
+
+
+def test_normalize_strips_title_that_only_differs_in_case():
+    """Casefold widening: an editor who retyped the title in
+    all-uppercase still gets stripped."""
+    item = _item_with_date("1902")
+    item["sourceResource"]["title"] = ["An Old Map"]
+    expected = dpla_metadata_params("abc", item, _PROVIDER, _DATA_PROVIDER)
+    wikitext = "{{DPLA metadata\n| title = AN OLD MAP\n}}\n"
+    _, stripped = normalize(wikitext, expected)
+    assert "title" in stripped
+
+
+def test_normalize_preserves_url_with_case_change():
+    """Identifier keys (url / dpla_id / hub / institution / local_id)
+    are opaque tokens — case differences are real. The tolerance
+    widening deliberately excludes them so an editor's URL variant
+    survives instead of being silently overwritten."""
+    item = _item_with_date("1902", dpla_id="abcdef1234567890")
+    expected = dpla_metadata_params("abc", item, _PROVIDER, _DATA_PROVIDER)
+    original_url = expected.get("url", "https://example.org/item/123")
+    variant = original_url.upper()  # case flip
+    if variant == original_url:
+        # Some URL forms are already all-lower; guarantee a case delta.
+        variant = original_url + "/EXTRA"
+    wikitext = f"{{{{DPLA metadata\n| url = {variant}\n}}}}\n"
+    _, stripped = normalize(wikitext, expected)
+    assert "url" not in stripped, (
+        f"URL is an identifier — case change must NOT strip; got "
+        f"stripped={stripped}. If this asserts, the casefold widening "
+        f"was accidentally applied to opaque tokens."
+    )
+
+
+def test_normalize_strips_description_with_case_and_trailing_punctuation():
+    """Combined tolerance: an editor's copy of the description in
+    different case AND missing the trailing period folds to the same
+    normaliser key and strips."""
+    item = _item_with_date("1902")
+    item["sourceResource"]["description"] = ["Some Description Text."]
+    expected = dpla_metadata_params("abc", item, _PROVIDER, _DATA_PROVIDER)
+    wikitext = "{{DPLA metadata\n| description = SOME DESCRIPTION TEXT\n}}\n"
+    _, stripped = normalize(wikitext, expected)
+    assert "description" in stripped

--- a/tests/test_wikitext_normalize.py
+++ b/tests/test_wikitext_normalize.py
@@ -745,3 +745,41 @@ def test_normalize_strips_description_with_case_and_trailing_punctuation():
     wikitext = "{{DPLA metadata\n| description = SOME DESCRIPTION TEXT\n}}\n"
     _, stripped = normalize(wikitext, expected)
     assert "description" in stripped
+
+
+def test_normalize_preserves_non_language_template_override():
+    """Regression guard (CR flagged on PR #351): a non-language template
+    like ``{{Cite|A description}}`` folds to ``cite|a description`` under
+    ``casefold_for_compare`` (leading/trailing braces are punctuation
+    the trim removes). Without a template-shape guard in the casefold
+    fallback, that folded key can accidentally match a bare canonical
+    scalar and strip the editor's citation template as if redundant.
+
+    The strip must NOT fire — an editor's citation is deliberate
+    structure, distinct from the plain-text value DPLA would supply."""
+    item = _item_with_date("1902")
+    item["sourceResource"]["description"] = ["A description"]
+    expected = dpla_metadata_params("abc", item, _PROVIDER, _DATA_PROVIDER)
+    wikitext = "{{DPLA metadata\n| description = {{Cite|A description}}\n}}\n"
+    _, stripped = normalize(wikitext, expected)
+    assert "description" not in stripped, (
+        f"expected non-language template {{Cite|...}} to be preserved; "
+        f"stripped={stripped}. Regression: the casefold fallback is "
+        f"accepting template-wrapped values whose stripped inner text "
+        f"folds to the canonical scalar."
+    )
+
+
+def test_normalize_preserves_multi_template_override():
+    """Related: a wikitext value carrying multiple templates (e.g.
+    ``{{en|foo}}{{ja|bar}}``) is complex editor structure. Only the
+    single-language-wrapper unwrap path is allowed; anything else
+    returns False before the casefold fallback runs."""
+    item = _item_with_date("1902")
+    item["sourceResource"]["title"] = ["Two languages"]
+    expected = dpla_metadata_params("abc", item, _PROVIDER, _DATA_PROVIDER)
+    wikitext = (
+        "{{DPLA metadata\n| title = {{en|Two languages}}{{ja|Some other text}}\n}}\n"
+    )
+    _, stripped = normalize(wikitext, expected)
+    assert "title" not in stripped

--- a/tests/test_wikitext_normalize.py
+++ b/tests/test_wikitext_normalize.py
@@ -783,3 +783,39 @@ def test_normalize_preserves_multi_template_override():
     )
     _, stripped = normalize(wikitext, expected)
     assert "title" not in stripped
+
+
+def test_normalize_preserves_bracketed_date_override():
+    """Regression guard (CR flagged on PR #351): a wikitext
+    ``| date = [1902]`` override carries archival "supplied/uncertain
+    date" semantics that ``_strip_date_decorators`` maps to the
+    approximate flag. ``dates_semantically_equal([1902], 1902)`` is
+    False on that flag difference. The strip MUST NOT fire.
+
+    Pre-fix: ``casefold_for_compare("[1902]")`` == ``"1902"`` because
+    the trim strips the wrapping brackets, and ``date`` was in
+    ``CASEFOLD_COMPARE_KEYS``, so the strip fired even though the
+    dates aren't semantically equal.
+    """
+    item = _item_with_date("1902")
+    expected = dpla_metadata_params("abc", item, _PROVIDER, _DATA_PROVIDER)
+    wikitext = "{{DPLA metadata\n| date = [1902]\n}}\n"
+    _, stripped = normalize(wikitext, expected)
+    assert "date" not in stripped, (
+        f"expected `[1902]` (archival supplied-date convention) to "
+        f"survive the strip; stripped={stripped}. If this asserts, the "
+        f"casefold path is bypassing the approximate-flag check."
+    )
+
+
+def test_normalize_preserves_question_marked_date_override():
+    """Same as the bracket case for ``1902?`` — ``?`` is one of the
+    approximate/uncertain decorators ``_strip_date_decorators``
+    strips. Casefold ALSO strips it (trailing punctuation), so a
+    ``| date = 1902?`` override folds to ``1902`` and would spuriously
+    match canonical ``1902`` under a naive casefold pass."""
+    item = _item_with_date("1902")
+    expected = dpla_metadata_params("abc", item, _PROVIDER, _DATA_PROVIDER)
+    wikitext = "{{DPLA metadata\n| date = 1902?\n}}\n"
+    _, stripped = normalize(wikitext, expected)
+    assert "date" not in stripped

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -3285,16 +3285,21 @@ def _statement_comparable_value(stmt):
             except (KeyError, TypeError):
                 return None
         if dtype == "string":
-            return (
-                ("string", casefold_for_compare(v), None)
-                if isinstance(v, str)
-                else None
-            )
+            if not isinstance(v, str):
+                return None
+            folded = casefold_for_compare(v)
+            # A punctuation-only string folds to the empty key; treating
+            # two such claims as equal would silently dedup distinct
+            # malformed values (e.g. ``"..."`` and ``"---"``). Skip.
+            return ("string", folded, None) if folded else None
         if dtype == "monolingualtext" and isinstance(v, dict):
             text = v.get("text")
             if not isinstance(text, str):
                 return None
-            return ("monolingual", casefold_for_compare(text), v.get("language"))
+            folded = casefold_for_compare(text)
+            if not folded:
+                return None
+            return ("monolingual", folded, v.get("language"))
         if dtype == "wikibase-entityid" and isinstance(v, dict):
             return ("item", v.get("id"), None)
         return None
@@ -3332,8 +3337,10 @@ def _statement_comparable_value(stmt):
             # Literal-string fallback — only matches another P1932
             # qualifier whose stated-as text folds to the same
             # comparator key (casefold + trim leading/trailing
-            # punctuation + collapse whitespace).
-            return ("p1932-string", casefold_for_compare(s), None)
+            # punctuation + collapse whitespace). Empty-folded values
+            # skip so two punctuation-only strings can't dedup.
+            folded = casefold_for_compare(s)
+            return ("p1932-string", folded, None) if folded else None
         return None
 
     return None

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -17,6 +17,7 @@ from pywikibot import pagegenerators
 from ingest_wikimedia.logs import setup_logging
 from ingest_wikimedia.sdc import (
     CHUNKABLE_PROPS,
+    casefold_for_compare,
     parse_date_range,
     parse_dpla_date,
     parse_nara_access_level,
@@ -3263,6 +3264,13 @@ def _statement_comparable_value(stmt):
     static analysis happy without changing equivalence semantics —
     shape_tag still discriminates type so cross-type values can't
     collide.
+
+    Text-shape comparables (``string``, ``monolingual``, ``p1932-string``)
+    fold their primary through :func:`casefold_for_compare` — trailing
+    period on a DPLA-authored description vs. an inferred community copy
+    without one, or wrapping ``[…]`` brackets on a supplied-title, must
+    not defeat dedup. The stored claim values are unchanged; only the
+    comparator key is folded.
     """
     ms = stmt.get("mainsnak") or {}
     snaktype = ms.get("snaktype")
@@ -3277,9 +3285,16 @@ def _statement_comparable_value(stmt):
             except (KeyError, TypeError):
                 return None
         if dtype == "string":
-            return ("string", v, None) if isinstance(v, str) else None
+            return (
+                ("string", casefold_for_compare(v), None)
+                if isinstance(v, str)
+                else None
+            )
         if dtype == "monolingualtext" and isinstance(v, dict):
-            return ("monolingual", v.get("text"), v.get("language"))
+            text = v.get("text")
+            if not isinstance(text, str):
+                return None
+            return ("monolingual", casefold_for_compare(text), v.get("language"))
         if dtype == "wikibase-entityid" and isinstance(v, dict):
             return ("item", v.get("id"), None)
         return None
@@ -3315,8 +3330,10 @@ def _statement_comparable_value(stmt):
             if rng:
                 return ("date-range", rng[0], rng[1])
             # Literal-string fallback — only matches another P1932
-            # qualifier whose stated-as text is byte-identical.
-            return ("p1932-string", s, None)
+            # qualifier whose stated-as text folds to the same
+            # comparator key (casefold + trim leading/trailing
+            # punctuation + collapse whitespace).
+            return ("p1932-string", casefold_for_compare(s), None)
         return None
 
     return None


### PR DESCRIPTION
## Summary

Widens the comparator paths that decide whether a community-contributed value (an inferred-from-Wikitext SDC claim, or a `{{DPLA metadata}}` template override) is really the same fact as DPLA's own value. Comparator-only changes — stored SDC values and rendered wikitext continue to match byte-for-byte.

## Motivating examples

- **[M174777532](https://commons.wikimedia.org/wiki/File:1959-06_(June_1959)._The_John_Herron_Art_School_Chronicle_-_DPLA_-_89d2f0466a5b87a16332538b22acf4af_(page_1).jpg)** (indiana): P571 DPLA-side stored as `somevalue+P1932="June 1959"` alongside an inferred-from-Wikitext value-typed `+1959-06-01|P10`. Same fact, but `parse_dpla_date` rejected the month-name form → the somevalue side produced a `("p1932-string", …)` comparable while the value-typed side produced `("time", …)`. Shape mismatch, no dedup.
- **[M114630785](https://commons.wikimedia.org/wiki/File:Abbott,_A.D._-_DPLA_-_137b40c34543635bf3f145cd2f450227.jpg)** (bpl): P10358 description with a trailing `.` on the DPLA side vs. no trailing period on the community side. Byte comparison failed.
- **[M100761231](https://commons.wikimedia.org/wiki/File:(Promissory_note_for_Thomas_Love)_-_DPLA_-_929a0beb5e9fe14c7f00b890dc05b966_(page_2).jpg)** (bpl): P1476 title bracketed `[…]` on the DPLA side (archival supplied-title convention) vs. unbracketed on the community side.
- **[M105419621](https://commons.wikimedia.org/wiki/File:%22A_Barn_Yard%22_essay_for_English_IV_by_Sarah_(Sallie)_M._Field,_Abbot_Academy,_class_of_1904_-_DPLA_-_e4d34f37c00df7d514f7b320d537f94b_(page_1).jpg)** (bpl): No inferred SDC dupe. `{{DPLA metadata}}` carries `| date = 19 November 1902` next to canonical DPLA `1902-11-19`. `normalize_page` can't strip because `parse_dpla_date` rejects the natural-language form.

## Changes

- **`parse_dpla_date`** (`ingest_wikimedia/sdc.py`) accepts English month-name forms: `Month YYYY` (month precision), `Month D, YYYY` / `Month D YYYY` / `D Month YYYY` (day precision), plus `MM/DD/YYYY`. Every day-precision path runs `datetime.date(y, mo, d)` so phantom days (`February 30 1902`, `13/40/1900`) still fall back. Adjacent prose still forces fall-back — regexes anchored.
- **`casefold_for_compare(s)`** helper: strips leading/trailing whitespace + Unicode punctuation, collapses internal whitespace runs, casefolds. Applied ONLY as a comparator key.
- **`dates_semantically_equal(a, b)`** helper: True iff both parse to the same time+precision+circa-flag.
- **`_statement_comparable_value`** in `tools/sdc_sync.py`: text-shape branches (`string`, `monolingual`, `p1932-string`) fold their primary through `casefold_for_compare`. Reconciler still only removes inferred-from-Wikitext claims — never DPLA, never third-party.
- **`_value_matches`** in `ingest_wikimedia/wikitext_normalize.py`: two fallback paths after byte-equal + language-wrapper unwrap.
  - `param_name == "date"` → try `dates_semantically_equal`.
  - Display-string keys (`title` / `description` / `date` / `permission` / `creator`) → try folded equality.
  - Identifier keys (`hub` / `institution` / `url` / `dpla_id` / `local_id`) deliberately excluded — a case change in an opaque token is a distinct value.
- **`plan_migration`** in `ingest_wikimedia/legacy_artwork.py`: uses the same equivalence, so a community edit that only reformatted DPLA's own value (case, punctuation, or date format) is not imported as a spurious community contribution.

## Idempotency

No scrubber tool needed — the existing sdc-sync post-cleanup already re-runs `normalize_page` on every pass. Files carrying already-embedded near-duplicate overrides collapse automatically on their next sync.

## Test plan

- [x] Existing 495-test suite green (was passing before the fix).
- [x] Extended: 834 tests total, all passing on EC2 (Python 3.13, pywikibot).
- [x] `ruff check` + `ruff format` clean on all changed files.
- New tests cover every failure mode in the motivating examples plus:
  - Casefold `_for_compare_` folds case but preserves internal punctuation (`"A.D. Abbott"` ≠ `"A D Abbott"`).
  - `dates_semantically_equal` rejects precision mismatch (`1902` ≠ `1902-11-19`) and circa-flag mismatch.
  - `parse_dpla_date` still returns None for month-name forms adjacent to prose (`"January 1945 AD"`, `"Jan 1945 or 1946"`).
  - `_value_matches` preserves URL / identifier keys under case change.
  - Reconciler preserves language-mismatched monolingualtext claims (`en` vs `es` same text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
Widened Wikitext↔SDC reconciliation/comparison so semantically equivalent community-entered values (not just byte-for-byte matches) no longer cause redundant updates, while keeping stored SDC values and rendered wikitext unchanged byte-for-byte.

### Highlights
- Extended `parse_dpla_date` to accept additional English month-name and slash-based date shapes (plus more natural month/day/year permutations), returning `None` for non-clean residue so callers fall back to `somevalue + P1932` rather than emitting incorrect precision.
- Added comparator utilities in `ingest_wikimedia/sdc.py`:
  - `casefold_for_compare` for tolerant display-string comparison (punctuation/whitespace trimming + internal whitespace collapsing).
  - `dates_semantically_equal` for structured date equality (value-typed time + precision + circa/approximate semantics).
  - `CASEFOLD_COMPARE_KEYS` to scope where casefold-based tolerance is applied.
- Applied the new matching rules in:
  - SDC reconciliation (including tolerance for display-like fields such as title/description/date/permission/creator).
  - wikitext normalization redundant-parameter stripping (parameter-aware via `param_name` and semantic date matching for `date`).
  - legacy `{{Artwork}}` migration, preventing redundant community imports when values are semantically equivalent to canonical DPLA values.
  - inferred-from-Wikitext sync cleanup, ensuring near-duplicates are removed only when differences are within supported tolerance.
- Institution handling in legacy migration:
  - Extracts Wikidata Q-IDs from both bare `Q...` strings and `{{Institution|wikidata=Q...}}` templates, and compares extracted IDs to suppress redundant community imports when they match.
- Bugfix/regression guard:
  - Prevents approximate/uncertain date strings (e.g., `[1902]`, `1902?`) from being incorrectly stripped by removing `date` from the casefold-tolerance path and relying on semantic date comparison instead.
- Tests updated/added across date parsing, casefolding behavior, legacy migration equivalence/guardrails, and inferred-from-Wikitext dedup tolerance (including explicit non-merging for language mismatches and substantively different text).

### Impact
- No manual pipeline trigger or ECS redeployment required.
- No environment variable or AWS Secrets Manager key changes.
- No database migration.
- No shared infrastructure configuration changes (CodePipeline/CodeBuild/ECS/IAM).
- No public-facing API response shape changes or endpoint additions/removals.
- No new security implications identified (logic-only comparator/tolerance changes; no auth/credential handling changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->