### PR TITLE
workflows: disable checkout credential persistence

### DIFF
--- a/.github/workflows/cim-pageviews.yml
+++ b/.github/workflows/cim-pageviews.yml
@@ -30,6 +30,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Don't leave a writable GITHUB_TOKEN in the runner for later steps.
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -71,6 +74,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Don't leave a writable GITHUB_TOKEN in the runner for later steps.
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,6 +13,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Don't leave a writable GITHUB_TOKEN in the runner for later steps.
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -11,4 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Don't leave a writable GITHUB_TOKEN in the runner for later steps.
+          persist-credentials: false
       - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0

--- a/.github/workflows/wikimedia-kill.yml
+++ b/.github/workflows/wikimedia-kill.yml
@@ -25,6 +25,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Don't leave a writable GITHUB_TOKEN in the runner for later steps.
+          persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/.github/workflows/wikimedia-launch.yml
+++ b/.github/workflows/wikimedia-launch.yml
@@ -73,6 +73,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Don't leave a writable GITHUB_TOKEN in the runner for later steps.
+          persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/.github/workflows/wikimedia-retry.yml
+++ b/.github/workflows/wikimedia-retry.yml
@@ -34,6 +34,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Don't leave a writable GITHUB_TOKEN in the runner for later steps.
+          persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/.github/workflows/wikimedia-upload-status.yml
+++ b/.github/workflows/wikimedia-upload-status.yml
@@ -26,6 +26,9 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Don't leave a writable GITHUB_TOKEN in the runner for later steps.
+          persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:


### PR DESCRIPTION
## Summary

Adds `persist-credentials: false` (with the same comment `codeql.yml` already carries) to every `actions/checkout` step across `.github/workflows/`. Nine checkout sites in eight files; `codeql.yml` was already hardened, everything else wasn't.

Without this the checkout action leaves the auto-generated `GITHUB_TOKEN` in the runner's Git config for the whole job, so any subsequent step in the same job — including third-party actions we pin — has push access to the repo. Setting `persist-credentials: false` narrows the token's lifetime to the checkout step itself.

## Why now

Deferred from Dependabot's [#358](https://github.com/dpla/ingest-wikimedia/pull/358). That PR was scoped to dependency version bumps; the seven identical `persist-credentials: false` nitpicks CR raised there wanted a dedicated review, and modifying the Dependabot branch risked breaking its auto-management.

Same nit was raised by [zizmor](https://woodruffw.github.io/zizmor/) as the \`artipacked\` rule.

## Test plan

- [x] YAML shape unchanged elsewhere — grep confirms every \`actions/checkout\` in the tree now has the block.
- [ ] Post-merge: workflows continue to pass on the next run of each (pytest, ruff, codeql, cim-pageviews, wikimedia-*).

Files touched: cim-pageviews.yml (2 sites), pytest.yml, ruff.yml, wikimedia-kill.yml, wikimedia-launch.yml, wikimedia-retry.yml, wikimedia-upload-status.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated workflow files under `.github/workflows/` to add `persist-credentials: false` to `actions/checkout` steps, so the auto-generated `GITHUB_TOKEN` is no longer left in the runner’s Git config for later steps.

Security impact: yes — this reduces credential persistence/availability in CI jobs. No manual pipeline trigger, ECS redeployment, environment variable/Secrets Manager, database migration, shared infrastructure, or public API changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->