### PR TITLE
Fix Slack failure messages surfacing wrong log / wrong hints

### DIFF
--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -45,14 +45,17 @@ def post_message(token: str, text: str) -> None:
 # probably an OOM" hint without having to SSM in and check dmesg.
 #
 # Common interpreter-level exits also have universally-recognised meanings:
-#   * 1 — Python uncaught exception (CRITICAL traceback printed to stderr)
 #   * 2 — Click misuse: bad CLI arguments / failed Click-side validation
 #         (e.g. ``click.BadParameter`` from a precheck like
 #         ``DPLA.check_partner``). Always points at config / args, never code.
 #   * 124 — GNU ``timeout`` (1) wrapper killed the child for exceeding its
 #         deadline. Not used in the pipeline today but cheap to include.
+#
+# Exit 1 is deliberately absent: it's Python's catch-all "something raised"
+# and any hint (previously "uncaught exception — see traceback") over-promised
+# a traceback the message often can't deliver, since the raise may have happened
+# in a ``finally`` block or before ``setup_logging`` ran.
 _EXIT_CODE_HINTS: dict[int, str] = {
-    1: "uncaught exception — see traceback",
     2: "rejected its arguments",
     124: "timed out",
     130: "SIGINT (Ctrl-C)",
@@ -79,12 +82,26 @@ def _decode_exit_code(rc_str: str | None) -> str:
     return f" (exit {rc}" + (f" — {hint})" if hint else ")")
 
 
-def _find_latest_log(partner_dir: str, label: str, phase: str = "*") -> str | None:
+def _find_latest_log(
+    partner_dir: str,
+    label: str,
+    phase: str = "*",
+    min_mtime: float | None = None,
+) -> str | None:
     """Return the most recently modified log file matching this label, or None.
 
     Logs are named `{timestamp}-{label}-{phase}.log` under `<partner_dir>/logs/`.
     Pass `phase` (e.g. "download", "upload") to restrict the match to a single
     phase; the default matches any phase.
+
+    ``min_mtime`` (Unix epoch seconds) filters out files older than the given
+    threshold. The launcher stamps ``WIKIMEDIA_STEP_START`` right before each
+    step so that a step which dies before ``setup_logging`` runs (i.e., writes
+    no log of its own) does NOT get a stale log from a previous run attached
+    to its Slack failure message — instead the caller sees ``None`` and can
+    say "no log written yet." Without this, a step that fails during
+    pre-``setup_logging`` init would post a log from an unrelated prior run,
+    which is worse than posting no log at all.
 
     Tolerates the rare race where a candidate disappears between glob and stat —
     raising OSError here would suppress the Slack failure notification entirely.
@@ -98,9 +115,29 @@ def _find_latest_log(partner_dir: str, label: str, phase: str = "*") -> str | No
             mtime = os.path.getmtime(path)
         except OSError:
             continue
+        if min_mtime is not None and mtime < min_mtime:
+            continue
         if newest is None or mtime > newest[0]:
             newest = (mtime, path)
     return newest[1] if newest is not None else None
+
+
+def _step_start_mtime() -> float | None:
+    """Return ``WIKIMEDIA_STEP_START`` as a float, or None if unset/malformed.
+
+    The launcher exports this via ``$(date +%s)`` right before each step,
+    scoping the failure-log lookup to files created after the step began.
+    Malformed values (empty, non-numeric) return None — same as if the launcher
+    predates the export, so the failure handler falls back to the unbounded
+    lookup rather than suppressing every message.
+    """
+    raw = os.environ.get("WIKIMEDIA_STEP_START", "").strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None
 
 
 # Counted markers shown in the failure summary.  Patterns match what the
@@ -122,6 +159,12 @@ def _summarize_log(log_path: str, tail_lines: int = 8) -> str | None:
     Tries to be cheap: only reads up to ~2 MB from the end of the file.  Counts
     common markers and tails the last N lines so the cause of the failure is
     visible without SSM-ing in.
+
+    Suppresses the "Counts so far" marker line when the tail already contains
+    the tool's own ``COUNTS:`` block: those tracker-side counters are
+    authoritative, and showing both side by side made the two numbers look
+    contradictory (the marker regex misses categories like
+    ``UPLOAD_SKIPPED_NOT_PRESENT`` that don't emit a ``Skipping …`` line).
     """
     try:
         size = os.path.getsize(log_path)
@@ -132,13 +175,16 @@ def _summarize_log(log_path: str, tail_lines: int = 8) -> str | None:
     except OSError:
         return None
 
-    counts = []
-    for label, pat in _LOG_MARKERS:
-        n = len(pat.findall(data))
-        if n:
-            counts.append(f"{n} {label}")
+    tail_line_list = data.splitlines()[-tail_lines:]
+    tail = "\n".join(tail_line_list)
+    tail_has_counts = any(line.startswith("COUNTS:") for line in tail_line_list)
 
-    tail = "\n".join(data.splitlines()[-tail_lines:])
+    counts = []
+    if not tail_has_counts:
+        for label, pat in _LOG_MARKERS:
+            n = len(pat.findall(data))
+            if n:
+                counts.append(f"{n} {label}")
 
     parts = [f"Log: `{os.path.basename(log_path)}`"]
     if counts:
@@ -303,13 +349,33 @@ def notify_pipeline_fail() -> None:
     # the tee'd stderr file the launcher writes — without this, a
     # failure inside get-ids-es would only ever surface as a bare
     # "exit N" in Slack.
+    #
+    # ``step_start`` filters out log files from earlier runs so a step
+    # that died before ``setup_logging`` ran doesn't get a stale log
+    # (potentially weeks old) attached to its failure message. See
+    # :func:`_find_latest_log` for the rationale.
     partner_dir = os.environ.get("WIKIMEDIA_PARTNER_DIR", "")
+    step_start = _step_start_mtime()
     summary: str | None = None
     log_suffix = _PHASE_LOG_SUFFIX.get(step)
     if log_suffix is not None:
-        log_path = _find_latest_log(partner_dir, label, phase=log_suffix)
+        log_path = _find_latest_log(
+            partner_dir, label, phase=log_suffix, min_mtime=step_start
+        )
         if log_path is not None:
             summary = _summarize_log(log_path)
+        elif step_start is not None:
+            # The mtime filter dropped every candidate, which means the
+            # step died before ``setup_logging`` could write its own log
+            # file. Say so explicitly instead of silently omitting the
+            # summary — surfacing a log from a prior run (the previous
+            # behavior) confused operators into diagnosing the wrong
+            # incident.
+            summary = (
+                f"No `{step}` log written for this run "
+                "(step likely died before `setup_logging` ran — "
+                "check tmux buffer or preceding step's exit chain)."
+            )
     elif step == "id-generation":
         stderr_tail = _tail_text_file(id_generation_stderr_tail_file(raw_label))
         if stderr_tail:
@@ -318,7 +384,7 @@ def notify_pipeline_fail() -> None:
         # Unknown step (or step unset on a stale launcher): fall back to
         # the legacy any-phase log lookup so we don't regress on the
         # info-density of the pre-step-tracking message.
-        log_path = _find_latest_log(partner_dir, label)
+        log_path = _find_latest_log(partner_dir, label, min_mtime=step_start)
         if log_path is not None:
             summary = _summarize_log(log_path)
     if summary:

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -143,11 +143,17 @@ _STEP_BY_FIRST_TOKEN: dict[str, str] = {
 
 
 def _wrap_step_with_marker(cmd: str) -> str:
-    """Prefix ``cmd`` with ``export WIKIMEDIA_STEP=<name> &&`` so the bash
-    shell's WIKIMEDIA_STEP reflects which step was running when the
+    """Prefix ``cmd`` with ``export WIKIMEDIA_STEP=<name> WIKIMEDIA_STEP_START=<epoch> &&``
+    so the bash shell's WIKIMEDIA_STEP reflects which step was running when the
     ``&&``-chain breaks. The export goes BEFORE the step's command in the
     same chain, so the failed-step's name is the most recent assignment
     when ``notify_pipeline_fail`` reads it.
+
+    ``WIKIMEDIA_STEP_START`` (Unix epoch seconds, evaluated at export time via
+    ``$(date +%s)``) scopes the failure-log lookup to files created after
+    this step began, so a step that dies before ``setup_logging`` runs
+    doesn't get a stale log from a prior day attached to its Slack message.
+    Read side: :func:`ingest_wikimedia.slack._find_latest_log`.
 
     For ``get-ids-es`` / ``get-ids-nara`` (the id-generation step), also
     tees stderr to the per-session path returned by
@@ -199,7 +205,9 @@ def _wrap_step_with_marker(cmd: str) -> str:
             '"/tmp/wm-id-generation-stderr-${WIKIMEDIA_SESSION_LABEL:-unknown}.log"'
         )
         wrapped = f"{cmd} 2> >(tee {per_session_path} >&2)"
-    return f"export WIKIMEDIA_STEP={step} && {wrapped}"
+    return (
+        f'export WIKIMEDIA_STEP={step} WIKIMEDIA_STEP_START="$(date +%s)" && {wrapped}'
+    )
 
 
 def _build_get_ids_command(

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -18,6 +18,7 @@ from ingest_wikimedia.slack import (
     _decode_exit_code,
     _find_latest_log,
     _read_download_failed_count,
+    _step_start_mtime,
     _summarize_log,
     notify_phase_start,
     notify_pipeline_fail,
@@ -65,7 +66,7 @@ def test_notify_phase_start_supports_sdc_sync_phase():
         ("", ""),
         (None, ""),
         ("not-a-number", ""),
-        ("1", " (exit 1 — uncaught exception — see traceback)"),
+        ("1", " (exit 1)"),
         ("2", " (exit 2 — rejected its arguments)"),
         ("124", " (exit 124 — timed out)"),
         ("137", " (exit 137 — SIGKILL — likely OOM)"),
@@ -103,6 +104,70 @@ def test_find_latest_log_picks_most_recent_match(tmp_path):
 def test_find_latest_log_returns_none_when_no_match(tmp_path):
     (tmp_path / "logs").mkdir()
     assert _find_latest_log(str(tmp_path), "nope") is None
+
+
+def test_find_latest_log_filters_files_older_than_min_mtime(tmp_path):
+    """A log written before the current step began must NOT be surfaced —
+    this is the June-13 incident: today's ``si`` upload step died before
+    ``setup_logging`` ran, so no fresh log existed, and the failure
+    handler picked up a 3-week-old ``si-upload.log`` from a prior run
+    and attached its (irrelevant, successful) COUNTS block to a Slack
+    failure message. The mtime filter is the read-side of the
+    launcher's ``WIKIMEDIA_STEP_START`` stamp.
+    """
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    label = "si"
+    step_start = time.time()
+
+    ancient = logs_dir / f"20260613-141221-{label}-upload.log"
+    ancient.write_text("[INFO] a run from three weeks ago\nCOUNTS:\nUPLOADED: 30\n")
+    # Force the file to look 20 days old relative to step_start.
+    twenty_days_ago = step_start - 20 * 86400
+    os.utime(str(ancient), (twenty_days_ago, twenty_days_ago))
+
+    # Unbounded lookup still returns it (legacy behavior; regression guard).
+    assert _find_latest_log(str(tmp_path), label, phase="upload") == str(ancient)
+
+    # Scoped lookup drops it — the caller sees ``None`` and can say
+    # "no log written yet" instead of surfacing a stale log.
+    assert (
+        _find_latest_log(str(tmp_path), label, phase="upload", min_mtime=step_start)
+        is None
+    )
+
+
+def test_find_latest_log_returns_current_run_when_present(tmp_path):
+    """The mtime filter must not drop a legitimately fresh log — a
+    step that failed AFTER ``setup_logging`` wrote its file should
+    still surface that log."""
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    label = "si"
+    step_start = time.time() - 60  # step began a minute ago
+
+    fresh = logs_dir / f"20260703-041300-{label}-upload.log"
+    fresh.write_text("[INFO] fresh run\n")
+    os.utime(str(fresh), (time.time(), time.time()))
+
+    assert _find_latest_log(
+        str(tmp_path), label, phase="upload", min_mtime=step_start
+    ) == str(fresh)
+
+
+def test_step_start_mtime_reads_env_and_handles_malformed():
+    """A stale launcher (no export) or a malformed value must fall back to
+    ``None`` — same as if the filter wasn't wired up — rather than
+    suppressing every failure message."""
+    with patch.dict(os.environ, {"WIKIMEDIA_STEP_START": "1751500000"}, clear=False):
+        assert _step_start_mtime() == 1751500000.0
+    with patch.dict(os.environ, {"WIKIMEDIA_STEP_START": ""}, clear=False):
+        assert _step_start_mtime() is None
+    with patch.dict(os.environ, {"WIKIMEDIA_STEP_START": "not-a-number"}, clear=False):
+        assert _step_start_mtime() is None
+    # Fully unset.
+    with patch.dict(os.environ, {}, clear=True):
+        assert _step_start_mtime() is None
 
 
 def test_find_latest_log_handles_missing_dir():
@@ -185,7 +250,7 @@ def test_drain_deferred_opportunistic_step_name_is_wired_consistently():
     from ingest_wikimedia.slack import _PHASE_LOG_SUFFIX
 
     wrapped = _wrap_step_with_marker("drain-deferred --no-wait nara")
-    assert "export WIKIMEDIA_STEP=drain-deferred-opportunistic &&" in wrapped, (
+    assert "WIKIMEDIA_STEP=drain-deferred-opportunistic " in wrapped, (
         "launcher must emit ``drain-deferred-opportunistic`` as the "
         "WIKIMEDIA_STEP value for the per-target ``--no-wait`` drain"
     )
@@ -274,11 +339,14 @@ def test_notify_pipeline_fail_treats_any_value_other_than_1_as_not_last():
 # ---------------------------------------------------------------------------
 
 
-def test_decode_exit_code_interprets_python_exit_1():
-    """Exit 1 ≈ Python uncaught exception. Including the hint makes the
-    Slack message actionable — "look for a CRITICAL traceback in the log"
-    instead of "the pipeline failed somehow with exit 1"."""
-    assert _decode_exit_code("1") == " (exit 1 — uncaught exception — see traceback)"
+def test_decode_exit_code_exit_1_has_no_hint():
+    """Exit 1 deliberately has no hint. The previous ``uncaught exception —
+    see traceback`` phrasing over-promised a traceback that the message
+    often couldn't deliver — the raise may happen in a ``finally`` block
+    (past ``setup_logging``'s excepthook install) or before ``setup_logging``
+    even ran, both of which leave no traceback in the file the failure
+    handler tails."""
+    assert _decode_exit_code("1") == " (exit 1)"
 
 
 def test_decode_exit_code_interprets_click_exit_2():
@@ -302,7 +370,6 @@ def test_notify_pipeline_fail_names_the_failing_step():
         }
     )
     assert "`id-generation` step failed" in msg, msg
-    assert "uncaught exception" in msg, msg
     assert "pipeline step failed" not in msg, (
         "step-aware header must replace the generic phrasing"
     )
@@ -432,6 +499,115 @@ def test_notify_pipeline_fail_phase_log_scopes_to_failing_step(tmp_path):
     # download log should NOT be the tailed file.
     assert "boom in uploader" in msg
     assert "downloader ran fine" not in msg
+
+
+def test_notify_pipeline_fail_says_no_log_when_step_died_before_setup_logging(
+    tmp_path,
+):
+    """When ``WIKIMEDIA_STEP_START`` is set and no matching log has been
+    written since (i.e. the step died before ``setup_logging`` ran), the
+    failure handler must say so explicitly rather than surfacing a
+    log from a prior run. This is the exact June-13-log-on-July-3 bug
+    the fix targets."""
+    base = tmp_path
+    logs = base / "logs"
+    logs.mkdir()
+    label = "si"
+    # Simulate a 3-week-old upload log left on disk from a prior run.
+    stale = logs / "20260613-141221-si-upload.log"
+    stale.write_text(
+        "[INFO] 14:12:21: unrelated older run\nCOUNTS:\nUPLOADED: 30\nSKIPPED: 6925\n"
+    )
+    twenty_days_ago = time.time() - 20 * 86400
+    os.utime(str(stale), (twenty_days_ago, twenty_days_ago))
+
+    step_start = int(time.time())
+    msg = _capture_message(
+        {
+            "DPLA_SLACK_BOT_TOKEN": "x",
+            "WIKIMEDIA_SESSION_LABEL": label,
+            "WIKIMEDIA_PARTNER_DIR": str(base),
+            "WIKIMEDIA_LAST_EXIT": "1",
+            "WIKIMEDIA_STEP": "upload",
+            "WIKIMEDIA_STEP_START": str(step_start),
+        }
+    )
+    # The stale log's tail must NOT be attached.
+    assert "unrelated older run" not in msg
+    assert "UPLOADED: 30" not in msg
+    # The message must say why there's no summary.
+    assert "No `upload` log written for this run" in msg
+    assert "setup_logging" in msg
+
+
+def test_summarize_log_suppresses_marker_counts_when_tail_has_counts_block(tmp_path):
+    """When the tail already contains the tool's authoritative ``COUNTS:``
+    block, suppress the ``Counts so far`` marker-regex line. Both
+    numbers shown side-by-side confused operators — the regex misses
+    categories that don't emit a ``Skipping …`` line
+    (``UPLOAD_SKIPPED_NOT_PRESENT`` in particular), so a 6925-vs-6918
+    mismatch reads like a bug even when both figures are ``correct``
+    for what they measure."""
+    log = tmp_path / "upload.log"
+    lines = [
+        "[INFO] 14:12:21: Skipping abc 1: Already exists on commons.",
+        "[INFO] 14:12:22: Skipping abc 2: Already exists on commons.",
+        "[INFO] 14:12:23: Uploaded to https://commons.wikimedia.org/wiki/File:Foo.jpg",
+        "[INFO] 14:43:29: ",
+        "COUNTS:",
+        "SKIPPED: 6925",
+        "UPLOAD_SKIPPED_NOT_PRESENT: 7",
+        "UPLOADED: 30",
+        "BYTES: 8991594",
+        "",
+        "[INFO] 14:43:29: 1868.85 seconds.",
+    ]
+    log.write_text("\n".join(lines) + "\n")
+
+    summary = _summarize_log(str(log), tail_lines=8)
+    assert summary is not None
+    # The authoritative COUNTS block is in the tail.
+    assert "COUNTS:" in summary
+    assert "UPLOADED: 30" in summary
+    # The "Counts so far" marker line MUST be gone — that's the whole point.
+    assert "Counts so far" not in summary
+
+
+def test_summarize_log_keeps_marker_counts_when_no_counts_block(tmp_path):
+    """The suppression must be conditional: when the tail does NOT contain
+    a ``COUNTS:`` block (e.g. the tool crashed mid-run), the marker-regex
+    line is still useful and should still appear."""
+    log = tmp_path / "crashed.log"
+    lines = [
+        "[INFO] Starting",
+        "[INFO] Uploaded to https://commons.wikimedia.org/wiki/File:A.jpg",
+        "[INFO] Uploaded to https://commons.wikimedia.org/wiki/File:B.jpg",
+        "[INFO] Skipping x 1: Already exists on commons.",
+        "[ERROR] Failed: something went wrong",
+    ]
+    log.write_text("\n".join(lines) + "\n")
+
+    summary = _summarize_log(str(log), tail_lines=8)
+    assert summary is not None
+    assert "Counts so far" in summary
+    assert "2 uploaded" in summary
+
+
+def test_wrap_step_with_marker_exports_step_start_alongside_step():
+    """The launcher must stamp ``WIKIMEDIA_STEP_START`` on the same
+    ``export`` line as ``WIKIMEDIA_STEP`` so the slack failure
+    handler can filter out logs older than the failing step. Both
+    must be evaluated at export time (not script-parse time) so
+    each step's start is fresh."""
+    from scripts.wikimedia_launch import _wrap_step_with_marker
+
+    wrapped = _wrap_step_with_marker("uploader nara.csv nara")
+    assert "WIKIMEDIA_STEP=upload " in wrapped or "WIKIMEDIA_STEP=upload\t" in wrapped
+    # Runtime-evaluated epoch stamp, quoted to survive shell splitting.
+    assert 'WIKIMEDIA_STEP_START="$(date +%s)"' in wrapped, wrapped
+    # Order: exports first, then the wrapped command after ``&&``.
+    assert wrapped.startswith("export WIKIMEDIA_STEP=")
+    assert " && uploader nara.csv nara" in wrapped
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -426,23 +426,30 @@ def test_wrap_step_with_marker_tags_each_tool_with_its_phase():
     pass through unchanged."""
     from scripts.wikimedia_launch import _wrap_step_with_marker
 
-    assert _wrap_step_with_marker("downloader x.csv georgia").startswith(
-        "export WIKIMEDIA_STEP=download && downloader "
+    # The export line now also stamps WIKIMEDIA_STEP_START (Unix epoch) so
+    # the failure handler can filter out logs older than the current step
+    # — see ``ingest_wikimedia.slack._find_latest_log``'s ``min_mtime``.
+    _STEP_START_FRAGMENT = 'WIKIMEDIA_STEP_START="$(date +%s)"'
+
+    def _assert_step_export(cmd: str, step: str, cmd_prefix: str) -> None:
+        w = _wrap_step_with_marker(cmd)
+        assert w.startswith(f"export WIKIMEDIA_STEP={step} ")
+        assert _STEP_START_FRAGMENT in w
+        assert f" && {cmd_prefix}" in w
+
+    _assert_step_export("downloader x.csv georgia", "download", "downloader ")
+    _assert_step_export("uploader x.csv ohio --no-create", "upload", "uploader ")
+    _assert_step_export(
+        "sdc-sync --partner texas --ids-file x.csv --workers 6", "sdc-sync", "sdc-sync "
     )
-    assert _wrap_step_with_marker("uploader x.csv ohio --no-create").startswith(
-        "export WIKIMEDIA_STEP=upload && uploader "
-    )
-    assert _wrap_step_with_marker(
-        "sdc-sync --partner texas --ids-file x.csv --workers 6"
-    ).startswith("export WIKIMEDIA_STEP=sdc-sync && sdc-sync ")
-    assert _wrap_step_with_marker("drain-deferred nara").startswith(
-        "export WIKIMEDIA_STEP=drain-deferred && drain-deferred "
-    )
+    _assert_step_export("drain-deferred nara", "drain-deferred", "drain-deferred ")
     # ``drain-deferred --no-wait`` (per-target opportunistic phase)
     # gets a distinct step name so the failure handler tails the
     # opportunistic log file rather than the batch-terminal one.
-    assert _wrap_step_with_marker("drain-deferred --no-wait nara").startswith(
-        "export WIKIMEDIA_STEP=drain-deferred-opportunistic && drain-deferred "
+    _assert_step_export(
+        "drain-deferred --no-wait nara",
+        "drain-deferred-opportunistic",
+        "drain-deferred ",
     )
     # Non-step commands (``cd``, the case-2 graceful-skip ``echo … ; true``,
     # and the ``sdc-sync --cat`` flavour the maintain builder emits — wait,
@@ -468,7 +475,8 @@ def test_wrap_step_with_marker_tees_id_generation_stderr():
         "get-ids-es digitalnc --institution 'Duke University Libraries'"
         " --maintain --skip-media-filter > out.csv"
     )
-    assert wrapped.startswith("export WIKIMEDIA_STEP=id-generation && ")
+    assert wrapped.startswith("export WIKIMEDIA_STEP=id-generation ")
+    assert 'WIKIMEDIA_STEP_START="$(date +%s)"' in wrapped
     # The redirect must keep stdout on the CSV (the existing >),
     # tee stderr to a per-session path interpolated from
     # ``${WIKIMEDIA_SESSION_LABEL}`` at runtime (so concurrent tmux

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -2081,6 +2081,15 @@ def main(
     workers_budget: int,
 ) -> None:
     start_time = time.time()
+    # ``setup_logging`` is the first thing we do so its
+    # ``_install_logging_excepthook`` covers the whole run — including
+    # pre-``try`` setup calls (``check_partner``, ``WorkerSlotBudget``,
+    # ``DuplicateCategoryThrottle``, ``get_site``) that historically ran
+    # before it. Without this, any of those raising produced an exit-1 with
+    # no log at all: the launcher's failure handler would then attach a
+    # log from an entirely different (older) run, leading operators to
+    # diagnose the wrong incident.
+    setup_logging(partner, "upload", logging.INFO)
     tools_context = ToolsContext.init(partner)
 
     commons_site = get_site()
@@ -2153,7 +2162,6 @@ def main(
 
     try:
         local_fs.setup_temp_dir()
-        setup_logging(partner, "upload", logging.INFO)
         notify_phase_start(partner, "upload")
         if dry_run:
             logging.warning("---=== DRY RUN ===---")


### PR DESCRIPTION
## Summary

Three related bugs all surfaced in a single incident this morning:

- Today's `/wikimedia-upload si` step died before its own `setup_logging` ran, so no fresh upload log was written.
- The launcher's failure handler then attached a **June-13 upload log** (three weeks old, from a fully-successful prior run) to a July-3 failure message.
- The message header said `"exit 1 — uncaught exception — see traceback"` promising a traceback that didn't exist in the log.
- The tail then showed a `Counts so far: 14 uploaded, 6918 skipped` line that disagreed with the log's own `COUNTS:` block (`UPLOADED: 30, SKIPPED: 6925, UPLOAD_SKIPPED_NOT_PRESENT: 7`) right below it.

Each of those is a separate bug worth fixing.

## Changes

### 1. Log-scoping by step-start time
- `scripts/wikimedia_launch.py::_wrap_step_with_marker` now exports `WIKIMEDIA_STEP_START="$(date +%s)"` alongside `WIKIMEDIA_STEP`. `$(...)` is evaluated at export time (right before each step) so the stamp is always fresh.
- `ingest_wikimedia/slack.py::_find_latest_log` takes a new `min_mtime` parameter and filters out files older than the threshold.
- `notify_pipeline_fail` reads the env via a new `_step_start_mtime()` helper and passes it to `_find_latest_log`. When the filter drops all candidates (step died before `setup_logging` ran), the message says **"No `<step>` log written for this run"** instead of surfacing a log from a prior run.
- Fallback is deliberately soft: a stale launcher without the export, or a malformed value, resolves to `None` and the handler falls back to unbounded lookup — same as pre-change behavior.

### 2. Uploader `setup_logging` moved to top of `main()`
`setup_logging(partner, "upload", …)` in `tools/uploader.py::main` moved from inside the `try:` block (line 2156) to the first statement of `main()` — before `ToolsContext.init`, `get_site`, `DuplicateCategoryThrottle`, `check_partner`, and `WorkerSlotBudget` construction. This means `_install_logging_excepthook` covers those pre-`try` calls, so any of them raising now produces a `CRITICAL Uncaught exception` log line + traceback in the upload log — exactly what the excepthook from #360 was supposed to guarantee but wasn't reaching, because the excepthook install happened after the raise site.

### 3. Slack display cleanup
- `_EXIT_CODE_HINTS[1]` removed. The prior `"uncaught exception — see traceback"` hint over-promised: an exit-1 raise can happen in a `finally:` block (past `setup_logging`'s excepthook install) or before `setup_logging` even ran, both of which leave no traceback in the tailed file. Exit 1 now renders as just `(exit 1)`.
- `_summarize_log` suppresses the "Counts so far" marker-regex line when the tail already contains a `COUNTS:` block. The tracker's counters are authoritative; the regex misses categories like `UPLOAD_SKIPPED_NOT_PRESENT` that don't emit a `Skipping …` line, so showing both side-by-side made the (correct) mismatch read like a bug.

## Test plan

- [x] `ruff check` + `ruff format` clean on all 5 changed files
- [x] Full pytest suite green (1076 passed, up from 1069 — 7 new tests added)
- [x] New tests pin: the mtime filter drops stale logs; the filter keeps current logs; `_step_start_mtime` handles empty/unset/malformed values; `notify_pipeline_fail` says "No `<step>` log written" when the filter drops everything; `_summarize_log` suppression is conditional on the tail containing `COUNTS:`; `_wrap_step_with_marker` exports STEP_START on the same line as STEP
- [x] Updated `test_decode_exit_code_interprets_python_exit_1` → `test_decode_exit_code_exit_1_has_no_hint`
- [x] Updated the `test_wrap_step_with_marker_tags_each_tool_with_its_phase` assertions to accommodate the new export shape (factored into a `_assert_step_export` helper)
- [x] `simplify` skill (reuse + quality + efficiency) — all three passes clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR improves Slack failure reporting and upload logging:

- Slack pipeline failures now scope log lookup to the current step by exporting `WIKIMEDIA_STEP_START` at step start and filtering candidate logs by modification time, preventing stale logs from older runs from being attached.
- If a step fails before any log is written for that run, Slack now reports that explicitly instead of falling back to an unrelated prior log.
- Upload logging is initialized earlier in `tools/uploader.py`, so exceptions raised during startup/validation are captured in the upload log with a traceback.
- Failure message formatting is cleaned up by removing the exit-1 traceback hint and avoiding duplicate “Counts so far” output when the log tail already includes a `COUNTS:` block.
- Tests were updated and expanded to cover the new step-start timestamp export, log filtering behavior, and the revised Slack formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->