### PR TITLE
Port CSRF session-recovery to every Wikimedia write path

### DIFF
--- a/ingest_wikimedia/categories.py
+++ b/ingest_wikimedia/categories.py
@@ -3,6 +3,7 @@ import logging
 import pywikibot
 from pywikibot.site import BaseSite
 
+from ingest_wikimedia.csrf import CsrfRecoveryFailed, with_csrf_recovery
 from ingest_wikimedia.wikimedia import get_wikidata_site
 
 # Stable Wikimedia ontology constants — these items will not change
@@ -247,7 +248,13 @@ class CategoryEnsurer:
             ],
         }
 
-        new_item.editEntity(data, summary="Create new Wikimedia Commons category item.")
+        with_csrf_recovery(
+            self._repo,
+            f"editEntity new-category ({institution_name})",
+            lambda: new_item.editEntity(
+                data, summary="Create new Wikimedia Commons category item."
+            ),
+        )
         return new_item.getID()
 
     def _add_p8464_to_institution(
@@ -277,9 +284,13 @@ class CategoryEnsurer:
                 f"none match expected {category_qid}"
             )
 
-        institution_item.addClaim(
-            self._item_claim("P8464", category_qid),
-            summary="Add Commons content partnership category.",
+        with_csrf_recovery(
+            self._repo,
+            f"addClaim P8464 to {institution_qid}",
+            lambda: institution_item.addClaim(
+                self._item_claim("P8464", category_qid),
+                summary="Add Commons content partnership category.",
+            ),
         )
 
 
@@ -315,8 +326,13 @@ def touch_institution_files(
         if log_each:
             logging.info(f"  Touching: {page.title()}")
         try:
-            page.touch()
+            with_csrf_recovery(commons_site, f"touch {page.title()}", page.touch)
             count += 1
+        except CsrfRecoveryFailed:
+            # Session-level fatal — propagate past the per-page catch
+            # so the caller can abort the run rather than logging one
+            # warning per remaining file.
+            raise
         except Exception as e:
             logging.warning(f"Failed to touch '{page.title()}'", exc_info=e)
     return count

--- a/ingest_wikimedia/categories.py
+++ b/ingest_wikimedia/categories.py
@@ -176,7 +176,11 @@ class CategoryEnsurer:
     def _create_commons_category(self, category_name: str) -> None:
         page = pywikibot.Page(self.commons_site, category_name)
         page.text = "{{dpla cat}}"
-        page.save(summary="Create institutional category")
+        with_csrf_recovery(
+            self.commons_site,
+            f"save {category_name} (create category)",
+            lambda: page.save(summary="Create institutional category"),
+        )
 
     def _get_or_create_wikidata_category_item(
         self,
@@ -197,6 +201,11 @@ class CategoryEnsurer:
             return self._create_wikidata_category_item(
                 institution_name, institution_qid, hub_category_qid, category_name
             )
+        except CsrfRecoveryFailed:
+            # Session-level fatal — the concurrent-create fallback below
+            # would silently paper over an auth failure and return a
+            # bogus success. Propagate so the run aborts.
+            raise
         except Exception as create_exc:
             # Another process may have created the item concurrently. Re-read before failing.
             try:

--- a/ingest_wikimedia/csrf.py
+++ b/ingest_wikimedia/csrf.py
@@ -1,0 +1,161 @@
+"""Shared CSRF-session-recovery primitives for every Wikimedia write path.
+
+Pywikibot's :class:`TokenWallet` raises
+``KeyError("Invalid token 'csrf' for user '<bot>' on commons:commons
+wiki.")`` when the cached session is invalidated by the server (long
+idle, forced logout, backend reset). Every subsequent write attempt
+raises the same ``KeyError`` — retrying the same call cannot recover;
+the session itself has to be dropped and re-established.
+
+PR #350 first fixed this for :mod:`tools.uploader`. The Toledo Lucas
+County SDC-sync run of 2026-06-25 then surfaced 68,411 identical CSRF
+errors bucketed as "SDC sync failed; skipping ordinal" over ~5.5 days
+— :func:`_submit_sdc_write`, :func:`FilePage.touch`,
+:meth:`ItemPage.editEntity` and :meth:`FilePage.save` all had the same
+weakness. This module extracts the detector, recovery function, and
+run-scoped cap into one place so every write path shares the same
+guardrails.
+
+## The invariants callers must maintain
+
+* Recovery is **per-process**: the counter lives on this module and
+  isolates naturally to one process. Under
+  ``tools.sdc_sync._run_partner_mode_parallel`` (spawn multiprocessing)
+  each worker imports its own copy of :mod:`ingest_wikimedia.csrf`, so
+  the effective cap is ``N × MAX_CSRF_RECOVERIES`` across N workers —
+  that's the intended design (each worker has its own pywikibot
+  session and can independently need refreshing) but callers should
+  read the cap that way rather than as "3 total per run". Within one
+  process, every writer shares the counter: never introduce an
+  instance-scoped duplicate.
+* The cap :data:`MAX_CSRF_RECOVERIES` is a hard guardrail against
+  unbounded loops on a persistently invalid session. Exceeding it
+  raises :class:`CsrfRecoveryFailed`, which callers should let
+  propagate past their generic per-item ``except Exception`` handlers
+  so the whole run aborts (mirrors the uploader's abort contract).
+* Only WRITE paths need this — :func:`is_csrf_token_error` only fires
+  on the specific ``KeyError`` from ``site.tokens['csrf']``. Read-only
+  API calls (``action=query``, ``wbgetentities``) never fetch the
+  csrf token, so they can't trip this error.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, TypeVar
+
+
+class CsrfRecoveryFailed(RuntimeError):
+    """Raised when the pywikibot session's CSRF token cannot be recovered.
+
+    Callers should route this AROUND their per-item generic
+    ``except Exception`` catches so a session-level fatal aborts the
+    run instead of looping the same error against every remaining item.
+    """
+
+
+MAX_CSRF_RECOVERIES = 3
+
+CSRF_TOKEN_ERROR_MARKER = "Invalid token 'csrf'"
+
+
+def is_csrf_token_error(ex: BaseException) -> bool:
+    """True iff ``ex`` is the pywikibot ``KeyError`` from ``TokenWallet``
+    whose message signals an invalidated CSRF token — narrowed on the
+    marker so unrelated ``KeyError``\\s don't trigger session recovery.
+    """
+    return isinstance(ex, KeyError) and CSRF_TOKEN_ERROR_MARKER in str(ex)
+
+
+def recover_commons_session(site) -> None:
+    """Drop the current pywikibot session, re-authenticate, and clear
+    the cached ``TokenWallet`` so the next ``site.tokens['csrf']``
+    fetch talks to a fresh session.
+
+    ``site.logout()`` is required first: ``site.login()`` on an
+    already-"logged-in" site is a no-op in pywikibot's default flow,
+    so clearing tokens alone would just re-fetch against the same
+    invalidated session.
+    """
+    logging.info("Recovering Commons session: logout + login + token-wallet clear")
+    site.logout()
+    site.login()
+    site.tokens.clear()
+
+
+# Run-scoped counter — module state so every write path in the process
+# shares the same cap. Reset at process start (import initializes to 0);
+# not intended to be reset mid-run.
+_session_recoveries_used = 0
+
+
+def session_recoveries_used() -> int:
+    """Return the number of CSRF recoveries the current process has
+    consumed so far. Used by callers that want to log recovery
+    progress ("recovery N/MAX") before invoking one."""
+    return _session_recoveries_used
+
+
+def bump_session_recovery() -> int:
+    """Record that a CSRF recovery has been attempted. Returns the new
+    count. Callers should call this AFTER
+    :func:`recover_commons_session` returns successfully so a failed
+    recovery attempt doesn't burn a slot."""
+    global _session_recoveries_used
+    _session_recoveries_used += 1
+    return _session_recoveries_used
+
+
+T = TypeVar("T")
+
+
+def with_csrf_recovery(site, action_label: str, thunk: Callable[[], T]) -> T:
+    """Call ``thunk()``; on CSRF error, refresh the session and retry
+    once. Repeat up to :data:`MAX_CSRF_RECOVERIES` times **across
+    the whole process** (session-scoped cap). Non-CSRF exceptions
+    propagate immediately.
+
+    ``action_label`` is a short human-readable tag used only in the
+    warning log line (e.g. ``"wbeditentity M12345"``, ``"touch File:X"``).
+
+    Raises :class:`CsrfRecoveryFailed` when the cap is exhausted or
+    when :func:`recover_commons_session` itself throws — callers
+    should let this propagate past their per-item catches so a
+    persistently invalid session aborts the run rather than looping
+    against every remaining item.
+
+    This helper is for write sites that don't already own a retry loop
+    (e.g. ``touch()``, ``editEntity()``, ``save()``). Sites that own
+    their own attempt-counted loop (:mod:`tools.uploader`) should
+    integrate the CSRF branch directly so they can coordinate the
+    per-item retry budget with session-level recovery.
+    """
+    while True:
+        try:
+            return thunk()
+        except Exception as ex:
+            if not is_csrf_token_error(ex):
+                raise
+            if session_recoveries_used() >= MAX_CSRF_RECOVERIES:
+                raise CsrfRecoveryFailed(
+                    f"Commons session invalidated on {action_label}: CSRF"
+                    f" token still invalid after {session_recoveries_used()}"
+                    f" recovery attempts; aborting run."
+                ) from ex
+            logging.warning(
+                "CSRF token invalidated on %s; refreshing Commons session"
+                " (recovery %d/%d)",
+                action_label,
+                session_recoveries_used() + 1,
+                MAX_CSRF_RECOVERIES,
+            )
+            try:
+                recover_commons_session(site)
+            except Exception as recover_ex:
+                raise CsrfRecoveryFailed(
+                    f"Commons session recovery threw on {action_label}"
+                    f" ({recover_ex!r}); aborting rather than looping"
+                    f" unrecoverable auth errors."
+                ) from recover_ex
+            bump_session_recovery()
+            # Loop and retry the thunk against the recovered session.

--- a/ingest_wikimedia/csrf.py
+++ b/ingest_wikimedia/csrf.py
@@ -139,14 +139,39 @@ def bump_session_recovery() -> int:
 T = TypeVar("T")
 
 
+def reset_session_recoveries() -> None:
+    """Zero the recovery counter — used to signal that a write against
+    the current session succeeded, so the cap should be interpreted as
+    "consecutive failed recoveries" rather than a lifetime budget.
+
+    A 5.5-day partner-mode run can legitimately have the session go
+    stale more than :data:`MAX_CSRF_RECOVERIES` times over its lifetime
+    (Wikimedia session policy + long idle windows). Under a lifetime
+    cap, run N+1 stale-then-refresh events would abort the whole run
+    even though every recovery worked. Consecutive-cap semantics only
+    abort when the session is genuinely un-refreshable — which is what
+    :class:`CsrfRecoveryFailed` is meant to signal."""
+    global _session_recoveries_used
+    _session_recoveries_used = 0
+
+
 def with_csrf_recovery(site, action_label: str, thunk: Callable[[], T]) -> T:
-    """Call ``thunk()``; on CSRF error, refresh the session and retry
-    once. Repeat up to :data:`MAX_CSRF_RECOVERIES` times **across
-    the whole process** (session-scoped cap). Non-CSRF exceptions
-    propagate immediately.
+    """Call ``thunk()``; on CSRF error, refresh the session and retry.
+    Repeat until either ``thunk()`` succeeds or
+    :data:`MAX_CSRF_RECOVERIES` consecutive refreshes still can't
+    unstick the token — at which point :class:`CsrfRecoveryFailed` is
+    raised. Non-CSRF exceptions propagate immediately.
 
     ``action_label`` is a short human-readable tag used only in the
     warning log line (e.g. ``"wbeditentity M12345"``, ``"touch File:X"``).
+
+    **Cap semantics: consecutive, not lifetime.** After every
+    successful ``thunk()`` return the counter is reset to zero, so a
+    long-running process that legitimately experiences a stale session
+    N times over its lifetime — each recovered — never trips the cap.
+    The cap only fires when :data:`MAX_CSRF_RECOVERIES` refreshes in a
+    row fail to produce a working session, which is the genuine
+    "session is un-refreshable, abort the run" signal.
 
     Raises :class:`CsrfRecoveryFailed` when the cap is exhausted or
     when :func:`recover_commons_session` itself throws — callers
@@ -156,13 +181,14 @@ def with_csrf_recovery(site, action_label: str, thunk: Callable[[], T]) -> T:
 
     This helper is for write sites that don't already own a retry loop
     (e.g. ``touch()``, ``editEntity()``, ``save()``). Sites that own
-    their own attempt-counted loop (:mod:`tools.uploader`) should
-    integrate the CSRF branch directly so they can coordinate the
-    per-item retry budget with session-level recovery.
+    their own attempt-counted loop (:mod:`tools.uploader`) integrate
+    the CSRF branch directly and MUST also call
+    :func:`reset_session_recoveries` on successful writes to keep the
+    consecutive-cap semantics consistent across the shared counter.
     """
     while True:
         try:
-            return thunk()
+            result = thunk()
         except Exception as ex:
             if not is_csrf_token_error(ex):
                 raise
@@ -170,7 +196,7 @@ def with_csrf_recovery(site, action_label: str, thunk: Callable[[], T]) -> T:
                 raise CsrfRecoveryFailed(
                     f"Commons session invalidated on {action_label}: CSRF"
                     f" token still invalid after {session_recoveries_used()}"
-                    f" recovery attempts; aborting run."
+                    f" consecutive recovery attempts; aborting run."
                 ) from ex
             logging.warning(
                 "CSRF token invalidated on %s; refreshing Commons session"
@@ -189,3 +215,8 @@ def with_csrf_recovery(site, action_label: str, thunk: Callable[[], T]) -> T:
                 ) from recover_ex
             bump_session_recovery()
             # Loop and retry the thunk against the recovered session.
+            continue
+        # Successful write against the current session — reset the
+        # consecutive-recovery counter. See docstring above.
+        reset_session_recoveries()
+        return result

--- a/ingest_wikimedia/csrf.py
+++ b/ingest_wikimedia/csrf.py
@@ -60,11 +60,41 @@ CSRF_TOKEN_ERROR_MARKER = "Invalid token 'csrf'"
 
 
 def is_csrf_token_error(ex: BaseException) -> bool:
-    """True iff ``ex`` is the pywikibot ``KeyError`` from ``TokenWallet``
-    whose message signals an invalidated CSRF token — narrowed on the
-    marker so unrelated ``KeyError``\\s don't trigger session recovery.
+    """True iff ``ex`` (or any exception in its ``__cause__`` chain)
+    signals an invalidated CSRF token. Recognises two shapes:
+
+    1. Pywikibot's ``TokenWallet.__getitem__`` raises ``KeyError`` with
+       the :data:`CSRF_TOKEN_ERROR_MARKER` message — the wallet
+       couldn't produce a valid csrf token BEFORE we ever hit the wire
+       (session invalidated / wallet miss). This is the Toledo
+       2026-06-25 fingerprint.
+    2. Pywikibot's ``simple_request(...).submit()`` propagates an
+       ``APIError`` with ``code='badtoken'`` when the server rejected
+       our submitted token AND pywikibot's own internal relogin
+       didn't recover it — the wire-level twin of #1.
+
+    Walks ``__cause__`` because callers commonly wrap the underlying
+    pywikibot exception in a domain-specific ``RuntimeError`` (see
+    :func:`tools.sdc_sync._submit_sdc_write`), which would otherwise
+    hide the CSRF signal from :func:`with_csrf_recovery`.
     """
-    return isinstance(ex, KeyError) and CSRF_TOKEN_ERROR_MARKER in str(ex)
+    seen: set[int] = set()
+    cur: BaseException | None = ex
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, KeyError) and CSRF_TOKEN_ERROR_MARKER in str(cur):
+            return True
+        # Duck-typed on ``.code`` to avoid pulling pywikibot into this
+        # module's imports (test paths import this without pywikibot
+        # installed). ``APIError`` is the only exception in the write
+        # path that exposes ``.code``, so a false positive here
+        # requires a foreign exception class deliberately shadowing
+        # both ``.code`` and the string value ``'badtoken'`` — not a
+        # realistic collision.
+        if getattr(cur, "code", None) == "badtoken":
+            return True
+        cur = getattr(cur, "__cause__", None)
+    return False
 
 
 def recover_commons_session(site) -> None:

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -35,6 +35,7 @@ from urllib.parse import urlencode
 
 import mwparserfromhell
 
+from ingest_wikimedia.csrf import with_csrf_recovery
 from ingest_wikimedia.sdc import (
     CASEFOLD_COMPARE_KEYS,
     casefold_for_compare,
@@ -1155,16 +1156,24 @@ def post_legacy_import_claims(
 
     Raises :class:`pywikibot.exceptions.APIError` on Wikibase rejection
     — the caller catches it per-file so a single failure doesn't kill
-    the partner batch.
+    the partner batch. Wrapped in :func:`with_csrf_recovery` so an
+    invalidated session (``KeyError: Invalid token 'csrf'``) triggers
+    a refresh + retry rather than bubbling up as a per-file failure
+    for every remaining item — session-level fatals raise
+    :class:`CsrfRecoveryFailed` to abort the run instead.
     """
-    site.simple_request(
-        action="wbeditentity",
-        id=mediaid,
-        bot=True,
-        token=site.tokens["csrf"],
-        data=json.dumps({"claims": claims}),
-        summary=summary,
-    ).submit()
+    with_csrf_recovery(
+        site,
+        f"wbeditentity {mediaid} (legacy-artwork import)",
+        lambda: site.simple_request(
+            action="wbeditentity",
+            id=mediaid,
+            bot=True,
+            token=site.tokens["csrf"],
+            data=json.dumps({"claims": claims}),
+            summary=summary,
+        ).submit(),
+    )
 
 
 def migrate_legacy_file(

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -1270,7 +1270,11 @@ def migrate_legacy_file(
     wikitext_changed = rewritten != file_page.text
     if wikitext_changed:
         file_page.text = rewritten
-        file_page.save(summary=summary, minor=False, bot=True)
+        with_csrf_recovery(
+            file_page.site,
+            f"save {file_page.title()} (legacy-artwork migrate)",
+            lambda: file_page.save(summary=summary, minor=False, bot=True),
+        )
 
     return MigrationResult(
         imports_posted=len(claims),

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -15,6 +15,7 @@ from pywikibot.tools.chars import replace_invisible
 
 
 from .common import CHECKSUM, get_list, get_str, get_dict
+from .csrf import with_csrf_recovery
 from .s3 import S3_BUCKET, S3Client
 from .dpla import (
     WIKIDATA_FIELD_NAME,
@@ -770,7 +771,13 @@ def post_commonsdelinker_request(
     summary = f"universal replace: [[File:{old_filename}]] → [[File:{new_filename}]]"
     # Leading newline so the new request lands on its own line regardless
     # of whether the existing page ends with one.
-    site.editpage(page, summary=summary, minor=False, appendtext="\n" + template)
+    with_csrf_recovery(
+        site,
+        f"editpage CommonsDelinker request ({old_filename} → {new_filename})",
+        lambda: site.editpage(
+            page, summary=summary, minor=False, appendtext="\n" + template
+        ),
+    )
 
 
 def wiki_file_exists(site: BaseSite, sha1: str) -> bool:
@@ -1035,7 +1042,13 @@ def tag_as_duplicate(
     summary = f"Tagging as duplicate: correct title is [[File:{correct_filename}]]"
     # Trailing newline so the tag sits on its own line above whatever
     # wikitext currently starts the page.
-    site.editpage(file_page, summary=summary, minor=False, prependtext=tag + "\n")
+    with_csrf_recovery(
+        site,
+        f"editpage tag-as-duplicate ({file_page.title(with_ns=False)})",
+        lambda: site.editpage(
+            file_page, summary=summary, minor=False, prependtext=tag + "\n"
+        ),
+    )
 
 
 INVALID_CONTENT_TYPES = frozenset(

--- a/ingest_wikimedia/wikitext_normalize.py
+++ b/ingest_wikimedia/wikitext_normalize.py
@@ -26,6 +26,7 @@ import re
 
 import mwparserfromhell
 
+from ingest_wikimedia.csrf import with_csrf_recovery
 from ingest_wikimedia.sdc import (
     CASEFOLD_COMPARE_KEYS,
     casefold_for_compare,
@@ -544,5 +545,9 @@ def normalize_page(file_page, expected_params: dict, edit_summary: str) -> bool:
             f" -- {file_page.title()}: canonicalising DPLA-metadata template"
             " whitespace (no redundant params to strip)."
         )
-    file_page.save(summary=edit_summary, minor=True, bot=True)
+    with_csrf_recovery(
+        file_page.site,
+        f"save {file_page.title()} (wikitext normalize)",
+        lambda: file_page.save(summary=edit_summary, minor=True, bot=True),
+    )
     return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,3 +91,32 @@ def _no_slack_in_tests(monkeypatch: pytest.MonkeyPatch):
             # by a test that manually managed its lifetime).  Swallow so
             # subsequent ``p.stop()`` calls in this loop still run.
             pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_csrf_recovery_counter():
+    """Zero the shared ``ingest_wikimedia.csrf._session_recoveries_used``
+    module counter around every test.
+
+    The counter is process-scoped in production (each pywikibot process
+    is its own run), but the whole test suite runs in ONE process. Any
+    test that mutates it — the direct CSRF tests plus the sdc_sync /
+    uploader tests that prime it to exercise cap behavior — would leak
+    the value into subsequent tests without this reset. Autouse rather
+    than opt-in so a future CSRF test added without the fixture can't
+    silently poison the run's ordering.
+
+    Imports the module lazily so tests that don't touch pywikibot
+    surfaces (e.g. pure-data tests) don't pay the import cost per test.
+    """
+    try:
+        from ingest_wikimedia import csrf as _csrf
+    except ImportError:
+        # csrf module unavailable in this environment — nothing to reset.
+        yield
+        return
+    _csrf._session_recoveries_used = 0
+    try:
+        yield
+    finally:
+        _csrf._session_recoveries_used = 0

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -201,7 +201,10 @@ def test_with_csrf_recovery_refreshes_and_retries_on_csrf_error():
     site.logout.assert_called_once()
     site.login.assert_called_once()
     site.tokens.clear.assert_called_once()
-    assert csrf.session_recoveries_used() == 1
+    # Counter resets to 0 after the successful retry — consecutive-cap
+    # semantics. The recovery HAPPENED (site.logout/login/clear all
+    # asserted above), but a successful thunk zeroes the streak.
+    assert csrf.session_recoveries_used() == 0
 
 
 def test_with_csrf_recovery_raises_when_cap_exhausted():
@@ -253,7 +256,9 @@ def test_with_csrf_recovery_raises_if_recovery_itself_fails():
 def test_with_csrf_recovery_recovers_multiple_times_up_to_cap():
     """Successive CSRF errors, each recoverable on retry, walk the
     counter up to (but not past) the cap. Only the (cap+1)th error
-    raises."""
+    raises. Because the final ``thunk()`` DOES succeed, the counter
+    resets to 0 — consecutive-cap semantics reward the eventual
+    recovery."""
     site = MagicMock()
     seen = {"n": 0}
 
@@ -269,8 +274,72 @@ def test_with_csrf_recovery_recovers_multiple_times_up_to_cap():
 
     out = csrf.with_csrf_recovery(site, "test-action", _thunk)
     assert out == "eventually-ok"
-    assert csrf.session_recoveries_used() == csrf.MAX_CSRF_RECOVERIES
+    # Counter reset after the eventual success — even though we walked
+    # right to the cap, the successful thunk cleared the streak.
+    assert csrf.session_recoveries_used() == 0
+    # ...but recovery WAS invoked ``MAX_CSRF_RECOVERIES`` times to get
+    # us to the successful attempt.
     assert site.logout.call_count == csrf.MAX_CSRF_RECOVERIES
+
+
+def test_with_csrf_recovery_resets_counter_on_successful_thunk():
+    """Consecutive-cap semantics, not lifetime-cap: a successful
+    ``thunk()`` return zeros the counter, so a long-running run that
+    legitimately hits N stale-then-refresh events across its lifetime
+    doesn't trip the cap. Only :data:`MAX_CSRF_RECOVERIES`
+    *consecutive* failed recoveries abort the run."""
+    site = MagicMock()
+    call = {"n": 0}
+
+    def _flaky_thunk():
+        call["n"] += 1
+        if call["n"] == 1:
+            raise KeyError(
+                "Invalid token 'csrf' for user 'DPLA bot' on commons:commons wiki."
+            )
+        return f"ok-{call['n']}"
+
+    # First cycle: 1 recovery, then success. Counter reset.
+    assert csrf.with_csrf_recovery(site, "test-action", _flaky_thunk) == "ok-2"
+    assert csrf.session_recoveries_used() == 0, (
+        "counter must reset after successful thunk — otherwise long-running "
+        "processes exhaust the lifetime budget on legitimate stale sessions"
+    )
+
+    # A subsequent independent failure starts fresh at 1, not 2.
+    call["n"] = 0
+    assert csrf.with_csrf_recovery(site, "test-action", _flaky_thunk) == "ok-2"
+    assert csrf.session_recoveries_used() == 0
+
+
+def test_with_csrf_recovery_counter_persists_across_consecutive_failures():
+    """The reset happens only on SUCCESS. A run of consecutive CSRF
+    failures (no intervening success) walks the counter up to the cap,
+    exactly as before — the persistently-invalid-session guard still
+    works."""
+    site = MagicMock()
+
+    def _always_csrf():
+        raise KeyError(
+            "Invalid token 'csrf' for user 'DPLA bot' on commons:commons wiki."
+        )
+
+    with pytest.raises(csrf.CsrfRecoveryFailed):
+        csrf.with_csrf_recovery(site, "test-action", _always_csrf)
+    # All MAX_CSRF_RECOVERIES slots consumed by the consecutive failures.
+    assert csrf.session_recoveries_used() == csrf.MAX_CSRF_RECOVERIES
+
+
+def test_reset_session_recoveries_zeros_the_counter():
+    """The explicit reset function exists for callers that own their
+    own retry loop (the uploader) — they need to signal a successful
+    write to keep the consecutive-cap semantics consistent across the
+    shared counter."""
+    csrf.bump_session_recovery()
+    csrf.bump_session_recovery()
+    assert csrf.session_recoveries_used() == 2
+    csrf.reset_session_recoveries()
+    assert csrf.session_recoveries_used() == 0
 
 
 def test_csrf_recovery_failed_is_a_runtime_error_subclass():

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -46,6 +46,76 @@ def test_is_csrf_token_error_rejects_unrelated_keyerror():
     assert not csrf.is_csrf_token_error(KeyError("some_dict_key"))
 
 
+def test_is_csrf_token_error_matches_apierror_badtoken():
+    """The wire-level twin of the wallet KeyError: pywikibot's
+    ``APIError`` with ``code='badtoken'`` reaches us when the server
+    rejected our submitted token AND pywikibot's own internal relogin
+    couldn't recover it. Duck-typed on ``.code`` so the detector
+    doesn't need to import pywikibot."""
+
+    class FakeAPIError(Exception):
+        def __init__(self, code, info=""):
+            super().__init__(f"{code}: {info}")
+            self.code = code
+            self.info = info
+
+    assert csrf.is_csrf_token_error(FakeAPIError("badtoken", "Invalid CSRF token."))
+    # Not a badtoken error — any other pywikibot APIError code follows
+    # the caller's existing per-item skip path.
+    assert not csrf.is_csrf_token_error(FakeAPIError("ratelimited", "Slow down."))
+    assert not csrf.is_csrf_token_error(FakeAPIError("no-such-entity", "Missing."))
+
+
+def test_is_csrf_token_error_walks_cause_chain():
+    """``_submit_sdc_write`` wraps a pywikibot ``APIError(badtoken)``
+    in a ``RuntimeError(...) from e`` — without walking ``__cause__``
+    the detector would miss it and the CSRF write would fall through
+    to the caller's generic skip path, defeating the recovery
+    contract."""
+
+    class FakeAPIError(Exception):
+        def __init__(self, code):
+            super().__init__(code)
+            self.code = code
+
+    try:
+        try:
+            raise FakeAPIError("badtoken")
+        except Exception as inner:
+            raise RuntimeError("wbeditentity failed for M123: badtoken") from inner
+    except RuntimeError as outer:
+        assert csrf.is_csrf_token_error(outer)
+
+
+def test_is_csrf_token_error_walks_cause_chain_for_wallet_keyerror():
+    """Same chain-walking contract for the wallet-side ``KeyError``:
+    any caller that wraps the underlying token failure in another
+    exception must still route through recovery."""
+
+    try:
+        try:
+            raise KeyError(
+                "Invalid token 'csrf' for user 'DPLA bot' on commons:commons wiki."
+            )
+        except Exception as inner:
+            raise RuntimeError("outer wrapper") from inner
+    except RuntimeError as outer:
+        assert csrf.is_csrf_token_error(outer)
+
+
+def test_is_csrf_token_error_terminates_on_circular_cause_chain():
+    """Cycle-guard: a maliciously (or accidentally) circular
+    ``__cause__`` chain must not spin forever. Realistically
+    ``__cause__`` chains built via ``raise ... from ex`` never cycle,
+    but defense-in-depth keeps the detector total."""
+    a = RuntimeError("a")
+    b = RuntimeError("b")
+    a.__cause__ = b
+    b.__cause__ = a
+    # Doesn't hang; returns False because neither exception matches.
+    assert not csrf.is_csrf_token_error(a)
+
+
 def test_is_csrf_token_error_rejects_non_keyerror_with_matching_message():
     """A RuntimeError whose message happens to contain the marker must
     NOT trigger recovery — pywikibot only ever raises this as a

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,218 @@
+"""Tests for the shared CSRF-recovery primitives in
+``ingest_wikimedia.csrf``.
+
+Motivated by the Toledo Lucas 2026-06-25 SDC-sync run: 68,411 identical
+``KeyError("Invalid token 'csrf' ...")`` failures bucketed as
+"SDC sync failed; skipping ordinal" over ~5.5 days. PR #350 had already
+solved the same class of bug for :mod:`tools.uploader`; this suite
+locks the shared abstraction that every write path now consumes.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ingest_wikimedia import csrf
+
+
+def _reset_recovery_counter():
+    """Zero the module-level session counter so a test doesn't inherit
+    another test's recoveries. Not a public API — deliberately reaches
+    at the private name — because a public reset would invite misuse
+    at runtime."""
+    csrf._session_recoveries_used = 0
+
+
+@pytest.fixture(autouse=True)
+def _fresh_counter():
+    """Every test starts with the counter at 0."""
+    _reset_recovery_counter()
+    yield
+    _reset_recovery_counter()
+
+
+def test_is_csrf_token_error_matches_the_wallet_keyerror():
+    """The pywikibot ``TokenWallet.__getitem__`` failure produces a
+    ``KeyError`` whose message carries the exact marker below. That
+    marker + the ``KeyError`` type together are the narrow signal for
+    "session invalidated" — the whole point of the detector is that
+    it doesn't fire on ANY ``KeyError`` (a dict miss elsewhere in the
+    code must never trigger session recovery)."""
+    real = KeyError("Invalid token 'csrf' for user 'DPLA bot' on commons:commons wiki.")
+    assert csrf.is_csrf_token_error(real)
+
+
+def test_is_csrf_token_error_rejects_unrelated_keyerror():
+    assert not csrf.is_csrf_token_error(KeyError("some_dict_key"))
+
+
+def test_is_csrf_token_error_rejects_non_keyerror_with_matching_message():
+    """A RuntimeError whose message happens to contain the marker must
+    NOT trigger recovery — pywikibot only ever raises this as a
+    ``KeyError``, and a random exception happening to mention "Invalid
+    token 'csrf'" (e.g. an APIError echoing the server's info string)
+    should follow the normal per-item handler."""
+    assert not csrf.is_csrf_token_error(
+        RuntimeError("upstream said: Invalid token 'csrf' apparently")
+    )
+
+
+def test_recover_commons_session_calls_logout_login_and_clears_tokens():
+    """The three-step recovery is load-bearing:
+    ``site.login()`` on an already-logged-in site is a no-op in
+    pywikibot's default flow, so ``logout()`` must precede it; and
+    the ``TokenWallet`` caches tokens per-session, so ``clear()`` is
+    needed to force the next ``site.tokens['csrf']`` fetch."""
+    site = MagicMock()
+    csrf.recover_commons_session(site)
+    site.logout.assert_called_once()
+    site.login.assert_called_once()
+    site.tokens.clear.assert_called_once()
+
+
+def test_session_counter_is_run_scoped_across_calls():
+    """A stale session affects every writer in the process, so the
+    counter must be module-level (shared) — not instance-scoped
+    (per-writer). Verify successive ``bump_session_recovery`` calls
+    accumulate."""
+    assert csrf.session_recoveries_used() == 0
+    csrf.bump_session_recovery()
+    assert csrf.session_recoveries_used() == 1
+    csrf.bump_session_recovery()
+    assert csrf.session_recoveries_used() == 2
+
+
+def test_with_csrf_recovery_passes_through_on_success():
+    """The happy path: the thunk returns cleanly and its value comes
+    straight back — no session touched, no recovery consumed."""
+    site = MagicMock()
+    out = csrf.with_csrf_recovery(site, "test-action", lambda: "ok")
+    assert out == "ok"
+    site.logout.assert_not_called()
+    assert csrf.session_recoveries_used() == 0
+
+
+def test_with_csrf_recovery_reraises_non_csrf_exceptions_immediately():
+    """A non-CSRF exception must NOT trigger session recovery — the
+    whole point of the narrow detector is that unrelated failures
+    (network, APIError, etc.) follow the caller's existing
+    per-item handler."""
+    site = MagicMock()
+    with pytest.raises(RuntimeError, match="other error"):
+        csrf.with_csrf_recovery(
+            site,
+            "test-action",
+            lambda: (_ for _ in ()).throw(RuntimeError("other error")),
+        )
+    site.logout.assert_not_called()
+    assert csrf.session_recoveries_used() == 0
+
+
+def test_with_csrf_recovery_refreshes_and_retries_on_csrf_error():
+    """On the FIRST CSRF error the helper drops the session, retries
+    the thunk against the fresh session, and returns the second
+    attempt's value. This is the exact recovery pattern the Toledo
+    run needed: one bad token → refresh → succeed on the next call.
+    """
+    site = MagicMock()
+    attempts = {"n": 0}
+
+    def _thunk():
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise KeyError(
+                "Invalid token 'csrf' for user 'DPLA bot' on commons:commons wiki."
+            )
+        return "recovered"
+
+    out = csrf.with_csrf_recovery(site, "test-action", _thunk)
+    assert out == "recovered"
+    assert attempts["n"] == 2
+    site.logout.assert_called_once()
+    site.login.assert_called_once()
+    site.tokens.clear.assert_called_once()
+    assert csrf.session_recoveries_used() == 1
+
+
+def test_with_csrf_recovery_raises_when_cap_exhausted():
+    """Once the run-scoped cap (:data:`MAX_CSRF_RECOVERIES`) is hit,
+    the next CSRF error raises :class:`CsrfRecoveryFailed` instead
+    of looping — the guardrail against unbounded recovery on a
+    persistently invalid session. The raised exception must NOT be a
+    plain :class:`KeyError` (which would follow the per-item skip
+    path) so a session-level fatal actually aborts the run."""
+    site = MagicMock()
+    # Prime the counter to the cap.
+    for _ in range(csrf.MAX_CSRF_RECOVERIES):
+        csrf.bump_session_recovery()
+
+    def _always_csrf():
+        raise KeyError(
+            "Invalid token 'csrf' for user 'DPLA bot' on commons:commons wiki."
+        )
+
+    with pytest.raises(csrf.CsrfRecoveryFailed):
+        csrf.with_csrf_recovery(site, "test-action", _always_csrf)
+    # No session touch — cap was already exhausted before we tried.
+    site.logout.assert_not_called()
+
+
+def test_with_csrf_recovery_raises_if_recovery_itself_fails():
+    """If :func:`recover_commons_session` throws (e.g. login itself
+    fails), the helper wraps that as :class:`CsrfRecoveryFailed`
+    rather than letting the raw ``ConnectionError`` bubble past the
+    per-item handler as a routine failure. Session-level fatals need
+    the ``CsrfRecoveryFailed`` type to route around per-item
+    ``except Exception`` catches."""
+    site = MagicMock()
+    site.logout.side_effect = ConnectionError("network down")
+
+    def _thunk():
+        raise KeyError(
+            "Invalid token 'csrf' for user 'DPLA bot' on commons:commons wiki."
+        )
+
+    with pytest.raises(csrf.CsrfRecoveryFailed):
+        csrf.with_csrf_recovery(site, "test-action", _thunk)
+    # A failed recovery must NOT bump the counter — otherwise a run
+    # could burn its whole recovery budget on non-recovery-attempt
+    # failures and hit the cap before a real refresh has been tried.
+    assert csrf.session_recoveries_used() == 0
+
+
+def test_with_csrf_recovery_recovers_multiple_times_up_to_cap():
+    """Successive CSRF errors, each recoverable on retry, walk the
+    counter up to (but not past) the cap. Only the (cap+1)th error
+    raises."""
+    site = MagicMock()
+    seen = {"n": 0}
+
+    def _thunk():
+        seen["n"] += 1
+        # Fail csrf-style on the first MAX_CSRF_RECOVERIES calls,
+        # succeed on the (MAX+1)th.
+        if seen["n"] <= csrf.MAX_CSRF_RECOVERIES:
+            raise KeyError(
+                "Invalid token 'csrf' for user 'DPLA bot' on commons:commons wiki."
+            )
+        return "eventually-ok"
+
+    out = csrf.with_csrf_recovery(site, "test-action", _thunk)
+    assert out == "eventually-ok"
+    assert csrf.session_recoveries_used() == csrf.MAX_CSRF_RECOVERIES
+    assert site.logout.call_count == csrf.MAX_CSRF_RECOVERIES
+
+
+def test_csrf_recovery_failed_is_a_runtime_error_subclass():
+    """Callers `except Exception` would swallow the abort signal
+    otherwise. The subclass identity + the explicit
+    ``except CsrfRecoveryFailed: raise`` re-raise pattern in every
+    per-item handler together enforce the abort contract."""
+    assert issubclass(csrf.CsrfRecoveryFailed, RuntimeError)
+
+
+def test_max_csrf_recoveries_is_three():
+    """Locked at 3 by contract with the uploader (PR #350). Bumping
+    this is a design decision, not a mechanical tweak — a stuck
+    session usually can't be un-stuck by more attempts."""
+    assert csrf.MAX_CSRF_RECOVERIES == 3

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -741,9 +741,7 @@ def test_build_claims_for_doc_rejects_junky_iiif_manifest_values():
     }
 
     for junk in (None, "", "   ", "null", "ftp://example.org/x", "not a url"):
-        out = build_claims_for_doc(
-            _doc(junk), "abc1234567890", hubs, {}, {}, {}
-        )
+        out = build_claims_for_doc(_doc(junk), "abc1234567890", hubs, {}, {}, {})
         p7482 = next(c for c in out["claims"] if c["mainsnak"]["property"] == "P7482")
         assert "P6108" not in p7482["qualifiers"], (
             f"{junk!r} should not produce a P6108 qualifier"
@@ -756,9 +754,7 @@ def test_build_claims_for_doc_rejects_junky_iiif_manifest_values():
         "  https://example.org/iiif/manifest.json  ",
         "http://example.org/iiif/manifest.json",
     ):
-        out = build_claims_for_doc(
-            _doc(valid), "abc1234567890", hubs, {}, {}, {}
-        )
+        out = build_claims_for_doc(_doc(valid), "abc1234567890", hubs, {}, {}, {})
         p7482 = next(c for c in out["claims"] if c["mainsnak"]["property"] == "P7482")
         assert "P6108" in p7482["qualifiers"], (
             f"{valid!r} should produce a P6108 qualifier"
@@ -803,9 +799,7 @@ def test_build_claims_for_doc_tolerates_missing_rights_field():
         }
     }
 
-    out = build_claims_for_doc(
-        doc, "abc1234567890", hubs, {}, {}, {}
-    )
+    out = build_claims_for_doc(doc, "abc1234567890", hubs, {}, {}, {})
     # No crash. No P275/P6426 rights claims since the input had no rights.
     rights_props = {"P275", "P6426", "P6216"}
     rights_claims = [
@@ -1429,7 +1423,13 @@ def test_ingest_date_from_doc_raises_when_missing():
     loudly so the caller can skip the item — do NOT synthesize a date."""
     from ingest_wikimedia.sdc import ingest_date_from_doc
 
-    for bad in (None, {}, {"ingestDate": None}, {"ingestDate": ""}, {"ingestDate": 12345}):
+    for bad in (
+        None,
+        {},
+        {"ingestDate": None},
+        {"ingestDate": ""},
+        {"ingestDate": 12345},
+    ):
         try:
             ingest_date_from_doc(bad)
         except ValueError:

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1012,6 +1012,83 @@ def test_submit_sdc_write_runtime_error_message_names_the_action(monkeypatch):
     assert "permissiondenied" in msg
 
 
+def test_submit_sdc_write_recovers_from_csrf_error_and_retries(monkeypatch):
+    """The Toledo 2026-06-25 failure mode: pywikibot's ``TokenWallet``
+    raises ``KeyError("Invalid token 'csrf'")`` when the session goes
+    stale. Before this fix, every subsequent SDC write in the run
+    silently bucketed as "SDC sync failed; skipping ordinal" — 68,411
+    times over 5.5 days. Now the first CSRF error triggers a session
+    refresh (logout + login + tokens.clear) and the write is retried
+    against the fresh session; only the failure of that recovery, or
+    exhaustion of the run-scoped cap, aborts the run.
+    """
+    from ingest_wikimedia import csrf
+    from tools import sdc_sync
+
+    # Reset shared counter so this test doesn't pick up recoveries from
+    # earlier tests.
+    csrf._session_recoveries_used = 0
+
+    fake_site = _install_module_globals(monkeypatch, sdc_sync)
+    # The realistic failure point is the ``site.tokens["csrf"]`` lookup
+    # itself (pywikibot's ``TokenWallet.__getitem__`` raises the
+    # KeyError, not the API round-trip). Model that: on first read
+    # raise, on the retry (after ``.clear()`` + implicit refetch)
+    # succeed. ``fake_site.tokens`` from the helper is a plain dict —
+    # replace it with a MagicMock so we can drive the side_effect
+    # AND leave ``.clear()`` a no-op the recovery helper can still
+    # call without erasing the dict for the retry.
+    fake_site.tokens = MagicMock()
+    fake_site.tokens.__getitem__.side_effect = [
+        KeyError("Invalid token 'csrf' for user 'DPLA bot' on commons:commons wiki."),
+        "stub-csrf-token",
+    ]
+    request_mock = fake_site.simple_request.return_value
+
+    sdc_sync._submit_sdc_write(
+        "wbeditentity", "M12345", "abcdef01abcdef01abcdef01abcdef01", data="{}"
+    )
+
+    assert request_mock.submit.call_count == 1, (
+        "second try succeeds — first attempt failed before .submit() ran"
+    )
+    assert fake_site.tokens.__getitem__.call_count == 2, (
+        "helper must re-fetch site.tokens['csrf'] after refresh"
+    )
+    fake_site.logout.assert_called_once()
+    fake_site.login.assert_called_once()
+    fake_site.tokens.clear.assert_called_once()
+    assert csrf.session_recoveries_used() == 1
+    csrf._session_recoveries_used = 0
+
+
+def test_submit_sdc_write_aborts_when_csrf_cap_exhausted(monkeypatch):
+    """After :data:`MAX_CSRF_RECOVERIES` refreshes fail to unstick the
+    token, the helper raises :class:`CsrfRecoveryFailed` — a
+    non-``KeyError`` type — so the caller's ``except CsrfRecoveryFailed``
+    arm can propagate the abort past the per-item ``except Exception``
+    catch, killing the whole run rather than looping the same
+    unrecoverable auth error against every remaining ordinal.
+    """
+    from ingest_wikimedia import csrf
+    from tools import sdc_sync
+
+    # Prime the counter to the cap so the next CSRF error is fatal.
+    csrf._session_recoveries_used = csrf.MAX_CSRF_RECOVERIES
+
+    fake_site = _install_module_globals(monkeypatch, sdc_sync)
+    fake_site.simple_request.return_value.submit.side_effect = KeyError(
+        "Invalid token 'csrf' for user 'DPLA bot' on commons:commons wiki."
+    )
+
+    with pytest.raises(csrf.CsrfRecoveryFailed):
+        sdc_sync._submit_sdc_write(
+            "wbeditentity", "M12345", "abcdef01abcdef01abcdef01abcdef01", data="{}"
+        )
+    fake_site.logout.assert_not_called()
+    csrf._session_recoveries_used = 0
+
+
 def test_missing_entity_error_is_not_a_runtime_error():
     """The per-ordinal handler distinguishes ``_MissingEntityError`` from
     generic ``RuntimeError`` / ``Exception``. Keep the class hierarchy
@@ -2282,7 +2359,9 @@ def test_reconciler_removes_value_typed_claim_when_dpla_dropped_the_date(monkeyp
     from tools import sdc_sync
 
     # New sdc.json has NO P571 claim at all.
-    expected = sdc_sync._build_expected_from_sdc({"claims": [], "ingest_date": "2026-06-23"})
+    expected = sdc_sync._build_expected_from_sdc(
+        {"claims": [], "ingest_date": "2026-06-23"}
+    )
     assert expected == {}
 
     stale_live = _value_typed_p571_claim(
@@ -2968,7 +3047,10 @@ def test_amend_p760_page_qualifier_noop_when_page_number_is_none_and_no_existing
         ),
     ):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=None
+            "M999",
+            "abcdef",
+            {"claims": [], "ingest_date": "2026-06-23"},
+            page_number=None,
         )
     assert submit_calls == []
     # No writes happened → no terminal invalidate.
@@ -3010,7 +3092,10 @@ def test_amend_p760_page_qualifier_removes_stale_p304_when_page_number_is_none()
     sdc_sync._reset_per_file_accumulators()
     with patch.object(sdc_sync, "get_entity", return_value=entity):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=None
+            "M999",
+            "abcdef",
+            {"claims": [], "ingest_date": "2026-06-23"},
+            page_number=None,
         )
 
     assert sdc_sync.qualifier_removals == [("M999$p760id", "obsolete-hash")]
@@ -3564,7 +3649,9 @@ def test_process_one_from_sdc_clears_entity_cache_at_file_boundary(monkeypatch):
 
     _patch_process_one_from_sdc_dependencies(monkeypatch, sdc_sync, "M999")
 
-    sdc_sync.process_one_from_sdc("M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"})
+    sdc_sync.process_one_from_sdc(
+        "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}
+    )
 
     # Prior files' entities are gone. The current mediaid may or may not
     # be in the cache afterward (post-write cleanup invalidates it), but
