### PR TITLE
SDC: pin P813 (retrieved on) to ingestDate to reduce diff noise

### DIFF
--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1666,13 +1666,15 @@ def build_claims_for_doc(
     rights: dict,
     subject_ids: dict,
     subjects_lookup: dict[tuple[str, str], str] | None,
-) -> dict[str, list[dict]] | None:
+) -> dict[str, Any] | None:
     """Build the complete ready-to-POST SDC claim list for a DPLA item.
 
-    Returns ``{"claims": [...]}`` matching the wbsetclaims POST shape.
-    Returns ``None`` when the doc can't be parsed (e.g. provider /
-    dataProvider not in the hubs map) — callers should skip the item
-    and not stage an sdc.json for it.
+    Returns ``{"claims": [...], "ingest_date": "YYYY-MM-DD"}`` matching
+    the wbsetclaims POST shape (the extra ``ingest_date`` envelope field
+    is read back by ``sdc-sync`` to pin its per-file P813 refresh — see
+    the module docstring). Returns ``None`` when the doc can't be
+    parsed (e.g. provider / dataProvider not in the hubs map) — callers
+    should skip the item and not stage an sdc.json for it.
 
     ``subjects_lookup`` is the pre-resolved reconciliation table; pass
     ``None`` for inline-only behavior (the parallel P921 statements for

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -39,8 +39,33 @@ Module structure:
 
   Top-level builder
     build_claims_for_doc(doc, dpla_id, hubs, rights, subject_ids,
-                        subjects_lookup, retrieval_date)
-        Returns `{"claims": [...]}` ready to POST to wbsetclaims.
+                        subjects_lookup)
+        Returns `{"claims": [...], "ingest_date": "YYYY-MM-DD"}` ready to
+        POST to wbsetclaims. The ingest date is derived internally from
+        ``doc["ingestDate"]`` (see the "P813" section below).
+
+## P813 (retrieved on) reference date — pinned to the DPLA ingest date
+
+Every DPLA-authored claim carries a ``P813`` (retrieved on) snak in
+its reference block, indicating when the DPLA data was fetched. This
+codebase pins that date to the **DPLA item's ``ingestDate``** — the
+timestamp DPLA's ingestion pipeline recorded when it harvested this
+item's metadata from the source hub — rather than to the sync run's
+``datetime.date.today()``.
+
+Rationale: ``ingestDate`` changes only when DPLA re-ingests the item
+(a genuine new fact about the DPLA-side data), whereas ``today()``
+changes with every sync run. Anchoring P813 to ``today()`` produced
+noisy Commons edit diffs — every re-sync of a file rewrote every
+P813 date across every one of the file's claims, drowning out the
+substantive changes in the diff. Anchoring to ``ingestDate`` means a
+sync that finds no factual delta produces no diff at all; a diff
+that DOES appear reflects a real DPLA-side change.
+
+See ``ingest_date_from_doc`` for extraction. Callers that build
+claims (``get-ids-es``, ``get-ids-nara``, ``sdc-sync``'s reference
+refresh) should derive ``retrieval_date`` per-item from the doc, not
+from ``today()``.
 """
 
 from __future__ import annotations
@@ -286,31 +311,61 @@ def _qualifier_string_snak(prop: str, value: str, datatype: str | None = None) -
     return snak
 
 
+def ingest_date_from_doc(doc: dict) -> datetime.date:
+    """Return the DPLA ingestion date from an item document (either a
+    live API response or a staged ``dpla-map.json`` sidecar) as a
+    ``datetime.date``.
+
+    The DPLA API emits ``ingestDate`` as an ISO 8601 timestamp string
+    (e.g. ``"2026-06-23T15:50:29.874Z"``); this helper strips the time
+    portion and returns the date part.
+
+    Raises ``ValueError`` if the field is missing, non-string, or not
+    parseable — every record that survives DPLA ingestion carries an
+    ``ingestDate``, so its absence signals a corrupted record / ES bug
+    / upstream data-integrity problem. Callers should catch per-item
+    (same convention as the existing ``ET.ParseError`` skip in
+    ``get-ids-es`` / ``get-ids-nara``), log the DPLA ID, and skip that
+    item's ``sdc.json`` rather than fall back to a synthetic date that
+    would mask the real issue.
+
+    Used as the anchor for the P813 (retrieved on) reference date; see
+    the module docstring for the rationale.
+    """
+    raw = doc.get("ingestDate") if isinstance(doc, dict) else None
+    if not isinstance(raw, str) or len(raw) < 10:
+        raise ValueError(
+            f"DPLA item document missing or has invalid ingestDate: {raw!r} "
+            "(every record ingested via DPLA carries a valid ingestDate; "
+            "an item without one signals a corrupted record — do not "
+            "silently synthesize a date)"
+        )
+    return datetime.date.fromisoformat(raw[:10])
+
+
 def formattedclaim(
     prop: str,
     value: Any,
     value_type: str,
     dpla_id: str,
-    retrieval_date: datetime.date | None = None,
+    retrieval_date: datetime.date,
 ) -> dict:
     """Build the canonical Wikibase claim envelope.
 
     Every DPLA-published claim carries:
       * a P459 (determination method) qualifier set to Q61848113 (heuristic)
       * a reference triple — P854 (DPLA item URL), P123 (publisher = DPLA),
-        P813 (retrieved on `retrieval_date`).
+        P813 (retrieved on ``retrieval_date``).
+
+    ``retrieval_date`` is required; callers derive it per-item from the
+    doc's ``ingestDate`` via :func:`ingest_date_from_doc`. See the
+    module docstring for why P813 is pinned to the ingest date rather
+    than the sync run's today().
 
     When called with `value == "somevalue"` the mainsnak is emitted as a
     snaktype=somevalue node instead of a value node — the caller adds the
     type-specific qualifier (P2093 for creators, P1932 for dates).
-
-    `retrieval_date` defaults to today's date when omitted; callers that
-    want a deterministic, persisted-to-S3 claim list (get-ids-es) should
-    pass the run date explicitly so the same `sdc.json` content is
-    reproducible from the same input doc.
     """
