### PR TITLE
Normalize _ → space and first-letter uppercase in get_page_title

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -185,9 +185,38 @@ def get_page_title(
         .replace(
             "\ufffd", "\u2019"
         )  # Unicode replacement char → right single quote (corrupted metadata)
+        # MediaWiki's ``Title`` normalisation converts ``_`` to space in
+        # stored titles. Without this replacement, a DPLA source title
+        # like ``doris_ulmann_0001`` produces the constructed title
+        # ``doris_ulmann_0001 - DPLA - <id>.jpg`` while Commons stores
+        # it as ``Doris ulmann 0001 - DPLA - <id>.jpg`` (and returns
+        # that form on any query). Every downstream title-equality
+        # check then treats the pair as a Case-2 hash-drift, triggering
+        # a bogus ``{{duplicate}}``-tag attempt that Commons itself
+        # rejects with ``fileexists-no-change``. Concrete repro: MWDL
+        # DPLA IDs fbfa741802e31f0b3b9ba69a79ed675b,
+        # df20cb360e0f5fb5d8e1e9ddf7ac557c,
+        # e34fac17587acd584cd038ced095fd01 — Doris Ulmann photographs
+        # whose ``sourceResource.title`` is a literal underscore-
+        # separated slug.
+        .replace("_", " ")
     )
 
     escaped_visible_title = replace_invisible(escaped_title)
