### PR TITLE
Drain rework + fix underscore-vs-space title false Case-2 deferrals

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -162,6 +162,11 @@ _PHASE_LOG_SUFFIX: dict[str, str] = {
     "upload": "upload",
     "sdc-sync": "sdc",
     "drain-deferred": "drain-deferred",
+    # Per-target opportunistic (``--no-wait``) drain runs inside each
+    # target's chain; a distinct log-file suffix keeps it from
+    # colliding with the batch-terminal patient drain of the same
+    # partner.
+    "drain-deferred-opportunistic": "drain-deferred-opportunistic",
 }
 
 # Per-session-label path the launcher tees ``get-ids-es`` stderr to.

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -169,6 +169,13 @@ def _wrap_step_with_marker(cmd: str) -> str:
     step = _STEP_BY_FIRST_TOKEN.get(first)
     if step is None:
         return cmd
+    # ``drain-deferred --no-wait`` is the per-target opportunistic
+    # phase; a distinct step name routes the failure handler to a
+    # distinct log-file suffix, avoiding collision with the terminal
+    # patient drain's ``drain-deferred`` log. The slack failure
+    # handler's ``_PHASE_LOG_SUFFIX`` map has the matching entry.
+    if step == "drain-deferred" and "--no-wait" in shlex.split(cmd):
+        step = "drain-deferred-opportunistic"
     wrapped = cmd
     if step == "id-generation":
         # The existing build emits ``... > csv_file`` for stdout; appending
@@ -1215,6 +1222,15 @@ def main() -> None:
     )
     target_blocks = []
     last_idx = len(targets) - 1
+    # A batch of full upload runs (not maintain, not sdc-only, not
+    # refresh-only) queues a terminal patient-drain phase per unique
+    # partner AFTER every target's chain finishes — so no partner sits
+    # idle waiting on Commons volunteers while later targets could be
+    # uploading. When those drains exist, the last TARGET is not the
+    # last thing in the batch — the last drain block is — so
+    # ``WIKIMEDIA_TARGET_IS_LAST`` moves to that drain block instead
+    # of the last target.
+    batch_has_terminal_drain = not maintain and not sdc_only and not refresh_only
     for idx, (canonical, institutions, session_label, dpla_id, collection) in enumerate(
         targets
     ):
@@ -1243,7 +1259,7 @@ def main() -> None:
         # earlier in the batch doesn't inherit a stale "is last" flag.
         is_last_env = (
             "export WIKIMEDIA_TARGET_IS_LAST=1"
-            if idx == last_idx
+            if idx == last_idx and not batch_has_terminal_drain
             else "unset WIKIMEDIA_TARGET_IS_LAST"
         )
         # ``unset WIKIMEDIA_STEP`` first so a failure in this target's
@@ -1327,11 +1343,15 @@ def main() -> None:
                 pipeline_steps.append(
                     f"sdc-sync --partner {canonical} --ids-file {csv_file}{sdc_opts}"
                 )
-                # Drain any Case-2 hash-drift uploads the uploader deferred
-                # because Category:Duplicate was at capacity. No-op when
-                # nothing deferred (the common case); patient loop when
-                # non-empty. See tools/drain_deferred.py for the design.
-                pipeline_steps.append(f"drain-deferred {canonical}")
+                # Opportunistic drain: single best-effort round that
+                # runs if Category:Duplicate happens to be below the
+                # resume threshold RIGHT NOW, otherwise exits without
+                # waiting. Never blocks the next target. The batch's
+                # patient drain (per partner, at the end of the whole
+                # pipeline — see the ``final_drain_blocks`` build
+                # below) picks up whatever this pass left in the
+                # sidecar.
+                pipeline_steps.append(f"drain-deferred --no-wait {canonical}")
         # Wrap each step with an ``export WIKIMEDIA_STEP=<name>`` prefix so
         # the per-target failure handler (``notify_pipeline_fail``) can name
         # the failing phase in Slack instead of just reporting an exit code.
@@ -1342,7 +1362,56 @@ def main() -> None:
             f"{label_export}; {{ {target_steps}; }}"
             f" || {{ {notify_fail_cmd} >/dev/null 2>&1 || true; }}"
         )