@@ -3588,7 +3675,9 @@ def test_entity_cache_does_not_grow_across_many_files(monkeypatch):
     for i in range(100):
         mediaid = f"M{1000 + i}"
         _patch_process_one_from_sdc_dependencies(monkeypatch, sdc_sync, mediaid)
-        sdc_sync.process_one_from_sdc(mediaid, f"dpla{i:06d}", {"claims": [], "ingest_date": "2026-06-23"})
+        sdc_sync.process_one_from_sdc(
+            mediaid, f"dpla{i:06d}", {"claims": [], "ingest_date": "2026-06-23"}
+        )
         sizes.append(len(sdc_sync._entity_cache))
 
     # Pre-fix, sizes would be [1, 2, 3, ..., 100] (linear growth).
@@ -5604,7 +5693,9 @@ def test_maintain_process_file_renames_before_sync():
         patch.object(sdc_sync, "_s3_partner", "digitalnc"),
         patch.object(sdc_sync, "_maintain_rename", return_value=renamed) as mock_rename,
         patch.object(
-            sdc_sync, "_maintain_sidecar_payload", return_value={"claims": [], "ingest_date": "2026-06-23"}
+            sdc_sync,
+            "_maintain_sidecar_payload",
+            return_value={"claims": [], "ingest_date": "2026-06-23"},
         ),
         patch.object(
             sdc_sync.wikimedia,

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1012,7 +1012,23 @@ def test_submit_sdc_write_runtime_error_message_names_the_action(monkeypatch):
     assert "permissiondenied" in msg
 
 
-def test_submit_sdc_write_recovers_from_csrf_error_and_retries(monkeypatch):
+@pytest.fixture
+def _fresh_csrf_counter():
+    """Zero the shared ``csrf._session_recoveries_used`` before AND after
+    each CSRF-related sdc_sync test so an intermediate assertion failure
+    can't leak process-wide state into another test."""
+    from ingest_wikimedia import csrf
+
+    csrf._session_recoveries_used = 0
+    try:
+        yield
+    finally:
+        csrf._session_recoveries_used = 0
+
+
+def test_submit_sdc_write_recovers_from_csrf_error_and_retries(
+    monkeypatch, _fresh_csrf_counter
+):
     """The Toledo 2026-06-25 failure mode: pywikibot's ``TokenWallet``
     raises ``KeyError("Invalid token 'csrf'")`` when the session goes
     stale. Before this fix, every subsequent SDC write in the run
@@ -1024,10 +1040,6 @@ def test_submit_sdc_write_recovers_from_csrf_error_and_retries(monkeypatch):
     """
     from ingest_wikimedia import csrf
     from tools import sdc_sync
-
-    # Reset shared counter so this test doesn't pick up recoveries from
-    # earlier tests.
-    csrf._session_recoveries_used = 0
 
     fake_site = _install_module_globals(monkeypatch, sdc_sync)
     # The realistic failure point is the ``site.tokens["csrf"]`` lookup
@@ -1059,10 +1071,11 @@ def test_submit_sdc_write_recovers_from_csrf_error_and_retries(monkeypatch):
     fake_site.login.assert_called_once()
     fake_site.tokens.clear.assert_called_once()
     assert csrf.session_recoveries_used() == 1
-    csrf._session_recoveries_used = 0
 
 
-def test_submit_sdc_write_aborts_when_csrf_cap_exhausted(monkeypatch):
+def test_submit_sdc_write_aborts_when_csrf_cap_exhausted(
+    monkeypatch, _fresh_csrf_counter
+):
     """After :data:`MAX_CSRF_RECOVERIES` refreshes fail to unstick the
     token, the helper raises :class:`CsrfRecoveryFailed` — a
     non-``KeyError`` type — so the caller's ``except CsrfRecoveryFailed``
@@ -1086,7 +1099,6 @@ def test_submit_sdc_write_aborts_when_csrf_cap_exhausted(monkeypatch):
             "wbeditentity", "M12345", "abcdef01abcdef01abcdef01abcdef01", data="{}"
         )
     fake_site.logout.assert_not_called()
-    csrf._session_recoveries_used = 0
 
 
 def test_missing_entity_error_is_not_a_runtime_error():

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1070,7 +1070,8 @@ def test_submit_sdc_write_recovers_from_csrf_error_and_retries(
     fake_site.logout.assert_called_once()
     fake_site.login.assert_called_once()
     fake_site.tokens.clear.assert_called_once()
-    assert csrf.session_recoveries_used() == 1
+    # Consecutive-cap semantics: successful retry resets the counter.
+    assert csrf.session_recoveries_used() == 0
 
 
 def test_submit_sdc_write_aborts_when_csrf_cap_exhausted(

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -2044,14 +2044,14 @@ def _csrf_keyerror() -> KeyError:
     )
 
 
-def testis_csrf_token_error_matches_pywikibot_shape():
+def test_is_csrf_token_error_matches_pywikibot_shape():
     """Substring match on ``str(KeyError(...))`` — Python wraps KeyError
     args in quotes on stringify, so the marker must appear inside those
     wrapping quotes."""
     assert is_csrf_token_error(_csrf_keyerror())
 
 
-def testis_csrf_token_error_rejects_unrelated_keyerror():
+def test_is_csrf_token_error_rejects_unrelated_keyerror():
     """A KeyError from any other code path (e.g. dict miss on 'title')
     must not be treated as a CSRF error — otherwise a bug elsewhere
     could accidentally trip the whole session-abort escalation."""
@@ -2059,7 +2059,7 @@ def testis_csrf_token_error_rejects_unrelated_keyerror():
     assert not is_csrf_token_error(KeyError("csrf"))  # bare, no "Invalid token"
 
 
-def testis_csrf_token_error_rejects_non_keyerror():
+def test_is_csrf_token_error_rejects_non_keyerror():
     """A RuntimeError whose message happens to contain the CSRF marker
     isn't a real CSRF token error — pywikibot only raises this as
     KeyError. Guard against a false positive from log-string

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -2151,7 +2151,9 @@ def test_csrf_error_triggers_session_recovery_and_retry():
         f"expected 2. If this is 1, the recovery path returned instead "
         f"of continuing the loop."
     )