+
+    # MediaWiki's ``Title::capitalize`` uppercases the first character
+    # of every title in a capitalized namespace, which ``File:`` is.
+    # A constructed title of ``doris ulmann 0001 - DPLA - <id>.jpg`` is
+    # stored on Commons as ``Doris ulmann 0001 - DPLA - <id>.jpg`` —
+    # so raw-string equality between our constructed title and the
+    # Commons-stored title only holds if we apply the same uppercase.
+    # Slice-and-upper rather than ``.capitalize()``: the latter ALSO
+    # lowercases the rest of the string, which Commons does NOT — it
+    # preserves internal case.
+    if escaped_visible_title:
+        escaped_visible_title = (
+            escaped_visible_title[:1].upper() + escaped_visible_title[1:]
+        )
 
     # Add pagination to page title if needed
     if page:

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -204,6 +204,20 @@ def get_page_title(
 
     escaped_visible_title = replace_invisible(escaped_title)
 
+    # MediaWiki collapses any run of whitespace in a stored title down to
+    # a single space and trims leading/trailing whitespace. Applied AFTER
+    # the ``_`` → space replacement above so mixed inputs like
+    # ``foo__bar`` (2 underscores → 2 spaces) or ``foo_ bar`` (underscore
+    # + space → 2 spaces) also collapse to the single-space form Commons
+    # actually stores. Without this collapse,
+    # :func:`find_file_by_hash` — which compares
+    # ``img.title(with_ns=False)`` to the raw ``preferred_title`` we
+    # construct here — would miss the match on any DPLA title with
+    # adjacent whitespace/underscore, sending the item down the wrong
+    # drift path. ``" ".join(s.split())`` collapses any Unicode
+    # whitespace run and strips edges, matching MediaWiki's behavior.
+    escaped_visible_title = " ".join(escaped_visible_title.split())
+
     # MediaWiki's ``Title::capitalize`` uppercases the first character
     # of every title in a capitalized namespace, which ``File:`` is.
     # A constructed title of ``doris ulmann 0001 - DPLA - <id>.jpg`` is

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -59,6 +59,60 @@ def test_get_page_title():
     assert title == expected_title
 
 
+def test_get_page_title_replaces_underscore_with_space():
+    """Regression: MediaWiki's ``Title`` normalisation converts ``_`` in
+    titles to spaces at store time, so a DPLA source title like
+    ``doris_ulmann_0001`` must be rewritten to ``Doris ulmann 0001``
+    at construction time — otherwise every downstream title-equality
+    check (skip-if-already-there, hash-drift, expected_item_titles
+    sibling protection, orphan probes, ``{{duplicate}}``-tag targets)
+    treats the constructed vs. stored pair as drift and triggers a
+    phantom Case-2 tag-upload that Commons itself rejects with
+    ``fileexists-no-change``.
+
+    Concrete pre-fix repro (2026-07-03 MWDL run): DPLA IDs
+    ``fbfa741802e31f0b3b9ba69a79ed675b``,
+    ``df20cb360e0f5fb5d8e1e9ddf7ac557c``,
+    ``e34fac17587acd584cd038ced095fd01`` — three Doris Ulmann
+    photographs whose ``sourceResource.title`` is a literal
+    underscore-separated slug that Commons stored as
+    ``File:Doris ulmann 000N - DPLA - <id>.jpg``.
+    """
+    title = get_page_title(
+        "doris_ulmann_0001", "fbfa741802e31f0b3b9ba69a79ed675b", ".jpg"
+    )
+    assert title == "Doris ulmann 0001 - DPLA - fbfa741802e31f0b3b9ba69a79ed675b.jpg", (
+        title
+    )
+    # ``_`` must NOT appear anywhere in the item-title portion.
+    assert "_" not in title.split(" - DPLA -")[0]
+
+
+def test_get_page_title_capitalizes_first_character_only():
+    """MediaWiki's ``Title::capitalize`` uppercases the FIRST character
+    of any title in a capitalized namespace (which ``File:`` is), but
+    does NOT lowercase the rest — internal case is preserved
+    verbatim. So a source title like ``eBookLibrary_1998`` becomes
+    ``EBookLibrary 1998`` on Commons (E capitalized, B/L/... preserved),
+    not ``Ebooklibrary 1998`` (which ``str.capitalize()`` would produce).
+    """
+    title = get_page_title("eBookLibrary_1998", "cafef00d" * 4, ".jpg")
+    assert title.startswith("EBookLibrary 1998"), title
+    # Rest of the casing is preserved — no forced lowercase.
+    assert "EBook" in title
+    assert "Ebook" not in title
+
+
+def test_get_page_title_leaves_already_capitalized_titles_alone():
+    """The uppercase-first-char step must be a no-op when the source
+    title already starts with an uppercase letter — regression guard
+    against a refactor that swaps in ``.capitalize()`` and silently
+    lowercases everything after the first character."""
+    title = get_page_title("Sample Title", "abcd1234", ".jpg")
+    # Byte-identical to pre-fix output for the common case.
+    assert title == "Sample Title - DPLA - abcd1234.jpg"
+
+
 def test_get_page_title_trims_trailing_whitespace_after_truncation():
     """Regression: a DPLA-supplied title longer than 181 chars whose 181st
     character lands on whitespace must NOT leave that whitespace in the
@@ -178,7 +232,9 @@ def test_get_page_title_breaks_query_string_when_both_present():
     # Both characters get rewritten so the title no longer matches `&...=`.
     assert "&" not in title
     assert "=" not in title
-    assert "filter-value+other-thing" in title
+    # Leading letter capitalized (MediaWiki ``Title::capitalize`` — see
+    # get_page_title docstring); rest of casing preserved.
+    assert "Filter-value+other-thing" in title
 
 
 def test_get_page_title_replaces_slash_with_dash():

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -128,7 +128,7 @@ def test_get_page_title_capitalizes_first_character_only():
     not ``Ebooklibrary 1998`` (which ``str.capitalize()`` would produce).
     """
     title = get_page_title("eBookLibrary_1998", "cafef00d" * 4, ".jpg")
-    assert title.startswith("EBookLibrary 1998"), title
+    assert title == f"EBookLibrary 1998 - DPLA - {'cafef00d' * 4}.jpg", title
     # Rest of the casing is preserved — no forced lowercase.
     assert "EBook" in title
     assert "Ebook" not in title

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -88,6 +88,37 @@ def test_get_page_title_replaces_underscore_with_space():
     assert "_" not in title.split(" - DPLA -")[0]
 
 
+def test_get_page_title_collapses_mixed_underscore_and_space_runs():
+    """Regression (CR flagged on PR #365): ``.replace("_", " ")`` alone
+    leaves ``foo__bar`` as ``foo  bar`` (two spaces) and ``foo_ bar``
+    similarly. MediaWiki collapses whitespace runs to a single space at
+    store time, so the constructed title MUST match. Without this
+    collapse, :func:`find_file_by_hash` (at
+    ``ingest_wikimedia/wikimedia.py`` — compares
+    ``img.title(with_ns=False) == preferred_title``) misses matches
+    against files stored with the single-space canonical form, sending
+    the item down the wrong drift path.
+    """
+    # Two adjacent underscores → single space.
+    t1 = get_page_title("foo__bar", "abcd1234", ".jpg")
+    assert t1 == "Foo bar - DPLA - abcd1234.jpg", t1
+
+    # Underscore + space (either order) → single space.
+    t2 = get_page_title("foo_ bar", "abcd1234", ".jpg")
+    assert t2 == "Foo bar - DPLA - abcd1234.jpg", t2
+    t3 = get_page_title("foo _bar", "abcd1234", ".jpg")
+    assert t3 == "Foo bar - DPLA - abcd1234.jpg", t3
+
+    # Multi-space run (no underscores) also collapses.
+    t4 = get_page_title("foo   bar", "abcd1234", ".jpg")
+    assert t4 == "Foo bar - DPLA - abcd1234.jpg", t4
+
+    # Leading/trailing whitespace stripped (matches MediaWiki's
+    # ``Title`` trim on stored titles).
+    t5 = get_page_title("  foo bar  ", "abcd1234", ".jpg")
+    assert t5 == "Foo bar - DPLA - abcd1234.jpg", t5
+
+
 def test_get_page_title_capitalizes_first_character_only():
     """MediaWiki's ``Title::capitalize`` uppercases the FIRST character
     of any title in a capitalized namespace (which ``File:`` is), but


### PR DESCRIPTION
## Summary

MediaWiki's `Title` normalisation applies two rewrites at store time that `get_page_title` in [ingest_wikimedia/wikimedia.py](ingest_wikimedia/wikimedia.py) was not replicating on the construction side:

1. `_` → space
2. First character uppercased (`Title::capitalize`; File namespace is a capitalized namespace)

Without these, a DPLA source title like `doris_ulmann_0001` produces the constructed title `doris_ulmann_0001 - DPLA - <id>.jpg` while Commons stores it as `Doris ulmann 0001 - DPLA - <id>.jpg`. Every downstream title-equality check (skip-if-already-there, hash-drift, `expected_item_titles` sibling protection, orphan probes, `{{duplicate}}`-tag targets, SDC sidecar bookkeeping — the load-bearing invariant list from `get_page_title`'s docstring) treats the constructed vs. stored pair as drift and triggers a phantom Case-2 `{{duplicate}}`-tag attempt that Commons itself refuses with `fileexists-no-change`.

## Concrete pre-fix repro

The 2026-07-03 MWDL run had exactly 3 residual Case-2 detections after PR #361's whitespace/underscore fix at comparison time. All three DPLA IDs:

- `fbfa741802e31f0b3b9ba69a79ed675b`
- `df20cb360e0f5fb5d8e1e9ddf7ac557c`
- `e34fac17587acd584cd038ced095fd01`

are Doris Ulmann photographs whose `sourceResource.title` is a literal underscore-separated slug (`doris_ulmann_0001`, `..._0002`, `..._0003`). Each attempted a `{{duplicate}}`-tag upload that Commons rejected because the bytes were already identical — the hash-drift detection thought hashes differed but Commons's own dedup check saw the file was already correct.

Same class of gap as #361, but at the source rather than in a canonicalization shim: every downstream title-consumer now gets the correct form without needing to know about the normalization.

## Why `s[:1].upper() + s[1:]`, not `.capitalize()`

`str.capitalize()` uppercases the first char AND lowercases the rest. Commons does NOT — internal case is preserved verbatim. So a source `eBookLibrary_1998` becomes `EBookLibrary 1998` on Commons (E capitalized, B/L/... preserved), not `Ebooklibrary 1998`. There's a dedicated regression test for this trap.

## Test plan

- [x] `ruff check` + `ruff format` clean
- [x] Full pytest suite green — 1069 → 1072 (three new tests added)
- [x] New tests pin: underscore → space (Ulmann repro), camelCase first-char-only preservation, already-capitalized no-op
- [x] Updated `test_get_page_title_breaks_query_string_when_both_present`'s expected string to reflect the new leading capital
- [x] `simplify` skill (reuse + quality + efficiency + altitude) — all four passes clean
- [x] Audited all ~10 `get_page_title` callers across `tools/` and `ingest_wikimedia/` — no consumer compares its raw output against something that would also need normalization; consumers use `_canonicalize_commons_title` (case-blind to the leading char after normalization) or pywikibot FilePage (which normalizes internally)

## Follow-up (not blocking)

An "altitude" reviewer flagged that `get_page_title` is now doing two jobs — building the DPLA suffix template AND hand-porting ~15 rules of MediaWiki's `Title::secureAndSplit`. Worth extracting a pure `to_commons_title(raw: str) -> str` helper as a follow-up so future additions (whitespace-run collapse, HTML-entity decode, control-char strip — still un-ported) land in one obvious place. Not this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `get_page_title` in `ingest_wikimedia/wikimedia.py` to match MediaWiki title normalization at construction time by adding the previously missing underscore-to-space rewrite and applying “uppercase only the first character” capitalization without lowercasing the remainder, before the existing invisible-character/sanitization and comparison steps. It also mirrors MediaWiki whitespace normalization (collapsing runs and trimming) so constructed titles align with Commons’ stored titles (fixing mismatches like `doris_ulmann_0001` vs `Doris ulmann 0001`).

Added regression tests for:
- underscore-to-space normalization
- preserving internal capitalization (avoiding `str.capitalize()`-style lowercasing)
- leaving already-capitalized titles unchanged

Updated existing test expectations to reflect the new leading capital (including the corrected title fragment in the query-string-related test) and tightened an `eBookLibrary` regression to assert full title equality so it also verifies the `- DPLA - <id>.jpg` suffix.

No manual pipeline trigger or ECS redeployment details are required; no environment variables/AWS Secrets Manager keys were added/removed/renamed; no database migrations were introduced; no shared infrastructure configuration (CodePipeline/CodeBuild/ECS/IAM) was changed; no public-facing API response shape/endpoints were modified; and there are no security/auth/credential handling implications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->