### PR TITLE
Maintenance sweep: code-quality nits + urllib3/idna security bump

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -684,8 +684,6 @@ def _expand_wikitext_for_date_parse(raw_date: str, site) -> str:
     # noise the date templates inject for downstream tooling should
     # disappear. Generic tag-strip on the second pass removes the
     # remaining bare tags but preserves their inner text.
-    import re
-
     expanded = re.sub(
         r"<(span|div)[^>]*"
         r"(?:style\s*=\s*[\"'][^\"']*display\s*:\s*none[^\"']*[\"']"

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1867,7 +1867,6 @@ def test_post_sdc_cleanup_for_item_isolates_per_page_failures(monkeypatch, caplo
     """A per-page cleanup failure is isolated: the failing page is skipped and
     its siblings still count. (See _post_sdc_cleanup_for_item for why this must
     not propagate.)"""
-    import json
     import logging as _logging
 
     from ingest_wikimedia import wikimedia
@@ -3798,8 +3797,6 @@ def test_submit_per_item_edit_bundles_all_fragments_into_one_post():
     """Every fragment kind — new claims, reference updates, qualifier
     updates, removals — gets bundled into a single ``wbeditentity``
     POST with the combined claims list in ``data.claims``."""
-    import json
-
     from tools import sdc_sync
 
     new_claim = {
@@ -4093,7 +4090,6 @@ def test_p813_refresh_added_when_other_edits_exist():
     refreshes P813 on all DPLA-authored claims whose P813 doesn't match
     the item's DPLA ingestDate."""
     import datetime as _dt
-    import json
 
     from tools import sdc_sync
 
@@ -4143,7 +4139,6 @@ def test_p813_refresh_skips_claims_already_dated_today():
     """A DPLA reference whose P813 already matches the ingestDate is not
     re-emitted."""
     import datetime as _dt
-    import json
 
     from tools import sdc_sync
 
@@ -4219,7 +4214,6 @@ def test_p813_refresh_preserves_user_added_references():
     ONLY the DPLA reference refreshed; user references are preserved
     verbatim in the rewritten references list."""
     import datetime as _dt
-    import json
 
     from tools import sdc_sync
 
@@ -4286,7 +4280,6 @@ def test_reference_refresh_repairs_partial_dpla_reference():
     have skipped it). This is the shape repair that lets us always
     re-assert the expected reference without a separate reconcile pass."""
     import datetime as _dt
-    import json
 
     from tools import sdc_sync
 
@@ -4359,7 +4352,6 @@ def test_reference_refresh_skips_fully_canonical_reference():
     item + P123 + P813 matching the ingestDate) produces no fragment — no
     spurious edit."""
     import datetime as _dt
-    import json
 
     from tools import sdc_sync
 
@@ -4414,8 +4406,6 @@ def test_flush_emits_type_statement_on_every_non_removal_fragment():
     (drives a P813 refresh fragment). Assert every non-removal claim
     in the POSTed payload carries ``type: "statement"``.
     """
-    import json
-
     from tools import sdc_sync
 
     stale_claim = {

--- a/tools/get_ids_nara.py
+++ b/tools/get_ids_nara.py
@@ -31,6 +31,7 @@ import json
 import logging
 import sys
 import xml.etree.ElementTree as ET
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 
 import click
@@ -39,6 +40,7 @@ from ingest_wikimedia.banlist import Banlist
 from ingest_wikimedia.es import ES_HARD_TIMEOUT, check_es_response, post_es
 from ingest_wikimedia.s3 import S3Client
 from ingest_wikimedia.sdc import (
+    NARA_PROVIDER_NAME,
     build_claims_for_doc,
     collect_subject_queries,
     fetch_institutions_v2,
@@ -56,7 +58,6 @@ from ingest_wikimedia.staging import (
 PAGE_SIZE = 500
 S3_WRITE_WORKERS = 4
 PARTNER = "nara"
-NARA_PROVIDER = "National Archives and Records Administration"
 
 # --- Tunable priority thresholds ---
 # Collections or formats exceeding these counts are deferred to future runs,
@@ -127,7 +128,7 @@ def _fetch_buckets(field: str, extra_filters: list[dict] | None = None) -> list[
             "query": {
                 "bool": {
                     "filter": [
-                        {"term": {"provider.name.not_analyzed": NARA_PROVIDER}},
+                        {"term": {"provider.name.not_analyzed": NARA_PROVIDER_NAME}},
                         {"term": {"rightsCategory": "Unlimited Re-Use"}},
                         *(extra_filters or []),
                     ]
@@ -153,7 +154,7 @@ def _fetch_buckets(field: str, extra_filters: list[dict] | None = None) -> list[
     return buckets
 
 
-def _paginate(extra_filter: dict):
+def _paginate(extra_filter: dict) -> Iterator[dict]:
     """Yield all ES hits for NARA items with Unlimited Re-Use and mediaMaster, filtered by extra_filter."""
     search_after = None
     while True:
@@ -163,7 +164,7 @@ def _paginate(extra_filter: dict):
             "query": {
                 "bool": {
                     "filter": [
-                        {"term": {"provider.name.not_analyzed": NARA_PROVIDER}},
+                        {"term": {"provider.name.not_analyzed": NARA_PROVIDER_NAME}},
                         {"term": {"rightsCategory": "Unlimited Re-Use"}},
                         {"exists": {"field": "mediaMaster"}},
                         extra_filter,

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -17,6 +17,7 @@ from pywikibot import pagegenerators
 from ingest_wikimedia.logs import setup_logging
 from ingest_wikimedia.sdc import (
     CHUNKABLE_PROPS,
+    NARA_PROVIDER_NAME,
     casefold_for_compare,
     ingest_date_from_doc,
     parse_date_range,
@@ -3675,7 +3676,7 @@ def _parse_dpla_doc(dpla, dpla_id):
             creators = [creators]
     except Exception:
         creators = []
-    if dpla["provider"]["name"] == "National Archives and Records Administration":
+    if dpla["provider"]["name"] == NARA_PROVIDER_NAME:
         naids = dpla["sourceResource"]["identifier"]
         if isinstance(naids, str):
             naids = [naids]

--- a/uv.lock
+++ b/uv.lock
@@ -221,11 +221,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -720,11 +720,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677, upload-time = "2024-09-12T10:52:18.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338, upload-time = "2024-09-12T10:52:16.589Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bundles low-risk code-quality findings (Copilot + CodeQL) and open Dependabot security alerts into one maintenance PR.

**Code cleanup**
- `tests/test_sdc_sync.py` — drop 8 redundant `import json` inside test bodies (already imported at L20).
- `ingest_wikimedia/legacy_artwork.py` — drop redundant `import re` inside `_expand_wikitext_for_date_parse` (already imported at L31).
- `tools/get_ids_nara.py`:
  - Import `NARA_PROVIDER_NAME` from `ingest_wikimedia.sdc` instead of duplicating the string literal (same value, prevents drift with the canonical constant used in `sdc.py:672`).
  - Add `Iterator[dict]` return annotation to `_paginate`.

**Dependabot security bumps (uv.lock only)**
- `idna` 3.10 → 3.18 — [GHSA-65pc-fj4g-8rjx](https://github.com/advisories/GHSA-65pc-fj4g-8rjx) (medium: bypass of CVE-2024-3651 fix in `idna.encode`)
- `urllib3` 2.2.3 → 2.7.0 — clears 6 open alerts:
  - [GHSA-qccp-gfcp-xxvc](https://github.com/advisories/GHSA-qccp-gfcp-xxvc) (high) — sensitive headers forwarded across origins in proxied redirects
  - [GHSA-38jv-5279-wg99](https://github.com/advisories/GHSA-38jv-5279-wg99) (high) — decompression-bomb bypass in streaming API redirects
  - [GHSA-2xpw-w6gg-jr37](https://github.com/advisories/GHSA-2xpw-w6gg-jr37) (high) — streaming API mishandles compressed data
  - [GHSA-gm62-xv2j-4w53](https://github.com/advisories/GHSA-gm62-xv2j-4w53) (high) — unbounded decompression chain length
  - [GHSA-48p4-8xcf-vxj5](https://github.com/advisories/GHSA-48p4-8xcf-vxj5) (medium) — redirect control in browsers/Node
  - [GHSA-pq67-6m6q-mj2v](https://github.com/advisories/GHSA-pq67-6m6q-mj2v) (medium) — redirect disable-flag interaction with retries

Reviewers checked urllib3 2.2 → 2.7 for breaking changes: none of the intervening minors touch APIs this repo uses (no HTTP/2 opt-in, no reliance on lenient URL parsing, TLS minimum bump was already effective in practice). `pywikibot`, `requests`, and `boto3` all accept `urllib3>=2`.

## Test plan

- [x] `ruff check` + `ruff format` clean on changed files
- [x] Full pytest suite green locally (1069 passed)
- [x] `simplify` skill (reuse + quality + efficiency) — all three passes clean
- [x] Verified branch contains only the intended commit against `origin/main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR is a maintenance sweep with small code-quality cleanups and dependency security updates.

Highlights:
- Removed redundant local `import json` statements from multiple tests in `tests/test_sdc_sync.py`
- Removed a redundant in-function `import re` in `_expand_wikitext_for_date_parse` (`ingest_wikimedia/legacy_artwork.py`)
- Updated `tools/get_ids_nara.py` and `tools/sdc_sync.py` to use the shared `NARA_PROVIDER_NAME` constant instead of duplicating the NARA provider string literal
- Added an explicit `Iterator[dict]` return annotation to `_paginate`
- Added/extended test coverage for per-page cleanup error isolation in `tests/test_sdc_sync.py`

Dependency/security updates (lockfile only):
- Updated `uv.lock`:
  - `idna` 3.10 → 3.18 (GHSA-65pc-fj4g-8rjx)
  - `urllib3` 2.2.3 → 2.7.0 (addressing open redirect/streaming/decompression-related advisories)
- No changes to auth, request handling logic, or credential management—only locked dependency versions.

Operational/infra/API impact:
- No manual pipeline trigger, ECS redeployment, or other infrastructure/shared configuration changes required
- No environment variables or AWS Secrets Manager keys added/removed/renamed
- No database migrations introduced
- No public API response shape or endpoints modified

Validation:
- `ruff check` and `ruff format` pass on changed files
- Full pytest suite passes locally
- `simplify` checks pass
<!-- end of auto-generated comment: release notes by coderabbit.ai -->