-    pipeline_cmd = f"{setup} && {{ {'; '.join(target_blocks)}; }}"
+
+    # Terminal patient-drain phase — one block per unique partner
+    # in the batch. Runs AFTER every target's chain has finished, so
+    # no partner sits idle waiting on Commons volunteers to clear
+    # Category:Duplicate while later targets could be uploading.
+    # The per-target opportunistic drain (``--no-wait``) inside each
+    # chain already actioned anything that fit; this phase does the
+    # unbounded patient wait. Dedup by canonical: two collection-
+    # scoped targets for the same partner share one terminal drain
+    # (a second drain would see an empty sidecar and no-op).
+    final_drain_blocks: list[str] = []
+    if batch_has_terminal_drain:
+        # ``dict.fromkeys`` gives an order-preserving unique iterator —
+        # same idiom used elsewhere in the tree (wikimedia.py, maintain.py).
+        unique_canonical = list(dict.fromkeys(t[0] for t in targets))
+        partners_to_drain: list[tuple[str, str]] = [
+            (
+                canonical,
+                f"/home/ec2-user/ingest-wikimedia/{PARTNER_DIR.get(canonical, canonical)}",
+            )
+            for canonical in unique_canonical
+        ]
+        for i, (canonical, base) in enumerate(partners_to_drain):
+            is_last_drain = i == len(partners_to_drain) - 1
+            drain_is_last_env = (
+                "export WIKIMEDIA_TARGET_IS_LAST=1"
+                if is_last_drain
+                else "unset WIKIMEDIA_TARGET_IS_LAST"
+            )
+            # Distinct session label per partner drain so the
+            # failure-handler's log lookup finds
+            # ``…-drain-{canonical}-drain-deferred.log`` (via
+            # ``setup_logging(canonical, "drain-deferred")`` in the
+            # drain tool).
+            drain_label = f"drain-{canonical}"
+            drain_label_export = (
+                f"export WIKIMEDIA_SESSION_LABEL={shlex.quote(drain_label)}; "
+                f"export WIKIMEDIA_PARTNER_DIR={shlex.quote(base)}; "
+                f"{drain_is_last_env}; "
+                f"unset WIKIMEDIA_SINGLE_ITEM; "
+                f"unset WIKIMEDIA_STEP"
+            )
+            drain_step = _wrap_step_with_marker(f"drain-deferred {canonical}")
+            final_drain_blocks.append(
+                f"{drain_label_export}; {{ cd {base} && {drain_step}; }}"
+                f" || {{ {notify_fail_cmd} >/dev/null 2>&1 || true; }}"
+            )
+
+    all_blocks = target_blocks + final_drain_blocks
+    pipeline_cmd = f"{setup} && {{ {'; '.join(all_blocks)}; }}"
 
     if slack_token:
         single_item_targets = [

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -255,3 +255,111 @@ def test_drain_removes_round_ids_from_sidecar_before_invoking_uploader(lock_fd):
     # sidecar — with a merge-only uploader this is what lets completed
     # items leave the queue.
     assert seen_by_uploader == [[]]
+
+
+# ---------------------------------------------------------------------------
+# ``--no-wait`` opportunistic mode: single best-effort round per invocation.
+# Runs inside each target's chain (per-target opportunistic phase) so a
+# partner whose Category:Duplicate cleared mid-batch gets its deferrals
+# actioned before subsequent targets start. The batch-terminal patient
+# drain (invoked WITHOUT ``--no-wait``, per unique partner, after every
+# target's chain) still handles anything the opportunistic pass left.
+# ---------------------------------------------------------------------------
+
+
+def test_no_wait_exits_immediately_when_category_at_capacity(lock_fd):
+    """When Category:Duplicate is at capacity, the opportunistic pass
+    must exit WITHOUT running any uploader/sdc-sync subprocess and
+    WITHOUT emitting the patient-mode Slack notifications — that
+    milestone is the terminal drain's, not this bonus pass."""
+    drain_sidecar.write_sidecar("nara", ["id-1"])
+
+    throttle = MagicMock()
+    # ``wait_for_capacity(0)`` returns False when the category is at
+    # or above threshold — mirrors ``DuplicateCategoryThrottle`` real
+    # behavior when the deadline is already past on first check.
+    throttle.wait_for_capacity.return_value = False
+    throttle.resume_below = 900
+    throttle.poll_secs = 300
+
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", return_value=lock_fd),
+        patch("tools.drain_deferred.subprocess.run") as sp,
+        patch(
+            "tools.drain_deferred.DuplicateCategoryThrottle",
+            return_value=throttle,
+        ),
+        patch("tools.drain_deferred.notify_drain_phase_start") as start_ping,
+        patch("tools.drain_deferred.notify_drain_phase_complete") as done_ping,
+    ):
+        result = CliRunner().invoke(drain_deferred.main, ["--no-wait", "nara"])
+
+    assert result.exit_code == 0, result.output
+    sp.assert_not_called()
+    # Slack pings are patient-mode milestones; opportunistic passes
+    # are silent so a run with no capacity doesn't spam #tech-alerts.
+    start_ping.assert_not_called()
+    done_ping.assert_not_called()
+    # Sidecar left intact for the terminal drain.
+    assert drain_sidecar.read_sidecar("nara") == ["id-1"]
+
+
+def test_no_wait_drains_single_round_when_under_capacity(lock_fd):
+    """When Category:Duplicate is under capacity, the opportunistic
+    pass DOES run one round — same clear-then-invoke pattern as the
+    patient loop — then exits without waiting for another round.
+    Contrast with patient mode, which loops until the sidecar is
+    empty (potentially many rounds)."""
+    drain_sidecar.write_sidecar("nara", ["id-1", "id-2"])
+
+    throttle = MagicMock()
+    throttle.wait_for_capacity.return_value = True  # capacity available now
+    throttle.resume_below = 900
+    throttle.poll_secs = 300
+
+    def fake_subprocess_run(argv, **kwargs):
+        return MagicMock(returncode=0)
+
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", return_value=lock_fd),
+        patch(
+            "tools.drain_deferred.subprocess.run", side_effect=fake_subprocess_run
+        ) as sp,
+        patch(
+            "tools.drain_deferred.DuplicateCategoryThrottle",
+            return_value=throttle,
+        ),
+        patch("tools.drain_deferred.notify_drain_phase_start") as start_ping,
+        patch("tools.drain_deferred.notify_drain_phase_complete") as done_ping,
+    ):
+        result = CliRunner().invoke(drain_deferred.main, ["--no-wait", "nara"])
+
+    assert result.exit_code == 0, result.output
+    # Exactly two subprocess calls: one uploader + one sdc-sync for
+    # the single round. Contrast with patient mode which could loop.
+    assert sp.call_count == 2
+    assert sp.call_args_list[0].args[0][0] == "uploader"
+    assert sp.call_args_list[1].args[0][0] == "sdc-sync"
+    # No patient-mode milestones — opportunistic passes are silent.
+    start_ping.assert_not_called()
+    done_ping.assert_not_called()
+
+
+def test_no_wait_empty_sidecar_early_exits(lock_fd):
+    """``--no-wait`` on an empty sidecar is the same no-op as patient
+    mode — no lock, no throttle, no subprocess."""
+    lock_mock = MagicMock()
+
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", lock_mock),
+        patch("tools.drain_deferred.subprocess.run") as sp,
+        patch(
+            "tools.drain_deferred.DuplicateCategoryThrottle",
+        ) as throttle_ctor,
+    ):
+        result = CliRunner().invoke(drain_deferred.main, ["--no-wait", "nara"])
+
+    assert result.exit_code == 0, result.output
+    lock_mock.assert_not_called()
+    sp.assert_not_called()
+    throttle_ctor.assert_not_called()

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -8,6 +8,7 @@ log-summary logic that produces the message body.
 import os
 import tempfile
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -158,6 +159,50 @@ def _capture_message(env: dict) -> str:
     ):
         notify_pipeline_fail()
     return sent.get("text", "")