-    if retrieval_date is None:
-        retrieval_date = datetime.date.today()
 
     claim = {
         "mainsnak": {
@@ -1611,22 +1666,25 @@ def build_claims_for_doc(
     rights: dict,
     subject_ids: dict,
     subjects_lookup: dict[tuple[str, str], str] | None,
-    retrieval_date: datetime.date,
 ) -> dict[str, list[dict]] | None:
     """Build the complete ready-to-POST SDC claim list for a DPLA item.
 
-    Returns `{"claims": [...]}` matching the wbsetclaims POST shape. Returns
-    `None` when the doc can't be parsed (e.g. provider/dataProvider not in
-    the hubs map) — callers should skip the item and not stage an sdc.json
-    for it.
+    Returns ``{"claims": [...]}`` matching the wbsetclaims POST shape.
+    Returns ``None`` when the doc can't be parsed (e.g. provider /
+    dataProvider not in the hubs map) — callers should skip the item
+    and not stage an sdc.json for it.
 
-    `subjects_lookup` is the pre-resolved reconciliation table; pass `None`
-    for inline-only behavior (the parallel P921 statements for NARA
-    `exactMatch` subjects are simply omitted in that case).
+    ``subjects_lookup`` is the pre-resolved reconciliation table; pass
+    ``None`` for inline-only behavior (the parallel P921 statements for
+    NARA ``exactMatch`` subjects are simply omitted in that case).
 
-    `retrieval_date` is stamped into every claim's P813 reference. For
-    deterministic, persisted-to-S3 output (get-ids-es), pass the run date.
+    The P813 (retrieved on) reference date is derived internally from
+    the doc's ``ingestDate`` via :func:`ingest_date_from_doc`. Raises
+    ``ValueError`` if the doc lacks a valid ``ingestDate`` — callers
+    catch per-item (same convention as ``ET.ParseError`` in
+    ``get-ids-es`` / ``get-ids-nara``), log, and skip that item.
     """
+    retrieval_date = ingest_date_from_doc(doc)
     parsed = parse_dpla_doc(doc, dpla_id, hubs, subject_ids, subjects_lookup)
     if parsed is None:
         return None
@@ -1802,4 +1860,4 @@ def build_claims_for_doc(
             )
         )
 
-    return {"claims": claims}
+    return {"claims": claims, "ingest_date": retrieval_date.isoformat()}

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -721,6 +721,7 @@ def test_build_claims_for_doc_rejects_junky_iiif_manifest_values():
     def _doc(iiif_value):
         return {
             "id": "abc1234567890",
+            "ingestDate": "2026-06-07T00:00:00Z",
             "provider": {"name": "Digital Commonwealth"},
             "dataProvider": {"name": "Boston Public Library"},
             "sourceResource": {
@@ -738,11 +739,10 @@ def test_build_claims_for_doc_rejects_junky_iiif_manifest_values():
             "institutions": {"Boston Public Library": {"Wikidata": "Q2"}},
         }
     }
-    import datetime as _dt
 
     for junk in (None, "", "   ", "null", "ftp://example.org/x", "not a url"):
         out = build_claims_for_doc(
-            _doc(junk), "abc1234567890", hubs, {}, {}, {}, _dt.date(2026, 6, 7)
+            _doc(junk), "abc1234567890", hubs, {}, {}, {}
         )
         p7482 = next(c for c in out["claims"] if c["mainsnak"]["property"] == "P7482")
         assert "P6108" not in p7482["qualifiers"], (
@@ -757,7 +757,7 @@ def test_build_claims_for_doc_rejects_junky_iiif_manifest_values():
         "http://example.org/iiif/manifest.json",
     ):
         out = build_claims_for_doc(
-            _doc(valid), "abc1234567890", hubs, {}, {}, {}, _dt.date(2026, 6, 7)
+            _doc(valid), "abc1234567890", hubs, {}, {}, {}
         )
         p7482 = next(c for c in out["claims"] if c["mainsnak"]["property"] == "P7482")
         assert "P6108" in p7482["qualifiers"], (
@@ -786,6 +786,7 @@ def test_build_claims_for_doc_tolerates_missing_rights_field():
 
     doc = {
         "id": "abc1234567890",
+        "ingestDate": "2026-06-29T00:00:00Z",
         "provider": {"name": "Internet Archive"},
         "dataProvider": {"name": "Duke University Libraries"},
         "sourceResource": {
@@ -801,10 +802,9 @@ def test_build_claims_for_doc_tolerates_missing_rights_field():
             "institutions": {"Duke University Libraries": {"Wikidata": "Q5312898"}},
         }
     }
-    import datetime as _dt
 
     out = build_claims_for_doc(
-        doc, "abc1234567890", hubs, {}, {}, {}, _dt.date(2026, 6, 29)
+        doc, "abc1234567890", hubs, {}, {}, {}
     )
     # No crash. No P275/P6426 rights claims since the input had no rights.
     rights_props = {"P275", "P6426", "P6216"}
@@ -1411,3 +1411,89 @@ def test_build_contributed_claims_service_hub_shape():
         ("Q12345", Q_ROLE_AGGREGATOR),
         ("Q67890", Q_ROLE_REPOSITORY),
     ]
+
+
+def test_ingest_date_from_doc_parses_iso_timestamp():
+    """The DPLA API emits ``ingestDate`` as ISO 8601. Strip the time part
+    and return a ``datetime.date``."""
+    import datetime
+
+    from ingest_wikimedia.sdc import ingest_date_from_doc
+
+    doc = {"ingestDate": "2026-06-23T15:50:29.874Z"}
+    assert ingest_date_from_doc(doc) == datetime.date(2026, 6, 23)
+
+
+def test_ingest_date_from_doc_raises_when_missing():
+    """A DPLA record without ingestDate is corrupted / an ES bug. Raise
+    loudly so the caller can skip the item — do NOT synthesize a date."""
+    from ingest_wikimedia.sdc import ingest_date_from_doc
+
+    for bad in (None, {}, {"ingestDate": None}, {"ingestDate": ""}, {"ingestDate": 12345}):
+        try:
+            ingest_date_from_doc(bad)
+        except ValueError:
+            continue
+        else:
+            raise AssertionError(f"expected ValueError for {bad!r}")
+
+
+def test_ingest_date_from_doc_raises_on_malformed_timestamp():
+    """A non-ISO ``ingestDate`` value is a data-integrity signal, not a
+    condition to paper over."""
+    from ingest_wikimedia.sdc import ingest_date_from_doc
+
+    try:
+        ingest_date_from_doc({"ingestDate": "not-a-date-value"})
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for malformed ingestDate")
+
+
+def test_build_claims_for_doc_pins_p813_to_ingest_date():
+    """Every P813 (retrieved on) reference across the returned claims is
+    pinned to the doc's ``ingestDate``, not the current date. Two calls
+    against the same doc must produce identical P813 values regardless of
+    when they run — this is the whole point of ingest-date pinning."""
+    from ingest_wikimedia.sdc import build_claims_for_doc
+
+    doc = {
+        "id": "abc1234567890",
+        "ingestDate": "2026-06-23T15:50:29.874Z",
+        "provider": {"name": "Digital Commonwealth"},
+        "dataProvider": {"name": "Boston Public Library"},
+        "sourceResource": {
+            "title": ["A title"],
+            "date": [{"displayDate": "1945"}],
+        },
+        "isShownAt": "https://example.org/item/abc",
+        "rights": "http://rightsstatements.org/vocab/InC/1.0/",
+    }
+    hubs = {
+        "Digital Commonwealth": {
+            "Wikidata": "Q1",
+            "institutions": {"Boston Public Library": {"Wikidata": "Q2"}},
+        }
+    }
+    out_a = build_claims_for_doc(doc, "abc1234567890", hubs, {}, {}, {})
+    out_b = build_claims_for_doc(doc, "abc1234567890", hubs, {}, {}, {})
+
+    assert out_a["ingest_date"] == "2026-06-23"
+    assert out_b["ingest_date"] == "2026-06-23"
+
+    def _p813_times(payload):
+        times = []
+        for claim in payload["claims"]:
+            for ref in claim.get("references") or []:
+                for snak in (ref.get("snaks") or {}).get("P813") or []:
+                    times.append(snak["datavalue"]["value"]["time"])
+        return times
+
+    times = _p813_times(out_a)
+    assert times, "every claim carries a P813 reference"
+    assert set(times) == {"+2026-06-23T00:00:00Z"}, (
+        f"P813 must be pinned to ingestDate; got {set(times)}"
+    )
+    assert _p813_times(out_a) == _p813_times(out_b), (
+        "identical doc must produce byte-identical P813 stamps"
+    )

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1062,6 +1062,12 @@ def test_legacy_process_one_treats_missing_entity_as_clean_skip(monkeypatch):
     monkeypatch.setattr(sdc_sync, "dpla_api", "stub-api-key", raising=False)
     monkeypatch.setattr(sdc_sync, "invalidate_entity", lambda *_a, **_k: None)
     monkeypatch.setattr(sdc_sync, "get_entity", lambda *_a, **_k: {})
+    # process_one reads the doc from _legacy_mode_doc_cache (populated
+    # by the real parsed()) to derive the ingest date. The stubbed parsed
+    # skips that step, so pre-seed the cache with a valid ingestDate.
+    sdc_sync._legacy_mode_doc_cache["abcdef01abcdef01abcdef01abcdef01"] = {
+        "ingestDate": "2026-06-23T00:00:00Z"
+    }
     # Skip every add_* helper — they call check() which hits the real
     # Commons API for entity reads. Replace them with no-ops.
     for name in [
@@ -2276,7 +2282,7 @@ def test_reconciler_removes_value_typed_claim_when_dpla_dropped_the_date(monkeyp
     from tools import sdc_sync
 
     # New sdc.json has NO P571 claim at all.
-    expected = sdc_sync._build_expected_from_sdc({"claims": []})
+    expected = sdc_sync._build_expected_from_sdc({"claims": [], "ingest_date": "2026-06-23"})
     assert expected == {}
 
     stale_live = _value_typed_p571_claim(
@@ -2962,7 +2968,7 @@ def test_amend_p760_page_qualifier_noop_when_page_number_is_none_and_no_existing
         ),
     ):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": []}, page_number=None
+            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=None
         )
     assert submit_calls == []
     # No writes happened → no terminal invalidate.
@@ -3004,7 +3010,7 @@ def test_amend_p760_page_qualifier_removes_stale_p304_when_page_number_is_none()
     sdc_sync._reset_per_file_accumulators()
     with patch.object(sdc_sync, "get_entity", return_value=entity):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": []}, page_number=None
+            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=None
         )
 
     assert sdc_sync.qualifier_removals == [("M999$p760id", "obsolete-hash")]
