### PR TITLE
drain: move deferred dup-tag drain out of uploader into a patient sidecar-driven phase

### DIFF
--- a/ingest_wikimedia/drain_sidecar.py
+++ b/ingest_wikimedia/drain_sidecar.py
@@ -1,0 +1,129 @@
+"""Persistent sidecar for the deferred-drain queue.
+
+The uploader defers a Case-2 hash-drift upload+tag as a unit when
+Category:Duplicate is at capacity. Rather than blocking the whole
+session (and downstream sdc-sync) waiting for volunteers to clear the
+category on human-admin timescales, the uploader writes the deferred
+DPLA IDs to this sidecar and exits normally. A subsequent
+``drain-deferred`` phase reads the sidecar, waits patiently for
+Category:Duplicate to drop below its resume threshold, re-invokes the
+uploader + sdc-sync on just those IDs, and loops until the sidecar is
+empty.
+
+Per-partner scope: the tmux session name is ``wikimedia-<partner>``, so
+only one session per partner runs at a time; a single per-partner
+sidecar is sufficient and unambiguous. Location:
+``<partner>/deferred-drain.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+SIDECAR_FILENAME = "deferred-drain.json"
+
+
+def sidecar_path(partner: str) -> Path:
+    """Absolute path to the deferred-drain sidecar for ``partner``.
+
+    Uses the same per-partner working directory the uploader / sdc-sync
+    CLI commands run from (their CWD when launched by the tmux
+    pipeline). Callers may pass either the canonical partner slug
+    (``nara``) or a directory-name variant (``smithsonian`` for the ``si``
+    slug); resolution belongs on the caller side.
+    """
+    return Path(partner) / SIDECAR_FILENAME
+
+
+def read_sidecar(partner: str) -> list[str]:
+    """Return the list of DPLA IDs currently in the sidecar, or an
+    empty list if the file is missing or unreadable.
+
+    Missing sidecar is the normal empty state — a fresh partner run with
+    no deferrals, or a drain that completed and cleaned up.  A file
+    present but unparseable is treated the same as missing to keep the
+    drain loop resilient against a mid-write crash; the operator would
+    see the corrupt file and can inspect it manually if needed.
+    """
+    path = sidecar_path(partner)
+    if not path.exists():
+        return []
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as ex:
+        logging.warning(
+            "deferred-drain sidecar at %s is unreadable (%s); treating as empty",
+            path,
+            ex,
+        )
+        return []
+    ids = data.get("deferred_dpla_ids") if isinstance(data, dict) else None
+    if not isinstance(ids, list):
+        return []
+    return [x for x in ids if isinstance(x, str)]
+
+
+def write_sidecar(partner: str, dpla_ids: list[str]) -> None:
+    """Overwrite the sidecar with ``dpla_ids``.  Removes the file when
+    the list is empty so an empty state is unambiguous (missing =
+    nothing to drain).
+
+    Atomic write via ``tempfile.NamedTemporaryFile`` + ``os.replace`` so a
+    crash mid-write can't leave a truncated file. A drain phase reading
+    the sidecar between our tempfile creation and the rename sees the
+    previous contents (or nothing) — never a partial write.
+    """
+    path = sidecar_path(partner)
+    if not dpla_ids:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as ex:
+            logging.warning(
+                "failed to remove empty deferred-drain sidecar at %s: %s", path, ex
+            )
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Dedup while preserving order — a partner re-run should not grow
+    # the queue with repeat entries.
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for dpla_id in dpla_ids:
+        if dpla_id not in seen:
+            seen.add(dpla_id)
+            ordered.append(dpla_id)
+    payload = {"partner": partner, "deferred_dpla_ids": ordered}
+    with tempfile.NamedTemporaryFile(
+        "w",
+        dir=str(path.parent),
+        prefix=".deferred-drain-",
+        suffix=".tmp",
+        delete=False,
+    ) as tf:
+        json.dump(payload, tf, indent=2)
+        tf.write("\n")
+        tempname = tf.name
+    os.replace(tempname, path)
+
+
+def merge_sidecar(partner: str, new_dpla_ids: list[str]) -> list[str]:
+    """Union ``new_dpla_ids`` into the sidecar and return the resulting
+    combined list. If the sidecar didn't exist, this is a plain create.
+
+    Merge (rather than overwrite) so a session that ran while a prior
+    drain still had items queued doesn't lose the prior queue.  Only
+    the drain phase removes items; the uploader only ever appends.
+    """
+    existing = read_sidecar(partner)
+    seen: set[str] = set(existing)
+    combined = list(existing)
+    for dpla_id in new_dpla_ids:
+        if dpla_id not in seen:
+            seen.add(dpla_id)
+            combined.append(dpla_id)
+    write_sidecar(partner, combined)
+    return combined

--- a/ingest_wikimedia/drain_sidecar.py
+++ b/ingest_wikimedia/drain_sidecar.py
@@ -18,6 +18,7 @@ sidecar is sufficient and unambiguous. Location:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -97,17 +98,28 @@ def write_sidecar(partner: str, dpla_ids: list[str]) -> None:
             seen.add(dpla_id)
             ordered.append(dpla_id)
     payload = {"partner": partner, "deferred_dpla_ids": ordered}
-    with tempfile.NamedTemporaryFile(
-        "w",
-        dir=str(path.parent),
-        prefix=".deferred-drain-",
-        suffix=".tmp",
-        delete=False,
-    ) as tf:
-        json.dump(payload, tf, indent=2)
-        tf.write("\n")
-        tempname = tf.name
-    os.replace(tempname, path)
+    # ``delete=False`` so the file survives the ``with`` for the rename —
+    # which means a failure before ``os.replace`` (e.g. disk full mid-dump)
+    # must clean the orphan up itself, or partner dirs would accumulate
+    # ``.deferred-drain-*.tmp`` litter.
+    tempname: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            dir=str(path.parent),
+            prefix=".deferred-drain-",
+            suffix=".tmp",
+            delete=False,
+        ) as tf:
+            tempname = tf.name
+            json.dump(payload, tf, indent=2)
+            tf.write("\n")
+        os.replace(tempname, path)
+    except Exception:
+        if tempname is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(tempname)
+        raise
 
 
 def remove_from_sidecar(partner: str, dpla_ids: list[str]) -> list[str]:

--- a/ingest_wikimedia/drain_sidecar.py
+++ b/ingest_wikimedia/drain_sidecar.py
@@ -110,6 +110,24 @@ def write_sidecar(partner: str, dpla_ids: list[str]) -> None:
     os.replace(tempname, path)
 
 
+def remove_from_sidecar(partner: str, dpla_ids: list[str]) -> list[str]:
+    """Remove ``dpla_ids`` from the sidecar and return the remaining
+    list. IDs not present are ignored; an empty remainder removes the
+    file (via :func:`write_sidecar`'s empty-list handling).
+
+    Used by the drain phase to take a round's worth of IDs out of the
+    queue before re-invoking the uploader on them: the uploader only
+    ever *merges* deferred IDs back in (it never removes completed
+    ones), so the drain must clear the round's IDs itself and let the
+    uploader's ``merge_sidecar`` re-add whichever ones re-deferred.
+    IDs a concurrent session appended mid-round are untouched.
+    """
+    to_remove = set(dpla_ids)
+    remaining = [x for x in read_sidecar(partner) if x not in to_remove]
+    write_sidecar(partner, remaining)
+    return remaining
+
+
 def merge_sidecar(partner: str, new_dpla_ids: list[str]) -> list[str]:
     """Union ``new_dpla_ids`` into the sidecar and return the resulting
     combined list. If the sidecar didn't exist, this is a plain create.

--- a/ingest_wikimedia/dup_throttle.py
+++ b/ingest_wikimedia/dup_throttle.py
@@ -80,7 +80,12 @@ class DuplicateCategoryThrottle:
         # size query) when it hits zero. Starts at 0 so the first grant queries.
         self._headroom = 0
 
-    def _category_size(self) -> int:
+    def category_size(self) -> int:
+        """Current live size of the tracked category — one ``categoryinfo``
+        API query per call (or the injected ``size_fn``). Public so
+        callers outside the throttle (e.g. the drain-deferred phase's
+        start-of-drain notification) can observe the category without
+        reaching into throttle internals."""
         if self._size_fn is not None:
             return self._size_fn()
         info = pywikibot.Category(self._site, self.category).categoryinfo
@@ -108,7 +113,7 @@ class DuplicateCategoryThrottle:
             self._headroom -= 1
             return True
         # Headroom is exhausted (0), so query the live size to decide.
-        size = self._category_size()
+        size = self.category_size()
         if size >= self.threshold:
             return False  # defer; banks no headroom, so the next attempt re-queries
         # Refill headroom, consuming one grant for this tag.
@@ -137,7 +142,7 @@ class DuplicateCategoryThrottle:
         """
         deadline = clock() + max_wait_secs if max_wait_secs is not None else None
         while True:
-            size = self._category_size()
+            size = self.category_size()
             if size < self.resume_below:
                 self._headroom = self._headroom_for(size)
                 return True

--- a/ingest_wikimedia/dup_throttle.py
+++ b/ingest_wikimedia/dup_throttle.py
@@ -34,7 +34,13 @@ import pywikibot
 DEFAULT_THRESHOLD = 1000
 DEFAULT_RESUME_BELOW = 900
 DEFAULT_RECHECK_CAP = 100
-DEFAULT_POLL_SECS = 120
+# Category:Duplicate drains on human-admin timescales — days, not
+# minutes — so polling every 5 minutes is fast enough that we won't sit
+# idle after a batch clears while still being a good API citizen. The
+# category has no user-visible latency requirement here; a session that
+# notices a drop 5 minutes late is indistinguishable from one that
+# notices instantly.
+DEFAULT_POLL_SECS = 300
 DUPLICATE_CATEGORY = "Category:Duplicate"
 
 
@@ -111,27 +117,39 @@ class DuplicateCategoryThrottle:
 
     def wait_for_capacity(
         self,
-        max_wait_secs: float,
+        max_wait_secs: float | None = None,
         *,
         sleep: Callable[[float], None] = time.sleep,
         clock: Callable[[], float] = time.monotonic,
     ) -> bool:
         """Block (polling every ``poll_secs``) until the category is below
-        ``resume_below``, then refill headroom and return ``True``. Return
-        ``False`` if ``max_wait_secs`` elapses first. Used by the drain pass.
+        ``resume_below``, then refill headroom and return ``True``.
+
+        ``max_wait_secs`` bounds the wait; ``None`` disables the timeout so
+        the caller waits indefinitely — appropriate for the drain-deferred
+        loop, which patiently waits out human-admin category-clearing.
+        Returns ``False`` iff a finite ``max_wait_secs`` elapses first.
+
+        The first poll fires immediately (no initial sleep). This matters
+        when a caller re-enters the wait after a subprocess pass: the
+        category may already have room, and sleeping first would waste
+        ``poll_secs`` of latency for no observation.
         """
-        deadline = clock() + max_wait_secs
+        deadline = clock() + max_wait_secs if max_wait_secs is not None else None
         while True:
             size = self._category_size()
             if size < self.resume_below:
                 self._headroom = self._headroom_for(size)
                 return True
-            now = clock()
-            if now >= deadline:
-                return False
-            # Don't oversleep the deadline: a sub-``poll_secs`` budget remaining
-            # should wake for its final check on time, not ~poll_secs late.
-            nap = min(self.poll_secs, deadline - now)
+            if deadline is not None:
+                now = clock()
+                if now >= deadline:
+                    return False
+                # Don't oversleep the deadline: a sub-``poll_secs`` budget remaining
+                # should wake for its final check on time, not ~poll_secs late.
+                nap = min(self.poll_secs, deadline - now)
+            else:
+                nap = self.poll_secs
             logging.info(
                 "Category:Duplicate at %d (>= resume threshold %d); waiting %ds "
                 "before retrying deferred duplicate-tags.",

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -661,17 +661,19 @@ def notify_upload_aborted(
     )
 
 
-def notify_dup_drain_incomplete(partner_label: str, remaining: int) -> None:
-    """Warn #tech-alerts that the dup-category drain pass exited with files
-    still deferred.
+def notify_drain_phase_start(
+    partner_label: str, deferred_count: int, category_size: int
+) -> None:
+    """Ping #tech-alerts that a session has entered the deferred-drain
+    phase — the uploader has finished processing every non-deferred
+    item, sdc-sync has (or is about to) run on those, and the session
+    is now patiently waiting for Category:Duplicate to fall below the
+    resume threshold so it can finish the deferred items.
 
-    The uploader defers ``{{duplicate}}``-tagging uploads while
-    Category:Duplicate is at capacity, then returns to them in a drain pass.
-    If that pass times out (the category stays full past the drain budget) or
-    makes no progress after capacity returns, the remaining files are left
-    un-uploaded and un-tagged — they need operator attention before a re-run
-    will finish them. This is the only path that leaves intended work undone,
-    so it warrants an explicit operator ping rather than a buried log line.
+    Emitted at drain-phase start so the operator knows the session is
+    in this state (rather than hung or making per-item progress). The
+    tmux session stays alive during the wait; kill via the existing
+    Slack kill-session command if you need to abandon.
     """
     token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
     if not token:
@@ -681,14 +683,43 @@ def notify_dup_drain_incomplete(partner_label: str, remaining: int) -> None:
         f"wikimedia-{os.environ.get('WIKIMEDIA_SESSION_LABEL') or partner_label}"
     )
     msg = (
-        f"⚠️ `{effective_label}`: {remaining:,} file(s) left deferred — "
-        "the duplicate-category drain pass exited before they could be retried, "
-        "so their uploads + `{{duplicate}}` tags were skipped. Clear "
-        "Category:Duplicate if needed, then re-run the partner to finish them."
+        f"⏳ `{effective_label}`: entering deferred-drain phase — "
+        f"{deferred_count:,} item(s) waiting for Category:Duplicate to "
+        f"drain (currently at {category_size:,}). No worker slots held; "
+        f"other partner sessions unaffected."
     )
     try:
         post_message(token, msg)
     except Exception:
         logging.warning(
-            "Failed to post dup-drain-incomplete notification to Slack", exc_info=True
+            "Failed to post drain-phase-start notification to Slack", exc_info=True
+        )
+
+
+def notify_drain_phase_complete(
+    partner_label: str, elapsed_seconds: float, emitted_count: int
+) -> None:
+    """Ping #tech-alerts that the deferred-drain phase drained cleanly —
+    every deferred upload + ``{{duplicate}}`` tag has landed. Emitted at
+    the drain phase's normal exit; a killed / aborted drain leaves the
+    sidecar in place for a future session to resume from.
+    """
+    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
+    if not token:
+        logging.warning("DPLA_SLACK_BOT_TOKEN not set — skipping Slack notification")
+        return
+    effective_label = (
+        f"wikimedia-{os.environ.get('WIKIMEDIA_SESSION_LABEL') or partner_label}"
+    )
+    runtime = _format_runtime(elapsed_seconds)
+    msg = (
+        f"✅ `{effective_label}`: deferred-drain phase complete — "
+        f"{emitted_count:,} item(s) emitted their upload + "
+        f"`{{{{duplicate}}}}` tag over {runtime}."
+    )
+    try:
+        post_message(token, msg)
+    except Exception:
+        logging.warning(
+            "Failed to post drain-phase-complete notification to Slack", exc_info=True
         )

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -161,6 +161,7 @@ _PHASE_LOG_SUFFIX: dict[str, str] = {
     "download": "download",
     "upload": "upload",
     "sdc-sync": "sdc",
+    "drain-deferred": "drain-deferred",
 }
 
 # Per-session-label path the launcher tees ``get-ids-es`` stderr to.
