### PR TITLE
uploader: fix phantom Case-2 hash-drift on truncation-trailing-whitespace

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -111,6 +111,19 @@ def get_page_title(
     bypass those checks (see PR #261's audit).
     """
     escaped_title = (
+        # ``rstrip`` after the 181-char truncation: MediaWiki collapses
+        # whitespace runs (and effectively trims whitespace adjacent to
+        # the ``... - DPLA - <id>...`` separator we append below) when
+        # storing file titles, so if the truncation cutoff lands on
+        # whitespace, the constructed title picks up a trailing space
+        # that Commons removes at store time. The Python-side raw-string
+        # identity check in ``process_file`` then thinks the file has
+        # drifted (constructed vs. stored differ by one space), triggers
+        # phantom Case-2 duplicate-tagging, and the item hangs in the
+        # dup-throttle drain. Concrete repro: DPLA ID
+        # 95bd6bee5aed3c5311a67d5f6cee490b (NARA / FDR Library), whose
+        # 264-char source title lands ``:181`` on the space after
+        # ``"...value of farm "``.
         # MediaWiki's `stripIllegalFilenameChars` strips `:` from File-
         # namespace titles unconditionally (filesystem path-separator
         # concern), replacing with `-`.  Apply the same rule here.  An
@@ -124,7 +137,7 @@ def get_page_title(
         # up as orphan duplicates because the uploader treated the
         # colon-form title as the canonical one while Commons stored
         # the dash form.
-        _break_query_string_pattern(item_title[:181])
+        _break_query_string_pattern(item_title[:181].rstrip())
         .replace(":", "-")
         # `/` must also be substituted.  An earlier reading of MediaWiki's
         # rules (PR #223) removed this substitution because

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -2335,23 +2335,36 @@ def test_canonicalize_commons_title_collapses_whitespace_runs():
     assert _canonicalize_commons_title("Foo Bar") == "Foo Bar"
 
 
-def test_resolve_hash_drift_returns_already_correct_on_exact_title_match():
+def test_resolve_hash_drift_returns_already_correct_on_whitespace_normalized_match():
     """Regression: when the SHA1-lookup returns the file already at the
-    intended title, ``_resolve_hash_drift`` must NOT fall through to
-    Case 2 (which would try to upload same-hash bytes and tag the file
-    as duplicate of itself). Return the new ``already_correct`` sentinel
-    so the caller records SKIPPED.
+    intended title (after whitespace normalisation), ``_resolve_hash_drift``
+    must NOT fall through to Case 2 (which would try to upload same-hash
+    bytes and tag the file as duplicate of itself). Return the new
+    ``already_correct`` sentinel so the caller records SKIPPED.
+
+    Uses a raw ``page_title`` with a double-space run (the exact shape
+    the pre-fix ``get_page_title`` truncation-lands-on-whitespace bug
+    used to produce) against a pywikibot-normalized ``existing_file``
+    title with the single-space form. Byte equality is false; the
+    canonicalized-equality guard is what catches this case. If the
+    guard regresses to raw equality (which would coincide with the
+    line-468 identity check ``process_file`` already runs before
+    calling here), this test fails.
     """
     uploader = _build_uploader_with_dpla()
-    same_title = "Item - DPLA - bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.gif"
+    commons_title = "Item - DPLA - bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.gif"
+    raw_page_title = "Item  - DPLA - bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.gif"  # 2 spaces
+    assert commons_title != raw_page_title, (
+        "test premise: titles must differ byte-wise so byte-equality won't fire"
+    )
     intended_page = MagicMock()
     intended_page.exists.return_value = True
     intended_page.isRedirectPage.return_value = False
-    intended_page.title.return_value = same_title
+    intended_page.title.return_value = commons_title
     with patch("tools.uploader.get_page", return_value=intended_page):
         action = uploader._resolve_hash_drift(
-            existing_file=_drift_existing_file(same_title),
-            page_title=same_title,
+            existing_file=_drift_existing_file(commons_title),
+            page_title=raw_page_title,
             dpla_id="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             ordinal=1,
             wiki_markup="",

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -2306,3 +2306,118 @@ def test_csrf_recovery_failed_propagates_past_process_item_outer_catch():
         "``except CsrfRecoveryFailed: raise`` before the generic "
         "handler so the run aborts instead of looping the next item."
     )
+
+
+# ---------------------------------------------------------------------------
+# Phantom-drift defense-in-depth (this PR).
+#
+# ``get_page_title``'s ``item_title[:181]`` truncation used to leak a
+# trailing space when the 181st character landed on whitespace, producing
+# a raw Python title with a double-space run around the ``- DPLA -``
+# separator. ``process_file``'s line-468 identity check
+# (``existing_file.title(with_ns=False) == page_title``) then failed on
+# the raw-string comparison, and ``_resolve_hash_drift`` fell through to
+# Case 2 tagging the file as a duplicate of itself. Commons's
+# ``fileexists-no-change`` server-side check happened to reject the
+# upload, so ``_tag_drift_duplicate`` was never called — but the guard
+# path is defense-in-depth for any future normalisation drift.
+# ---------------------------------------------------------------------------
+
+
+def test_canonicalize_commons_title_collapses_whitespace_runs():
+    """The guard helper mirrors MediaWiki's ``.trim()`` +
+    whitespace-run collapse on file titles."""
+    from tools.uploader import _canonicalize_commons_title
+
+    assert _canonicalize_commons_title("Foo  Bar") == "Foo Bar"
+    assert _canonicalize_commons_title("  Foo Bar  ") == "Foo Bar"
+    assert _canonicalize_commons_title("Foo\tBar") == "Foo Bar"
+    assert _canonicalize_commons_title("Foo Bar") == "Foo Bar"
+
+
+def test_resolve_hash_drift_returns_already_correct_on_exact_title_match():
+    """Regression: when the SHA1-lookup returns the file already at the
+    intended title, ``_resolve_hash_drift`` must NOT fall through to
+    Case 2 (which would try to upload same-hash bytes and tag the file
+    as duplicate of itself). Return the new ``already_correct`` sentinel
+    so the caller records SKIPPED.
+    """
+    uploader = _build_uploader_with_dpla()
+    same_title = "Item - DPLA - bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.gif"
+    intended_page = MagicMock()
+    intended_page.exists.return_value = True
+    intended_page.isRedirectPage.return_value = False
+    intended_page.title.return_value = same_title
+    with patch("tools.uploader.get_page", return_value=intended_page):
+        action = uploader._resolve_hash_drift(
+            existing_file=_drift_existing_file(same_title),
+            page_title=same_title,
+            dpla_id="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ordinal=1,
+            wiki_markup="",
+        )
+    assert action == "already_correct"
+
+
+def test_tag_drift_duplicate_refuses_self_tag_byte_equal():
+    """Belt: even if some caller passes the same title as both
+    ``old_filename`` and ``new_filename``, ``_tag_drift_duplicate``
+    refuses to call ``tag_as_duplicate`` — that would flag the file
+    for admin deletion of itself."""
+    uploader = _build_uploader_with_dpla()
+    same = "Foo - DPLA - cccccccccccccccccccccccccccccccc.jpg"
+    with (
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+        patch("tools.uploader.get_page") as get_page_mock,
+    ):
+        uploader._tag_drift_duplicate(
+            old_filename=same,
+            new_filename=same,
+            wiki_markup="wt",
+            dpla_id="cccccccccccccccccccccccccccccccc",
+        )
+    tag_mock.assert_not_called()
+    get_page_mock.assert_not_called()
+
+
+def test_tag_drift_duplicate_refuses_self_tag_whitespace_run_equal():
+    """Suspenders: two titles that differ only in whitespace runs
+    (the exact shape ``get_page_title``'s truncation bug used to
+    produce) resolve to the same Commons page under MediaWiki
+    normalisation. Must not tag."""
+    uploader = _build_uploader_with_dpla()
+    single_space = "Foo Bar - DPLA - dddddddddddddddddddddddddddddddd.jpg"
+    double_space = "Foo Bar  - DPLA - dddddddddddddddddddddddddddddddd.jpg"
+    with (
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+        patch("tools.uploader.get_page") as get_page_mock,
+    ):
+        uploader._tag_drift_duplicate(
+            old_filename=single_space,
+            new_filename=double_space,
+            wiki_markup="wt",
+            dpla_id="dddddddddddddddddddddddddddddddd",
+        )
+    tag_mock.assert_not_called()
+    get_page_mock.assert_not_called()
+
+
+def test_tag_drift_duplicate_still_tags_when_names_genuinely_differ():
+    """Positive: a genuine hash-drift case (different filenames) still
+    reaches ``tag_as_duplicate`` — the self-tag guard doesn't over-fire."""
+    uploader = _build_uploader_with_dpla()
+    old_page = MagicMock()
+    old_page.exists.return_value = True
+    old_page.text = ""
+    with (
+        patch("tools.uploader.tag_as_duplicate") as tag_mock,
+        patch("tools.uploader.get_page", return_value=old_page),
+        patch("tools.uploader.merge_preserved_wikitext", return_value="wt"),
+    ):
+        uploader._tag_drift_duplicate(
+            old_filename="Old title - DPLA - eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.jpg",
+            new_filename="New title - DPLA - eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.jpg",
+            wiki_markup="wt",
+            dpla_id="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        )
+    tag_mock.assert_called_once()

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -59,6 +59,79 @@ def test_get_page_title():
     assert title == expected_title
 
 
+def test_get_page_title_trims_trailing_whitespace_after_truncation():
+    """Regression: a DPLA-supplied title longer than 181 chars whose 181st
+    character lands on whitespace must NOT leave that whitespace in the
+    constructed Commons title. Commons normalises whitespace runs at
+    store time, so the raw Python-side title (with trailing space) and
+    the actual Commons-stored title (without) will not compare equal
+    under the process_file identity check — that check drives every
+    downstream skip-if-already-there / hash-drift / duplicate-tag
+    branch, so a mismatch produces phantom Case-2 drift.
+
+    Concrete repro: DPLA ID 95bd6bee5aed3c5311a67d5f6cee490b
+    (NARA / FDR Library) has a 264-char source title. Truncated to 181
+    chars, the last character is a space right after "...value of farm ".
+    Pre-fix that space survived into the constructed page title,
+    breaking equality with the Commons file at "...value of farm - DPLA
+    - <id>.gif" and hanging the entire upload session in the phantom
+    duplicate-tag drain.
+    """
+    # NB: single-string literal — Python's implicit-concat would elide
+    # the spaces at the line breaks and change ``[181]``'s character.
+    source_title = "Planning for an adequate home grown food supply brought to this New York woman, as to hundred thousands like her throughout the country, a realization of the economic value of farm produced food and fuel, and a keener appreciation of the advantages of farm living."
+    # Sanity check the repro: ``[:181]``'s last character must be
+    # whitespace so the fix's trailing-strip is what causes this test's
+    # assertion to hold. Python slicing is end-exclusive — ``s[:181]``
+    # covers indices 0..180, so we probe ``s[180]``.
+    assert len(source_title) > 181
+    assert source_title[:181].endswith(" "), (
+        f"Test premise broken: source_title[:181] ends with "
+        f"{source_title[:181][-3:]!r} — needs to end in whitespace for "
+        f"this to be a truncation-lands-on-space repro."
+    )
+    title = get_page_title(source_title, "95bd6bee5aed3c5311a67d5f6cee490b", ".gif")
+    assert " - DPLA -" in title
+    assert "  - DPLA -" not in title, (
+        f"expected no double-space before ` - DPLA -`; got {title!r}. "
+        f"If this asserts, the `item_title[:181]` truncation left a "
+        f"trailing space that leaks into the assembled title."
+    )
+    # Also pin the exact expected shape so a future refactor can't
+    # silently drop the fix.
+    assert title == (
+        "Planning for an adequate home grown food supply brought to this "
+        "New York woman, as to hundred thousands like her throughout the "
+        "country, a realization of the economic value of farm - DPLA - "
+        "95bd6bee5aed3c5311a67d5f6cee490b.gif"
+    )
+
+
+def test_get_page_title_preserves_short_title_trailing_whitespace_absent():
+    """Trailing-whitespace strip only applies at the truncation boundary
+    — a short title with no trailing whitespace must be identical to
+    pre-fix output. Sanity check that the rstrip doesn't inadvertently
+    alter titles that don't hit the 181-char cap."""
+    title = get_page_title("Sample Title", "abcd1234", ".jpg")
+    assert title == "Sample Title - DPLA - abcd1234.jpg"
+
+
+def test_get_page_title_trims_multiple_trailing_whitespace_chars():
+    """If DPLA's source title happens to have multiple whitespace chars
+    at the 181-char boundary (e.g. a tab plus a space), the rstrip
+    removes all of them, not just one — matching MediaWiki's ``.trim()``
+    of leading/trailing whitespace on stored titles."""
+    # Construct a 200-char title whose chars 180-183 are various
+    # whitespace, so ``[:181]`` yields a chunk ending in `[<chars>\t `.
+    prefix = "A" * 180
+    source_title = prefix + "\t   more text after"
+    title = get_page_title(source_title, "deadbeef" * 4, ".jpg")
+    # No whitespace immediately before the ` - DPLA -` separator.
+    assert title.startswith(prefix + " - DPLA -"), (
+        f"expected trailing whitespace runs to be stripped; got {title!r}"
+    )
+
+
 def test_get_page_title_preserves_ampersand_when_no_equals():
     """Regression: titles containing `&` alone (no `=`) must NOT be rewritten.
 

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -117,14 +117,20 @@ def test_get_page_title_preserves_short_title_trailing_whitespace_absent():
 
 
 def test_get_page_title_trims_multiple_trailing_whitespace_chars():
-    """If DPLA's source title happens to have multiple whitespace chars
-    at the 181-char boundary (e.g. a tab plus a space), the rstrip
-    removes all of them, not just one — matching MediaWiki's ``.trim()``
-    of leading/trailing whitespace on stored titles."""
-    # Construct a 200-char title whose chars 180-183 are various
-    # whitespace, so ``[:181]`` yields a chunk ending in `[<chars>\t `.
-    prefix = "A" * 180
-    source_title = prefix + "\t   more text after"
+    """If the 181-char truncation lands inside a run of multiple
+    whitespace characters, ``rstrip`` removes all of them, not just
+    one — matching MediaWiki's ``.trim()`` on stored titles.
+
+    Sizing: ``[:181]`` covers indices 0..180. Prefix is 178 A's, then
+    ``\\t  `` at indices 178, 179, 180 — so the truncated chunk ends
+    with three whitespace chars (tab + two spaces) that all need to
+    strip cleanly.
+    """
+    prefix = "A" * 178
+    source_title = prefix + "\t  more text after"
+    assert source_title[:181] == prefix + "\t  ", (
+        "test premise: truncation covers tab + 2 spaces"
+    )
     title = get_page_title(source_title, "deadbeef" * 4, ".jpg")
     # No whitespace immediately before the ` - DPLA -` separator.
     assert title.startswith(prefix + " - DPLA -"), (

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -6,6 +6,7 @@ import logging
 import mimetypes
 import os
 import random
+import re
 import time
 
 import click
@@ -231,6 +232,28 @@ def _is_csrf_token_error(ex: BaseException) -> bool:
     whose message signals an invalidated CSRF token — narrowed on the
     marker so unrelated ``KeyError``s don't trigger session recovery."""
     return isinstance(ex, KeyError) and _CSRF_TOKEN_ERROR_MARKER in str(ex)
+
+
+_WHITESPACE_RUN_RE = re.compile(r"\s+")
+
+
+def _canonicalize_commons_title(title: str) -> str:
+    """Return ``title`` under a light MediaWiki-title normalisation:
+    strip leading/trailing whitespace and collapse internal whitespace
+    runs to a single space.
+
+    Used by ``_tag_drift_duplicate``'s self-tag defense — a raw Python
+    string comparison of "the old title" vs "the new title" can miss
+    a match when the two names disagree only in whitespace-run form
+    (the exact shape ``get_page_title``'s ``[:181]`` truncation-lands-
+    on-whitespace bug used to produce). This helper mirrors just enough
+    of MediaWiki's title normalisation to catch that class of case
+    without pulling in the broader normalisation surface (Unicode NFC,
+    underscore ↔ space, namespace-first-letter capitalisation, etc.);
+    those live on the API side and the defense-in-depth guard doesn't
+    need every one of them to be a safety net.
+    """
+    return _WHITESPACE_RUN_RE.sub(" ", title).strip()
 
 
 def _recover_commons_session(site) -> None:
@@ -573,6 +596,25 @@ class Uploader:
                             # by MediaWiki across moves so we can stamp it here.
                             return {
                                 "status": ORDINAL_UPLOADED,
+                                "title": page_title,
+                                "pageid": existing_file.pageid,
+                            }
+                        elif drift_action == "already_correct":
+                            # ``_resolve_hash_drift`` caught a phantom drift —
+                            # the file the SHA1-lookup returned IS the file
+                            # at the intended title, once pywikibot's title
+                            # normalisation collapsed the raw
+                            # ``page_title`` difference. Treat the same as
+                            # the line-468 identity check that ``process_file``
+                            # attempted before we called ``_resolve_hash_drift``.
+                            logging.info(
+                                f"Skipping {dpla_id} {ordinal}: "
+                                f"Already exists on commons (normalized "
+                                f"identity)."
+                            )
+                            self.tracker.increment(Result.SKIPPED)
+                            return {
+                                "status": ORDINAL_SKIPPED,
                                 "title": page_title,
                                 "pageid": existing_file.pageid,
                             }
@@ -1171,15 +1213,50 @@ class Uploader:
         already lives on Commons at a different title than intended.
 
         Returns one of:
-          "moved"          — Case 1/3: file moved to correct title; caller should
-                             increment UPLOADED and return (no upload needed).
-          "upload_and_tag" — Case 2: correct title has a different file; caller
-                             should upload (ignore_warnings=True) then tag the
-                             orphaned old title as a duplicate.
-          "upload_only"    — Cross-item hash collision with a still-valid DPLA ID;
-                             upload to the correct title but leave the other file alone.
+          "moved"           — Case 1/3: file moved to correct title; caller should
+                              increment UPLOADED and return (no upload needed).
+          "upload_and_tag"  — Case 2: correct title has a different file; caller
+                              should upload (ignore_warnings=True) then tag the
+                              orphaned old title as a duplicate.
+          "upload_only"     — Cross-item hash collision with a still-valid DPLA ID;
+                              upload to the correct title but leave the other file alone.
+          "already_correct" — No drift after normalisation: the file the SHA1
+                              lookup returned IS the file at the intended title.
+                              Caller should record SKIPPED and return.
         """
         actual_filename = existing_file.title(with_ns=False)
+
+        # Defense-in-depth: if pywikibot's normalized title for the file
+        # that carries this SHA1 equals the intended title we're about
+        # to upload to, there is no drift to resolve — MediaWiki
+        # collapsed whatever difference our raw ``page_title`` had
+        # (typically a whitespace-run artefact from title truncation,
+        # see ``get_page_title``) and the file we found IS the file at
+        # the canonical title. Return early rather than fall through to
+        # Case 1/2/3, all of which are destructive in this state:
+        # Case 3 would attempt a move-to-self; Case 1/2 would attempt an
+        # upload + tag-as-duplicate against the same page (in practice
+        # Commons rejects the upload with ``fileexists-no-change``, so
+        # the tag path was never reached — but the ordinal was recorded
+        # as FAILED instead of SKIPPED, inflating counters across 7,550
+        # DPLA items in past runs).
+        #
+        # The upstream ``process_file`` identity check
+        # (``existing_file.title(with_ns=False) == page_title``) SHOULD
+        # catch this earlier, but that comparison is a raw Python
+        # equality on the constructed vs. pywikibot-normalized strings —
+        # any character MediaWiki normalises that our constructor
+        # doesn't (or vice versa) leaks through. This guard closes the
+        # remaining gap without depending on the constructor's
+        # correctness for every future normalisation change on either
+        # side.
+        if actual_filename == page_title:
+            logging.info(
+                f"Hash drift for {dpla_id} {ordinal}: "
+                f"[[File:{actual_filename}]] IS the intended title after "
+                f"pywikibot normalisation; nothing to resolve."
+            )
+            return "already_correct"
 
         # --- Hash collision safety check ---
         # Cross-item collision: the file at the wrong title was uploaded for a
@@ -1363,7 +1440,32 @@ class Uploader:
         file's revision history still contains the community
         contributions even if the rescue's save fails, so manual
         recovery from page history is always possible.
+
+        Defense-in-depth self-tag guard: if ``old_filename`` and
+        ``new_filename`` resolve to the same Commons page (after
+        whitespace-run normalisation), refuse to tag. Tagging a file as
+        a duplicate of itself would flag it for admin deletion — the
+        destructive outcome the caller's Case 2 detection can slip
+        into if the two names disagree only in whitespace-run form.
+        Commons's ``fileexists-no-change`` check has historically
+        rejected the preceding upload attempt (so ``_tag_drift_duplicate``
+        wasn't reached in practice — see PR authoring for the log
+        audit), but the audit cannot cover future changes to Commons's
+        server-side behaviour, so we belt-and-suspender here.
         """
+        if _canonicalize_commons_title(old_filename) == _canonicalize_commons_title(
+            new_filename
+        ):
+            logging.warning(
+                f"Refusing to tag [[File:{old_filename}]] as duplicate of "
+                f"[[File:{new_filename}]] — the two names resolve to the "
+                f"same Commons page under whitespace normalisation. This "
+                f"is a phantom-drift signal upstream (see "
+                f"``_resolve_hash_drift``'s ``already_correct`` return); "
+                f"no destructive action taken."
+            )
+            return
+
         old_page = get_page(self.site, f"File:{old_filename}")
 
         # Rescue community contributions, if any.

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -607,6 +607,14 @@ class Uploader:
                             # ``page_title`` difference. Treat the same as
                             # the line-468 identity check that ``process_file``
                             # attempted before we called ``_resolve_hash_drift``.
+                            # Persist the pywikibot-normalized title, not the
+                            # raw constructed ``page_title`` — downstream
+                            # sidecars / SDC-sync key on the Commons-stored
+                            # form, so returning the raw double-space form
+                            # here would break the very equality checks
+                            # elsewhere in the pipeline this branch exists
+                            # to accommodate.
+                            canonical_title = existing_file.title(with_ns=False)
                             logging.info(
                                 f"Skipping {dpla_id} {ordinal}: "
                                 f"Already exists on commons (normalized "
@@ -615,7 +623,7 @@ class Uploader:
                             self.tracker.increment(Result.SKIPPED)
                             return {
                                 "status": ORDINAL_SKIPPED,
-                                "title": page_title,
+                                "title": canonical_title,
                                 "pageid": existing_file.pageid,
                             }
                         elif drift_action == "upload_and_tag":
@@ -1250,7 +1258,9 @@ class Uploader:
         # remaining gap without depending on the constructor's
         # correctness for every future normalisation change on either
         # side.
-        if actual_filename == page_title:
+        if _canonicalize_commons_title(actual_filename) == _canonicalize_commons_title(
+            page_title
+        ):
             logging.info(
                 f"Hash drift for {dpla_id} {ordinal}: "
                 f"[[File:{actual_filename}]] IS the intended title after "


### PR DESCRIPTION
## Summary

Fixes a title-construction bug that has been producing phantom Case-2 "hash drift" detections since `get_page_title`'s current 181-char truncation was introduced. Two defense-in-depth guards also added so any future normalisation drift can't reach the destructive `tag_as_duplicate` path.

## Symptoms

A single-file NARA session (`nara+95bd6bee`) hung for 3+ hours in the dup-throttle drain, blocked on a phantom `{{Duplicate}}`-tag emission for DPLA ID `95bd6bee5aed3c5311a67d5f6cee490b` — a 2006-uploaded FDR Library GIF. The item's SHA1 matched a Commons file, and that Commons file was at the intended title, so nothing should have needed doing.

## Root cause

`get_page_title`'s `item_title[:181]` truncation ended in whitespace when the 181st char of the DPLA-supplied title fell on a space. The resulting page title had a double-space run around ` - DPLA -`. MediaWiki collapses that at store time; the raw-Python `existing_file.title(with_ns=False) == page_title` identity check at `tools/uploader.py:468` failed on the byte comparison; `_resolve_hash_drift` fell through to Case 2; the uploader tried to tag the file as a duplicate of itself.

## Log audit — every upload log since 2025-04

- **17,724 phantom Case-2 firings** across **7,550 unique DPLA items**.
- **Zero completed destructive tags.** Commons's server-side `fileexists-no-change` check rejected every same-hash upload attempt with an APIError (unsuppressed by `ignore_warnings=True`), so `_tag_drift_duplicate` was never reached in production.
- **Impact**: 17,724 ordinals were recorded as FAILED in past tracker counters (should have been SKIPPED). Files on Commons are intact. No cleanup / revert required.

Breakdown by partner:

| Partner | Phantom ordinals | Unique items |
|---|---|---|
| mwdl | 14,059 | 7,148 |
| ohio | 2,324 | 47 |
| nara | 859 | 200 |
| pa | 306 | 77 |
| minnesota | 93 | 2 |
| bpl | 70 | 70 |
| indiana | 8 | 2 |
| heartland | 2 | 1 |
| p2p | 2 | 2 |
| northwest-heritage | 1 | 1 |
| **TOTAL** | **17,724** | **7,550** |

## Fixes

1. **Root cause** — `item_title[:181].rstrip()` in `get_page_title`. Constructed title now matches Commons's stored form; the line-468 identity check in `process_file` catches "already exists on commons" cleanly.
2. **Defense-in-depth in `_resolve_hash_drift`** — new `already_correct` return sentinel handles the case where the SHA1-lookup returns the file already at the intended title (after pywikibot's title normalisation). Caller records SKIPPED. Closes any future normalisation-drift gap without depending on the constructor's correctness for every character class MediaWiki decides to normalise.
3. **Defense-in-depth in `_tag_drift_duplicate`** — a whitespace-run-normalising self-tag guard refuses to call `tag_as_duplicate` when `old_filename` and `new_filename` resolve to the same Commons page. Belt-and-suspenders against Fix 2 being bypassed by a future refactor.

## Test plan

- [x] New tests exercise all three paths, including the exact NARA FDR Library 264-char title that triggered the audit.
- [x] 1004 tests pass on EC2.
- [x] `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixed a Commons title-normalization bug that could create phantom Case-2 “hash drift” detections when `get_page_title` truncated a source title leaving trailing whitespace. The truncated title is now `rstrip()`’d before assembling the final Commons page title, preventing whitespace mismatches around the `- DPLA -` separator.

Added defense-in-depth in the uploader flow to ensure normalized identity doesn’t reach the destructive duplicate-tagging path:
- `_resolve_hash_drift` now returns an `already_correct` outcome when the existing Commons title matches the intended title after canonicalizing whitespace, causing the case to be treated as `SKIPPED` instead of proceeding to corrective tagging.
- `_tag_drift_duplicate` now prevents self-tagging by refusing to tag when `old_filename` and `new_filename` resolve to the same Commons target after canonicalization.
- Introduced a whitespace-canonicalization helper to collapse/trims whitespace runs for comparisons.

Expanded regression coverage with new tests for:
- truncation-boundary trimming (including multiple whitespace characters, e.g., tab+spaces) before the `- DPLA -` separator,
- `already_correct` handling for normalized title matches,
- self-tag prevention when old/new filenames resolve to the same Commons page (byte-equal and whitespace-only differences),
including the specific NARA FDR Library case that previously exposed the issue.

No manual deployment trigger, ECS redeployment, environment variable/Secrets Manager key changes, database migrations, shared infrastructure configuration changes, or public API/endpoint changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->