+
+
+def test_drain_deferred_opportunistic_step_name_is_wired_consistently():
+    """Three files must agree on the literal ``drain-deferred-opportunistic``
+    for the per-target opportunistic drain to route its failure summary
+    to the right log file:
+
+      1. ``scripts.wikimedia_launch._wrap_step_with_marker`` sets it as
+         the ``WIKIMEDIA_STEP`` value when the command carries
+         ``--no-wait``.
+      2. ``ingest_wikimedia.slack._PHASE_LOG_SUFFIX`` maps it to a
+         log-file suffix that the failure handler tails.
+      3. ``tools.drain_deferred.main`` calls ``setup_logging(partner,
+         "drain-deferred-opportunistic", …)`` under ``--no-wait``, so
+         the log file the failure handler tails is the one the drain
+         actually wrote to.
+
+    Any divergence between the three would silently break the failure-
+    summary path: Slack would show either the wrong log's tail or no
+    tail at all. Pin the three-way agreement so a future rename in
+    one place can't slip.
+    """
+    from scripts.wikimedia_launch import _wrap_step_with_marker
+    from ingest_wikimedia.slack import _PHASE_LOG_SUFFIX
+
+    wrapped = _wrap_step_with_marker("drain-deferred --no-wait nara")
+    assert "export WIKIMEDIA_STEP=drain-deferred-opportunistic &&" in wrapped, (
+        "launcher must emit ``drain-deferred-opportunistic`` as the "
+        "WIKIMEDIA_STEP value for the per-target ``--no-wait`` drain"
+    )
+    assert "drain-deferred-opportunistic" in _PHASE_LOG_SUFFIX, (
+        "slack's _PHASE_LOG_SUFFIX map must include the opportunistic "
+        "step so the failure handler tails the right log"
+    )
+    # The log-file suffix drain_deferred.py writes to must match what
+    # slack.py's failure handler will search for.
+    drain_source = (
+        Path(__file__).resolve().parent.parent / "tools" / "drain_deferred.py"
+    ).read_text()
+    assert '"drain-deferred-opportunistic"' in drain_source, (
+        "tools/drain_deferred.py must call setup_logging with the "
+        "``drain-deferred-opportunistic`` event_type under --no-wait, "
+        "matching what slack.py tails and the launcher emits"
+    )
 
 
 def test_notify_pipeline_fail_says_aborting_this_target_when_not_last():

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -2269,6 +2269,37 @@ def test_canonicalize_commons_title_collapses_whitespace_runs():
     assert _canonicalize_commons_title("Foo Bar") == "Foo Bar"
 
 