@@ -3033,7 +3039,7 @@ def test_amend_p760_page_qualifier_stamps_missing_p304_via_accumulator():
     sdc_sync._reset_per_file_accumulators()
     with patch.object(sdc_sync, "get_entity", return_value=entity):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": []}, page_number=2
+            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=2
         )
 
     assert len(sdc_sync.qualifier_amends) == 1
@@ -3070,7 +3076,7 @@ def test_amend_p760_page_qualifier_idempotent_when_p304_already_matches():
         patch.object(sdc_sync, "invalidate_entity"),
     ):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": []}, page_number=2
+            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=2
         )
 
 
@@ -3096,7 +3102,7 @@ def test_amend_p760_page_qualifier_skips_when_no_dpla_authored_p760():
         patch.object(sdc_sync, "invalidate_entity"),
     ):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": []}, page_number=1
+            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=1
         )
 
 
@@ -3135,7 +3141,7 @@ def test_amend_p760_page_qualifier_removes_stale_value_when_page_changes():
     sdc_sync._reset_per_file_accumulators()
     with patch.object(sdc_sync, "get_entity", return_value=entity):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": []}, page_number=2
+            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=2
         )
 
     assert sdc_sync.qualifier_removals == [("M999$p760id", "stale-snak-hash-3")]
@@ -3185,7 +3191,7 @@ def test_amend_p760_page_qualifier_removes_stale_when_expected_also_present():
     sdc_sync._reset_per_file_accumulators()
     with patch.object(sdc_sync, "get_entity", return_value=entity):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": []}, page_number=2
+            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=2
         )
 
     # Only the stale snak got queued for removal; the expected value
