### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+
+# Dependabot config for dpla/ingest-wikimedia.
+#
+# Structurally mirrors dpla/dashboard-analytics's config, with three
+# repo-specific adjustments:
+#
+#   1. ``package-ecosystem: "uv"`` — this repo is Python + uv.lock (not
+#      Ruby/bundler like dashboard-analytics). Dependabot's ``uv``
+#      ecosystem reads ``pyproject.toml`` + ``uv.lock`` and produces PRs
+#      that update both together.
+#   2. No ``ignore:`` block on the primary language runtime. The
+#      analogous dashboard-analytics rule ignores rails major-version
+#      bumps because they're rare and disruptive. For us, major bumps
+#      on pywikibot are the OPPOSITE — they're how we get upstream
+#      CSRF-handling fixes (e.g. T428817 landed in pywikibot 11.4.0),
+#      so we deliberately keep the majors flowing.
+#   3. Weekly cadence with grouped PRs — one Python-deps PR and one
+#      github-actions PR per week, not N per package. Matches
+#      dashboard-analytics's approach to keeping the PR volume tolerable.
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: auto
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary

Adds \`.github/dependabot.yml\` — Dependabot was not previously configured on this repo.

Structurally mirrors [dpla/dashboard-analytics](https://github.com/dpla/dashboard-analytics/blob/main/.github/dependabot.yml)'s config, with three repo-specific adjustments:

1. **\`package-ecosystem: "uv"\`** — this repo is Python + \`uv.lock\`, not Ruby/bundler. Dependabot officially supports \`uv\` as an ecosystem (per [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)) and reads \`pyproject.toml\` + \`uv.lock\` together.
2. **No \`ignore:\` block on the primary runtime.** The analogous dashboard-analytics rule ignores rails major-version bumps as rare and disruptive. For us, major bumps on pywikibot are the **opposite** — that's exactly how we get upstream CSRF-handling fixes (e.g. [T428817](https://phabricator.wikimedia.org/T428817) landed in pywikibot 11.4.0). Keeping the majors flowing is deliberate.
3. **Weekly grouped PRs**, matching dashboard-analytics's approach: one Python-deps PR and one github-actions PR per week, not N per package.

## Test plan

- [x] YAML validates locally (parses cleanly, no tabs, correct top-level shape).
- [ ] Post-merge: verify Dependabot picks up the config and opens its first grouped PR within the next weekly cadence tick.
- [ ] Post-merge follow-up (separate PR): bump pywikibot \`>=9.4.1\` → \`>=11.4.2\` (closes T428817 upstream — see earlier discussion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added `.github/dependabot.yml` to enable weekly Dependabot updates for:
- Python dependencies via `uv` (`pyproject.toml` + `uv.lock`), grouped into a single `python-dependencies` PR and labeled `dependencies`/`python`
- GitHub Actions, grouped into a single `github-actions` PR and labeled `dependencies`/`github-actions`

The config is adapted for this repo’s `uv.lock` workflow and intentionally keeps major updates flowing for the primary runtime dependency.

Validation was done locally against the YAML, and Dependabot behavior should be confirmed after merge to ensure grouped weekly PRs are created as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->