### PR TITLE
Fix drain-deferred None-site crash + capture uncaught tracebacks

### DIFF
--- a/ingest_wikimedia/dup_throttle.py
+++ b/ingest_wikimedia/dup_throttle.py
@@ -67,6 +67,12 @@ class DuplicateCategoryThrottle:
             raise ValueError("resume_below must be <= threshold")
         if recheck_cap < 1:
             raise ValueError("recheck_cap must be >= 1")
+        if site is None and size_fn is None:
+            raise ValueError(
+                "DuplicateCategoryThrottle requires either a pywikibot "
+                "``site`` (for the default categoryinfo query) or an "
+                "injected ``size_fn`` (for tests)."
+            )
         self._site = site
         self.threshold = threshold
         self.resume_below = resume_below

--- a/ingest_wikimedia/logs.py
+++ b/ingest_wikimedia/logs.py
@@ -1,8 +1,42 @@
-import os
 import logging
+import os
+import sys
 from datetime import datetime
 
 from tqdm import tqdm
+
+
+def _install_logging_excepthook() -> None:
+    """Replace ``sys.excepthook`` with a wrapper that logs the
+    exception via ``logging.critical(exc_info=...)`` before delegating
+    to whatever hook was previously installed.
+
+    Uncaught exceptions otherwise write only to ``sys.stderr``. Tools
+    running under tmux lose stderr when the session ends, leaving the
+    file logger (populated by :func:`setup_logging`) as the only
+    surviving artifact — but the default hook never routes through
+    that logger, so the file log stops at whatever logged just before
+    the crash.
+
+    The previous hook is captured (not ``sys.__excepthook__``) so an
+    outer wrapper — pywikibot, click, pytest, a debugger — stays in
+    the chain rather than being silently discarded.
+
+    ``KeyboardInterrupt`` and ``SystemExit`` skip the logging branch:
+    they're operator-driven / clean-exit signals, not crashes, and
+    logging them at CRITICAL would fill the log with false alarms on
+    every ``Ctrl-C`` or ``sys.exit(0)``.
+    """
+    prev_hook = sys.excepthook
+
+    def _hook(exc_type, exc_value, exc_tb):
+        if issubclass(exc_type, (KeyboardInterrupt, SystemExit)):
+            prev_hook(exc_type, exc_value, exc_tb)
+            return
+        logging.critical("Uncaught exception", exc_info=(exc_type, exc_value, exc_tb))
+        prev_hook(exc_type, exc_value, exc_tb)
+
+    sys.excepthook = _hook
 
 
 class TqdmLoggingHandler(logging.Handler):
@@ -27,7 +61,9 @@ def setup_logging(partner: str, event_type: str, level: int = logging.INFO) -> N
     """
     Creates a logfile for this process with a unique timestamp and with the partner's
     name. Passes local logging through tqdm so the progress bars don't get mangled.
-    Suppresses pywikibot logging below ERROR.
+    Suppresses pywikibot logging below ERROR. Installs a
+    logging-aware ``sys.excepthook`` so uncaught tracebacks reach the
+    log file — see :func:`_install_logging_excepthook`.
     """
     os.makedirs(LOGS_DIR_BASE, exist_ok=True)
     time_str = datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -47,6 +83,7 @@ def setup_logging(partner: str, event_type: str, level: int = logging.INFO) -> N
     for d in logging.Logger.manager.loggerDict:
         if d.startswith("pywiki"):
             logging.getLogger(d).setLevel(level)
+    _install_logging_excepthook()
 
 
 LOGS_DIR_BASE = "./logs"

--- a/ingest_wikimedia/logs.py
+++ b/ingest_wikimedia/logs.py
@@ -26,7 +26,16 @@ def _install_logging_excepthook() -> None:
     they're operator-driven / clean-exit signals, not crashes, and
     logging them at CRITICAL would fill the log with false alarms on
     every ``Ctrl-C`` or ``sys.exit(0)``.