+def test_canonicalize_commons_title_treats_underscores_as_space_equivalent():
+    """MediaWiki treats ``_`` and space as equivalent in page titles
+    (``File:X_Y`` and ``File:X Y`` are the same page). The guard MUST
+    fold both forms — otherwise an uploader-constructed underscore
+    title vs a previously-uploaded space title (same DPLA ID, same
+    SHA1) reads as drift, falls through to Case 2 UPLOAD_AND_TAG, and
+    inflates the Category:Duplicate deferral sidecar with false
+    positives.
+    """
+    from tools.uploader import _canonicalize_commons_title
+
+    # Direct underscore ↔ space equivalence.
+    assert _canonicalize_commons_title("Foo_Bar") == _canonicalize_commons_title(
+        "Foo Bar"
+    )
+    # Mixed underscore + space runs collapse to a single space.
+    assert _canonicalize_commons_title("Foo _ Bar") == "Foo Bar"
+    assert _canonicalize_commons_title("Foo__Bar") == "Foo Bar"
+    assert _canonicalize_commons_title("Foo_ _Bar") == "Foo Bar"
+    # Leading/trailing underscores are stripped alongside whitespace.
+    assert _canonicalize_commons_title("_Foo Bar_") == "Foo Bar"
+    # Realistic file-title shape with an underscore/space mismatch
+    # between the uploader-constructed form and the already-uploaded
+    # Commons form — must canonicalize to the same string.
+    space_form = "COLL FRAZIER AUGUSTUS PH119 BX4 IMG100 - DPLA - aef63c89.jpg"
+    underscore_form = "COLL_FRAZIER_AUGUSTUS_PH119_BX4_IMG100 - DPLA - aef63c89.jpg"
+    assert _canonicalize_commons_title(space_form) == _canonicalize_commons_title(
+        underscore_form
+    )
+
+
 def test_resolve_hash_drift_returns_already_correct_on_whitespace_normalized_match():
     """Regression: when the SHA1-lookup returns the file already at the
     intended title (after whitespace normalisation), ``_resolve_hash_drift``

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -438,6 +438,12 @@ def test_wrap_step_with_marker_tags_each_tool_with_its_phase():
     assert _wrap_step_with_marker("drain-deferred nara").startswith(
         "export WIKIMEDIA_STEP=drain-deferred && drain-deferred "
     )
+    # ``drain-deferred --no-wait`` (per-target opportunistic phase)
+    # gets a distinct step name so the failure handler tails the
+    # opportunistic log file rather than the batch-terminal one.
+    assert _wrap_step_with_marker("drain-deferred --no-wait nara").startswith(
+        "export WIKIMEDIA_STEP=drain-deferred-opportunistic && drain-deferred "
+    )
     # Non-step commands (``cd``, the case-2 graceful-skip ``echo … ; true``,
     # and the ``sdc-sync --cat`` flavour the maintain builder emits — wait,
     # that one IS sdc-sync. Use a true non-step instead.):

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -3,42 +3,36 @@
 The uploader defers Case-2 hash-drift upload+tag operations as an
 atomic unit whenever ``Category:Duplicate`` on Commons is at capacity,
 persisting the deferred DPLA IDs to a per-partner sidecar (see
-``ingest_wikimedia.drain_sidecar``). This command runs as the final
-step of the wikimedia-upload pipeline:
+``ingest_wikimedia.drain_sidecar``). The drain-deferred command comes
+in two modes:
 
-    cd → get-ids-es → downloader → uploader → sdc-sync → drain-deferred
+  * **Patient (default)** — the terminal phase of a batch. Acquires a
+    host-level ``flock`` and loops until the sidecar is empty,
+    polling ``Category:Duplicate`` (every ``DEFAULT_POLL_SECS`` = 5
+    min by default) with no time budget — designed to wait days or
+    weeks on human-admin category clearing. Emits Slack
+    start/complete notifications so the operator knows the session
+    is in this state.
 
-If the sidecar is empty (or missing), the command exits immediately —
-the common case where no items deferred is a no-op.
-
-If the sidecar is non-empty, the command:
-
-  1. Acquires a host-level ``flock`` at
-     ``/home/ec2-user/ingest-wikimedia/.drain-lock`` so only one drain
-     runs concurrently on the box. The existing throttle's per-session
-     ``try_acquire`` cap on Case-2 tag emissions was designed for a
-     single active writer; letting multiple sessions drain in parallel
-     could overshoot Category:Duplicate's threshold before either
-     session re-queried. The flock serialises the work; other
-     drain-deferred processes wait their turn.
-  2. Enters a loop that patiently polls Category:Duplicate (every
-     ``DEFAULT_POLL_SECS`` = 5 min by default) until the size falls
-     below the resume threshold. There is no time budget — this can
-     wait days or weeks. Volunteers clear the category on human-admin
-     timescales and this command is designed to be as patient as they
-     are.
-  3. When capacity is available, removes the round's IDs from the
-     sidecar and re-invokes ``uploader`` and ``sdc-sync`` (as
-     subprocesses) on them. The uploader only ever *merges* deferred
-     IDs into the sidecar (it never removes completed ones), so the
-     drain clears the round up front and the uploader's re-run merges
-     back whichever items re-deferred — those stay queued for the next
-     loop iteration; completed items stay out.
-  4. Loops until the sidecar is empty.
+  * **``--no-wait`` (opportunistic)** — the interstitial phase
+    embedded in each target's upload chain. Runs a single best-effort
+    round: if ``Category:Duplicate`` is currently below the
+    throttle's resume threshold, drain what fits and return; if it's
+    at capacity, exit immediately without waiting. Never blocks
+    subsequent targets in the batch. No Slack notifications — this
+    pass is a bonus, not a milestone. Items that don't clear here
+    stay in the sidecar for the batch's final patient drain.
 
 Cancellation is operator-driven — ``tmux kill-session`` at any time.
 The sidecar persists across kills, so a subsequent partner run picks
 up wherever this left off.
+
+See the launcher (``scripts/wikimedia_launch.py``) for the chain
+ordering: per-target opportunistic drains run inside each target's
+chain (so a partner whose Category:Duplicate happened to clear
+mid-run gets its deferrals actioned before the next partner starts),
+and a per-partner patient drain runs at the end of the whole batch
+(so no partner sits idle waiting on Commons volunteers).
 """
 
 from __future__ import annotations