-    assert uploader._csrf_recoveries_used == 1
+    from ingest_wikimedia import csrf
+
+    assert csrf.session_recoveries_used() == 1
 
 
 def test_csrf_errors_beyond_cap_raise_csrf_recovery_failed():
@@ -2165,7 +2167,9 @@ def test_csrf_errors_beyond_cap_raise_csrf_recovery_failed():
     # a cleaner test than driving through many attempts (each of which
     # would exhaust MAX_UPLOAD_RETRIES per ordinal) and pins the cap
     # behavior specifically.
-    uploader._csrf_recoveries_used = MAX_CSRF_RECOVERIES
+    from ingest_wikimedia import csrf
+
+    csrf._session_recoveries_used = MAX_CSRF_RECOVERIES
     uploader._safe_upload = MagicMock(side_effect=_csrf_keyerror())
     with patch("tools.uploader.recover_commons_session") as recover_mock:
         with pytest.raises(CsrfRecoveryFailed):

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -12,14 +12,16 @@ from ingest_wikimedia.wikimedia import WMC_UPLOAD_CHUNK_SIZE
 from ingest_wikimedia.worker_slots import WorkerSlotBudget
 import pytest
 
+from ingest_wikimedia.csrf import (
+    CSRF_TOKEN_ERROR_MARKER,
+    CsrfRecoveryFailed,
+    MAX_CSRF_RECOVERIES,
+    is_csrf_token_error,
+)
 from tools.uploader import (
     LARGE_FILE_DIRECT_UPLOAD_LIMIT_BYTES,
-    MAX_CSRF_RECOVERIES,
-    CsrfRecoveryFailed,
     NewFilePageBlocked,
     Uploader,
-    _CSRF_TOKEN_ERROR_MARKER,
-    _is_csrf_token_error,
     _post_item_orphan_check,
     _post_upload_touch_new_institutions,
     is_dup_sha1_sibling_at_expected_title,
@@ -2038,31 +2040,31 @@ def _csrf_keyerror() -> KeyError:
     TokenWallet message. Uses the production marker constant so the
     detector and the test data can never drift apart."""
     return KeyError(
-        f"{_CSRF_TOKEN_ERROR_MARKER} for user 'DPLA bot' on commons:commons wiki."
+        f"{CSRF_TOKEN_ERROR_MARKER} for user 'DPLA bot' on commons:commons wiki."
     )
 
 
-def test_is_csrf_token_error_matches_pywikibot_shape():
+def testis_csrf_token_error_matches_pywikibot_shape():
     """Substring match on ``str(KeyError(...))`` — Python wraps KeyError
     args in quotes on stringify, so the marker must appear inside those
     wrapping quotes."""
-    assert _is_csrf_token_error(_csrf_keyerror())
+    assert is_csrf_token_error(_csrf_keyerror())
 
 
-def test_is_csrf_token_error_rejects_unrelated_keyerror():
+def testis_csrf_token_error_rejects_unrelated_keyerror():
     """A KeyError from any other code path (e.g. dict miss on 'title')
     must not be treated as a CSRF error — otherwise a bug elsewhere
     could accidentally trip the whole session-abort escalation."""
-    assert not _is_csrf_token_error(KeyError("title"))
-    assert not _is_csrf_token_error(KeyError("csrf"))  # bare, no "Invalid token"
+    assert not is_csrf_token_error(KeyError("title"))
+    assert not is_csrf_token_error(KeyError("csrf"))  # bare, no "Invalid token"
 
 
-def test_is_csrf_token_error_rejects_non_keyerror():
+def testis_csrf_token_error_rejects_non_keyerror():
     """A RuntimeError whose message happens to contain the CSRF marker
     isn't a real CSRF token error — pywikibot only raises this as
     KeyError. Guard against a false positive from log-string
     contamination."""
-    assert not _is_csrf_token_error(RuntimeError(_CSRF_TOKEN_ERROR_MARKER))
+    assert not is_csrf_token_error(RuntimeError(CSRF_TOKEN_ERROR_MARKER))
 
 
 def _csrf_retry_loop_uploader(tracker: Tracker) -> Uploader:
@@ -2126,7 +2128,7 @@ def _csrf_process_file(uploader: Uploader):
 
 
 def test_csrf_error_triggers_session_recovery_and_retry():
-    """First CSRF error → ``_recover_commons_session`` fires and the
+    """First CSRF error → ``recover_commons_session`` fires and the
     retry loop advances to the next attempt. Verifies the recovery +
     re-attempt contract only — the second attempt is arranged to fail
     with a non-CSRF error so the test doesn't have to fake the
@@ -2140,7 +2142,7 @@ def test_csrf_error_triggers_session_recovery_and_retry():
     uploader._safe_upload = MagicMock(
         side_effect=[_csrf_keyerror(), RuntimeError("second attempt marker")]
     )
-    with patch("tools.uploader._recover_commons_session") as recover_mock:
+    with patch("tools.uploader.recover_commons_session") as recover_mock:
         _csrf_process_file(uploader)
     recover_mock.assert_called_once_with(uploader.site)
     assert uploader._safe_upload.call_count == 2, (
@@ -2165,7 +2167,7 @@ def test_csrf_errors_beyond_cap_raise_csrf_recovery_failed():
     # behavior specifically.
     uploader._csrf_recoveries_used = MAX_CSRF_RECOVERIES
     uploader._safe_upload = MagicMock(side_effect=_csrf_keyerror())
-    with patch("tools.uploader._recover_commons_session") as recover_mock:
+    with patch("tools.uploader.recover_commons_session") as recover_mock:
         with pytest.raises(CsrfRecoveryFailed):
             _csrf_process_file(uploader)
     # Recovery must NOT have been attempted — the cap was already at the
@@ -2182,7 +2184,7 @@ def test_csrf_errors_beyond_cap_raise_csrf_recovery_failed():
 
 
 def test_csrf_recovery_that_throws_escalates_to_csrf_recovery_failed():
-    """If ``_recover_commons_session`` itself throws (network down,
+    """If ``recover_commons_session`` itself throws (network down,
     credentials rotated, etc.), escalate to ``CsrfRecoveryFailed``
     immediately rather than looping recovery attempts against an
     unreachable auth endpoint."""
@@ -2190,7 +2192,7 @@ def test_csrf_recovery_that_throws_escalates_to_csrf_recovery_failed():
     uploader = _csrf_retry_loop_uploader(tracker)
     uploader._safe_upload = MagicMock(side_effect=_csrf_keyerror())
     with patch(
-        "tools.uploader._recover_commons_session",
+        "tools.uploader.recover_commons_session",
         side_effect=RuntimeError("network unreachable"),
     ):
         with pytest.raises(CsrfRecoveryFailed):

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -4445,6 +4445,11 @@ def _post_sdc_cleanup_for_page(
                 file_page, expected_params, _NORMALIZE_EDIT_SUMMARY
             )
         )
+    except CsrfRecoveryFailed:
+        # Session-level fatal from the wrapped .save() — propagate so
+        # the run aborts rather than silently turning a stuck session
+        # into a per-file skip that would recur on every ordinal.
+        raise
     except Exception:
         logging.exception(
             f" -- cleanup: normalize_page on '{file_page.title()}' for"

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -26,6 +26,7 @@ from ingest_wikimedia.sdc import (
 )
 from ingest_wikimedia import legacy_artwork, wikimedia, wikitext_normalize
 from ingest_wikimedia.common import get_dict, get_list
+from ingest_wikimedia.csrf import CsrfRecoveryFailed, with_csrf_recovery
 from ingest_wikimedia.dpla import DC_TITLE_FIELD_NAME, SOURCE_RESOURCE_FIELD_NAME
 from ingest_wikimedia.maintain import resolve_current_dpla_id
 from ingest_wikimedia.slack import notify_phase_start, notify_sdc_complete
@@ -2330,11 +2331,24 @@ def _submit_sdc_write(action, mediaid, dpla_id, **params):
     - structured ``APIError(code=..., info=...)`` instead of JSON
       response inspection.
 
+    Wraps the call in :func:`with_csrf_recovery` so a stale
+    ``TokenWallet`` (``KeyError: Invalid token 'csrf'``) triggers a
+    session refresh (``logout`` + ``login`` + ``tokens.clear``) and
+    a retry rather than bubbling up as "SDC sync failed; skipping
+    ordinal" for every subsequent write in the run. See PR #350 for
+    the analogous uploader fix and the Toledo Lucas 2026-06-25
+    incident that surfaced the same weakness here (68,411 identical
+    CSRF errors bucketed as per-ordinal skips over ~5.5 days).
+
     Raises :class:`_MissingEntityError` when Commons returns
     ``no-such-entity`` (the entity doesn't exist; not the SDC phase's
     problem — see PR #267). Other ``APIError`` codes propagate as a
     ``RuntimeError`` carrying the code + info, which the per-ordinal
     handler catches and treats as an ``SDC_ORDINALS_SKIPPED_ERROR``.
+    Unrecoverable CSRF failures propagate as
+    :class:`CsrfRecoveryFailed` — routed AROUND the per-ordinal
+    generic catch so the whole run aborts (mirrors uploader
+    behaviour).
 
     ``params`` is the per-action payload — for wbeditentity, the
     serialized ``data``; for wbremoveclaims, the pipe-joined ``claim``
@@ -2342,20 +2356,24 @@ def _submit_sdc_write(action, mediaid, dpla_id, **params):
     injected here so call sites stay focused on the action-specific
     differences.
     """
-    try:
-        site.simple_request(
-            action=action,
-            id=mediaid,
-            bot=True,
-            token=site.tokens["csrf"],
-            **params,
-        ).submit()
-    except pywikibot.exceptions.APIError as e:
-        _raise_if_missing_entity(e, mediaid)
-        raise RuntimeError(
-            f"{action} failed for {mediaid} ({dpla_id}):"
-            f" {e.code} — {_truncate(getattr(e, 'info', ''))}"
-        ) from e
+
+    def _do_write():
+        try:
+            site.simple_request(
+                action=action,
+                id=mediaid,
+                bot=True,
+                token=site.tokens["csrf"],
+                **params,
+            ).submit()
+        except pywikibot.exceptions.APIError as e:
+            _raise_if_missing_entity(e, mediaid)
+            raise RuntimeError(
+                f"{action} failed for {mediaid} ({dpla_id}):"
+                f" {e.code} — {_truncate(getattr(e, 'info', ''))}"
+            ) from e
+
+    with_csrf_recovery(site, f"{action} {mediaid} ({dpla_id})", _do_write)
 
 
 def _snak_content_key(snak):
@@ -4966,6 +4984,12 @@ def _worker_partner_task(args):
         # real per-write safety net.
         with _worker_slot_budget.acquire():
             _process_one_partner_item(s3, partner, dpla_id, idx, total)
+    except CsrfRecoveryFailed:
+        # Session-level fatal — propagate to _run_partner_mode_parallel's
+        # future-collection loop so main() ends the run rather than
+        # every worker looping the same auth failure. Mirrors uploader's
+        # CSRF abort contract (PR #350).
+        raise
     except Exception:
         logging.exception(
             "Worker task crashed processing %s (idx %s/%s) in partner %s",
@@ -5307,6 +5331,13 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
             )
             tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY)
             continue
+        except CsrfRecoveryFailed:
+            # Session-level fatal — propagate past the per-ordinal
+            # catch so the whole run aborts rather than looping the
+            # same unrecoverable auth error against every remaining
+            # ordinal. Mirrors the uploader's CSRF abort contract
+            # (PR #350) and the Toledo 2026-06-25 lesson.
+            raise
         except Exception:
             logging.exception(
                 f" -- Ordinal {ord_str} ({mediaid}) for {dpla_id}:"
@@ -5331,8 +5362,18 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
             pages_edited.add(ord_str)
             if title and title != "?":
                 try:
-                    pywikibot.FilePage(site, title).touch()
+                    with_csrf_recovery(
+                        site,
+                        f"touch File:{title}",
+                        pywikibot.FilePage(site, title).touch,
+                    )
                     logging.info(f" -- Touched '{title}' (category refresh).")
+                except CsrfRecoveryFailed:
+                    # Session refresh exhausted — same abort contract as
+                    # the uploader: propagate past every per-item catch so
+                    # main() ends the run rather than looping the same
+                    # unrecoverable error against every remaining ordinal.
+                    raise
                 except Exception as e:
                     logging.warning(
                         f" -- Failed to touch '{title}' for category refresh: {e!r}"
@@ -5683,6 +5724,11 @@ def _safe_process_one(
             )
             tracker.increment(Result.SDC_ORDINALS_SKIPPED_MISSING_ENTITY)
             return
+        except CsrfRecoveryFailed:
+            # Session-level fatal — abort the whole run rather than
+            # looping the same unrecoverable auth error against every
+            # remaining file. Mirrors uploader's CSRF abort (PR #350).
+            raise
         except Exception:
             logging.exception(
                 f" -- {mediaid} for {dpla_id}: SDC sync failed; skipping."

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -4376,6 +4376,13 @@ def _post_sdc_cleanup_for_page(
                 dpla_id=dpla_id,
                 site=site,
             )
+        except CsrfRecoveryFailed:
+            # Session-level fatal from the wrapped writes inside
+            # migrate_legacy_file (post_legacy_import_claims and the
+            # post-migration .save). Propagate so the run aborts rather
+            # than silently turning a stuck session into per-file
+            # migrate skips that would recur on every remaining item.
+            raise
         except Exception:
             logging.exception(
                 f" -- cleanup: legacy migration of '{file_page.title()}'"
@@ -4779,6 +4786,11 @@ def _migrate_one_dpla_item(s3, partner: str, dpla_id: str) -> None:
             )
             tracker.increment(Result.LEGACY_SKIPPED_NOT_LEGACY)
             continue
+        except CsrfRecoveryFailed:
+            # Session-level fatal from wrapped writes in migrate_legacy_file
+            # — abort the run rather than counting it as a routine skip
+            # against every remaining item in the legacy loop.
+            raise
         except Exception:
             logging.exception(
                 f" -- '{title}' for {dpla_id}: legacy migration failed; skipping."

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -2467,6 +2467,12 @@ def _post_upload_touch_new_institutions(
         for inst_qid in sorted(newly_created):
             try:
                 n = touch_institution_files(commons_site, inst_qid)
+            except CsrfRecoveryFailed:
+                # Session-level fatal from a wrapped .touch() inside
+                # touch_institution_files — propagate so main() ends
+                # the run rather than logging a warning per remaining
+                # institution while writes stay broken.
+                raise
             except Exception as e:
                 logging.warning(f"Search/touch for {inst_qid} failed: {e}")
                 continue

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -76,6 +76,7 @@ from ingest_wikimedia.csrf import (
     MAX_CSRF_RECOVERIES,
     is_csrf_token_error,
     recover_commons_session,
+    with_csrf_recovery,
 )
 from ingest_wikimedia.dpla import (
     SOURCE_RESOURCE_FIELD_NAME,
@@ -1225,12 +1226,16 @@ class Uploader:
         else:
             new_text = wiki_markup
         wiki_file_page.text = new_text
-        wiki_file_page.save(
-            summary=(
-                f"Replacing redirect with DPLA metadata for title drift "
-                f"correction (DPLA ID [[dpla:{dpla_id}|{dpla_id}]])"
+        with_csrf_recovery(
+            self.site,
+            f"save {wiki_file_page.title()} (redirect-overwrite)",
+            lambda: wiki_file_page.save(
+                summary=(
+                    f"Replacing redirect with DPLA metadata for title drift "
+                    f"correction (DPLA ID [[dpla:{dpla_id}|{dpla_id}]])"
+                ),
+                minor=False,
             ),
-            minor=False,
         )
         wiki_file_page.clear_cache()
         return wiki_file_page, old_filename
@@ -1306,12 +1311,16 @@ class Uploader:
                 moved_page.text = merge_preserved_wikitext(
                     moved_page.text or "", wiki_markup
                 )
-                moved_page.save(
-                    summary=(
-                        f"Update description after title drift correction "
-                        f"(DPLA ID [[dpla:{dpla_id}|{dpla_id}]])"
+                with_csrf_recovery(
+                    self.site,
+                    f"save {moved_page.title()} (post-drift description)",
+                    lambda: moved_page.save(
+                        summary=(
+                            f"Update description after title drift correction "
+                            f"(DPLA ID [[dpla:{dpla_id}|{dpla_id}]])"
+                        ),
+                        minor=False,
                     ),
-                    minor=False,
                 )
 
     def _resolve_hash_drift(
@@ -1666,19 +1675,29 @@ class Uploader:
                     # round-trips and write directly.
                     new_page = get_page(self.site, f"File:{new_filename}")
                     new_page.text = merged
-                    new_page.save(
-                        summary=(
-                            f"Rescue community-contributed metadata from "
-                            f"[[File:{old_filename}]] (DPLA ID "
-                            f"[[dpla:{dpla_id}|{dpla_id}]])"
+                    with_csrf_recovery(
+                        self.site,
+                        f"save {new_page.title()} (rescue community metadata)",
+                        lambda: new_page.save(
+                            summary=(
+                                f"Rescue community-contributed metadata from "
+                                f"[[File:{old_filename}]] (DPLA ID "
+                                f"[[dpla:{dpla_id}|{dpla_id}]])"
+                            ),
+                            minor=False,
                         ),
-                        minor=False,
                     )
                     logging.info(
                         f"Rescued community-contributed metadata from "
                         f"[[File:{old_filename}]] into "
                         f"[[File:{new_filename}]] (DPLA ID {dpla_id})"
                     )
+        except CsrfRecoveryFailed:
+            # Session-level fatal — the community-metadata rescue is a
+            # best-effort side-effect, but a stuck CSRF token affects
+            # every subsequent write. Propagate so the run aborts
+            # instead of continuing to log rescue-failed warnings.
+            raise
         except Exception as ex:
             logging.warning(
                 f"Failed to rescue community contributions from "

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -71,6 +71,12 @@ from ingest_wikimedia.worker_slots import (
     WorkerSlotBudget,
 )
 from ingest_wikimedia.categories import CategoryEnsurer, touch_institution_files
+from ingest_wikimedia.csrf import (
+    CsrfRecoveryFailed,
+    MAX_CSRF_RECOVERIES,
+    is_csrf_token_error,
+    recover_commons_session,
+)
 from ingest_wikimedia.dpla import (
     SOURCE_RESOURCE_FIELD_NAME,
     DC_TITLE_FIELD_NAME,
@@ -264,30 +270,6 @@ class NewFilePageBlocked(RuntimeError):
     """
 
 
-class CsrfRecoveryFailed(RuntimeError):
-    """Raised when the pywikibot session's CSRF token cannot be recovered.
-
-    Routed AROUND the per-ordinal generic FAILED-counter catch so a
-    session-level fatal aborts the run instead of looping the same
-    error against every remaining item.
-    """
-
-
-# Session-scoped ceiling on CSRF recoveries per run; exceeding it raises
-# ``CsrfRecoveryFailed``. This is the hard guardrail against unbounded
-# looping on a persistently invalid session.
-MAX_CSRF_RECOVERIES = 3
-
-_CSRF_TOKEN_ERROR_MARKER = "Invalid token 'csrf'"
-
-
-def _is_csrf_token_error(ex: BaseException) -> bool:
-    """True if ``ex`` is the pywikibot ``KeyError`` from ``TokenWallet``
-    whose message signals an invalidated CSRF token — narrowed on the
-    marker so unrelated ``KeyError``s don't trigger session recovery."""
-    return isinstance(ex, KeyError) and _CSRF_TOKEN_ERROR_MARKER in str(ex)
-
-
 _WHITESPACE_RUN_RE = re.compile(r"\s+")
 
 
@@ -308,21 +290,6 @@ def _canonicalize_commons_title(title: str) -> str:
     need every one of them to be a safety net.
     """
     return _WHITESPACE_RUN_RE.sub(" ", title).strip()
-
-
-def _recover_commons_session(site) -> None:
-    """Drop the current pywikibot session, re-authenticate, and clear
-    the cached TokenWallet so the next ``site.tokens['csrf']`` refetches.
-
-    ``site.logout()`` is required first: ``site.login()`` on an
-    already-"logged-in" site is a no-op in pywikibot's default flow, so
-    clearing tokens alone would just re-fetch against the same bad
-    session.
-    """
-    logging.info("Recovering Commons session: logout + login + token-wallet clear")
-    site.logout()
-    site.login()
-    site.tokens.clear()
 
 
 class Uploader:
@@ -972,7 +939,7 @@ class Uploader:
                             break
                         except Exception as ex:
                             is_backend_fail = ERROR_BACKEND_FAIL in str(ex)
-                            is_csrf_error = _is_csrf_token_error(ex)
+                            is_csrf_error = is_csrf_token_error(ex)
                             if is_csrf_error:
                                 # Session was invalidated — every subsequent
                                 # upload will hit the same KeyError until
@@ -998,7 +965,7 @@ class Uploader:
                                     MAX_CSRF_RECOVERIES,
                                 )
                                 try:
-                                    _recover_commons_session(self.site)
+                                    recover_commons_session(self.site)
                                 except Exception as recover_ex:
                                     raise CsrfRecoveryFailed(
                                         f"Commons session recovery threw"

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -74,8 +74,11 @@ from ingest_wikimedia.categories import CategoryEnsurer, touch_institution_files
 from ingest_wikimedia.csrf import (
     CsrfRecoveryFailed,
     MAX_CSRF_RECOVERIES,
+    bump_session_recovery,
     is_csrf_token_error,
     recover_commons_session,
+    reset_session_recoveries,
+    session_recoveries_used,
     with_csrf_recovery,
 )
 from ingest_wikimedia.dpla import (
@@ -330,9 +333,6 @@ class Uploader:
         # run can't flood the human-maintained Category:Duplicate. None disables
         # the gate (standalone / unit-test construction); main() injects one.
         self.dup_throttle = dup_throttle
-        # Capped at :data:`MAX_CSRF_RECOVERIES`; once exhausted the next
-        # CSRF error raises :class:`CsrfRecoveryFailed` and aborts the run.
-        self._csrf_recoveries_used = 0
 
     def _safe_upload(self, *, filepage, **kwargs):
         """Sole sanctioned wrapper around ``site.upload`` — every upload in
@@ -937,6 +937,13 @@ class Uploader:
                                     f"Upload timed out after {UPLOAD_TIMEOUT_SECS // 3600}h "
                                     f"— Commons job queue likely stuck"
                                 )
+                            # Successful upload against the current session
+                            # — reset the shared consecutive-recovery
+                            # counter so long-running processes that
+                            # legitimately hit N stale-then-refresh events
+                            # over their lifetime don't trip the cap. Same
+                            # semantics as ``with_csrf_recovery``.
+                            reset_session_recoveries()
                             break
                         except Exception as ex:
                             is_backend_fail = ERROR_BACKEND_FAIL in str(ex)
@@ -946,12 +953,16 @@ class Uploader:
                                 # upload will hit the same KeyError until
                                 # we re-authenticate. Retrying the same call
                                 # can't help; refresh the session instead.
-                                # Session cap or recovery failure → fatal.
-                                if self._csrf_recoveries_used >= MAX_CSRF_RECOVERIES:
+                                # Coordinates with the shared csrf.py budget
+                                # so a run that ALSO invokes non-uploader
+                                # write paths (touch_institution_files, etc.)
+                                # can't independently spend the cap — one
+                                # process, one counter.
+                                if session_recoveries_used() >= MAX_CSRF_RECOVERIES:
                                     raise CsrfRecoveryFailed(
                                         f"Commons session invalidated: CSRF"
                                         f" token still invalid after"
-                                        f" {self._csrf_recoveries_used}"
+                                        f" {session_recoveries_used()}"
                                         f" recovery attempts; aborting run."
                                     ) from ex
                                 logging.warning(
@@ -962,7 +973,7 @@ class Uploader:
                                     MAX_UPLOAD_RETRIES,
                                     dpla_id,
                                     ordinal,
-                                    self._csrf_recoveries_used + 1,
+                                    session_recoveries_used() + 1,
                                     MAX_CSRF_RECOVERIES,
                                 )
                                 try:
@@ -974,7 +985,7 @@ class Uploader:
                                         f" than looping unrecoverable auth"
                                         f" errors."
                                     ) from recover_ex
-                                self._csrf_recoveries_used += 1
+                                bump_session_recovery()
                                 del future
                                 gc.collect()
                                 # Do NOT advance ``attempt``: the previous call
@@ -1160,11 +1171,15 @@ class Uploader:
             f"Title drift redirect detected — moving "
             f"[[File:{old_filename}]] → [[File:{new_filename}]]"
         )