@@ -234,7 +235,8 @@ def notify_pipeline_fail() -> None:
       WIKIMEDIA_SESSION_LABEL  — identifies the target in the message
       WIKIMEDIA_STEP           — name of the pipeline step that was running
                                  when the chain broke (``id-generation``,
-                                 ``download``, ``upload``, ``sdc-sync``).
+                                 ``download``, ``upload``, ``sdc-sync``,
+                                 ``drain-deferred``).
                                  Empty / unset → "pipeline step" generic
                                  wording. Set by the launcher's per-step
                                  ``export`` so the latest assignment before
@@ -675,7 +677,7 @@ def notify_drain_phase_start(
     tmux session stays alive during the wait; kill via the existing
     Slack kill-session command if you need to abandon.
     """
-    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
+    token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
     if not token:
         logging.warning("DPLA_SLACK_BOT_TOKEN not set — skipping Slack notification")
         return
@@ -704,7 +706,7 @@ def notify_drain_phase_complete(
     the drain phase's normal exit; a killed / aborted drain leaves the
     sidecar in place for a future session to resume from.
     """
-    token = os.environ.get("DPLA_SLACK_BOT_TOKEN")
+    token = (os.environ.get("DPLA_SLACK_BOT_TOKEN") or "").strip()
     if not token:
         logging.warning("DPLA_SLACK_BOT_TOKEN not set — skipping Slack notification")
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,4 +55,5 @@ resolve-dpla-ids = "tools.resolve_dpla_ids:main"
 fix-unknown-categories = "tools.fix_unknown_categories:main"
 get-ids-retry = "tools.get_ids_retry:main"
 sdc-sync = "tools.sdc_sync:main"
+drain-deferred = "tools.drain_deferred:main"
 

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -1326,6 +1326,11 @@ def main() -> None:
                 pipeline_steps.append(
                     f"sdc-sync --partner {canonical} --ids-file {csv_file}{sdc_opts}"
                 )
+                # Drain any Case-2 hash-drift uploads the uploader deferred
+                # because Category:Duplicate was at capacity. No-op when
+                # nothing deferred (the common case); patient loop when
+                # non-empty. See tools/drain_deferred.py for the design.
+                pipeline_steps.append(f"drain-deferred {canonical}")
         # Wrap each step with an ``export WIKIMEDIA_STEP=<name>`` prefix so
         # the per-target failure handler (``notify_pipeline_fail``) can name
         # the failing phase in Slack instead of just reporting an exit code.

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -138,6 +138,7 @@ _STEP_BY_FIRST_TOKEN: dict[str, str] = {
     "downloader": "download",
     "uploader": "upload",
     "sdc-sync": "sdc-sync",
+    "drain-deferred": "drain-deferred",
 }
 
 

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 from unittest.mock import MagicMock, patch
 
@@ -34,6 +35,22 @@ def stub_setup_logging(monkeypatch):
     monkeypatch.setattr(drain_deferred, "setup_logging", lambda *a, **kw: None)
 
 
+@pytest.fixture
+def lock_fd():
+    """A real (closable) file descriptor for stubbing
+    ``_acquire_host_lock`` — ``main()`` closes the lock fd in its
+    ``finally`` via ``os.close()``, so a MagicMock won't do. The
+    fixture guarantees cleanup itself in case a test bails before
+    ``main()`` gets to close it (suppressing the EBADF from the
+    already-closed happy path)."""
+    fd = os.open(os.devnull, os.O_RDONLY)
+    try:
+        yield fd
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+
+
 def test_empty_sidecar_early_exits_without_starting_the_loop(monkeypatch):
     """The common case: no items deferred. Command must exit without
     acquiring the host lock, without polling the category, and
@@ -55,7 +72,7 @@ def test_empty_sidecar_early_exits_without_starting_the_loop(monkeypatch):
     done_ping.assert_not_called()
 
 
-def test_populated_sidecar_runs_drain_loop_until_empty(monkeypatch):
+def test_populated_sidecar_runs_drain_loop_until_empty(monkeypatch, lock_fd):
     """Non-empty sidecar: acquire host lock, poll category, run
     uploader + sdc-sync subprocesses, and loop until the sidecar is
     empty. The drain itself removes the round's IDs from the sidecar
@@ -64,10 +81,6 @@ def test_populated_sidecar_runs_drain_loop_until_empty(monkeypatch):
     as the real uploader would be when every item completes.
     """
     drain_sidecar.write_sidecar("nara", ["id-1"])
-
-    # main() closes the lock fd in its ``finally`` via os.close(), so
-    # the stub must be a real (closable) file descriptor.
-    lock_fd = os.open(os.devnull, os.O_RDONLY)
 
     def fake_wait(*a, **kw):
         return True  # capacity immediately available
@@ -110,16 +123,13 @@ def test_populated_sidecar_runs_drain_loop_until_empty(monkeypatch):
     done_ping.assert_called_once()
 
 
-def test_drain_loop_re_reads_sidecar_between_rounds():
+def test_drain_loop_re_reads_sidecar_between_rounds(lock_fd):
     """If a round processes N items but a later round finds new items
     in the sidecar (e.g., a concurrent uploader session appended
     while we were mid-round), the loop picks them up rather than
     exiting on the pre-round snapshot.
     """
     drain_sidecar.write_sidecar("nara", ["id-1"])
-    # main() closes the lock fd in its ``finally`` via os.close(), so
-    # the stub must be a real (closable) file descriptor.
-    lock_fd = os.open(os.devnull, os.O_RDONLY)
 
     throttle = MagicMock()
     throttle.wait_for_capacity.return_value = True
@@ -158,15 +168,12 @@ def test_drain_loop_re_reads_sidecar_between_rounds():
     assert sp.call_count == 4
 
 
-def test_drain_loop_continues_on_no_progress_round():
+def test_drain_loop_continues_on_no_progress_round(lock_fd):
     """A round that made no progress despite reported capacity (e.g.
     category refilled while we were mid-round) is not fatal — the
     loop continues waiting rather than aborting.
     """
     drain_sidecar.write_sidecar("nara", ["id-1"])
-    # main() closes the lock fd in its ``finally`` via os.close(), so
-    # the stub must be a real (closable) file descriptor.
-    lock_fd = os.open(os.devnull, os.O_RDONLY)
 
     throttle = MagicMock()
     throttle.wait_for_capacity.return_value = True
@@ -203,7 +210,7 @@ def test_drain_loop_continues_on_no_progress_round():
     assert call_state["round"] == 2
 
 
-def test_drain_removes_round_ids_from_sidecar_before_invoking_uploader():
+def test_drain_removes_round_ids_from_sidecar_before_invoking_uploader(lock_fd):
     """The drain — not the uploader — must clear the round's IDs from
     the sidecar before the subprocess pass. The uploader only ever
     *merges* deferred IDs back in (it never removes completed ones), so
@@ -212,9 +219,6 @@ def test_drain_removes_round_ids_from_sidecar_before_invoking_uploader():
     ordering by observing the sidecar from inside the uploader
     subprocess: the round's IDs must already be gone."""
     drain_sidecar.write_sidecar("nara", ["id-1", "id-2"])
-    # main() closes the lock fd in its ``finally`` via os.close(), so
-    # the stub must be a real (closable) file descriptor.
-    lock_fd = os.open(os.devnull, os.O_RDONLY)
 
     throttle = MagicMock()
     throttle.wait_for_capacity.return_value = True

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -1,0 +1,196 @@
+"""Tests for the ``drain-deferred`` command (``tools.drain_deferred``)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ingest_wikimedia import drain_sidecar
+from tools import drain_deferred
+
+
+@pytest.fixture(autouse=True)
+def chdir_tmp(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def stub_host_lock(monkeypatch, tmp_path):
+    """Redirect the host-level lock file into ``tmp_path`` so tests
+    don't clobber (or block on) the real ``/home/ec2-user/...`` lock."""
+    monkeypatch.setattr(
+        drain_deferred, "_DRAIN_LOCK_PATH", str(tmp_path / ".drain-lock")
+    )
+
+
+@pytest.fixture(autouse=True)
+def stub_setup_logging(monkeypatch):
+    """The real setup_logging writes to <partner>/logs/... and expects
+    a partner dir; tests just need it to be a no-op."""
+    monkeypatch.setattr(drain_deferred, "setup_logging", lambda *a, **kw: None)
+
+
+def test_empty_sidecar_early_exits_without_starting_the_loop(monkeypatch):
+    """The common case: no items deferred. Command must exit without
+    acquiring the host lock, without polling the category, and
+    without invoking uploader/sdc-sync subprocesses."""
+    lock_mock = MagicMock()
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", lock_mock),
+        patch("tools.drain_deferred.subprocess.run") as subproc,
+        patch("tools.drain_deferred.DuplicateCategoryThrottle") as throttle_ctor,
+        patch("tools.drain_deferred.notify_drain_phase_start") as start_ping,
+        patch("tools.drain_deferred.notify_drain_phase_complete") as done_ping,
+    ):
+        result = CliRunner().invoke(drain_deferred.main, ["nara"])
+    assert result.exit_code == 0, result.output
+    lock_mock.assert_not_called()
+    subproc.assert_not_called()
+    throttle_ctor.assert_not_called()
+    start_ping.assert_not_called()
+    done_ping.assert_not_called()
+
+
+def test_populated_sidecar_runs_drain_loop_until_empty(monkeypatch):
+    """Non-empty sidecar: acquire host lock, poll category, run
+    uploader + sdc-sync subprocesses, and loop until the sidecar is
+    empty. The subprocess side-effect removes the ID from the sidecar
+    (as the real uploader would after a successful re-run).
+    """
+    drain_sidecar.write_sidecar("nara", ["id-1"])
+
+    lock_fd = MagicMock()
+
+    def fake_wait(*a, **kw):
+        return True  # capacity immediately available
+
+    throttle = MagicMock()
+    throttle.wait_for_capacity.side_effect = fake_wait
+    throttle.resume_below = 900
+    throttle.poll_secs = 300
+    throttle._category_size.return_value = 850
+
+    def fake_subprocess_run(argv, **kwargs):
+        # After the first (uploader) subprocess, the deferred item is
+        # "processed". Empty the sidecar so the loop exits after this
+        # round.
+        if argv[0] == "uploader":
+            drain_sidecar.write_sidecar("nara", [])
+        return MagicMock(returncode=0)
+
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", return_value=lock_fd),
+        patch(
+            "tools.drain_deferred.subprocess.run", side_effect=fake_subprocess_run
+        ) as sp,
+        patch(
+            "tools.drain_deferred.DuplicateCategoryThrottle",
+            return_value=throttle,
+        ),
+        patch("tools.drain_deferred.notify_drain_phase_start") as start_ping,
+        patch("tools.drain_deferred.notify_drain_phase_complete") as done_ping,
+    ):
+        result = CliRunner().invoke(drain_deferred.main, ["nara"])
+    assert result.exit_code == 0, result.output
+    # Two subprocess calls per round: uploader + sdc-sync.
+    assert sp.call_count == 2
+    assert sp.call_args_list[0].args[0][0] == "uploader"
+    assert sp.call_args_list[1].args[0][0] == "sdc-sync"
+    # Drain phase pings.
+    start_ping.assert_called_once()
+    args, _ = start_ping.call_args
+    assert args[0] == "nara"
+    assert args[1] == 1  # deferred_count
+    assert args[2] == 850  # category_size
+    done_ping.assert_called_once()
+
+
+def test_drain_loop_re_reads_sidecar_between_rounds():
+    """If a round processes N items but a later round finds new items
+    in the sidecar (e.g., a concurrent uploader session appended
+    while we were mid-round), the loop picks them up rather than
+    exiting on the pre-round snapshot.
+    """
+    drain_sidecar.write_sidecar("nara", ["id-1"])
+    lock_fd = MagicMock()
+
+    throttle = MagicMock()
+    throttle.wait_for_capacity.return_value = True
+    throttle.resume_below = 900
+    throttle.poll_secs = 300
+    throttle._category_size.return_value = 850
+
+    call_state = {"round": 0}
+
+    def fake_subprocess_run(argv, **kwargs):
+        if argv[0] == "uploader":
+            call_state["round"] += 1
+            if call_state["round"] == 1:
+                # First round clears id-1 but appends id-2 (concurrent).
+                drain_sidecar.write_sidecar("nara", ["id-2"])
+            else:
+                drain_sidecar.write_sidecar("nara", [])
+        return MagicMock(returncode=0)
+
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", return_value=lock_fd),
+        patch(
+            "tools.drain_deferred.subprocess.run", side_effect=fake_subprocess_run
+        ) as sp,
+        patch(
+            "tools.drain_deferred.DuplicateCategoryThrottle",
+            return_value=throttle,
+        ),
+        patch("tools.drain_deferred.notify_drain_phase_start"),
+        patch("tools.drain_deferred.notify_drain_phase_complete"),
+    ):
+        result = CliRunner().invoke(drain_deferred.main, ["nara"])
+    assert result.exit_code == 0, result.output
+    # Two rounds → 4 subprocess calls (2× uploader + 2× sdc-sync).
+    assert sp.call_count == 4
+
+
+def test_drain_loop_continues_on_no_progress_round():
+    """A round that made no progress despite reported capacity (e.g.
+    category refilled while we were mid-round) is not fatal — the
+    loop continues waiting rather than aborting.
+    """
+    drain_sidecar.write_sidecar("nara", ["id-1"])
+    lock_fd = MagicMock()
+
+    throttle = MagicMock()
+    throttle.wait_for_capacity.return_value = True
+    throttle.resume_below = 900
+    throttle.poll_secs = 300
+    throttle._category_size.return_value = 850
+
+    call_state = {"round": 0}
+
+    def fake_subprocess_run(argv, **kwargs):
+        if argv[0] == "uploader":
+            call_state["round"] += 1
+            if call_state["round"] < 2:
+                # Round 1: no progress (id-1 still in sidecar).
+                return MagicMock(returncode=0)
+            # Round 2: cleared.
+            drain_sidecar.write_sidecar("nara", [])
+        return MagicMock(returncode=0)
+
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", return_value=lock_fd),
+        patch("tools.drain_deferred.subprocess.run", side_effect=fake_subprocess_run),
+        patch(
+            "tools.drain_deferred.DuplicateCategoryThrottle",
+            return_value=throttle,
+        ),
+        patch("tools.drain_deferred.notify_drain_phase_start"),
+        patch("tools.drain_deferred.notify_drain_phase_complete") as done_ping,
+    ):
+        result = CliRunner().invoke(drain_deferred.main, ["nara"])
+    assert result.exit_code == 0, result.output
+    done_ping.assert_called_once()
+    # Two rounds ran (no-progress round did NOT abort).
+    assert call_state["round"] == 2

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -57,12 +58,16 @@ def test_empty_sidecar_early_exits_without_starting_the_loop(monkeypatch):
 def test_populated_sidecar_runs_drain_loop_until_empty(monkeypatch):
     """Non-empty sidecar: acquire host lock, poll category, run
     uploader + sdc-sync subprocesses, and loop until the sidecar is
-    empty. The subprocess side-effect removes the ID from the sidecar
-    (as the real uploader would after a successful re-run).
+    empty. The drain itself removes the round's IDs from the sidecar
+    before invoking the subprocesses; a successful re-run (nothing
+    re-deferred) leaves it empty, so the fake uploader is a no-op —
+    as the real uploader would be when every item completes.
     """
     drain_sidecar.write_sidecar("nara", ["id-1"])
 