@@ -56,11 +50,11 @@ import click
 from ingest_wikimedia import drain_sidecar
 from ingest_wikimedia.dup_throttle import DuplicateCategoryThrottle
 from ingest_wikimedia.logs import setup_logging
-from ingest_wikimedia.wikimedia import get_site
 from ingest_wikimedia.slack import (
     notify_drain_phase_complete,
     notify_drain_phase_start,
 )
+from ingest_wikimedia.wikimedia import get_site
 
 # Host-level lock file. One drain-deferred process at a time across the
 # shared EC2 instance — see module docstring for the concurrency
@@ -162,13 +156,117 @@ def _run_deferred_items(partner: str, dpla_ids: list[str]) -> None:
             )
 
 
+def _run_one_round(partner: str, pending: list[str]) -> int:
+    """Execute one drain round: clear ``pending`` from the sidecar,
+    invoke uploader + sdc-sync on those IDs, return how many the
+    round emitted (``pre - post``).
+
+    Taking the round's IDs out BEFORE the subprocess is load-bearing
+    — the uploader only ever *merges* deferred IDs back in, never
+    removes completed ones. Leaving the round's IDs in place would
+    make the queue permanent: completed items would replay every
+    round and the loop would never terminate. Items the uploader
+    re-defers reappear via its ``merge_sidecar``; completed (or
+    hard-failed) items stay out. IDs a concurrent session appends
+    mid-round are untouched and picked up on the next round's read.
+    """
+    pre_count = len(pending)
+    drain_sidecar.remove_from_sidecar(partner, pending)
+    _run_deferred_items(partner, pending)
+    post_round = drain_sidecar.read_sidecar(partner)
+    return pre_count - len(post_round)
+
+
+def _drain_loop(partner: str, throttle: DuplicateCategoryThrottle) -> int:
+    """Patient drain loop for ``partner``. Blocks on
+    :meth:`DuplicateCategoryThrottle.wait_for_capacity` between rounds;
+    returns the total number of items emitted (drained from the
+    sidecar) once it's empty. See module docstring for the rationale
+    on the unbounded wait."""
+    total_emitted = 0
+    while True:
+        pending = drain_sidecar.read_sidecar(partner)
+        if not pending:
+            return total_emitted
+        logging.info(
+            "Drain-deferred: %d item(s) still pending; waiting for "
+            "Category:Duplicate to drop below %d (currently polled every %ds).",
+            len(pending),
+            throttle.resume_below,
+            throttle.poll_secs,
+        )
+        # Unlimited wait — patient by design. See module docstring.
+        throttle.wait_for_capacity(max_wait_secs=None)
+        emitted = _run_one_round(partner, pending)
+        if emitted > 0:
+            total_emitted += emitted
+            logging.info(
+                "Drain-deferred: round emitted %d item(s); %d still pending.",
+                emitted,
+                len(pending) - emitted,
+            )
+        else:
+            # A round that made no progress despite reported capacity is
+            # not fatal here (unlike the old bounded drain that would
+            # abort). Category:Duplicate may have refilled while we were
+            # processing, or the round hit unrelated per-item failures.
+            # Loop back to wait_for_capacity; next round will re-observe.
+            logging.warning(
+                "Drain-deferred: round made no progress (%d item(s) still "
+                "pending). Continuing to wait; category may have refilled.",
+                len(pending),
+            )
+
+
+def _drain_opportunistic_once(partner: str, throttle: DuplicateCategoryThrottle) -> int:
+    """Single best-effort drain round for ``partner``. If
+    ``Category:Duplicate`` is below the resume threshold RIGHT NOW,
+    drain what's queued; if it's at capacity, exit immediately without
+    waiting. Never blocks the caller.
+
+    Returns the number of items drained (0 if the round didn't fire,
+    positive if it did).
+
+    The opportunistic pass exists so a partner whose category clears
+    mid-batch (a Commons volunteer processes some entries between the
+    partner's upload phase and end-of-batch) gets its deferrals
+    actioned as part of its own chain — before the next target starts
+    — rather than waiting on the batch's terminal patient drain.
+    """
+    pending = drain_sidecar.read_sidecar(partner)
+    if not pending:
+        return 0
+    if not throttle.wait_for_capacity(max_wait_secs=0):
+        logging.info(
+            "Drain-deferred (opportunistic): Category:Duplicate at capacity; "
+            "%d item(s) remain in sidecar for the batch's terminal drain.",
+            len(pending),
+        )
+        return 0
+    emitted = _run_one_round(partner, pending)
+    logging.info(
+        "Drain-deferred (opportunistic): emitted %d item(s); %d still pending.",
+        emitted,
+        len(pending) - emitted,
+    )
+    return emitted
+
+
 @click.command()