+
+    Idempotent: a repeat install is a no-op. Without this a caller that
+    invoked ``setup_logging`` twice would wrap the hook around itself,
+    logging every uncaught exception N times where N is the install
+    count. No production caller does this today, but the guard keeps
+    the behavior safe against future reuse (e.g. a partner-mode worker
+    re-initializing per file).
     """
+    if getattr(sys.excepthook, "_is_logging_excepthook", False):
+        return
     prev_hook = sys.excepthook
 
     def _hook(exc_type, exc_value, exc_tb):
@@ -36,6 +45,7 @@ def _install_logging_excepthook() -> None:
         logging.critical("Uncaught exception", exc_info=(exc_type, exc_value, exc_tb))
         prev_hook(exc_type, exc_value, exc_tb)
 
+    _hook._is_logging_excepthook = True
     sys.excepthook = _hook
 
 

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -245,10 +245,12 @@ def notify_pipeline_fail() -> None:
       WIKIMEDIA_PARTNER_DIR    — absolute path to the partner dir, used to
                                  locate the most recent log for tailing
       WIKIMEDIA_TARGET_IS_LAST — "1" iff this is the final target in the
-                                 batch; switches the message suffix from
-                                 "skipping to next target" to "no further
-                                 targets in batch", which is accurate even
-                                 for single-target sessions
+                                 batch; switches the failure message
+                                 suffix between "aborting this target;
+                                 batch continues with the next" and
+                                 "aborting batch (this was the final
+                                 target)". Accurate even for
+                                 single-target sessions.
 
     Designed to be called as a one-liner from a shell failure handler:
         rc=$?; WIKIMEDIA_LAST_EXIT=$rc python3 -c \\
@@ -275,7 +277,9 @@ def notify_pipeline_fail() -> None:
 
     is_last = os.environ.get("WIKIMEDIA_TARGET_IS_LAST") == "1"
     tail_phrase = (
-        "no further targets in batch" if is_last else "skipping to next target"
+        "aborting batch (this was the final target)"
+        if is_last
+        else "aborting this target; batch continues with the next"
     )
     # Step-aware header: tells the operator WHICH phase failed
     # (id-generation / download / upload / sdc-sync), not just "the

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -38,7 +38,7 @@ def stub_setup_logging_and_get_site(monkeypatch):
     ``DuplicateCategoryThrottle``, so the return value is only used
     as an opaque argument to the patched throttle constructor."""
     monkeypatch.setattr(drain_deferred, "setup_logging", lambda *a, **kw: None)
-    monkeypatch.setattr(drain_deferred, "get_site", lambda: MagicMock())
+    monkeypatch.setattr(drain_deferred, "get_site", MagicMock)
 
 
 @pytest.fixture

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -29,10 +29,16 @@ def stub_host_lock(monkeypatch, tmp_path):
 
 
 @pytest.fixture(autouse=True)
-def stub_setup_logging(monkeypatch):
-    """The real setup_logging writes to <partner>/logs/... and expects
-    a partner dir; tests just need it to be a no-op."""
+def stub_setup_logging_and_get_site(monkeypatch):
+    """The real ``setup_logging`` writes to ``<partner>/logs/...`` and
+    expects a partner dir; tests just need it to be a no-op. Also
+    stub ``get_site`` — the real helper runs ``pywikibot.Site(...)``
+    plus ``.login()`` and requires a ``user-config.py``, which tests
+    don't have. Every test in this file patches
+    ``DuplicateCategoryThrottle``, so the return value is only used
+    as an opaque argument to the patched throttle constructor."""
     monkeypatch.setattr(drain_deferred, "setup_logging", lambda *a, **kw: None)
+    monkeypatch.setattr(drain_deferred, "get_site", lambda: MagicMock())
 
 
 @pytest.fixture

--- a/tests/test_dup_throttle.py
+++ b/tests/test_dup_throttle.py
@@ -143,3 +143,38 @@ def test_recheck_cap_must_be_positive():
     except ValueError:
         return
     raise AssertionError("expected ValueError for recheck_cap < 1")
+
+
+def test_construction_without_site_or_size_fn_raises():
+    """The MWDL 2026-07-02 drain-deferred crash: ``drain_deferred.py``
+    called ``DuplicateCategoryThrottle()`` with no arguments, so the
+    site defaulted to ``None`` and the first ``category_size`` call
+    exploded on ``pywikibot.Category(None, ...)``. Fail fast at
+    construction so a similarly broken future caller can't silently
+    sit dormant until the first API call."""
+    try:
+        DuplicateCategoryThrottle()
+    except ValueError as e:
+        assert "site" in str(e).lower() or "size_fn" in str(e).lower(), (
+            "error message should mention site or size_fn to point the "
+            f"caller at the fix; got: {e!r}"
+        )
+        return
+    raise AssertionError(
+        "expected ValueError when neither site nor size_fn is provided"
+    )
+
+
+def test_construction_with_size_fn_only_is_accepted():
+    """Tests inject ``size_fn`` to avoid the real pywikibot path;
+    that use case must remain valid (no ``site`` required)."""
+    t = DuplicateCategoryThrottle(size_fn=lambda: 0)
+    assert t.category_size() == 0
+
+
+def test_construction_with_site_only_is_accepted():
+    """Production callers pass a real pywikibot Site; that use case
+    must remain valid (no ``size_fn`` required). The site is not used
+    at construction, only when ``category_size`` runs, so any non-None
+    sentinel proves the guard passes."""
+    DuplicateCategoryThrottle(site=object())  # no exception → guard passes