@@ -3406,14 +3412,13 @@ def test_chunked_claim_roundtrip_extract_comparable_value_preserves_chunk_identi
     the P1545 series ordinal must follow A1/A2/A3 in order. Without
     this end-to-end coverage, the sdc.py and sdc_sync.py halves could
     drift on the chunk-key contract."""
-    import datetime as _dt
-
     from ingest_wikimedia.sdc import build_claims_for_doc
     from tools import sdc_sync
 
     long_desc = "a" * 1500 + " " + "b" * 1500 + " " + "c" * 800
     doc = {
         "id": "abc1234567890",
+        "ingestDate": "2026-06-01T00:00:00Z",
         "provider": {"name": "Digital Commonwealth"},
         "dataProvider": {"name": "Boston Public Library"},
         "sourceResource": {
@@ -3429,9 +3434,7 @@ def test_chunked_claim_roundtrip_extract_comparable_value_preserves_chunk_identi
             "institutions": {"Boston Public Library": {"Wikidata": "Q2"}},
         }
     }
-    out = build_claims_for_doc(
-        doc, "abc1234567890", hubs, {}, {}, {}, _dt.date(2026, 6, 1)
-    )
+    out = build_claims_for_doc(doc, "abc1234567890", hubs, {}, {}, {})
     assert out is not None, "doc should be parseable; check fixture shape"
     desc_claims = [c for c in out["claims"] if c["mainsnak"]["property"] == "P10358"]
     assert len(desc_claims) == 3, (
@@ -3477,7 +3480,7 @@ def test_amend_p760_page_qualifier_does_not_re_invalidate_when_p304_matches():
         ),
     ):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": []}, page_number=2
+            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=2
         )
 
     assert invalidate_calls == []
@@ -3561,7 +3564,7 @@ def test_process_one_from_sdc_clears_entity_cache_at_file_boundary(monkeypatch):
 
     _patch_process_one_from_sdc_dependencies(monkeypatch, sdc_sync, "M999")
 
-    sdc_sync.process_one_from_sdc("M999", "abcdef", {"claims": []})
+    sdc_sync.process_one_from_sdc("M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"})
 
     # Prior files' entities are gone. The current mediaid may or may not
     # be in the cache afterward (post-write cleanup invalidates it), but
@@ -3585,7 +3588,7 @@ def test_entity_cache_does_not_grow_across_many_files(monkeypatch):
     for i in range(100):
         mediaid = f"M{1000 + i}"
         _patch_process_one_from_sdc_dependencies(monkeypatch, sdc_sync, mediaid)
-        sdc_sync.process_one_from_sdc(mediaid, f"dpla{i:06d}", {"claims": []})
+        sdc_sync.process_one_from_sdc(mediaid, f"dpla{i:06d}", {"claims": [], "ingest_date": "2026-06-23"})
         sizes.append(len(sdc_sync._entity_cache))
 
     # Pre-fix, sizes would be [1, 2, 3, ..., 100] (linear growth).
@@ -3985,8 +3988,8 @@ def _stale_p813_ref(dpla_id):
 
 def test_p813_refresh_added_when_other_edits_exist():
     """When any other edit is being made on the file, the dispatcher
-    refreshes P813 on all DPLA-authored claims whose P813 isn't already
-    today's date."""
+    refreshes P813 on all DPLA-authored claims whose P813 doesn't match
+    the item's DPLA ingestDate."""
     import datetime as _dt
     import json
 
@@ -4005,6 +4008,7 @@ def test_p813_refresh_added_when_other_edits_exist():
     entity = {"pageid": 999, "statements": {"P760": [old_claim]}}
 
     sdc_sync._reset_per_file_accumulators()
+    sdc_sync._current_ingest_date = _dt.date(2026, 6, 23)
     # Queue ONE unrelated removal so the dispatcher decides to edit.
     sdc_sync.removals.append("M999$some-other-claim")
 
@@ -4021,7 +4025,7 @@ def test_p813_refresh_added_when_other_edits_exist():
         sdc_sync._flush_per_file_edits("M999", "abcdef")
 
     payload = json.loads(submit_calls[0][1]["data"])
-    today_iso = "+" + _dt.date.today().isoformat() + "T00:00:00Z"
+    expected_iso = "+2026-06-23T00:00:00Z"
     refresh = [
         c for c in payload["claims"] if c.get("id") == "M999$old" and "references" in c
     ]
@@ -4029,18 +4033,19 @@ def test_p813_refresh_added_when_other_edits_exist():
     refreshed_p813 = refresh[0]["references"][0]["snaks"]["P813"][0]["datavalue"][
         "value"
     ]["time"]
-    assert refreshed_p813 == today_iso
+    assert refreshed_p813 == expected_iso
     sdc_sync._reset_per_file_accumulators()
 
 
 def test_p813_refresh_skips_claims_already_dated_today():
-    """A DPLA reference whose P813 is already today is not re-emitted."""
+    """A DPLA reference whose P813 already matches the ingestDate is not
+    re-emitted."""
     import datetime as _dt
     import json
 
     from tools import sdc_sync
 