-    lock_fd = MagicMock()
+    # main() closes the lock fd in its ``finally`` via os.close(), so
+    # the stub must be a real (closable) file descriptor.
+    lock_fd = os.open(os.devnull, os.O_RDONLY)
 
     def fake_wait(*a, **kw):
         return True  # capacity immediately available
@@ -71,14 +76,11 @@ def test_populated_sidecar_runs_drain_loop_until_empty(monkeypatch):
     throttle.wait_for_capacity.side_effect = fake_wait
     throttle.resume_below = 900
     throttle.poll_secs = 300
-    throttle._category_size.return_value = 850
+    throttle.category_size.return_value = 850
 
     def fake_subprocess_run(argv, **kwargs):
-        # After the first (uploader) subprocess, the deferred item is
-        # "processed". Empty the sidecar so the loop exits after this
-        # round.
-        if argv[0] == "uploader":
-            drain_sidecar.write_sidecar("nara", [])
+        # Every item completes: the real uploader would touch the
+        # sidecar only to merge re-deferrals back in, so do nothing.
         return MagicMock(returncode=0)
 
     with (
@@ -115,13 +117,15 @@ def test_drain_loop_re_reads_sidecar_between_rounds():
     exiting on the pre-round snapshot.
     """
     drain_sidecar.write_sidecar("nara", ["id-1"])
-    lock_fd = MagicMock()
+    # main() closes the lock fd in its ``finally`` via os.close(), so
+    # the stub must be a real (closable) file descriptor.
+    lock_fd = os.open(os.devnull, os.O_RDONLY)
 
     throttle = MagicMock()
     throttle.wait_for_capacity.return_value = True
     throttle.resume_below = 900
     throttle.poll_secs = 300
-    throttle._category_size.return_value = 850
+    throttle.category_size.return_value = 850
 
     call_state = {"round": 0}
 
@@ -129,10 +133,11 @@ def test_drain_loop_re_reads_sidecar_between_rounds():
         if argv[0] == "uploader":
             call_state["round"] += 1
             if call_state["round"] == 1:
-                # First round clears id-1 but appends id-2 (concurrent).
-                drain_sidecar.write_sidecar("nara", ["id-2"])
-            else:
-                drain_sidecar.write_sidecar("nara", [])
+                # Round 1: id-1 completes (the drain already removed it
+                # from the sidecar); a concurrent uploader session
+                # appends id-2 while we're mid-round.
+                drain_sidecar.merge_sidecar("nara", ["id-2"])
+            # Round 2: id-2 completes — nothing merged back.
         return MagicMock(returncode=0)
 
     with (
@@ -159,13 +164,15 @@ def test_drain_loop_continues_on_no_progress_round():
     loop continues waiting rather than aborting.
     """
     drain_sidecar.write_sidecar("nara", ["id-1"])
-    lock_fd = MagicMock()
+    # main() closes the lock fd in its ``finally`` via os.close(), so
+    # the stub must be a real (closable) file descriptor.
+    lock_fd = os.open(os.devnull, os.O_RDONLY)
 
     throttle = MagicMock()
     throttle.wait_for_capacity.return_value = True
     throttle.resume_below = 900
     throttle.poll_secs = 300
-    throttle._category_size.return_value = 850
+    throttle.category_size.return_value = 850
 
     call_state = {"round": 0}
 
@@ -173,10 +180,10 @@ def test_drain_loop_continues_on_no_progress_round():
         if argv[0] == "uploader":
             call_state["round"] += 1
             if call_state["round"] < 2:
-                # Round 1: no progress (id-1 still in sidecar).
-                return MagicMock(returncode=0)
-            # Round 2: cleared.
-            drain_sidecar.write_sidecar("nara", [])
+                # Round 1: no progress — the uploader re-defers id-1,
+                # merging it back into the sidecar the drain cleared.
+                drain_sidecar.merge_sidecar("nara", ["id-1"])
+            # Round 2: id-1 completes — nothing merged back.
         return MagicMock(returncode=0)
 
     with (
@@ -194,3 +201,47 @@ def test_drain_loop_continues_on_no_progress_round():
     done_ping.assert_called_once()
     # Two rounds ran (no-progress round did NOT abort).
     assert call_state["round"] == 2
+
+
+def test_drain_removes_round_ids_from_sidecar_before_invoking_uploader():
+    """The drain — not the uploader — must clear the round's IDs from
+    the sidecar before the subprocess pass. The uploader only ever
+    *merges* deferred IDs back in (it never removes completed ones), so
+    if the drain left the round's IDs in place, completed items would
+    replay every round and the loop would never terminate. Pin the
+    ordering by observing the sidecar from inside the uploader
+    subprocess: the round's IDs must already be gone."""
+    drain_sidecar.write_sidecar("nara", ["id-1", "id-2"])
+    # main() closes the lock fd in its ``finally`` via os.close(), so
+    # the stub must be a real (closable) file descriptor.
+    lock_fd = os.open(os.devnull, os.O_RDONLY)
+
+    throttle = MagicMock()
+    throttle.wait_for_capacity.return_value = True
+    throttle.resume_below = 900
+    throttle.poll_secs = 300
+    throttle.category_size.return_value = 850
+
+    seen_by_uploader: list[list[str]] = []
+
+    def fake_subprocess_run(argv, **kwargs):
+        if argv[0] == "uploader":
+            seen_by_uploader.append(drain_sidecar.read_sidecar("nara"))
+        return MagicMock(returncode=0)
+
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", return_value=lock_fd),
+        patch("tools.drain_deferred.subprocess.run", side_effect=fake_subprocess_run),
+        patch(
+            "tools.drain_deferred.DuplicateCategoryThrottle",
+            return_value=throttle,
+        ),
+        patch("tools.drain_deferred.notify_drain_phase_start"),
+        patch("tools.drain_deferred.notify_drain_phase_complete"),
+    ):
+        result = CliRunner().invoke(drain_deferred.main, ["nara"])
+    assert result.exit_code == 0, result.output
+    # Exactly one round ran, and the uploader saw an already-cleared
+    # sidecar — with a merge-only uploader this is what lets completed
+    # items leave the queue.
+    assert seen_by_uploader == [[]]

--- a/tests/test_drain_sidecar.py
+++ b/tests/test_drain_sidecar.py
@@ -137,6 +137,25 @@ def test_no_stray_tempfiles_after_successful_writes(tmp_path):
     assert drain_sidecar.sidecar_path("nara").exists()
 
 
+def test_failed_write_cleans_up_its_tempfile(tmp_path, monkeypatch):
+    """A write that dies before the atomic rename (e.g. disk full
+    mid-``json.dump``) must remove its own ``.deferred-drain-*.tmp``
+    orphan and leave the previous sidecar contents untouched."""
+    drain_sidecar.write_sidecar("nara", ["keep-me"])
+
+    def boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    with monkeypatch.context() as m:
+        m.setattr(drain_sidecar.json, "dump", boom)
+        with pytest.raises(OSError, match="disk full"):
+            drain_sidecar.write_sidecar("nara", ["new-id"])
+
+    tempfiles = list((tmp_path / "nara").glob(".deferred-drain-*"))
+    assert tempfiles == [], f"orphaned tempfiles: {tempfiles}"
+    assert drain_sidecar.read_sidecar("nara") == ["keep-me"]
+
+
 def test_read_ignores_non_string_entries():
     """A hand-edited sidecar with garbage in the list still reads
     cleanly — the drain loop should ignore junk rather than crash."""

--- a/tests/test_drain_sidecar.py
+++ b/tests/test_drain_sidecar.py
@@ -70,6 +70,33 @@ def test_merge_sidecar_creates_when_missing():
     assert drain_sidecar.read_sidecar("nara") == ["a", "b"]
 
 
+def test_remove_from_sidecar_drops_only_the_given_ids():
+    drain_sidecar.write_sidecar("nara", ["a", "b", "c", "d"])
+    remaining = drain_sidecar.remove_from_sidecar("nara", ["b", "d"])
+    assert remaining == ["a", "c"]
+    assert drain_sidecar.read_sidecar("nara") == ["a", "c"]
+
+
+def test_remove_from_sidecar_ignores_absent_ids():
+    drain_sidecar.write_sidecar("nara", ["a"])
+    remaining = drain_sidecar.remove_from_sidecar("nara", ["never-queued", "a"])
+    assert remaining == []
+
+
+def test_remove_from_sidecar_empty_remainder_deletes_the_file():
+    """Removing the last IDs leaves the unambiguous empty state
+    (missing file), same as ``write_sidecar([])``."""
+    drain_sidecar.write_sidecar("nara", ["a", "b"])
+    remaining = drain_sidecar.remove_from_sidecar("nara", ["a", "b"])
+    assert remaining == []
+    assert not drain_sidecar.sidecar_path("nara").exists()
+
+
+def test_remove_from_sidecar_on_missing_file_is_a_noop():
+    assert drain_sidecar.remove_from_sidecar("nara", ["a"]) == []
+    assert not drain_sidecar.sidecar_path("nara").exists()
+
+
 def test_read_tolerates_unparseable_file():
     """A file present but corrupted (mid-write crash, hand-edit,
     disk error) is treated the same as missing — the drain loop

--- a/tests/test_drain_sidecar.py
+++ b/tests/test_drain_sidecar.py
@@ -1,0 +1,139 @@
+"""Tests for the deferred-drain sidecar (``ingest_wikimedia.drain_sidecar``)."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from ingest_wikimedia import drain_sidecar
+
+
+@pytest.fixture(autouse=True)
+def chdir_tmp(tmp_path, monkeypatch):
+    """Every test runs in an isolated tmp directory so the sidecar
+    path (``<partner>/deferred-drain.json``) doesn't collide with any
+    real partner tree or between tests."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_read_sidecar_missing_returns_empty_list():
+    assert drain_sidecar.read_sidecar("nara") == []
+
+
+def test_write_then_read_roundtrip():
+    drain_sidecar.write_sidecar("nara", ["abc", "def"])
+    assert drain_sidecar.read_sidecar("nara") == ["abc", "def"]
+
+
+def test_write_empty_deletes_the_file():
+    drain_sidecar.write_sidecar("nara", ["abc"])
+    assert drain_sidecar.sidecar_path("nara").exists()
+    drain_sidecar.write_sidecar("nara", [])
+    assert not drain_sidecar.sidecar_path("nara").exists()
+    # Missing == empty for reader.
+    assert drain_sidecar.read_sidecar("nara") == []
+
+
+def test_write_dedupes_within_the_input():
+    drain_sidecar.write_sidecar("nara", ["abc", "def", "abc", "ghi", "def"])
+    assert drain_sidecar.read_sidecar("nara") == ["abc", "def", "ghi"]
+
+
+def test_write_is_atomic(tmp_path):
+    """The temp-file+rename shape shouldn't leave a truncated file
+    observable at the final path. Sanity check by seeing that a
+    partially-written file at the temp name (from a hypothetical
+    crash) doesn't affect a subsequent successful write."""
+    partner_dir = tmp_path / "nara"
+    partner_dir.mkdir()
+    # Simulate crash residue: a stray tempfile that was never renamed.
+    (partner_dir / ".deferred-drain-crashed.tmp").write_text("{ broken")
+    drain_sidecar.write_sidecar("nara", ["abc"])
+    assert drain_sidecar.read_sidecar("nara") == ["abc"]
+
+
+def test_merge_sidecar_appends_new_ids_preserving_order():
+    drain_sidecar.write_sidecar("nara", ["a", "b"])
+    combined = drain_sidecar.merge_sidecar("nara", ["c", "b", "d"])
+    # Existing preserved in original order; new entries appended in input
+    # order; dupes suppressed.
+    assert combined == ["a", "b", "c", "d"]
+    assert drain_sidecar.read_sidecar("nara") == ["a", "b", "c", "d"]
+
+
+def test_merge_sidecar_creates_when_missing():
+    combined = drain_sidecar.merge_sidecar("nara", ["a", "b"])
+    assert combined == ["a", "b"]
+    assert drain_sidecar.read_sidecar("nara") == ["a", "b"]
+
+
+def test_read_tolerates_unparseable_file():
+    """A file present but corrupted (mid-write crash, hand-edit,
+    disk error) is treated the same as missing — the drain loop
+    should stay resilient rather than crash on a bad sidecar."""
+    path = drain_sidecar.sidecar_path("nara")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{ this is not json")
+    assert drain_sidecar.read_sidecar("nara") == []
+
+
+def test_read_tolerates_wrong_shape():
+    """A JSON file whose payload doesn't have the expected shape
+    returns [] — same as unparseable."""
+    path = drain_sidecar.sidecar_path("nara")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"partner": "nara", "wrong_key": ["a"]}))
+    assert drain_sidecar.read_sidecar("nara") == []
+
+
+def test_sidecar_payload_is_stable_shape():
+    """Pin the on-disk format so a future refactor can't silently
+    rename ``deferred_dpla_ids`` and cause every existing sidecar in
+    production to be treated as empty on read."""
+    drain_sidecar.write_sidecar("nara", ["abc"])
+    with open(drain_sidecar.sidecar_path("nara")) as f:
+        data = json.load(f)
+    assert data == {"partner": "nara", "deferred_dpla_ids": ["abc"]}
+
+
+def test_no_stray_tempfiles_after_successful_writes(tmp_path):
+    """Belt: repeat writes shouldn't accumulate ``.deferred-drain-*``
+    tempfiles in the partner dir."""
+    for i in range(5):
+        drain_sidecar.write_sidecar("nara", [f"id-{i}"])
+    tempfiles = list((tmp_path / "nara").glob(".deferred-drain-*"))
+    assert tempfiles == [], f"stray tempfiles: {tempfiles}"
+    # Sanity: the intended file exists.
+    assert drain_sidecar.sidecar_path("nara").exists()
+
+
+def test_read_ignores_non_string_entries():
+    """A hand-edited sidecar with garbage in the list still reads
+    cleanly — the drain loop should ignore junk rather than crash."""
+    path = drain_sidecar.sidecar_path("nara")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"partner": "nara", "deferred_dpla_ids": ["good", 42, None, "also-good"]}
+        )
+    )
+    assert drain_sidecar.read_sidecar("nara") == ["good", "also-good"]
+
+
+def test_sidecar_path_is_partner_scoped():
+    """One sidecar per partner. Partner slug lands as the parent dir."""
+    p = drain_sidecar.sidecar_path("nara")
+    assert p.name == "deferred-drain.json"
+    assert p.parent.name == "nara"
+
+
+def test_write_creates_partner_directory_if_missing():
+    """A drain phase that starts before any partner-dir files exist
+    still gets a working sidecar."""
+    assert not os.path.isdir("nara")
+    drain_sidecar.write_sidecar("nara", ["abc"])
+    assert os.path.isdir("nara")
+    assert drain_sidecar.read_sidecar("nara") == ["abc"]