--- a/tests/test_dup_throttle.py
+++ b/tests/test_dup_throttle.py
@@ -12,6 +12,8 @@ key behaviours pinned here:
     ``resume_below`` (hysteresis), refills headroom, and times out cleanly.
 """
 
+import pytest
+
 from ingest_wikimedia.dup_throttle import DuplicateCategoryThrottle
 
 
@@ -152,16 +154,12 @@ def test_construction_without_site_or_size_fn_raises():
     exploded on ``pywikibot.Category(None, ...)``. Fail fast at
     construction so a similarly broken future caller can't silently
     sit dormant until the first API call."""
-    try:
+    with pytest.raises(ValueError) as exc_info:
         DuplicateCategoryThrottle()
-    except ValueError as e:
-        assert "site" in str(e).lower() or "size_fn" in str(e).lower(), (
-            "error message should mention site or size_fn to point the "
-            f"caller at the fix; got: {e!r}"
-        )
-        return
-    raise AssertionError(
-        "expected ValueError when neither site nor size_fn is provided"
+    message = str(exc_info.value).lower()
+    assert "site" in message or "size_fn" in message, (
+        "error message should mention site or size_fn to point the "
+        f"caller at the fix; got: {exc_info.value!r}"
     )
 
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -19,6 +19,7 @@ def test_setup_logging_installs_uncaught_exception_hook(tmp_path, monkeypatch):
     monkeypatch.setattr(logs_mod, "LOGS_DIR_BASE", str(tmp_path))
     root = logging.getLogger()
     saved_handlers = list(root.handlers)
+    saved_level = root.level
     for h in saved_handlers:
         root.removeHandler(h)
     original_hook = sys.excepthook
@@ -31,10 +32,15 @@ def test_setup_logging_installs_uncaught_exception_hook(tmp_path, monkeypatch):
         )
     finally:
         sys.excepthook = original_hook
+        # setup_logging installs a FileHandler that opens a file
+        # descriptor — close it explicitly before dropping the handler
+        # so the fd doesn't outlive the test.
         for h in list(root.handlers):
             root.removeHandler(h)
+            h.close()
         for h in saved_handlers:
             root.addHandler(h)
+        root.setLevel(saved_level)
 
 
 def test_installed_excepthook_routes_traceback_to_root_logger():

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -46,6 +46,7 @@ def test_installed_excepthook_routes_traceback_to_root_logger():
     LogRecord's ``exc_info`` field pins the behavior instead."""
     root = logging.getLogger()
     saved_handlers = list(root.handlers)
+    saved_level = root.level
     for h in saved_handlers:
         root.removeHandler(h)
     original_hook = sys.excepthook
@@ -69,6 +70,7 @@ def test_installed_excepthook_routes_traceback_to_root_logger():
             root.removeHandler(h)
         for h in saved_handlers:
             root.addHandler(h)
+        root.setLevel(saved_level)
 
     assert len(captured) == 1
     rec = captured[0]
@@ -79,6 +81,26 @@ def test_installed_excepthook_routes_traceback_to_root_logger():
     )
     assert rec.exc_info[0] is RuntimeError
     assert "crash-payload" in str(rec.exc_info[1])