-    today_iso = "+" + _dt.date.today().isoformat() + "T00:00:00Z"
+    expected_iso = "+2026-06-23T00:00:00Z"
     fresh_ref = {
         "snaks": {
             "P854": [
@@ -4061,7 +4066,7 @@ def test_p813_refresh_skips_claims_already_dated_today():
                     "datavalue": {
                         "type": "time",
                         "value": {
-                            "time": today_iso,
+                            "time": expected_iso,
                             "timezone": 0,
                             "before": 0,
                             "after": 0,
@@ -4086,6 +4091,7 @@ def test_p813_refresh_skips_claims_already_dated_today():
     entity = {"pageid": 999, "statements": {"P760": [fresh_claim]}}
 
     sdc_sync._reset_per_file_accumulators()
+    sdc_sync._current_ingest_date = _dt.date(2026, 6, 23)
     sdc_sync.removals.append("M999$some-other-claim")
 
     submit_calls = []
@@ -4142,6 +4148,7 @@ def test_p813_refresh_preserves_user_added_references():
     entity = {"pageid": 999, "statements": {"P760": [claim]}}
 
     sdc_sync._reset_per_file_accumulators()
+    sdc_sync._current_ingest_date = _dt.date(2026, 6, 23)
     sdc_sync.removals.append("M999$some-other-claim")
 
     submit_calls = []
@@ -4164,8 +4171,8 @@ def test_p813_refresh_preserves_user_added_references():
     )
     refs = refresh["references"]
     assert refs[0] == user_ref
-    today_iso = "+" + _dt.date.today().isoformat() + "T00:00:00Z"
-    assert refs[1]["snaks"]["P813"][0]["datavalue"]["value"]["time"] == today_iso
+    expected_iso = "+2026-06-23T00:00:00Z"
+    assert refs[1]["snaks"]["P813"][0]["datavalue"]["value"]["time"] == expected_iso
     sdc_sync._reset_per_file_accumulators()
 
 
@@ -4173,15 +4180,15 @@ def test_reference_refresh_repairs_partial_dpla_reference():
     """A DPLA reference that is the publisher marker (P123) but is MISSING
     P854 — e.g. one a foreign bot wrote, or an older sdc-sync left partial —
     is rebuilt to the full canonical P854+P123+P813 triple, EVEN when its
-    P813 is already today (the old date-only refresh would have skipped it).
-    This is the shape repair that lets us always re-assert the expected
-    reference without a separate reconcile pass."""
+    P813 already matches the ingestDate (the old date-only refresh would
+    have skipped it). This is the shape repair that lets us always
+    re-assert the expected reference without a separate reconcile pass."""
     import datetime as _dt
     import json
 
     from tools import sdc_sync
 
-    today_iso = "+" + _dt.date.today().isoformat() + "T00:00:00Z"
+    expected_iso = "+2026-06-23T00:00:00Z"
     partial_ref = {
         "snaks": {
             # No P854 — the partial/broken shape.
@@ -4193,7 +4200,7 @@ def test_reference_refresh_repairs_partial_dpla_reference():
                     "datavalue": {
                         "type": "time",
                         "value": {
-                            "time": today_iso,
+                            "time": expected_iso,
                             "timezone": 0,
                             "before": 0,
                             "after": 0,
@@ -4221,6 +4228,7 @@ def test_reference_refresh_repairs_partial_dpla_reference():
     entity = {"pageid": 999, "statements": {"P275": [claim]}}
 
     sdc_sync._reset_per_file_accumulators()
+    sdc_sync._current_ingest_date = _dt.date(2026, 6, 23)
     sdc_sync.removals.append("M999$some-other-claim")
 
     submit_calls = []
@@ -4240,18 +4248,20 @@ def test_reference_refresh_repairs_partial_dpla_reference():
     ref_snaks = repaired["references"][0]["snaks"]
     assert ref_snaks["P854"][0]["datavalue"]["value"] == "https://dp.la/item/abcdef"
     assert ref_snaks["P123"][0]["datavalue"]["value"]["id"] == "Q2944483"
-    assert ref_snaks["P813"][0]["datavalue"]["value"]["time"] == today_iso
+    assert ref_snaks["P813"][0]["datavalue"]["value"]["time"] == expected_iso
     sdc_sync._reset_per_file_accumulators()
 
 
 def test_reference_refresh_skips_fully_canonical_reference():
     """A DPLA reference already at the full canonical shape (P854 for this
-    item + P123 + P813 today) produces no fragment — no spurious edit."""
+    item + P123 + P813 matching the ingestDate) produces no fragment — no
+    spurious edit."""
+    import datetime as _dt
     import json
 
     from tools import sdc_sync
 
-    canonical = sdc_sync._build_dpla_reference("abcdef")
+    canonical = sdc_sync._build_dpla_reference("abcdef", _dt.date(2026, 6, 23))
     claim = {
         "id": "M999$canon",
         "mainsnak": {
@@ -4268,6 +4278,7 @@ def test_reference_refresh_skips_fully_canonical_reference():
     entity = {"pageid": 999, "statements": {"P275": [claim]}}
 
     sdc_sync._reset_per_file_accumulators()
+    sdc_sync._current_ingest_date = _dt.date(2026, 6, 23)
     sdc_sync.removals.append("M999$some-other-claim")
 
     submit_calls = []
@@ -4337,7 +4348,10 @@ def test_flush_emits_type_statement_on_every_non_removal_fragment():
         },
     }
 
+    import datetime as _dt
+
     sdc_sync._reset_per_file_accumulators()
+    sdc_sync._current_ingest_date = _dt.date(2026, 6, 23)
     sdc_sync.qualifier_amends.append(
         ("M999$amend", "P2699", sdc_sync._url_snak("P2699", "https://example.com/foo"))
     )
@@ -5590,7 +5604,7 @@ def test_maintain_process_file_renames_before_sync():
         patch.object(sdc_sync, "_s3_partner", "digitalnc"),
         patch.object(sdc_sync, "_maintain_rename", return_value=renamed) as mock_rename,
         patch.object(
-            sdc_sync, "_maintain_sidecar_payload", return_value={"claims": []}
+            sdc_sync, "_maintain_sidecar_payload", return_value={"claims": [], "ingest_date": "2026-06-23"}
         ),
         patch.object(
             sdc_sync.wikimedia,

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -37,7 +37,6 @@ consumed by the downloader and uploader:
     get-ids-es pa > pa/pa.csv
 """
 
-import datetime
 import json
 import logging
 import sys
@@ -390,7 +389,6 @@ def main(
     # SDC pre-compute inputs.
     rights = load_rights_json()
     subject_ids = fetch_subjects_json()
-    retrieval_date = datetime.date.today()
 
     banlist = Banlist()
     s3_client = S3Client()
@@ -596,17 +594,19 @@ def main(
                     rights,
                     subject_ids,
                     subjects_lookup,
-                    retrieval_date,
                 )
-            except ET.ParseError as e:
-                # parse_nara_access_level surfaces malformed NARA
-                # originalRecord XML here instead of silently writing a
-                # partial sdc.json missing P7228/P6224. One bad item
-                # must not abort staging for the whole NARA hub.
+            except (ET.ParseError, ValueError) as e:
+                # ET.ParseError: parse_nara_access_level on malformed
+                # NARA originalRecord XML. ValueError:
+                # ingest_date_from_doc on missing / unparseable
+                # ingestDate. Both are per-item data-integrity signals,
+                # not conditions to abort the whole hub for — skip the
+                # sdc.json for this item and keep going.
                 logging.warning(
-                    "build_claims_for_doc for %s raised ET.ParseError (%s); "
+                    "build_claims_for_doc for %s raised %s (%s); "
                     "skipping sdc.json for this item",
                     dpla_id,
+                    type(e).__name__,
                     e,
                 )
                 sdc_skipped += 1

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -622,8 +622,9 @@ def main(
 
     if sdc_skipped:
         print(
-            f"Skipped sdc.json for {sdc_skipped} items "
-            "(unparseable provider/institution).",
+            f"Skipped sdc.json for {sdc_skipped} items"
+            " (missing/malformed dpla-map.json, unmappable source, or"
+            " missing/invalid ingestDate).",
             file=sys.stderr,
         )
     if sdc_failed[0]:

--- a/tools/get_ids_nara.py
+++ b/tools/get_ids_nara.py
@@ -27,7 +27,6 @@ Output: one DPLA ID per line to stdout. Redirect to produce the IDs CSV:
     get-ids-nara > nara/nara.csv
 """
 
-import datetime
 import json
 import logging
 import sys
@@ -328,7 +327,6 @@ def main() -> None:
     institutions_json = fetch_institutions_v2()
     rights = load_rights_json()
     subject_ids = fetch_subjects_json()
-    retrieval_date = datetime.date.today()
 
     dpla_ids: list[str] = []
     subject_queries: set[tuple[str, str]] = set()
@@ -415,16 +413,19 @@ def main() -> None:
                     rights,
                     subject_ids,
                     subjects_lookup,
-                    retrieval_date,
                 )
-            except ET.ParseError as e:
-                # Malformed NARA originalRecord XML (parse_nara_access_level
-                # surfaces this). Skip the sdc.json for this item rather than
-                # abort the whole run — same boundary get-ids-es uses.
+            except (ET.ParseError, ValueError) as e:
+                # ET.ParseError: parse_nara_access_level on malformed
+                # NARA originalRecord XML. ValueError:
+                # ingest_date_from_doc on missing / unparseable
+                # ingestDate. Both are per-item data-integrity signals;
+                # skip the sdc.json for this item rather than abort the
+                # whole run.
                 logging.warning(
-                    "build_claims_for_doc for %s raised ET.ParseError (%s);"
+                    "build_claims_for_doc for %s raised %s (%s);"
                     " skipping sdc.json for this item",
                     dpla_id,
+                    type(e).__name__,
                     e,
                 )
                 sdc_skipped += 1

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -18,6 +18,7 @@ from ingest_wikimedia.logs import setup_logging
 from ingest_wikimedia.sdc import (
     CHUNKABLE_PROPS,
     casefold_for_compare,
+    ingest_date_from_doc,
     parse_date_range,
     parse_dpla_date,
     parse_nara_access_level,
@@ -667,10 +668,12 @@ def formattedclaim(prop, value, value_type, dpla_id):
     ref_url.setTarget(_dpla_item_url(dpla_id))
     ref_publisher = pywikibot.Claim(site, "P123", is_reference=True)
     ref_publisher.setTarget(pywikibot.ItemPage(repo, "Q2944483"))
-    today = datetime.date.today()
+    ingest_date = _require_ingest_date()
     ref_retrieved = pywikibot.Claim(site, "P813", is_reference=True)
     ref_retrieved.setTarget(
-        pywikibot.WbTime(year=today.year, month=today.month, day=today.day)
+        pywikibot.WbTime(
+            year=ingest_date.year, month=ingest_date.month, day=ingest_date.day
+        )
     )
     claim.addSources([ref_url, ref_publisher, ref_retrieved])
 
@@ -734,17 +737,41 @@ qualifier_amends = []  # list of (claimid, prop, snak_to_add)
 qualifier_removals = []  # list of (claimid, snak_hash_to_remove)
 removals = []  # list of statement IDs to remove from Commons
 
+# Per-file DPLA ingest date. Set at the top of each ``process_one`` /
+# ``process_one_from_sdc`` call from the item's ``ingestDate`` and used by
+# ``formattedclaim`` (P813 stamp) and ``_flush_per_file_edits`` (reference
+# refresh). ``None`` outside a process_one* call — reading it in that state
+# is a programming error and raises so a rogue caller can't silently fall
+# back to today. See ``ingest_wikimedia.sdc.ingest_date_from_doc`` for the
+# rationale on pinning to the ingest date rather than today.
+_current_ingest_date: datetime.date | None = None
+
 
 def _reset_per_file_accumulators():
     """Drop every per-file accumulator at the start of a new file's
     processing. Used by both ``process_one`` and ``process_one_from_sdc``
     so the dispatcher only ever sees the current file's fragments."""
     global claims, refclaims, qualifier_amends, qualifier_removals, removals
+    global _current_ingest_date
     claims = {"claims": []}
     refclaims = {"claims": []}
     qualifier_amends = []
     qualifier_removals = []
     removals = []
+    _current_ingest_date = None
+
+
+def _require_ingest_date() -> datetime.date:
+    """Return the per-file ingest date set by the current ``process_one*``
+    call. Raises ``RuntimeError`` when called outside a process_one* run —
+    fallback to today would defeat the whole point of ingest-date pinning."""
+    if _current_ingest_date is None:
+        raise RuntimeError(
+            "sdc_sync: no ingest_date set — a P813-producing helper was called "
+            "outside process_one / process_one_from_sdc, or the entry point "
+            "didn't set _current_ingest_date before the call."
+        )
+    return _current_ingest_date
 
 
 def _url_snak(prop, url):
@@ -2677,29 +2704,33 @@ def _entity_snak(prop, qid):
     }
 
 
-def _build_dpla_reference(dpla_id, retrieved=None):
+def _build_dpla_reference(dpla_id, ingest_date):
     """The canonical DPLA reference as a wbeditentity reference dict: the
     3-snak group ``P854`` (this item's dp.la URL) + ``P123`` (publisher =
-    DPLA, Q2944483) + ``P813`` (retrieved date, default today). Same shape
-    ``formattedclaim`` stamps on new claims (P813 via the shared
-    ``_build_p813_snak``), so a rebuilt reference is indistinguishable from
-    a freshly authored one."""
+    DPLA, Q2944483) + ``P813`` (retrieved date, pinned to the item's DPLA
+    ``ingestDate``). Same shape ``formattedclaim`` stamps on new claims
+    (P813 via the shared ``_build_p813_snak``), so a rebuilt reference is
+    indistinguishable from a freshly authored one.
+
+    See ``ingest_wikimedia.sdc.ingest_date_from_doc`` for why P813 is
+    pinned to the ingest date rather than today."""
     return {
         "snaks": {
             "P854": [_string_snak("P854", _dpla_item_url(dpla_id))],
             "P123": [_entity_snak("P123", "Q2944483")],
-            "P813": [_build_p813_snak(retrieved or datetime.date.today())],
+            "P813": [_build_p813_snak(ingest_date)],
         }
     }
 
 
-def _dpla_reference_is_canonical(reference, dpla_id):
+def _dpla_reference_is_canonical(reference, dpla_id, ingest_date):
     """True iff ``reference`` is already the complete, current DPLA reference
-    — publisher = DPLA (P123), this item's dp.la URL (P854), and today's
-    retrieved date (P813). A DPLA reference missing or wrong on any of these
-    is treated as needing a rebuild, so the refresh repairs a partial
-    reference (e.g. a foreign-bot rights claim that only ever carried P123)
-    in the same write that refreshes the date — no separate reconcile pass.
+    — publisher = DPLA (P123), this item's dp.la URL (P854), and the P813
+    retrieved date matching this item's DPLA ``ingestDate``. A DPLA
+    reference missing or wrong on any of these is treated as needing a
+    rebuild, so the refresh repairs a partial reference (e.g. a foreign-bot
+    rights claim that only ever carried P123) in the same write — no
+    separate reconcile pass.
 
     Identity keys on the P123 publisher marker (via ``_is_dpla_reference``);
     a reference that lost P123 entirely reads as foreign and is left
@@ -2713,31 +2744,34 @@ def _dpla_reference_is_canonical(reference, dpla_id):
         (snak.get("datavalue") or {}).get("value") == expected_url
         for snak in snaks.get("P854") or []
     )
-    return p854_ok and _p813_already_today(reference)
+    return p854_ok and _p813_matches(reference, ingest_date)
 
 
-def _build_reference_refresh_fragments(mediaid, dpla_id, already_touched_ids):
+def _build_reference_refresh_fragments(
+    mediaid, dpla_id, already_touched_ids, ingest_date
+):
     """Build reference-update fragments that make each DPLA-authored claim's
-    DPLA reference *canonical and current* — the full P854+P123+P813-today
-    triple — rewriting it wholesale rather than only swapping the P813 date.
+    DPLA reference *canonical and up-to-date* — the full P854+P123+P813
+    triple with P813 pinned to the item's DPLA ``ingestDate`` — rewriting
+    it wholesale rather than only swapping the P813 date.
 
-    This both refreshes the "as-of" retrieved date AND repairs a partial or
-    stale DPLA reference (e.g. one a foreign bot wrote with P123 but no P854)
-    in a single write — relying on the fact that re-asserting an identical
-    reference is a Wikibase no-op, so the only claims that actually change are
-    those whose DPLA reference isn't already canonical. User-added (non-DPLA)
-    references are preserved verbatim; a duplicate second DPLA reference (rare
-    legacy state) is collapsed to the single canonical one.
+    This both refreshes the retrieved date to match the current
+    ``ingestDate`` AND repairs a partial or stale DPLA reference (e.g. one
+    a foreign bot wrote with P123 but no P854) in a single write —
+    relying on the fact that re-asserting an identical reference is a
+    Wikibase no-op, so the only claims that actually change are those
+    whose DPLA reference isn't already canonical. User-added (non-DPLA)
+    references are preserved verbatim; a duplicate second DPLA reference
+    (rare legacy state) is collapsed to the single canonical one.
 
     Only fires for claims NOT already covered by another fragment in this
     file's edit (``already_touched_ids``), and only when the dispatcher is
     already making some other edit on the file (the call site builds these
     only when the bundle is otherwise non-empty) — so a file where every DPLA
-    reference is already canonical gets no spurious edit.
+    reference is already canonical gets no spurious edit. Pinning P813 to
+    ``ingestDate`` (rather than today) means back-to-back sync runs against
+    unchanged partner data produce no reference-refresh churn at all.
     """
-    # One date for the whole file's rebuilds, so fragments built either side
-    # of a UTC midnight boundary still agree on the retrieved date.
-    today = datetime.date.today()
     entity = get_entity(mediaid)
     fragments = []
     for prop_stmts in (entity.get("statements") or {}).values():
@@ -2762,10 +2796,10 @@ def _build_reference_refresh_fragments(mediaid, dpla_id, already_touched_ids):
                     changed = True  # duplicate DPLA reference — drop it
                     continue
                 seen_dpla = True
-                if _dpla_reference_is_canonical(ref, dpla_id):
+                if _dpla_reference_is_canonical(ref, dpla_id, ingest_date):
                     new_refs.append(ref)
                 else:
-                    new_refs.append(_build_dpla_reference(dpla_id, today))
+                    new_refs.append(_build_dpla_reference(dpla_id, ingest_date))
                     changed = True
             if changed:
                 # Same wholesale-replace contract as
@@ -2805,16 +2839,17 @@ def _build_p813_snak(retrieval_date):
     }
 
 
-def _p813_already_today(reference):
+def _p813_matches(reference, target_date):
     """Return True iff the reference's P813 (retrieved on) snak already
-    carries today's date in its time value. Avoids emitting spurious
-    edits on references that were already refreshed today (e.g. an
-    item processed twice in the same UTC day).
+    carries ``target_date`` in its time value. Used by the reference-refresh
+    path to skip references that are already up-to-date with the item's
+    DPLA ``ingestDate`` — the whole point of pinning P813 to the ingest
+    date is that a re-sync of unchanged partner data produces no diff.
     """
-    today_iso = "+" + datetime.date.today().isoformat() + "T00:00:00Z"
+    target_iso = "+" + target_date.isoformat() + "T00:00:00Z"
     for snak in (reference.get("snaks") or {}).get("P813") or []:
         try:
-            if snak["datavalue"]["value"]["time"] == today_iso:
+            if snak["datavalue"]["value"]["time"] == target_iso:
                 return True
         except (KeyError, TypeError):
             continue
@@ -2829,15 +2864,19 @@ def _flush_per_file_edits(mediaid, dpla_id):
     separate API calls.
 
     When any other edit fragments are present, opportunistically make
-    every other DPLA-authored claim's DPLA reference canonical and current
-    — the full P854+P123+P813-today triple — via
+    every other DPLA-authored claim's DPLA reference canonical and
+    up-to-date — the full P854+P123+P813 triple with P813 pinned to
+    the item's DPLA ``ingestDate`` — via
     ``_build_reference_refresh_fragments``. This both refreshes the
-    "retrieved on" date (the bot has just re-verified the file against
-    DPLA's source metadata, so every assertion is effectively "as-of
-    today") AND repairs a partial or stale DPLA reference left by an older
-    sync or a foreign bot. Re-asserting an already-canonical reference is a
-    Wikibase no-op, so there are no spurious edits when the file has
-    nothing else to change.
+    "retrieved on" date (against the current ingest date, not today)
+    AND repairs a partial or stale DPLA reference left by an older
+    sync or a foreign bot. Re-asserting an already-canonical reference
+    is a Wikibase no-op, so there are no spurious edits when the file
+    has nothing else to change.
+
+    The ingest date is read from ``_current_ingest_date``, which the
+    entry point set from the item's ``ingestDate``. See
+    ``ingest_wikimedia.sdc.ingest_date_from_doc`` for rationale.
 
     After a successful write, invalidate the cached entity once so any
     follow-up code reading from cache picks up the new revision.
@@ -2853,13 +2892,20 @@ def _flush_per_file_edits(mediaid, dpla_id):
         or removal_fragments
     )
     if has_any_other_edit:
+        # Only need the ingest date when we're actually building a
+        # reference-refresh fragment. This keeps the "nothing to do"
+        # path callable without a set ingest date (used by tests and by
+        # process_one entry points that short-circuit before setting it).
+        ingest_date = _require_ingest_date()
         touched_ids = set()
         for frag in qualifier_fragments + removal_fragments + reference_updates:
             fid = frag.get("id")
             if fid:
                 touched_ids.add(fid)
         reference_updates.extend(
-            _build_reference_refresh_fragments(mediaid, dpla_id, touched_ids)
+            _build_reference_refresh_fragments(
+                mediaid, dpla_id, touched_ids, ingest_date
+            )
         )
 
     _submit_per_item_edit(
@@ -4018,6 +4064,12 @@ def process_one(mediaid, dpla_id):
             missing.write(dpla_id + "\n")
             print(" -- Missing ID recorded.")
         return
+
+    # Pin P813 to the item's DPLA ingestDate for the whole file's writes.
+    # ``parsed()`` stashed the raw doc in ``_legacy_mode_doc_cache``; the
+    # legacy-mode cleanup helper pops it after we're done.
+    global _current_ingest_date
+    _current_ingest_date = ingest_date_from_doc(_legacy_mode_doc_cache[dpla_id])
     (
         url,
         descs,
@@ -4146,6 +4198,19 @@ def process_one_from_sdc(
     _entity_cache.clear()
     _reset_per_file_accumulators()
     get_entity(mediaid)
+
+    # Pin P813 to the ingest date the sdc.json envelope records — same date
+    # baked into every P813 snak in the payload's claims, kept as a
+    # top-level field so the reference-refresh path doesn't have to peel it
+    # out of a claim.
+    global _current_ingest_date
+    raw_ingest_date = sdc_payload.get("ingest_date")
+    if not isinstance(raw_ingest_date, str):
+        raise ValueError(
+            f"sdc.json for {dpla_id} is missing 'ingest_date' — regenerate "
+            "the sidecar with a post-P813-pinning get-ids-* run."
+        )
+    _current_ingest_date = datetime.date.fromisoformat(raw_ingest_date)
 
     sdc_claims = sdc_payload.get("claims", [])
     first_check = True


### PR DESCRIPTION
## Summary

Every substantive SDC edit currently rewrites the `P813` (retrieved on) reference date across every claim on the file to `datetime.date.today()`, so a re-sync that changes one thing (e.g. removes a stale claim) produces a diff where every one of the file's ~15 claims has its P813 date bumped. Example: [Abbott File on Commons](https://commons.wikimedia.org/w/index.php?title=File:Abbott,_A.D._-_DPLA_-_137b40c34543635bf3f145cd2f450227.jpg&diff=prev&oldid=1242360716) — a one-claim removal shows up as a mass reference-refresh, drowning out the substantive change.

Fix: pin `P813` to the DPLA item's **`ingestDate`** (the ISO 8601 timestamp DPLA's ingestion pipeline recorded when it harvested the item) rather than to the sync run's `today()`. Intellectually, this is still a true statement — that's the date DPLA acquired the data, and it doesn't change without a re-ingest that would update the field.

Result: a re-sync against unchanged partner data produces **no P813 diff at all** (`_p813_matches` short-circuits and `_dpla_reference_is_canonical` returns True for every existing ref). A diff that does appear reflects a real DPLA-side change.

## Changes

- **`ingest_wikimedia/sdc.py`**
  - New `ingest_date_from_doc(doc)` helper — parses `doc["ingestDate"]` (10-char ISO prefix) to a `datetime.date`. Raises `ValueError` when the field is missing/unparseable; callers skip that item's `sdc.json` (same convention as the existing `ET.ParseError` skip in `get-ids-*`).
  - `build_claims_for_doc` — removes the `retrieval_date` parameter; derives it internally via `ingest_date_from_doc(doc)`.
  - Envelope now includes `"ingest_date": "YYYY-MM-DD"` alongside `"claims"`, so `sdc-sync` doesn't have to peel a P813 snak to find the date.
  - Module docstring section added explaining the rationale.

- **`tools/sdc_sync.py`**
  - New module-level `_current_ingest_date` set at the top of `process_one` (from `_legacy_mode_doc_cache`) and `process_one_from_sdc` (from `sdc_payload["ingest_date"]`). Cleared by `_reset_per_file_accumulators`. `_require_ingest_date()` raises loudly if a P813-emitting helper is called outside a `process_one*` scope — no silent `today()` fallback.
  - `_build_dpla_reference`, `_dpla_reference_is_canonical`, `_build_reference_refresh_fragments`, `_flush_per_file_edits`, and `formattedclaim` all consume `_current_ingest_date` / an explicit `ingest_date` parameter.
  - `_p813_already_today` → `_p813_matches(reference, target_date)` (generalized).

- **`tools/get_ids_es.py`, `tools/get_ids_nara.py`**
  - Drop the now-unused `retrieval_date = datetime.date.today()` (and the `datetime` import in get-ids-es where it was the only use).
  - Catch `(ET.ParseError, ValueError)` per-item and log-skip.

- **Tests**
  - 4 new tests for `ingest_date_from_doc` and the outcome guarantee (same doc twice → same P813).
  - Existing `test_sdc_sync.py` reference-refresh tests updated to seed `_current_ingest_date` and check the pinned date rather than today.

Total: 1033 tests pass (was 1029).

## Also in this PR

Nothing for the [Pages workflow run](https://github.com/dpla/ingest-wikimedia/actions/runs/28604904360) — the failure is a Pages backend deployment-queue timeout (`##[error]Timeout reached, aborting!` after 10 min of `deployment_queued`), not a Markdown syntax issue. Build phase succeeded and Jekyll rendered `docs/upload-invariant.md` cleanly. Nothing to fix in the repo.

## Test plan

- [x] Full pytest suite passes (1033 tests) on wiki EC2 (`i-033eff6c8c168f999`, Python 3.13)
- [x] `ingest_date_from_doc` raises on missing / malformed / non-string values
- [x] `build_claims_for_doc` emits identical P813 for two calls against the same doc
- [x] Reference-refresh path skips claims whose P813 already matches the ingestDate
- [x] Reference-refresh path repairs partial DPLA refs (missing P854) even when P813 matches — shape repair
- [ ] Post-merge: manually inspect the next few Commons edits from partner-mode runs to confirm P813 diffs disappear on unchanged partner data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Pinned SDC `P813` (“retrieved on”) dates to each DPLA item’s `ingestDate` instead of the current sync date, reducing noisy diffs on re-syncs.

- `ingest_wikimedia/sdc.py` now parses `doc["ingestDate"]`, derives the reference date internally, and includes `ingest_date` in the generated SDC envelope.
- `tools/sdc_sync.py` carries the ingest date through legacy and partner sync paths, updates reference-refresh logic to use it, and removes the old “today” fallback behavior.
- `tools/get_ids_es.py` and `tools/get_ids_nara.py` drop unused retrieval-date handling and now skip only the affected item when parse/value errors occur.
- Tests were updated and expanded to cover ingest-date parsing, stable `P813` output, and the new reference-refresh behavior.

No API, infrastructure, secrets, database, or deployment changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->