--- a/tests/test_dup_throttle.py
+++ b/tests/test_dup_throttle.py
@@ -107,6 +107,28 @@ def test_wait_for_capacity_times_out():
     assert slept == []  # deadline hit before any sleep
 
 
+def test_wait_for_capacity_unbounded_never_times_out():
+    """``max_wait_secs=None`` disables the deadline — appropriate for
+    the drain-deferred loop, which waits patiently on human-admin
+    category clearing. Category stays full for many polls, then drains;
+    the wait returns True whenever the category actually falls."""
+    sizes = _Sizes(1000, 1000, 1000, 1000, 880)
+    t = DuplicateCategoryThrottle(
+        threshold=1000, resume_below=900, poll_secs=60, size_fn=sizes
+    )
+    slept: list[float] = []
+    # Clock never advances past any deadline because there is no
+    # deadline; the loop is size-driven, not time-driven.
+    drained = t.wait_for_capacity(
+        max_wait_secs=None,
+        sleep=lambda s: slept.append(s),
+        clock=lambda: 0,
+    )
+    assert drained is True
+    # 4 polls at 1000, 1 poll at 880: 4 sleeps of the full poll interval.
+    assert slept == [60, 60, 60, 60]
+
+
 def test_resume_below_must_not_exceed_threshold():
     try:
         DuplicateCategoryThrottle(threshold=1000, resume_below=1001)

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -19,7 +19,6 @@ from tools.uploader import (
     NewFilePageBlocked,
     Uploader,
     _CSRF_TOKEN_ERROR_MARKER,
-    _drain_deferred_dups,
     _is_csrf_token_error,
     _post_item_orphan_check,
     _post_upload_touch_new_institutions,
@@ -970,77 +969,6 @@ def test_chunk_size_file_exists_small_returns_direct():
         force_ignore_warnings=False,
         file_size_bytes=10 * 1024 * 1024,
     ) == (0, True)