+
+
+def test_installed_excepthook_is_idempotent():
+    """A repeat install must be a no-op. Without the guard, a caller
+    that invoked ``setup_logging`` twice (e.g. a future partner-mode
+    worker re-initializing per file) would wrap the hook around
+    itself, so a single uncaught exception would log at CRITICAL N
+    times where N is the install count."""
+    original_hook = sys.excepthook
+    try:
+        logs_mod._install_logging_excepthook()
+        first = sys.excepthook
+        logs_mod._install_logging_excepthook()
+        assert sys.excepthook is first, (
+            "second _install_logging_excepthook call must be a no-op; "
+            "wrapping the hook again would produce duplicate CRITICAL "
+            "logs per uncaught exception"
+        )
+    finally:
+        sys.excepthook = original_hook
 
 
 def test_installed_excepthook_delegates_to_previous_hook_in_chain():

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,180 @@
+"""Tests for ``ingest_wikimedia.logs``.
+
+Focused on the ``sys.excepthook`` install: without it, uncaught
+exceptions in tools running under tmux print their tracebacks to the
+terminal buffer and vanish when the session ends — leaving the
+per-tool log file's final line as whatever logged just before the
+crash. These tests pin the recovery behavior in place.
+"""
+
+import logging
+import sys
+
+from ingest_wikimedia import logs as logs_mod
+
+
+def test_setup_logging_installs_uncaught_exception_hook(tmp_path, monkeypatch):
+    """``setup_logging`` must replace ``sys.excepthook`` with a wrapper
+    that routes tracebacks through the logging system."""
+    monkeypatch.setattr(logs_mod, "LOGS_DIR_BASE", str(tmp_path))
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    for h in saved_handlers:
+        root.removeHandler(h)
+    original_hook = sys.excepthook
+    try:
+        logs_mod.setup_logging("test-partner", "test-event")
+        assert sys.excepthook is not original_hook, (
+            "setup_logging must replace sys.excepthook so tracebacks "
+            "reach the file logger instead of vanishing with the tmux "
+            "session"
+        )
+    finally:
+        sys.excepthook = original_hook
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        for h in saved_handlers:
+            root.addHandler(h)
+
+
+def test_installed_excepthook_routes_traceback_to_root_logger():
+    """End-to-end: the installed hook must produce a log record whose
+    ``exc_info`` carries the traceback triple, so any handler attached
+    to root (including the FileHandler ``setup_logging`` installs) gets
+    the full stack. Weaker mock-based tests would lock in a specific
+    implementation of that routing; asserting on the emitted
+    LogRecord's ``exc_info`` field pins the behavior instead."""
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    for h in saved_handlers:
+        root.removeHandler(h)
+    original_hook = sys.excepthook
+    captured: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            captured.append(record)
+
+    root.addHandler(_Capture(level=logging.CRITICAL))
+    root.setLevel(logging.CRITICAL)
+    try:
+        logs_mod._install_logging_excepthook()
+        try:
+            raise RuntimeError("crash-payload")
+        except RuntimeError:
+            sys.excepthook(*sys.exc_info())
+    finally:
+        sys.excepthook = original_hook
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        for h in saved_handlers:
+            root.addHandler(h)
+
+    assert len(captured) == 1
+    rec = captured[0]
+    assert rec.levelno == logging.CRITICAL
+    assert rec.exc_info is not None, (
+        "the LogRecord must carry exc_info so FileHandler renders the "
+        "traceback — without it, only the message string is written"
+    )
+    assert rec.exc_info[0] is RuntimeError
+    assert "crash-payload" in str(rec.exc_info[1])
+
+
+def test_installed_excepthook_delegates_to_previous_hook_in_chain():
+    """The install captures ``sys.excepthook`` BEFORE overwriting it,
+    so a caller that had already installed an outer hook (pywikibot,
+    click, pytest, a debugger) stays in the chain. Delegating to
+    ``sys.__excepthook__`` (the untouched default) instead would
+    silently discard any such outer wrapper."""
+    original_hook = sys.excepthook
+    prev_called: list[tuple] = []
+
+    def _prev(exc_type, exc_value, exc_tb):
+        prev_called.append((exc_type, exc_value, exc_tb))
+
+    sys.excepthook = _prev
+    try:
+        logs_mod._install_logging_excepthook()
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            sys.excepthook(*sys.exc_info())
+    finally:
+        sys.excepthook = original_hook
+
+    assert len(prev_called) == 1, (
+        "installed hook must delegate to the previously-installed hook "
+        "— otherwise an outer wrapper is silently discarded"
+    )
+    assert prev_called[0][0] is RuntimeError
+
+
+def test_installed_excepthook_skips_logging_for_keyboard_interrupt():
+    """Ctrl-C is operator-driven, not a crash. Logging it at CRITICAL
+    would fill the log with false alarms on every deliberate abort."""
+    original_hook = sys.excepthook
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    for h in saved_handlers:
+        root.removeHandler(h)
+    captured: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            captured.append(record)
+
+    root.addHandler(_Capture(level=logging.DEBUG))
+    try:
+        logs_mod._install_logging_excepthook()
+        try:
+            raise KeyboardInterrupt()
+        except KeyboardInterrupt:
+            sys.excepthook(*sys.exc_info())
+    finally:
+        sys.excepthook = original_hook
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        for h in saved_handlers:
+            root.addHandler(h)
+
+    assert captured == [], (
+        "Ctrl-C must not log at CRITICAL — the file would fill with "
+        "false alarms on every operator abort"
+    )
+
+
+def test_installed_excepthook_skips_logging_for_system_exit():
+    """``sys.exit(0)`` (or any ``SystemExit``) is a clean-exit signal,
+    not a crash. Logging every clean exit at CRITICAL would produce
+    spurious tracebacks in the log for tools that use ``sys.exit()``
+    as a normal control-flow primitive."""
+    original_hook = sys.excepthook
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    for h in saved_handlers:
+        root.removeHandler(h)
+    captured: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            captured.append(record)
+
+    root.addHandler(_Capture(level=logging.DEBUG))
+    try:
+        logs_mod._install_logging_excepthook()
+        try:
+            raise SystemExit(0)
+        except SystemExit:
+            sys.excepthook(*sys.exc_info())
+    finally:
+        sys.excepthook = original_hook
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        for h in saved_handlers:
+            root.addHandler(h)
+
+    assert captured == [], (
+        "SystemExit must not log at CRITICAL — every sys.exit() would "
+        "otherwise produce a spurious traceback in the log"
+    )

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -10,31 +10,46 @@ crash. These tests pin the recovery behavior in place.
 import logging
 import sys
 