+@click.option(
+    "--no-wait",
+    is_flag=True,
+    help=(
+        "Best-effort single-round drain: if Category:Duplicate is at capacity, "
+        "exit immediately rather than waiting. For the per-target opportunistic "
+        "phase; the batch's terminal patient drain runs without this flag."
+    ),
+)
 @click.argument("partner")
-def main(partner: str) -> None:
-    """Drain the deferred-drain sidecar for ``partner`` — waits
-    indefinitely on ``Category:Duplicate`` capacity, retrying deferred
-    uploads until the sidecar is empty. See module docstring."""
-    setup_logging(partner, "drain-deferred", logging.INFO)
+def main(no_wait: bool, partner: str) -> None:
+    """Drain the deferred-drain sidecar for ``partner``. See module docstring."""
+    event_type = "drain-deferred-opportunistic" if no_wait else "drain-deferred"
+    setup_logging(partner, event_type, logging.INFO)
 
     initial_ids = drain_sidecar.read_sidecar(partner)
     if not initial_ids:
@@ -178,15 +276,18 @@ def main(partner: str) -> None:
         )
         return
 
+    mode_label = "opportunistic" if no_wait else "patient"
     logging.info(
         "Drain-deferred: sidecar for partner %s has %d item(s) queued; "
-        "acquiring host lock and beginning drain loop.",
+        "acquiring host lock (mode: %s).",
         partner,
         len(initial_ids),
+        mode_label,
     )
 
     # Advisory host-level lock. Held for the entire drain (potentially
-    # days). The ``finally`` below closes the fd (releasing the flock)
+    # days in patient mode; usually milliseconds in opportunistic
+    # mode). The ``finally`` below closes the fd (releasing the flock)
     # on normal exit or exception; a kill releases it on process exit.
     lock_fd = _acquire_host_lock()
     try:
@@ -195,56 +296,17 @@ def main(partner: str) -> None:
         # tools use; also runs ``site.login()``. The throttle requires a
         # non-None site (see :class:`DuplicateCategoryThrottle` guard).
         throttle = DuplicateCategoryThrottle(get_site())
+
+        if no_wait:
+            _drain_opportunistic_once(partner, throttle)
+            return
+
+        # Patient mode: Slack-notify start (so the operator knows the
+        # session is waiting on human-admin category clearing), loop
+        # until empty, Slack-notify complete.
         initial_category_size = throttle.category_size()
         notify_drain_phase_start(partner, len(initial_ids), initial_category_size)
-
-        total_emitted = 0
-        while True:
-            pending = drain_sidecar.read_sidecar(partner)
-            if not pending:
-                break
-            logging.info(
-                "Drain-deferred: %d item(s) still pending; waiting for "
-                "Category:Duplicate to drop below %d (currently polled every %ds).",
-                len(pending),
-                throttle.resume_below,
-                throttle.poll_secs,
-            )
-            # Unlimited wait — patient by design. See module docstring.
-            throttle.wait_for_capacity(max_wait_secs=None)
-            pre_round_count = len(pending)
-            # Take this round's IDs out of the sidecar BEFORE the
-            # subprocess pass. The uploader only ever merges deferred IDs
-            # back in — it never removes completed ones — so leaving the
-            # round's IDs in place would make the queue permanent:
-            # completed items would replay every round and the loop would
-            # never terminate. Items the uploader re-defers reappear via
-            # its ``merge_sidecar``; completed (or hard-failed) items stay
-            # out. IDs a concurrent session appends mid-round are
-            # untouched and picked up on the next loop iteration.
-            drain_sidecar.remove_from_sidecar(partner, pending)
-            _run_deferred_items(partner, pending)
-            post_round = drain_sidecar.read_sidecar(partner)
-            emitted_this_round = pre_round_count - len(post_round)
-            if emitted_this_round > 0:
-                total_emitted += emitted_this_round
-                logging.info(
-                    "Drain-deferred: round emitted %d item(s); %d still pending.",
-                    emitted_this_round,
-                    len(post_round),
-                )
-            else:
-                # A round that made no progress despite reported capacity is
-                # not fatal here (unlike the old bounded drain that would
-                # abort). Category:Duplicate may have refilled while we were
-                # processing, or the round hit unrelated per-item failures.
-                # Loop back to wait_for_capacity; next round will re-observe.
-                logging.warning(
-                    "Drain-deferred: round made no progress (%d item(s) still "
-                    "pending). Continuing to wait; category may have refilled.",
-                    len(post_round),
-                )
-
+        total_emitted = _drain_loop(partner, throttle)
         elapsed = time.monotonic() - started_at
         logging.info(
             "Drain-deferred: complete. Emitted %d item(s) over %.0f seconds.",

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -274,26 +274,31 @@ class NewFilePageBlocked(RuntimeError):
     """
 
 
-_WHITESPACE_RUN_RE = re.compile(r"\s+")
+_TITLE_WHITESPACE_RE = re.compile(r"[\s_]+")
 
 
 def _canonicalize_commons_title(title: str) -> str:
     """Return ``title`` under a light MediaWiki-title normalisation:
-    strip leading/trailing whitespace and collapse internal whitespace
-    runs to a single space.
+    strip leading/trailing whitespace/underscores and collapse runs
+    of whitespace and underscores to a single space.
 
-    Used by ``_tag_drift_duplicate``'s self-tag defense — a raw Python
-    string comparison of "the old title" vs "the new title" can miss
-    a match when the two names disagree only in whitespace-run form
-    (the exact shape ``get_page_title``'s ``[:181]`` truncation-lands-
-    on-whitespace bug used to produce). This helper mirrors just enough
-    of MediaWiki's title normalisation to catch that class of case
-    without pulling in the broader normalisation surface (Unicode NFC,
-    underscore ↔ space, namespace-first-letter capitalisation, etc.);
-    those live on the API side and the defense-in-depth guard doesn't
-    need every one of them to be a safety net.
+    MediaWiki treats ``_`` and space as equivalent in page titles
+    (``File:X_Y`` and ``File:X Y`` are the same page). Callers doing
+    Python-string equality between an uploader-constructed title and
+    one returned from Commons must fold both forms — otherwise a
+    same-page pair reads as drift and misroutes through
+    ``_resolve_hash_drift`` → Case 2 → UPLOAD_AND_TAG, inflating
+    the Case-2 deferral sidecar with false positives.
+
+    Also folds whitespace-run vs single-space differences (the
+    ``get_page_title`` truncation-lands-on-whitespace edge case).
+
+    Not exhaustive — Unicode NFC, namespace-first-letter
+    capitalisation, and other server-side normalisations still live
+    on the API side. Covers exactly the two classes that produce
+    false-drift signals in the uploader's Python-side identity check.
     """
-    return _WHITESPACE_RUN_RE.sub(" ", title).strip()
+    return _TITLE_WHITESPACE_RE.sub(" ", title).strip()
 
 
 class Uploader:


### PR DESCRIPTION
## Summary

Bundles two related fixes that both landed in the MWDL 2026-07-02 investigation:

1. **Title-canonicalizer underscore fix** — `_canonicalize_commons_title` now folds `_` and space as MediaWiki does. Without this, an uploader-constructed underscore title vs a previously-uploaded space title (same DPLA ID, same SHA1) reads as drift, falls through to Case 2 UPLOAD_AND_TAG, and defers. That's what produced ~7K false-positive deferrals in MWDL's sidecar this week.

2. **Drain redesign** — per-target opportunistic `--no-wait` drain inside each target's chain, plus a terminal per-partner patient drain AFTER all target chains, so no partner sits idle waiting on Commons volunteers while later targets could be uploading.

## Detail

**Title canonicalizer** (`tools/uploader.py:277`):

```python
_TITLE_WHITESPACE_RE = re.compile(r"[\s_]+")  # was \s+
```

Also folds runs and strips underscores at edges, mirroring MediaWiki's normalization for our purposes (`File:X_Y` and `File:X Y` are the same page).

**Drain rework** (`tools/drain_deferred.py`, `scripts/wikimedia_launch.py`):

- `drain-deferred --no-wait <partner>` — single best-effort round; if Category:Duplicate has capacity right now, drain what fits; if it's at capacity, exit without waiting. Never blocks the caller. No Slack notifications (bonus, not a milestone).
- The launcher now emits `drain-deferred --no-wait <canonical>` inside each target chain (so a partner whose category cleared mid-batch gets its deferrals actioned before the next target starts), and appends a terminal `drain-deferred <canonical>` block per unique partner AFTER all target chains — patient patient-wait phase, one per partner, dedup'd via `dict.fromkeys`.
- `_drain_loop` + `_drain_opportunistic_once` share a new `_run_one_round(partner, pending) -> int` helper (was near-identical clear-then-invoke shape).

**Failure-summary routing** (`ingest_wikimedia/slack.py`, `scripts/wikimedia_launch.py`):

- `setup_logging(partner, "drain-deferred-opportunistic", ...)` under `--no-wait` writes to a distinct log filename.
- `_PHASE_LOG_SUFFIX` has a matching entry so the failure handler tails the right file.
- `_wrap_step_with_marker` emits `WIKIMEDIA_STEP=drain-deferred-opportunistic` when the command carries `--no-wait` (via `shlex.split`, not string sniff).
- New coupling test in `test_slack.py` pins the three-way agreement (launcher step name / slack log suffix / drain-deferred event_type) so a future rename in one place can't silently break the failure summary.

**IS_LAST semantics** — per-target `WIKIMEDIA_TARGET_IS_LAST` is now `1` only when there is no terminal drain phase (maintain / sdc-only / refresh-only). Full upload runs move `IS_LAST` to the last terminal drain block, so Slack's "aborting batch (this was the final target)" fires on the right step.

## Test plan

- [x] pytest: **1069 tests pass** on wiki EC2 (was 1064; +5 new — 3 for `--no-wait` behavior, 1 for the coupling, 1 for underscore canonicalization).
- [x] Ruff + format clean locally.
- [ ] Post-merge: clear MWDL's stale sidecar (`mwdl/mwdl/deferred-drain.json`) so the next MWDL run doesn't re-fire on its ~7K false-positive entries; the title-canonicalizer fix will short-circuit these as ALREADY_CORRECT on the following run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Fixed Commons title canonicalization to treat underscores and spaces as equivalent, preventing false drift detection on otherwise identical file titles.
- Reworked deferred draining to add a non-blocking `--no-wait` opportunistic mode, plus a final patient drain phase deduplicated per partner after target processing completes.
- Updated Slack/failure routing and step naming so opportunistic drains map to the correct log suffix and final-target messaging applies to the right phase.
- Added regression coverage for underscore canonicalization, opportunistic drain behavior, and step-name/log-suffix consistency.

## Notes
- No manual pipeline trigger, ECS redeployment, env var/Secrets Manager changes, database migration, shared infrastructure changes, public API changes, or security-impacting changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->