-
-
-# --------------------------------------------------------------------------
-# _drain_deferred_dups — the post-upload pass that re-runs items whose
-# {{duplicate}}-tagging upload was deferred while Category:Duplicate was full.
-# --------------------------------------------------------------------------
-
-
-def _drain_args(process_item_side_effect):
-    """Build the (uploader, throttle, slot_budget) mocks _drain_deferred_dups
-    needs. ``process_item`` returns the count of ordinals still deferred for
-    that item (0 = item fully cleared)."""
-    uploader = MagicMock()
-    uploader.process_item.side_effect = process_item_side_effect
-    throttle = MagicMock()
-    # A no-op slot context manager — slot accounting isn't under test here.
-    return uploader, throttle, _DISABLED_BUDGET
-
-
-def test_drain_retries_until_all_emitted():
-    # "a" clears on round 1; "b" stays deferred through round 1 and clears on
-    # round 2. Call order: a→0 cleared, b→1 deferred, (round 2) b→0 cleared.
-    uploader, throttle, budget = _drain_args([0, 1, 0])
-    throttle.wait_for_capacity.return_value = True
-    remaining = _drain_deferred_dups(
-        uploader, throttle, {"a": 1, "b": 1}, {}, "partner", False, False, budget
-    )
-    assert remaining == {}
-    assert throttle.wait_for_capacity.call_count == 2
-    assert uploader.process_item.call_count == 3
-
-
-def test_drain_counts_partial_ordinal_progress_as_progress():
-    # A single multi-page item with 3 deferred ordinals clears 2 on round 1
-    # (3→1) and the last on round 2. Per-item counting would see "still 1 item
-    # deferred" and falsely abort; per-ordinal counting sees real progress.
-    uploader, throttle, budget = _drain_args([1, 0])
-    throttle.wait_for_capacity.return_value = True
-    with patch("tools.uploader.notify_dup_drain_incomplete") as notify:
-        remaining = _drain_deferred_dups(
-            uploader, throttle, {"a": 3}, {}, "partner", False, False, budget
-        )
-    assert remaining == {}
-    assert uploader.process_item.call_count == 2
-    notify.assert_not_called()
-
-
-def test_drain_times_out_and_notifies():
-    uploader, throttle, budget = _drain_args([])  # never reached
-    throttle.wait_for_capacity.return_value = False  # category never drains
-    with patch("tools.uploader.notify_dup_drain_incomplete") as notify:
-        remaining = _drain_deferred_dups(
-            uploader, throttle, {"a": 1, "b": 2}, {}, "partner", False, False, budget
-        )
-    assert remaining == {"a": 1, "b": 2}
-    uploader.process_item.assert_not_called()
-    notify.assert_called_once_with("partner", 3)  # total deferred ordinals
-
-
-def test_drain_bails_when_no_progress():
-    # Capacity is available but the re-run clears no ordinals (category refilling
-    # as fast as we drain): bail rather than spin a hot loop.
-    uploader, throttle, budget = _drain_args([1, 1])
-    throttle.wait_for_capacity.return_value = True
-    with patch("tools.uploader.notify_dup_drain_incomplete") as notify:
-        remaining = _drain_deferred_dups(
-            uploader, throttle, {"a": 1, "b": 1}, {}, "partner", False, False, budget
-        )
-    assert remaining == {"a": 1, "b": 1}
-    assert throttle.wait_for_capacity.call_count == 1
-    notify.assert_called_once_with("partner", 2)
 
 
 def test_chunk_size_force_ignore_warnings_small_returns_direct():

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -435,6 +435,9 @@ def test_wrap_step_with_marker_tags_each_tool_with_its_phase():
     assert _wrap_step_with_marker(
         "sdc-sync --partner texas --ids-file x.csv --workers 6"
     ).startswith("export WIKIMEDIA_STEP=sdc-sync && sdc-sync ")