+import pytest
+
 from ingest_wikimedia import logs as logs_mod
 
 
-def test_setup_logging_installs_uncaught_exception_hook(tmp_path, monkeypatch):
-    """``setup_logging`` must replace ``sys.excepthook`` with a wrapper
-    that routes tracebacks through the logging system."""
-    monkeypatch.setattr(logs_mod, "LOGS_DIR_BASE", str(tmp_path))
+@pytest.fixture
+def isolated_logging():
+    """Snapshot ``sys.excepthook`` and root-logger state around a test.
+
+    Every test in this file mutates one or both. Duplicating the
+    save/restore boilerplate in each test invited exactly the kind of
+    incomplete cleanup CR flagged (missing ``root.level`` restore,
+    unclosed ``FileHandler``) — the fixture centralizes it so a new
+    test can't forget a step.
+
+    Cleanup:
+      * ``sys.excepthook`` restored.
+      * Any handlers attached during the test are removed AND closed
+        (``setup_logging`` installs a ``FileHandler`` that opens an
+        fd — closing it explicitly avoids leaking it across the test
+        session).
+      * Root logger's level restored (``logging.basicConfig`` inside
+        ``setup_logging`` mutates it).
+
+    Tests that need a capturing handler still install their own; the
+    fixture only guarantees teardown, not setup.
+    """
     root = logging.getLogger()
     saved_handlers = list(root.handlers)
     saved_level = root.level
+    saved_hook = sys.excepthook
+    # Pre-remove existing handlers so ``logging.basicConfig`` inside
+    # ``setup_logging`` actually installs its new handlers (basicConfig
+    # is a no-op if any handlers are already attached).
     for h in saved_handlers:
         root.removeHandler(h)
-    original_hook = sys.excepthook
     try:
-        logs_mod.setup_logging("test-partner", "test-event")
-        assert sys.excepthook is not original_hook, (
-            "setup_logging must replace sys.excepthook so tracebacks "
-            "reach the file logger instead of vanishing with the tmux "
-            "session"
-        )
+        yield
     finally:
-        sys.excepthook = original_hook
-        # setup_logging installs a FileHandler that opens a file
-        # descriptor — close it explicitly before dropping the handler
-        # so the fd doesn't outlive the test.
+        sys.excepthook = saved_hook
         for h in list(root.handlers):
             root.removeHandler(h)
             h.close()
@@ -43,40 +58,42 @@ def test_setup_logging_installs_uncaught_exception_hook(tmp_path, monkeypatch):
         root.setLevel(saved_level)
 
 
-def test_installed_excepthook_routes_traceback_to_root_logger():
+def test_setup_logging_installs_uncaught_exception_hook(
+    tmp_path, monkeypatch, isolated_logging
+):
+    """``setup_logging`` must replace ``sys.excepthook`` with a wrapper
+    that routes tracebacks through the logging system."""
+    monkeypatch.setattr(logs_mod, "LOGS_DIR_BASE", str(tmp_path))
+    original_hook = sys.excepthook
+    logs_mod.setup_logging("test-partner", "test-event")
+    assert sys.excepthook is not original_hook, (
+        "setup_logging must replace sys.excepthook so tracebacks reach "
+        "the file logger instead of vanishing with the tmux session"
+    )
+
+
+def test_installed_excepthook_routes_traceback_to_root_logger(isolated_logging):
     """End-to-end: the installed hook must produce a log record whose
     ``exc_info`` carries the traceback triple, so any handler attached
     to root (including the FileHandler ``setup_logging`` installs) gets
     the full stack. Weaker mock-based tests would lock in a specific
     implementation of that routing; asserting on the emitted
     LogRecord's ``exc_info`` field pins the behavior instead."""
-    root = logging.getLogger()
-    saved_handlers = list(root.handlers)
-    saved_level = root.level
-    for h in saved_handlers:
-        root.removeHandler(h)
-    original_hook = sys.excepthook
     captured: list[logging.LogRecord] = []
 
     class _Capture(logging.Handler):
         def emit(self, record):
             captured.append(record)
 
+    root = logging.getLogger()
     root.addHandler(_Capture(level=logging.CRITICAL))
     root.setLevel(logging.CRITICAL)
+
+    logs_mod._install_logging_excepthook()
     try:
-        logs_mod._install_logging_excepthook()
-        try:
-            raise RuntimeError("crash-payload")
-        except RuntimeError:
-            sys.excepthook(*sys.exc_info())
-    finally:
-        sys.excepthook = original_hook
-        for h in list(root.handlers):
-            root.removeHandler(h)
-        for h in saved_handlers:
-            root.addHandler(h)
-        root.setLevel(saved_level)
+        raise RuntimeError("crash-payload")
+    except RuntimeError:
+        sys.excepthook(*sys.exc_info())
 
     assert len(captured) == 1
     rec = captured[0]