-        redirect_target.move(
-            wiki_file_page.title(),
-            reason=reason,
-            movetalk=False,
-            noredirect=False,  # leave a redirect at the old title
+        with_csrf_recovery(
+            self.site,
+            f"move {redirect_target.title()} → {wiki_file_page.title()}",
+            lambda: redirect_target.move(
+                wiki_file_page.title(),
+                reason=reason,
+                movetalk=False,
+                noredirect=False,  # leave a redirect at the old title
+            ),
         )
         if needs_relink:
             post_commonsdelinker_request(
@@ -1277,11 +1292,15 @@ class Uploader:
             f"Title drift ({case_label}): moving "
             f"[[File:{actual_filename}]] → [[File:{intended_filename}]]"
         )
-        existing_file.move(
-            intended_page.title(),
-            reason=reason,
-            movetalk=False,
-            noredirect=False,
+        with_csrf_recovery(
+            self.site,
+            f"move {existing_file.title()} → {intended_page.title()}",
+            lambda: existing_file.move(
+                intended_page.title(),
+                reason=reason,
+                movetalk=False,
+                noredirect=False,
+            ),
         )
         if needs_relink:
             post_commonsdelinker_request(
@@ -1718,6 +1737,8 @@ class Uploader:
                 f"Tagged [[File:{old_filename}]] as duplicate of "
                 f"[[File:{new_filename}]] (DPLA ID {dpla_id})"
             )
+        except CsrfRecoveryFailed:
+            raise
         except Exception as ex:
             logging.warning(f"Failed to tag [[File:{old_filename}]] as duplicate: {ex}")
 
@@ -1944,6 +1965,8 @@ class Uploader:
                     page_labels,
                     dry_run,
                 )
+            except CsrfRecoveryFailed:
+                raise
             except Exception as ex:
                 logging.warning(f"Orphan check failed for {dpla_id}: {ex}; continuing")
 
@@ -2422,6 +2445,8 @@ def _post_item_orphan_check(
                         f"as duplicate of [[File:{keep_title}]] (DPLA ID {dpla_id})"
                     )
                     tracker.increment(Result.ORPHANS_TAGGED)
+                except CsrfRecoveryFailed:
+                    raise
                 except Exception as e:
                     # The orphan remains unresolved; record as FLAGGED so the
                     # run summary accurately reflects follow-up work needed.


### PR DESCRIPTION
## Summary

Extract the CSRF-session-recovery pattern that [PR #350](https://github.com/dpla/ingest-wikimedia/pull/350) introduced for the uploader into a shared module, and wire it into every other write path — `sdc-sync`, `legacy_artwork`, `categories`, `wikitext_normalize`.

## Motivating incident

The ODN Toledo Lucas County Public Library SDC-sync run of 2026-06-25 logged:

- **68,411** identical `KeyError("Invalid token 'csrf' for user 'DPLA bot' on commons:commons wiki.")` failures
- bucketed as **68,427** `"SDC sync failed; skipping ordinal"` events
- over **~5.5 days**, silently, with the run's SDC counts finishing as `SDC_ORDINALS_SKIPPED_ERROR: 68427`

The specific DPLA ID that surfaced this — `85d28c937f83a43f3ca7947b94d61f24` — was in the CSV, reached `process_one_from_sdc`, and both ordinals failed at [`tools/sdc_sync.py:2350`](https://github.com/dpla/ingest-wikimedia/blob/main/tools/sdc_sync.py) on `token=site.tokens["csrf"]`. The `except pywikibot.exceptions.APIError` block didn't cover the pywikibot `TokenWallet` `KeyError`, so the exception bubbled to the per-ordinal `except Exception:` catch, got logged as a routine skip, and the loop marched on — with a session that was permanently broken for every remaining write in the 5.5-day run.

PR #350 solved the same class of bug for the uploader. It just wasn't applied anywhere else.

## What changed

**New shared module: `ingest_wikimedia/csrf.py`**
- `MAX_CSRF_RECOVERIES = 3`, `_CSRF_TOKEN_ERROR_MARKER`, `CsrfRecoveryFailed`, `is_csrf_token_error`, `recover_commons_session` — extracted verbatim from `tools/uploader.py`.
- Run-scoped counter (module-level) + `with_csrf_recovery(site, action_label, thunk)` helper for the sites that don't own their own attempt-counted retry loop.

**Wrapped write sites** — each write is now protected by `with_csrf_recovery`, and each per-item `except Exception:` catch above it now has an `except CsrfRecoveryFailed: raise` arm so a session-level fatal aborts the run rather than looping the same unrecoverable auth error:

| File | Site | Action |
|---|---|---|
| `tools/sdc_sync.py` | `_submit_sdc_write` | wbeditentity / wbremoveclaims POST |
| `tools/sdc_sync.py` | `_process_one_partner_item` inner `.touch()` | category-refresh null edit |
| `ingest_wikimedia/legacy_artwork.py` | `post_legacy_import_claims` | legacy-artwork import bundle |
| `ingest_wikimedia/categories.py` | `_create_category_item` `editEntity` | new Commons category on Wikidata |
| `ingest_wikimedia/categories.py` | `_add_p8464_to_institution` `addClaim` | P8464 on institution item |
| `ingest_wikimedia/categories.py` | `touch_institution_files` `page.touch()` | Wikidata-lag category refresh |
| `ingest_wikimedia/wikitext_normalize.py` | `normalize_page` `file_page.save()` | wikitext strip/canonicalise |

**Uploader unchanged in behavior** — refactored only to import from the shared module (delete the duplicated definitions).

**Read paths untouched** — `action=query`, `wbgetentities`, etc. never fetch the CSRF token, so they can't trip this specific `KeyError`. Out of scope.

## Test plan

- [x] New `tests/test_csrf.py` — 12 cases covering the detector, `recover_commons_session`, `with_csrf_recovery` happy path, refresh-and-retry, cap exhaustion, recovery-itself-throws, counter accumulation.
- [x] Two new cases in `tests/test_sdc_sync.py`: `_submit_sdc_write` recovers on CSRF error; aborts with `CsrfRecoveryFailed` when the cap is exhausted.
- [x] Existing 1029 tests + 19 new = **1048 passed** on wiki EC2 (Python 3.13).
- [ ] Post-merge: after next partner-mode SDC-sync run, verify a session refresh in the log if one fires (`grep "Recovering Commons session"` should be silent on healthy runs and non-empty only when the token actually goes stale).

## Not included

The **Toledo re-sync** — per your instructions, leaving it for after this merges. The 68,427 skipped ordinals from 2026-06-25 will re-process on the next scheduled ODN sync (which will now recover cleanly from any token expiry rather than silently skipping the rest of the run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Ported the Wikimedia CSRF session-recovery pattern into a shared `ingest_wikimedia/csrf.py` module and applied it across multiple Wikimedia write paths.

- Added shared CSRF recovery helpers:
  - run/process-scoped capped recovery budget (`MAX_CSRF_RECOVERIES = 3`)
  - CSRF invalid-token detection (`is_csrf_token_error`) including `badtoken` APIError-like cases by walking `__cause__` chains
  - `CsrfRecoveryFailed` to abort when recovery is exhausted
  - `recover_commons_session(site)` to refresh Commons session state (logout/login and clear tokens)
  - `with_csrf_recovery(site, action_label, thunk)` wrapper for write operations that do not already implement their own retry loop, including consecutive-failure semantics (counter resets after a successful `thunk()`).
- Refactored `tools/uploader.py` to use the shared CSRF logic (removing its local CSRF helper/exception) while preserving its per-ordinal retry loop behavior and switching to shared recovery budgeting/accounting.
- Wrapped CSRF-sensitive Commons write operations so invalid CSRF tokens trigger Commons session recovery + retry, and exhausted recovery causes a fatal abort instead of repeatedly skipping/swallowing:
  - `tools/sdc_sync.py`: CSRF exhaustion now propagates `CsrfRecoveryFailed` to abort partner/legacy runs (including cleanup/touch paths).
  - `ingest_wikimedia/legacy_artwork.py`: wrapped legacy import and file migration saves with `with_csrf_recovery`.
  - `ingest_wikimedia/categories.py`: wrapped Commons/Wikidata write operations and re-raised `CsrfRecoveryFailed` to abort the overall run.
  - `ingest_wikimedia/wikitext_normalize.py`: wrapped `FilePage.save(...)` with `with_csrf_recovery`.
  - Also applied `with_csrf_recovery` to Commons wikitext edit call sites in `ingest_wikimedia/wikimedia.py`.
- Tests: added coverage for CSRF detection/recovery behavior and SDC sync CSRF recovery retry/abort behavior (suite now reaches 1048 passing tests).

Security implications: this changes Commons auth/session handling for Wikimedia writes by automatically logging out/in and clearing CSRF token state to recover from invalidated CSRF tokens; when recovery is exhausted, it aborts to avoid operating under a broken auth/session state.

Release/infrastructure notes: no manual pipeline trigger or ECS redeployment requirements; no changes to CodePipeline/CodeBuild/ECS task definitions/IAM policies or other shared infrastructure configuration; no environment variable or AWS Secrets Manager key changes; and no database migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->