+    assert _wrap_step_with_marker("drain-deferred nara").startswith(
+        "export WIKIMEDIA_STEP=drain-deferred && drain-deferred "
+    )
     # Non-step commands (``cd``, the case-2 graceful-skip ``echo … ; true``,
     # and the ``sdc-sync --cat`` flavour the maintain builder emits — wait,
     # that one IS sdc-sync. Use a true non-step instead.):

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -27,11 +27,13 @@ If the sidecar is non-empty, the command:
      wait days or weeks. Volunteers clear the category on human-admin
      timescales and this command is designed to be as patient as they
      are.
-  3. When capacity is available, re-invokes ``uploader`` and
-     ``sdc-sync`` (as subprocesses) on the deferred IDs. The uploader's
-     re-run either completes the deferred items (moving them out of
-     the sidecar) or re-defers them (leaving them in the sidecar for
-     the next loop iteration).
+  3. When capacity is available, removes the round's IDs from the
+     sidecar and re-invokes ``uploader`` and ``sdc-sync`` (as
+     subprocesses) on them. The uploader only ever *merges* deferred
+     IDs into the sidecar (it never removes completed ones), so the
+     drain clears the round up front and the uploader's re-run merges
+     back whichever items re-deferred — those stay queued for the next
+     loop iteration; completed items stay out.
   4. Loops until the sidecar is empty.
 
 Cancellation is operator-driven — ``tmux kill-session`` at any time.
@@ -113,16 +115,24 @@ def _run_deferred_items(partner: str, dpla_ids: list[str]) -> None:
             len(dpla_ids),
             csv_path,
         )