@@ -89,47 +106,39 @@ def test_installed_excepthook_routes_traceback_to_root_logger():
     assert "crash-payload" in str(rec.exc_info[1])
 
 
-def test_installed_excepthook_is_idempotent():
+def test_installed_excepthook_is_idempotent(isolated_logging):
     """A repeat install must be a no-op. Without the guard, a caller
     that invoked ``setup_logging`` twice (e.g. a future partner-mode
     worker re-initializing per file) would wrap the hook around
     itself, so a single uncaught exception would log at CRITICAL N
     times where N is the install count."""
-    original_hook = sys.excepthook
-    try:
-        logs_mod._install_logging_excepthook()
-        first = sys.excepthook
-        logs_mod._install_logging_excepthook()
-        assert sys.excepthook is first, (
-            "second _install_logging_excepthook call must be a no-op; "
-            "wrapping the hook again would produce duplicate CRITICAL "
-            "logs per uncaught exception"
-        )
-    finally:
-        sys.excepthook = original_hook
+    logs_mod._install_logging_excepthook()
+    first = sys.excepthook
+    logs_mod._install_logging_excepthook()
+    assert sys.excepthook is first, (
+        "second _install_logging_excepthook call must be a no-op; "
+        "wrapping the hook again would produce duplicate CRITICAL logs "
+        "per uncaught exception"
+    )
 
 
-def test_installed_excepthook_delegates_to_previous_hook_in_chain():
+def test_installed_excepthook_delegates_to_previous_hook_in_chain(isolated_logging):
     """The install captures ``sys.excepthook`` BEFORE overwriting it,
     so a caller that had already installed an outer hook (pywikibot,
     click, pytest, a debugger) stays in the chain. Delegating to
     ``sys.__excepthook__`` (the untouched default) instead would
     silently discard any such outer wrapper."""
-    original_hook = sys.excepthook
     prev_called: list[tuple] = []
 
     def _prev(exc_type, exc_value, exc_tb):
         prev_called.append((exc_type, exc_value, exc_tb))
 
     sys.excepthook = _prev
+    logs_mod._install_logging_excepthook()
     try:
-        logs_mod._install_logging_excepthook()
-        try:
-            raise RuntimeError("boom")
-        except RuntimeError:
-            sys.excepthook(*sys.exc_info())
-    finally:
-        sys.excepthook = original_hook
+        raise RuntimeError("boom")
+    except RuntimeError:
+        sys.excepthook(*sys.exc_info())
 
     assert len(prev_called) == 1, (
         "installed hook must delegate to the previously-installed hook "
@@ -138,33 +147,21 @@ def test_installed_excepthook_delegates_to_previous_hook_in_chain():
     assert prev_called[0][0] is RuntimeError
 
 
-def test_installed_excepthook_skips_logging_for_keyboard_interrupt():
+def test_installed_excepthook_skips_logging_for_keyboard_interrupt(isolated_logging):
     """Ctrl-C is operator-driven, not a crash. Logging it at CRITICAL
     would fill the log with false alarms on every deliberate abort."""
-    original_hook = sys.excepthook
-    root = logging.getLogger()
-    saved_handlers = list(root.handlers)
-    for h in saved_handlers:
-        root.removeHandler(h)
     captured: list[logging.LogRecord] = []
 
     class _Capture(logging.Handler):
         def emit(self, record):
             captured.append(record)
 
-    root.addHandler(_Capture(level=logging.DEBUG))
+    logging.getLogger().addHandler(_Capture(level=logging.DEBUG))
+    logs_mod._install_logging_excepthook()
     try:
-        logs_mod._install_logging_excepthook()
-        try:
-            raise KeyboardInterrupt()
-        except KeyboardInterrupt:
-            sys.excepthook(*sys.exc_info())
-    finally:
-        sys.excepthook = original_hook
-        for h in list(root.handlers):
-            root.removeHandler(h)
-        for h in saved_handlers:
-            root.addHandler(h)
+        raise KeyboardInterrupt()
+    except KeyboardInterrupt:
+        sys.excepthook(*sys.exc_info())
 
     assert captured == [], (
         "Ctrl-C must not log at CRITICAL — the file would fill with "
@@ -172,35 +169,23 @@ def test_installed_excepthook_skips_logging_for_keyboard_interrupt():
     )
 
 
-def test_installed_excepthook_skips_logging_for_system_exit():
+def test_installed_excepthook_skips_logging_for_system_exit(isolated_logging):
     """``sys.exit(0)`` (or any ``SystemExit``) is a clean-exit signal,
     not a crash. Logging every clean exit at CRITICAL would produce
     spurious tracebacks in the log for tools that use ``sys.exit()``
     as a normal control-flow primitive."""
-    original_hook = sys.excepthook
-    root = logging.getLogger()
-    saved_handlers = list(root.handlers)
-    for h in saved_handlers:
-        root.removeHandler(h)
     captured: list[logging.LogRecord] = []
 
     class _Capture(logging.Handler):
         def emit(self, record):
             captured.append(record)
 
-    root.addHandler(_Capture(level=logging.DEBUG))
+    logging.getLogger().addHandler(_Capture(level=logging.DEBUG))
+    logs_mod._install_logging_excepthook()
     try:
-        logs_mod._install_logging_excepthook()
-        try:
-            raise SystemExit(0)
-        except SystemExit:
-            sys.excepthook(*sys.exc_info())
-    finally:
-        sys.excepthook = original_hook
-        for h in list(root.handlers):
-            root.removeHandler(h)
-        for h in saved_handlers:
-            root.addHandler(h)
+        raise SystemExit(0)
+    except SystemExit:
+        sys.excepthook(*sys.exc_info())
 
     assert captured == [], (
         "SystemExit must not log at CRITICAL — every sys.exit() would "

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -160,7 +160,13 @@ def _capture_message(env: dict) -> str:
     return sent.get("text", "")
 
 
-def test_notify_pipeline_fail_says_skipping_to_next_when_not_last():
+def test_notify_pipeline_fail_says_aborting_this_target_when_not_last():
+    """Wording on the not-last branch must unambiguously frame the
+    message as a failure — the prior ``skipping to next target`` was
+    OK but the new phrasing keeps ``aborting`` in both branches so an
+    operator scanning Slack can't misread either as a normal-completion
+    state (which the prior ``no further targets in batch`` on the
+    last-target branch did suggest)."""
     msg = _capture_message(
         {
             "DPLA_SLACK_BOT_TOKEN": "x",
@@ -168,11 +174,19 @@ def test_notify_pipeline_fail_says_skipping_to_next_when_not_last():
             "WIKIMEDIA_LAST_EXIT": "1",
         }
     )
-    assert "skipping to next target" in msg
+    assert "aborting this target" in msg
+    assert "batch continues with the next" in msg
+    assert "aborting batch" not in msg
+    # The OLD wording must be gone — a soft-completion phrasing on a
+    # failure notification is what motivated the reword.
     assert "no further targets in batch" not in msg
+    assert "skipping to next target" not in msg
 
 
-def test_notify_pipeline_fail_says_no_further_when_last():
+def test_notify_pipeline_fail_says_aborting_batch_when_last():
+    """On the final target, the failure ends the batch — the wording
+    now says so explicitly (rather than the prior ``no further targets
+    in batch``, which read like a normal-completion summary)."""
     msg = _capture_message(
         {
             "DPLA_SLACK_BOT_TOKEN": "x",
@@ -181,8 +195,11 @@ def test_notify_pipeline_fail_says_no_further_when_last():
             "WIKIMEDIA_TARGET_IS_LAST": "1",
         }
     )
-    assert "no further targets in batch" in msg
-    assert "skipping to next target" not in msg
+    assert "aborting batch" in msg
+    assert "this was the final target" in msg
+    assert "aborting this target" not in msg
+    # Old wording is gone.
+    assert "no further targets in batch" not in msg
     # The OOM hint should still be included.
     assert "SIGKILL" in msg
 
@@ -198,7 +215,7 @@ def test_notify_pipeline_fail_treats_any_value_other_than_1_as_not_last():
                 "WIKIMEDIA_TARGET_IS_LAST": value,
             }
         )
-        assert "skipping to next target" in msg, (
+        assert "aborting this target" in msg, (
             f"value {value!r} should be treated as not-last"
         )
 

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -56,6 +56,7 @@ import click
 from ingest_wikimedia import drain_sidecar
 from ingest_wikimedia.dup_throttle import DuplicateCategoryThrottle
 from ingest_wikimedia.logs import setup_logging
+from ingest_wikimedia.wikimedia import get_site
 from ingest_wikimedia.slack import (
     notify_drain_phase_complete,
     notify_drain_phase_start,
@@ -190,7 +191,10 @@ def main(partner: str) -> None:
     lock_fd = _acquire_host_lock()
     try:
         started_at = time.monotonic()
-        throttle = DuplicateCategoryThrottle()
+        # ``get_site()`` — same helper the uploader/retirer/fix-categories
+        # tools use; also runs ``site.login()``. The throttle requires a
+        # non-None site (see :class:`DuplicateCategoryThrottle` guard).
+        throttle = DuplicateCategoryThrottle(get_site())
         initial_category_size = throttle.category_size()
         notify_drain_phase_start(partner, len(initial_ids), initial_category_size)
 


### PR DESCRIPTION
## Summary

Closes the four issues surfaced by the MWDL 2026-07-02 drain-deferred crash. Each is independently a real gap; bundling because they're all in the same failure-mode chain (crash → no traceback → misleading Slack message → operator confusion).

## The crash chain we're fixing

1. MWDL's drain-deferred phase started at 21:29 UTC, logged `Drain-phase host lock acquired.`, then silently exited 1.
2. The log file ended right there — no traceback — because Python's default `sys.excepthook` writes to `sys.stderr`, which for our tmux-hosted tools dies with the session.
3. The tmux failure handler emitted a Slack message worded `\`drain-deferred\` step failed — no further targets in batch`, which reads more like completion than failure.
4. The traceback was diagnosable only by reading source code and re-deriving the call chain — the crash was `pywikibot.Category(None, ...)` inside `DuplicateCategoryThrottle.category_size()`, because `drain_deferred.py` called `DuplicateCategoryThrottle()` with no site argument and the class silently accepted `site=None`.

## Changes

**`tools/drain_deferred.py`** — construct the throttle via `ingest_wikimedia.wikimedia.get_site()` (the same helper `uploader`, `retirer`, and `fix_unknown_categories` use). This resolves the site AND logs in — matching every other tool in the drain/upload family.

**`ingest_wikimedia/dup_throttle.py`** — reject `site=None AND size_fn=None` at construction. The class already validated `resume_below` and `recheck_cap` the same way at line 66-69; `site` was the one silent-fail gap. Tests that don't want the real API path continue to inject `size_fn`.

**`ingest_wikimedia/logs.py`** — install a `sys.excepthook` that routes uncaught exceptions through `logging.critical(exc_info=...)` before delegating to the previously-installed hook. The delegation captures `sys.excepthook` (not `sys.__excepthook__`) so an outer wrapper — pywikibot, click, pytest, a debugger — stays in the chain. `KeyboardInterrupt` and `SystemExit` skip the logging branch so operator aborts and `sys.exit(0)` don't fill the log with false-alarm CRITICAL entries.

**`ingest_wikimedia/slack.py`** — reword `notify_pipeline_fail`'s tail phrases:
- OLD: `no further targets in batch` / `skipping to next target`
- NEW: `aborting batch (this was the final target)` / `aborting this target; batch continues with the next`

The prior wording read like a normal-completion summary attached to a failure notification — the exact confusion that started this thread.

## Test plan

- [x] 1063 tests pass on wiki EC2 (was 1055; +8 new)
- [x] `test_logs.py` (new) — hook install, log-record `exc_info` routing, previous-hook delegation (verifies we chain, not overwrite), `KeyboardInterrupt` + `SystemExit` passthrough
- [x] `test_dup_throttle.py` — 3 new cases for the site-or-size_fn guard
- [x] `test_slack.py` — the two tail-phrase branches with the new wording, and lock-in that the old wording is gone
- [x] `test_drain_deferred.py` — autouse fixture stubs `get_site` alongside `setup_logging`
- [x] Ruff clean + format clean locally

## Not in this PR

The chain-ordering redesign (opportunistic per-target drain + single pooled final wait-drain) — separate PR to keep this bugfix reviewable.

The reused `get_site()` in `drain_deferred.py` triggers `pywikibot.Site(...).login()` at process start, which requires `user-config.py`. That's already the shape every other tool uses (matches uploader/retirer/fix_unknown_categories) and works in production; test-side we stub `get_site` in the autouse fixture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
Fixes a `drain-deferred` crash caused by a `None` site and closes related failure-handling gaps from the MWDL incident.

### What changed
- `tools/drain_deferred.py` now calls `get_site()` and constructs `DuplicateCategoryThrottle(get_site())` instead of constructing it with no site.
- `ingest_wikimedia/dup_throttle.py` now validates constructor inputs and raises `ValueError` when both `site` and the injected `size_fn` are missing.
- `ingest_wikimedia/logs.py` installs an idempotent `sys.excepthook` wrapper that logs uncaught exceptions via `logging.critical(..., exc_info=...)` while skipping `KeyboardInterrupt` and `SystemExit`, then delegates to the previously installed hook.
- `ingest_wikimedia/slack.py` revises Slack failure-message suffix wording so abort conditions are explicit, with updated “aborting …” phrasing based on `WIKIMEDIA_TARGET_IS_LAST`.
- Tests were added/updated for the logging hook behavior, throttle constructor validation, Slack wording, and the `drain-deferred` test fixture.

### Impact
- No manual pipeline trigger / ECS redeployment required beyond normal deployment of this code.
- No environment variable or AWS Secrets Manager key additions/removals.
- No database migration.
- No shared infrastructure configuration changes (CodePipeline/CodeBuild/ECS/IAM).
- No public API changes.
- No new security implications (this primarily improves logging of uncaught exceptions already present in the failure path).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->