-        subprocess.run(
+        result = subprocess.run(
             ["uploader", os.path.basename(csv_path), partner],
             cwd=partner,
             check=False,
         )
+        if result.returncode != 0:
+            logging.warning(
+                "Drain round: uploader exited %d for partner %s (ids file %s); "
+                "any still-deferred items remain in the sidecar for the next round.",
+                result.returncode,
+                partner,
+                csv_path,
+            )
         logging.info(
             "Drain round: invoking sdc-sync on the same %d item(s)",
             len(dpla_ids),
         )
-        subprocess.run(
+        result = subprocess.run(
             [
                 "sdc-sync",
                 "--partner",
@@ -133,11 +143,22 @@ def _run_deferred_items(partner: str, dpla_ids: list[str]) -> None:
             cwd=partner,
             check=False,
         )
+        if result.returncode != 0:
+            logging.warning(
+                "Drain round: sdc-sync exited %d for partner %s (ids file %s).",
+                result.returncode,
+                partner,
+                csv_path,
+            )
     finally:
         try:
             os.unlink(csv_path)
-        except OSError:
-            pass
+        except OSError as exc:
+            # Non-fatal — a stray temp ids file in the partner dir is only
+            # cosmetic — but record it rather than failing silently.
+            logging.warning(
+                "Drain round: could not remove temp ids file %s: %s", csv_path, exc
+            )
 
 
 @click.command()
@@ -164,58 +185,71 @@ def main(partner: str) -> None:
     )
 
     # Advisory host-level lock. Held for the entire drain (potentially
-    # days). Released on process exit — kill via ``tmux kill-session``.
-    lock_fd = _acquire_host_lock()  # noqa: F841 — kept alive by scope
+    # days). The ``finally`` below closes the fd (releasing the flock)
+    # on normal exit or exception; a kill releases it on process exit.
+    lock_fd = _acquire_host_lock()
+    try:
+        started_at = time.monotonic()
+        throttle = DuplicateCategoryThrottle()
+        initial_category_size = throttle.category_size()
+        notify_drain_phase_start(partner, len(initial_ids), initial_category_size)
 
-    started_at = time.monotonic()
-    throttle = DuplicateCategoryThrottle()
-    initial_category_size = throttle._category_size()
-    notify_drain_phase_start(partner, len(initial_ids), initial_category_size)
-
-    total_emitted = 0
-    while True:
-        pending = drain_sidecar.read_sidecar(partner)
-        if not pending:
-            break
-        logging.info(
-            "Drain-deferred: %d item(s) still pending; waiting for "
-            "Category:Duplicate to drop below %d (currently polled every %ds).",
-            len(pending),
-            throttle.resume_below,
-            throttle.poll_secs,
-        )
-        # Unlimited wait — patient by design. See module docstring.
-        throttle.wait_for_capacity(max_wait_secs=None)
-        pre_round_count = len(pending)
-        _run_deferred_items(partner, pending)
-        post_round = drain_sidecar.read_sidecar(partner)
-        emitted_this_round = pre_round_count - len(post_round)
-        if emitted_this_round > 0:
-            total_emitted += emitted_this_round
+        total_emitted = 0
+        while True:
+            pending = drain_sidecar.read_sidecar(partner)
+            if not pending:
+                break
             logging.info(
-                "Drain-deferred: round emitted %d item(s); %d still pending.",
-                emitted_this_round,
-                len(post_round),
+                "Drain-deferred: %d item(s) still pending; waiting for "
+                "Category:Duplicate to drop below %d (currently polled every %ds).",
+                len(pending),
+                throttle.resume_below,
+                throttle.poll_secs,
             )
-        else:
-            # A round that made no progress despite reported capacity is
-            # not fatal here (unlike the old bounded drain that would
-            # abort). Category:Duplicate may have refilled while we were
-            # processing, or the round hit unrelated per-item failures.
-            # Loop back to wait_for_capacity; next round will re-observe.
-            logging.warning(
-                "Drain-deferred: round made no progress (%d item(s) still "
-                "pending). Continuing to wait; category may have refilled.",
-                len(post_round),
-            )
+            # Unlimited wait — patient by design. See module docstring.
+            throttle.wait_for_capacity(max_wait_secs=None)
+            pre_round_count = len(pending)
+            # Take this round's IDs out of the sidecar BEFORE the
+            # subprocess pass. The uploader only ever merges deferred IDs
+            # back in — it never removes completed ones — so leaving the
+            # round's IDs in place would make the queue permanent:
+            # completed items would replay every round and the loop would
+            # never terminate. Items the uploader re-defers reappear via
+            # its ``merge_sidecar``; completed (or hard-failed) items stay
+            # out. IDs a concurrent session appends mid-round are
+            # untouched and picked up on the next loop iteration.
+            drain_sidecar.remove_from_sidecar(partner, pending)
+            _run_deferred_items(partner, pending)
+            post_round = drain_sidecar.read_sidecar(partner)
+            emitted_this_round = pre_round_count - len(post_round)
+            if emitted_this_round > 0:
+                total_emitted += emitted_this_round
+                logging.info(
+                    "Drain-deferred: round emitted %d item(s); %d still pending.",
+                    emitted_this_round,
+                    len(post_round),
+                )
+            else:
+                # A round that made no progress despite reported capacity is
+                # not fatal here (unlike the old bounded drain that would
+                # abort). Category:Duplicate may have refilled while we were
+                # processing, or the round hit unrelated per-item failures.
+                # Loop back to wait_for_capacity; next round will re-observe.
+                logging.warning(
+                    "Drain-deferred: round made no progress (%d item(s) still "
+                    "pending). Continuing to wait; category may have refilled.",
+                    len(post_round),
+                )
 
-    elapsed = time.monotonic() - started_at
-    logging.info(
-        "Drain-deferred: complete. Emitted %d item(s) over %.0f seconds.",
-        total_emitted,
-        elapsed,
-    )
-    notify_drain_phase_complete(partner, elapsed, total_emitted)
+        elapsed = time.monotonic() - started_at
+        logging.info(
+            "Drain-deferred: complete. Emitted %d item(s) over %.0f seconds.",
+            total_emitted,
+            elapsed,
+        )
+        notify_drain_phase_complete(partner, elapsed, total_emitted)
+    finally:
+        os.close(lock_fd)
 
 
 if __name__ == "__main__":

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -1,0 +1,222 @@
+"""Drain the per-partner deferred-drain sidecar.
+
+The uploader defers Case-2 hash-drift upload+tag operations as an
+atomic unit whenever ``Category:Duplicate`` on Commons is at capacity,
+persisting the deferred DPLA IDs to a per-partner sidecar (see
+``ingest_wikimedia.drain_sidecar``). This command runs as the final
+step of the wikimedia-upload pipeline:
+
+    cd → get-ids-es → downloader → uploader → sdc-sync → drain-deferred
+
+If the sidecar is empty (or missing), the command exits immediately —
+the common case where no items deferred is a no-op.
+
+If the sidecar is non-empty, the command:
+
+  1. Acquires a host-level ``flock`` at
+     ``/home/ec2-user/ingest-wikimedia/.drain-lock`` so only one drain
+     runs concurrently on the box. The existing throttle's per-session
+     ``try_acquire`` cap on Case-2 tag emissions was designed for a
+     single active writer; letting multiple sessions drain in parallel
+     could overshoot Category:Duplicate's threshold before either
+     session re-queried. The flock serialises the work; other
+     drain-deferred processes wait their turn.
+  2. Enters a loop that patiently polls Category:Duplicate (every
+     ``DEFAULT_POLL_SECS`` = 5 min by default) until the size falls
+     below the resume threshold. There is no time budget — this can
+     wait days or weeks. Volunteers clear the category on human-admin
+     timescales and this command is designed to be as patient as they
+     are.
+  3. When capacity is available, re-invokes ``uploader`` and
+     ``sdc-sync`` (as subprocesses) on the deferred IDs. The uploader's
+     re-run either completes the deferred items (moving them out of
+     the sidecar) or re-defers them (leaving them in the sidecar for
+     the next loop iteration).
+  4. Loops until the sidecar is empty.
+
+Cancellation is operator-driven — ``tmux kill-session`` at any time.
+The sidecar persists across kills, so a subsequent partner run picks
+up wherever this left off.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import logging
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import click
+
+from ingest_wikimedia import drain_sidecar
+from ingest_wikimedia.dup_throttle import DuplicateCategoryThrottle
+from ingest_wikimedia.logs import setup_logging
+from ingest_wikimedia.slack import (
+    notify_drain_phase_complete,
+    notify_drain_phase_start,
+)
+
+# Host-level lock file. One drain-deferred process at a time across the
+# shared EC2 instance — see module docstring for the concurrency
+# rationale. Path is host-scoped (not partner-scoped) so cross-partner
+# drains serialize.
+_DRAIN_LOCK_PATH = "/home/ec2-user/ingest-wikimedia/.drain-lock"
+
+
+def _acquire_host_lock():
+    """Return a file descriptor holding an exclusive ``flock`` on
+    ``_DRAIN_LOCK_PATH``. Blocks until acquired.
+
+    Advisory ``flock`` is released automatically on process exit, so a
+    crashed drain doesn't leave a stuck lock. The lock file itself is
+    created (empty) if missing; it never grows.
+    """
+    Path(_DRAIN_LOCK_PATH).parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(_DRAIN_LOCK_PATH, os.O_RDWR | os.O_CREAT, 0o644)
+    logging.info(
+        "Acquiring drain-phase host lock at %s (blocking until available)…",
+        _DRAIN_LOCK_PATH,
+    )
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    logging.info("Drain-phase host lock acquired.")
+    return fd
+
+
+def _run_deferred_items(partner: str, dpla_ids: list[str]) -> None:
+    """Write ``dpla_ids`` to a temp CSV and invoke ``uploader`` +
+    ``sdc-sync`` on that CSV, both as subprocesses. Each subprocess
+    inherits our environment, so DPLA_SLACK_BOT_TOKEN and the
+    pywikibot user-config resolve the same as they do in a normal
+    partner run.
+
+    Errors from either subprocess are logged but not re-raised — a
+    partial-success round leaves the still-deferred items in the
+    sidecar for the next loop iteration, which is the intended
+    behaviour.
+    """
+    with tempfile.NamedTemporaryFile(
+        "w",
+        dir=partner,
+        prefix=".drain-ids-",
+        suffix=".csv",
+        delete=False,
+    ) as tf:
+        for dpla_id in dpla_ids:
+            tf.write(dpla_id + "\n")
+        csv_path = tf.name
+    try:
+        logging.info(
+            "Drain round: invoking uploader on %d deferred item(s) via %s",
+            len(dpla_ids),
+            csv_path,
+        )
+        subprocess.run(
+            ["uploader", os.path.basename(csv_path), partner],
+            cwd=partner,
+            check=False,
+        )
+        logging.info(
+            "Drain round: invoking sdc-sync on the same %d item(s)",
+            len(dpla_ids),
+        )
+        subprocess.run(
+            [
+                "sdc-sync",
+                "--partner",
+                partner,
+                "--ids-file",
+                os.path.basename(csv_path),
+            ],
+            cwd=partner,
+            check=False,
+        )
+    finally:
+        try:
+            os.unlink(csv_path)
+        except OSError:
+            pass
+
+
+@click.command()
+@click.argument("partner")
+def main(partner: str) -> None:
+    """Drain the deferred-drain sidecar for ``partner`` — waits
+    indefinitely on ``Category:Duplicate`` capacity, retrying deferred
+    uploads until the sidecar is empty. See module docstring."""
+    setup_logging(partner, "drain-deferred", logging.INFO)
+
+    initial_ids = drain_sidecar.read_sidecar(partner)
+    if not initial_ids:
+        logging.info(
+            "Drain-deferred: sidecar for partner %s is empty (or missing); nothing to do.",
+            partner,
+        )
+        return
+
+    logging.info(
+        "Drain-deferred: sidecar for partner %s has %d item(s) queued; "
+        "acquiring host lock and beginning drain loop.",
+        partner,
+        len(initial_ids),
+    )
+
+    # Advisory host-level lock. Held for the entire drain (potentially
+    # days). Released on process exit — kill via ``tmux kill-session``.
+    lock_fd = _acquire_host_lock()  # noqa: F841 — kept alive by scope
+
+    started_at = time.monotonic()
+    throttle = DuplicateCategoryThrottle()
+    initial_category_size = throttle._category_size()
+    notify_drain_phase_start(partner, len(initial_ids), initial_category_size)
+
+    total_emitted = 0
+    while True:
+        pending = drain_sidecar.read_sidecar(partner)
+        if not pending:
+            break
+        logging.info(
+            "Drain-deferred: %d item(s) still pending; waiting for "
+            "Category:Duplicate to drop below %d (currently polled every %ds).",
+            len(pending),
+            throttle.resume_below,
+            throttle.poll_secs,
+        )
+        # Unlimited wait — patient by design. See module docstring.
+        throttle.wait_for_capacity(max_wait_secs=None)
+        pre_round_count = len(pending)
+        _run_deferred_items(partner, pending)
+        post_round = drain_sidecar.read_sidecar(partner)
+        emitted_this_round = pre_round_count - len(post_round)
+        if emitted_this_round > 0:
+            total_emitted += emitted_this_round
+            logging.info(
+                "Drain-deferred: round emitted %d item(s); %d still pending.",
+                emitted_this_round,
+                len(post_round),
+            )
+        else:
+            # A round that made no progress despite reported capacity is
+            # not fatal here (unlike the old bounded drain that would
+            # abort). Category:Duplicate may have refilled while we were
+            # processing, or the round hit unrelated per-item failures.
+            # Loop back to wait_for_capacity; next round will re-observe.
+            logging.warning(
+                "Drain-deferred: round made no progress (%d item(s) still "
+                "pending). Continuing to wait; category may have refilled.",
+                len(post_round),
+            )
+
+    elapsed = time.monotonic() - started_at
+    logging.info(
+        "Drain-deferred: complete. Emitted %d item(s) over %.0f seconds.",
+        total_emitted,
+        elapsed,
+    )
+    notify_drain_phase_complete(partner, elapsed, total_emitted)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -46,8 +46,8 @@ from ingest_wikimedia.dpla import (
     WIKIDATA_FIELD_NAME,
     DPLA,
 )
+from ingest_wikimedia import drain_sidecar
 from ingest_wikimedia.slack import (
-    notify_dup_drain_incomplete,
     notify_upload_aborted,
     notify_upload_complete,
 )
@@ -1964,20 +1964,25 @@ def main(
                         deferred[dpla_id] = deferred_count
 
             # Any item whose {{duplicate}}-tagging upload was deferred because
-            # Category:Duplicate was full: wait for the category to drain, then
-            # re-run those items in this same session (not an operator re-run).
-            # Inside the same try so a CSRF-fatal from the drain pass also
-            # routes to the notify_upload_aborted + re-raise path below.
+            # Category:Duplicate was full: persist the deferred DPLA IDs to
+            # the per-partner sidecar and exit normally. The pipeline's
+            # next step (``sdc-sync``) will process every item that DID
+            # upload; the ``drain-deferred`` step at the end of the
+            # pipeline reads the sidecar and patiently loops on
+            # Category:Duplicate until the deferred items can complete.
+            #
+            # This replaces the previous in-line ``_drain_deferred_dups``
+            # loop that held the whole session (and blocked sdc-sync) for
+            # up to 4 hours. See ``ingest_wikimedia.drain_sidecar``.
             if deferred:
-                _drain_deferred_dups(
-                    uploader,
-                    dup_throttle,
-                    deferred,
-                    providers_json,
+                combined = drain_sidecar.merge_sidecar(partner, list(deferred))
+                logging.info(
+                    "Deferred %d item(s) to the drain-phase sidecar "
+                    "(%d total now queued for partner %s): %s",
+                    len(deferred),
+                    len(combined),
                     partner,
-                    verbose,
-                    dry_run,
-                    slot_budget,
+                    drain_sidecar.sidecar_path(partner),
                 )
         except CsrfRecoveryFailed as ex:
             # Session's auth is broken and unrecoverable. Abort — do NOT
@@ -2028,93 +2033,6 @@ def main(
                 elapsed_seconds=elapsed,
                 dry_run=dry_run,
             )
-
-
-# Upper bound on how long the drain pass will wait for Category:Duplicate to
-# fall back below the throttle's resume threshold. Volunteers clear the
-# category on human timescales, so give it real headroom — but cap it so a
-# session never hangs indefinitely. On timeout the remaining files are left
-# un-uploaded and the operator is pinged to re-run after the category drains.
-_DRAIN_MAX_WAIT_SECS = 4 * 60 * 60  # 4 hours
-
-
-def _drain_deferred_dups(
-    uploader: "Uploader",
-    throttle: DuplicateCategoryThrottle,
-    deferred: dict[str, int],
-    providers_json,
-    partner: str,
-    verbose: bool,
-    dry_run: bool,
-    slot_budget: WorkerSlotBudget,
-    *,
-    max_wait_secs: float = _DRAIN_MAX_WAIT_SECS,
-) -> dict[str, int]:
-    """Re-run items whose {{duplicate}}-tagging upload was deferred, once
-    Category:Duplicate has drained.
-
-    ``deferred`` maps each item's dpla_id to its count of deferred ordinals.
-    Each round waits (via the throttle) for the category to fall below its
-    resume threshold, then re-processes the still-deferred items. Re-processing
-    may itself defer again if the category refills mid-drain, so it loops until
-    nothing remains, no progress is made, or the wait budget is exhausted.
-    Returns the {id: count} still deferred at exit (empty on full success).
-
-    Progress is measured by total deferred *ordinals*, not items: a single
-    multi-page item can clear some ordinals while others remain, which is real
-    progress and must not read as a stall.
-    """
-    remaining = dict(deferred)
-    deadline = time.monotonic() + max_wait_secs
-    logging.info(
-        "Drain pass: %d file(s) across %d item(s) deferred while "
-        "Category:Duplicate was at capacity; waiting for it to drain, then "
-        "retrying their uploads.",
-        sum(remaining.values()),
-        len(remaining),
-    )
-    while remaining:
-        budget = deadline - time.monotonic()
-        if budget <= 0 or not throttle.wait_for_capacity(budget):
-            still = sum(remaining.values())
-            logging.error(
-                "Drain pass timed out with %d file(s) still deferred; their "
-                "uploads + {{duplicate}} tags were NOT emitted. Clear "
-                "Category:Duplicate, then re-run the partner to finish them.",
-                still,
-            )
-            notify_dup_drain_incomplete(partner, still)
-            return remaining
-
-        still_deferred: dict[str, int] = {}
-        for dpla_id in remaining:
-            with slot_budget.acquire():
-                count = uploader.process_item(
-                    dpla_id, providers_json, partner, verbose, dry_run
-                )
-                if count:
-                    still_deferred[dpla_id] = count
-
-        # A batch larger than the throttle's headroom (recheck_cap) legitimately
-        # takes several rounds — each round re-queries and clears up to a cap's
-        # worth, so partial progress is normal, not a stall. But if a round that
-        # began with confirmed capacity cleared NO ordinals, the category is
-        # refilling as fast as we drain (or another mechanism keeps deferring) —
-        # bail rather than spin a hot loop re-querying the category every round.
-        if sum(still_deferred.values()) >= sum(remaining.values()):
-            still = sum(still_deferred.values())
-            logging.error(
-                "Drain pass made no progress despite available capacity (%d "
-                "file(s) still deferred); aborting drain. Clear "
-                "Category:Duplicate, then re-run the partner to finish them.",
-                still,
-            )
-            notify_dup_drain_incomplete(partner, still)
-            return still_deferred
-        remaining = still_deferred
-
-    logging.info("Drain pass complete: all deferred uploads + duplicate-tags emitted.")
-    return remaining
 
 
 # Wait between the last ensure() and the first touch.  Wikidata→Commons


### PR DESCRIPTION
## Summary

The old in-uploader `_drain_deferred_dups` blocked the uploader session (and downstream sdc-sync) for up to 4 hours waiting on Category:Duplicate to drain. Category:Duplicate is processed by Commons volunteers on human-admin timescales — routinely days — so 4 hours was unrealistic. When the timeout fired, the deferred uploads + `{{duplicate}}` tags were dropped entirely; operator had to re-run the partner later.

## New shape

1. **Uploader** completes its main loop across every item in the session. Non-deferred items upload cleanly. Deferred items (Case-2 hash-drift upload+tag when Category:Duplicate is at capacity) persist their DPLA IDs to a per-partner sidecar at `<partner>/deferred-drain.json`.
2. **Uploader exits normally** after its main loop. COUNTS reports deferred count. Invariant preserved: nothing on Commons in a half-uploaded / untagged state — the deferred items are exactly the ones that never got their upload started.
3. **sdc-sync** runs on all uploaded items with no waiting.
4. **New `drain-deferred <partner>` pipeline step** at the end of the shell chain. Empty sidecar → exit 0 (common case). Non-empty → acquires host-level `flock` at `/home/ec2-user/ingest-wikimedia/.drain-lock` so only one drainer runs at a time on the box, then patiently loops:
   - poll Category:Duplicate every 5 min (bumped from 2 min — category doesn't move on second timescales),
   - when the size drops below the resume threshold, re-invoke `uploader` + `sdc-sync` as subprocesses on just the deferred IDs,
   - re-read the sidecar (uploader rewrites it with any items still deferred after the round),
   - loop until sidecar is empty.
5. **No time budget** — the drain waits indefinitely. Cancellation via the existing `tmux kill-session` mechanism. Sidecar persists across kills, so a subsequent partner run picks up wherever the drain left off.

## Concurrency

Host-level `flock` at `/home/ec2-user/ingest-wikimedia/.drain-lock` is the only new coordination primitive. Sessions with pending deferrals queue up in drain order; whichever holds the lock is the sole writer against Category:Duplicate, so the existing per-session throttle's per-batch cap continues to give a well-defined ceiling. Advisory `flock` is released automatically on process exit, so a killed drainer doesn't leave a stuck lock.

## Cost profile of a long-lived drain phase

- **Memory**: ~200MB per idle drain process, static. Fine for weeks.
- **API rate limit**: one `categoryinfo` call per 5 min = 288/day. Wikimedia's bot rate limit is ~500/min → 3 orders of magnitude under budget.
- **Worker slots**: none held during the wait. Other partner sessions unaffected.
- **tmux slot occupation**: real cost but bounded — one slot per partner with pending deferrals, released on drain completion or kill.
- **sdc-sync no longer blocked**: the biggest hidden cost of the old design goes away.

## Observability

Replaced `notify_dup_drain_incomplete` (only fired on timeout — no longer possible) with:
- `notify_drain_phase_start(partner, deferred_count, category_size)` — pinged when drain phase begins.
- `notify_drain_phase_complete(partner, elapsed, emitted_count)` — pinged when drain completes cleanly.

The `/wikimedia-status` and existing periodic Slack reports can surface drain state by reading the sidecar path (follow-up work — not in this PR).

## Test plan

- [x] New `tests/test_drain_sidecar.py` (13 cases): read/write/merge/atomic-write/corruption tolerance.
- [x] New `tests/test_drain_deferred.py` (4 cases): empty-sidecar early exit, populated drain loop, re-read between rounds, no-progress round continues (doesn't abort).
- [x] Extended `tests/test_dup_throttle.py`: `wait_for_capacity(max_wait_secs=None)` waits indefinitely on capacity.
- [x] Removed obsolete `_drain_deferred_dups` tests (function deleted).
- [x] 1016 tests pass on EC2.
- [x] `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the Wikimedia ingest flow to move deferred `Category:Duplicate` handling out of the uploader and into a standalone, sidecar-driven drain phase so the uploader no longer blocks (up to hours) waiting for duplicates to clear.

- The uploader now persists deferred DPLA IDs by merging them into a persistent per-partner sidecar at `<partner>/deferred-drain.json`, logging the queued/sidecar state, and then exits normally (removing the in-session deferred drain loop and its bounded wait/drop behavior).
- Added `drain-deferred <partner>` (`tools/drain_deferred.py`) and wired it into the Wikimedia launcher’s end-of-chain sequence after `sdc-sync`.
  - Acquires a host-level `flock` lock for the entire drain duration (`/home/ec2-user/ingest-wikimedia/.drain-lock`), so only one drain runs at a time across the host.
  - Polls `Category:Duplicate` indefinitely (throttle now supports `max_wait_secs=None`; default poll interval increased to 5 minutes).
  - Repeatedly drains “rounds” from the sidecar by removing the current round’s IDs from the sidecar *before* invoking work.
  - For each round, runs `uploader` then `sdc-sync`, tolerating subprocess failures (logs without raising), reloads the sidecar, and continues until it becomes empty; logs/retries when a round makes no progress.
  - Sends Slack notifications for drain phase start and completion (replacing the prior timeout/incomplete notification).
  - Drain cancellation remains operator-driven via existing `tmux kill-session` behavior.
- Updated/added sidecar utilities (`ingest_wikimedia/drain_sidecar.py`) to robustly read/write/merge/remove the deferred ID queue, including tolerant handling of missing/unreadable/corrupt JSON and atomic write semantics.
- Added/updated tests covering:
  - sidecar lifecycle (read/write/merge/remove + atomic-write failure cleanup),
  - the `drain-deferred` loop behavior (host lock acquisition, round clearing before subprocesses, re-reading sidecar between rounds, and unbounded throttle waiting),
  - updated throttle semantics for unbounded waits.
  - Removed uploader tests that specifically exercised the old in-session deferred drain logic.
- Follow-up: cleaned up temporary per-sidecar “.tmp” residues on the error path when an atomic write fails before rename, with a regression test.

Operational notes / explicit checks:
- **Requires manual pipeline trigger or ECS redeployment?** No—behavior takes effect on the next normal Wikimedia launch run using the updated code rollout.
- **Environment variables / AWS Secrets Manager keys:** No new env vars or Secrets Manager keys introduced. The drain phase reuses existing Slack inputs (e.g., `DPLA_SLACK_BOT_TOKEN`, `WIKIMEDIA_SESSION_LABEL`) used elsewhere for pipeline notifications.
- **Database migrations:** None.
- **Shared infra configuration (CodePipeline/CodeBuild/ECS/IAM):** None detected/changed; this is implemented in tooling + launcher wiring.
- **Public-facing API / endpoints:** None.
- **Security implications:** No auth changes and no new external data inputs; Slack credential handling remains the same as existing pipeline notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->