### PR TITLE
Per-session [Slots: N] readout in Wikimedia Upload Status when pool is saturated

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -564,33 +564,44 @@ def _fetch_slot_snapshot(ssm) -> SlotSnapshot | None:
         logging.warning("Could not read slot snapshot: %s", e)
         return None
 
-    total: int | None = None
-    held_samples: list[int] = []
-    holds_by_label: dict[str, int] = {}
-    final_holder_count: int | None = None
-    for ln in (out or "").splitlines():
-        ln = ln.strip()
-        if ln in ("NODIR", "NODATA"):
+    # Parse guarded by its own try/except: unexpected output (a malformed
+    # ``TOTAL``/``COUNT`` sample, an ``lslocks`` upgrade that reshapes a
+    # column) MUST NOT propagate through ``slots_future.result()`` in
+    # ``main`` and abort the entire status post — the slot line is
+    # optional context, not load-bearing. Degrades to ``None`` the same
+    # way :func:`fetch_memory_snapshot` does for its own parse failures.
+    try:
+        total: int | None = None
+        held_samples: list[int] = []
+        holds_by_label: dict[str, int] = {}
+        final_holder_count: int | None = None
+        for ln in (out or "").splitlines():
+            ln = ln.strip()
+            if ln in ("NODIR", "NODATA"):
+                return None
+            if ln.startswith("TOTAL "):
+                total = int(ln.split()[1])
+            elif ln.startswith("COUNT "):
+                final_holder_count = int(ln.split()[1])
+            elif ln.startswith("HOLDER "):
+                label = ln[len("HOLDER ") :]
+                holds_by_label[label] = holds_by_label.get(label, 0) + 1
+            elif ln.isdigit():
+                held_samples.append(int(ln))
+        if not total or not held_samples:
             return None
-        if ln.startswith("TOTAL "):
-            total = int(ln.split()[1])
-        elif ln.startswith("COUNT "):
-            final_holder_count = int(ln.split()[1])
-        elif ln.startswith("HOLDER "):
-            label = ln[len("HOLDER ") :]
-            holds_by_label[label] = holds_by_label.get(label, 0) + 1
-        elif ln.isdigit():
-            held_samples.append(int(ln))
-    if not total or not held_samples:
+        # Feed the final structured pass into the median alongside the
+        # count-only samples so a run that transiently drops between samples
+        # still smooths.
+        if final_holder_count is not None:
+            held_samples.append(final_holder_count)
+        held = round(statistics.median(held_samples))
+        free = max(0, total - held)
+        line = f"Worker slots: ~{free} free of {total} ({held} held)"
+        return SlotSnapshot(line=line, free=free, holds_by_label=holds_by_label)
+    except Exception as e:
+        logging.warning("Could not parse slot snapshot output: %s", e)
         return None
-    # Feed the final structured pass into the median alongside the count-only
-    # samples so a run that transiently drops between samples still smooths.
-    if final_holder_count is not None:
-        held_samples.append(final_holder_count)
-    held = round(statistics.median(held_samples))
-    free = max(0, total - held)
-    line = f"Worker slots: ~{free} free of {total} ({held} held)"
-    return SlotSnapshot(line=line, free=free, holds_by_label=holds_by_label)
 
 
 def _slot_suffix_for_row(

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -25,16 +25,36 @@ from ingest_wikimedia.worker_slots import (
     UPLOADER_PRIORITY_SLOT_DIR,
 )
 
-# Bash regex used inside :func:`_fetch_slot_snapshot` to filter ``lslocks``
-# rows to just this project's slot pools. Interpolated from the shared
-# ``worker_slots`` constants so a rename of either directory can't leave
-# this file silently wrong (previously the basenames were hardcoded here
-# alongside their definitions in ``worker_slots.py`` — a two-site
-# stringly-typed contract that would drift on any pool rename).
-_SLOT_DIR_BASENAME_RE = "|".join(
+# Bash regexes used inside :func:`_fetch_slot_snapshot` to filter
+# ``lslocks`` rows. The shared-pool regex drives the ``free``/``held``
+# aggregate line (bounded by the shared pool's known ``TOTAL``); the
+# both-pools regex drives per-session attribution (a Case-2 uploader
+# holding a priority-pool slot should still be visible in the per-session
+# ``[Slots: 1]`` readout even though the shared pool's aggregate ignores
+# it). Interpolated from the shared ``worker_slots`` constants so a
+# rename of either directory can't leave this file silently wrong.
+_SHARED_SLOT_DIR_BASENAME = os.path.basename(DEFAULT_SLOT_DIR)
+_ALL_SLOT_DIR_BASENAME_RE = "|".join(
     re.escape(os.path.basename(p))
     for p in (DEFAULT_SLOT_DIR, UPLOADER_PRIORITY_SLOT_DIR)
 )
+
+
+def _strip_batch_suffix(display_id: str) -> str:
+    """Return ``display_id`` with any trailing ``" [n/m]"`` batch-position
+    annotation removed.
+
+    Multi-target sessions render ``"partner+institution [pos/total]"`` as
+    their row label (see ``_with_batch_suffix`` in ``main``), but the
+    ``WIKIMEDIA_SESSION_LABEL`` env var carries only the raw
+    ``partner+institution`` slug. Any keyed lookup against a dict of
+    session-labels must strip the batch suffix first — otherwise
+    multi-target rows will miss their own slot-holder counts.
+    """
+    return _BATCH_SUFFIX_RE.sub("", display_id)
+
+
+_BATCH_SUFFIX_RE = re.compile(r" \[\d+/\d+\]$")
 
 
 class SlotSnapshot(NamedTuple):
@@ -511,17 +531,23 @@ def _fetch_slot_snapshot(ssm) -> SlotSnapshot | None:
             f"command -v lslocks >/dev/null 2>&1 || {{ echo NODATA; exit 0; }}; "
             f'echo "TOTAL $(ls "$D" 2>/dev/null | wc -l)"; '
             # Three quick count-only samples for median smoothing (transient
-            # all-held/all-free blips are common on churn). The final
-            # sample also emits per-PID session-label lines so callers can
-            # attribute holds to rows under saturation.
-            f"SLOT_RE='{_SLOT_DIR_BASENAME_RE}'; "
+            # all-held/all-free blips are common on churn). Counts the
+            # SHARED pool only — the ``TOTAL`` line above is the shared
+            # pool's file count, so ``free = TOTAL - held`` only balances
+            # when both operands sample the same pool.
+            f"SHARED_RE='{_SHARED_SLOT_DIR_BASENAME}'; "
+            f"ALL_RE='{_ALL_SLOT_DIR_BASENAME_RE}'; "
             f"for i in 1 2 3; do "
-            f'  lslocks 2>/dev/null | grep -cE "$SLOT_RE"; '
+            f'  lslocks 2>/dev/null | grep -cE "$SHARED_RE"; '
             f"  sleep 1; "
             f"done; "
+            # Final structured pass: both pools for per-session attribution
+            # (a Case-2 uploader in the priority pool should still appear in
+            # ``[Slots: 1]`` for its row) plus a 4th shared-only count that
+            # feeds the median alongside the earlier samples.
             f"HOLDERS=$(lslocks -n -o PID,PATH 2>/dev/null "
-            f'  | grep -E "$SLOT_RE" || true); '
-            f'echo "$HOLDERS" | grep -c . '
+            f'  | grep -E "$ALL_RE" || true); '
+            f'echo "$HOLDERS" | grep -cE "$SHARED_RE" '
             f"  | (read -r n; echo COUNT $n); "
             f'echo "$HOLDERS" | awk "{{print \\$1}}" | while read pid; do '
             f'  [ -z "$pid" ] && continue; '
@@ -586,7 +612,12 @@ def _slot_suffix_for_row(
     """
     if not any(phase.startswith(p) for p in _SLOT_CONSUMING_PHASE_PREFIXES):
         return ""
-    held = holds_by_label.get(display_id, 0)
+    # ``display_id`` may carry a trailing ``" [n/m]"`` for multi-target
+    # sessions; ``holds_by_label`` is keyed by the raw
+    # ``WIKIMEDIA_SESSION_LABEL`` (no such suffix), so strip before lookup
+    # or every multi-target row would miss its own hold count and render
+    # ``[Awaiting slot]`` even while its workers are actively uploading.
+    held = holds_by_label.get(_strip_batch_suffix(display_id), 0)
     if held > 0:
         return f" [Slots: {held}]"
     if "waiting on slots" in phase:

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -15,9 +15,57 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import boto3
 import requests
 
+from typing import NamedTuple
+
 from ingest_wikimedia.partners import PARTNER_DIR, parse_session_labels, resolve_slug
 from ingest_wikimedia.ssm import REGION, fetch_memory_snapshot, ssm_run
-from ingest_wikimedia.worker_slots import DEFAULT_SLOT_DIR, SLOTS_BUSY_LOG_MARKER
+from ingest_wikimedia.worker_slots import (
+    DEFAULT_SLOT_DIR,
+    SLOTS_BUSY_LOG_MARKER,
+    UPLOADER_PRIORITY_SLOT_DIR,
+)
+
+# Bash regex used inside :func:`_fetch_slot_snapshot` to filter ``lslocks``
+# rows to just this project's slot pools. Interpolated from the shared
+# ``worker_slots`` constants so a rename of either directory can't leave
+# this file silently wrong (previously the basenames were hardcoded here
+# alongside their definitions in ``worker_slots.py`` — a two-site
+# stringly-typed contract that would drift on any pool rename).
+_SLOT_DIR_BASENAME_RE = "|".join(
+    re.escape(os.path.basename(p))
+    for p in (DEFAULT_SLOT_DIR, UPLOADER_PRIORITY_SLOT_DIR)
+)
+
+
+class SlotSnapshot(NamedTuple):
+    """Aggregate + per-session view of the box-wide slot pool at snapshot time.
+
+    ``line`` is the human-readable summary rendered under the row block.
+    ``free`` is the free-slot count in the shared 24-slot pool (used to gate
+    the per-session ``[Slots: N]`` augmentation — we only show it under
+    saturation so the row block stays quiet during headroom).
+    ``holds_by_label`` maps WIKIMEDIA_SESSION_LABEL → number of slots that
+    session currently holds. Includes holders from BOTH the shared pool and
+    the uploader priority pool. Labels are extracted from
+    ``/proc/<pid>/environ`` on each holder PID; a session appears with
+    ``holds == 0`` only implicitly (via absence from the dict).
+    """
+
+    line: str
+    free: int
+    holds_by_label: dict[str, int]
+
+
+# Phase-string prefixes that indicate a session is CURRENTLY in a
+# slot-consuming phase (upload / SDC-sync / drain). Used to decide whether
+# ``[Awaiting slot]`` is applicable when a saturated snapshot shows the
+# session holds zero slots — a session in "Downloading" or "Generating IDs"
+# is legitimately not waiting for a Commons-write slot, so no suffix.
+_SLOT_CONSUMING_PHASE_PREFIXES: tuple[str, ...] = (
+    "Uploading",
+    "SDC syncing",
+    "Draining",
+)
 
 SLACK_CHANNEL = "C02HEU2L3"
 SLACK_API_URL = "https://slack.com/api/chat.postMessage"
@@ -438,13 +486,21 @@ def _format_memory_line(snapshot: tuple[int, int] | None) -> str | None:
     return f"Memory: {used_mb:,} / {total_mb:,} MB used ({pct_available}% available)"
 
 
-def _format_slots_line(ssm) -> str | None:
-    """Report box-wide worker-slot headroom (free count) for the status post,
-    or ``None`` if no budget-enabled session has created the slot dir.
+def _fetch_slot_snapshot(ssm) -> SlotSnapshot | None:
+    """Return a :class:`SlotSnapshot` for the box-wide worker-slot pool, or
+    ``None`` if no budget-enabled session has created the slot dir.
 
     The cap is shared by every Commons-writing phase — uploader (uploads,
-    renames, template migrations, purges) as well as sdc-sync — so the line
-    is not SDC-specific."""
+    renames, template migrations, purges) as well as sdc-sync — so the
+    reported line is not SDC-specific.
+
+    One SSM roundtrip collects both the median-smoothed held-count (three
+    count-only polls) AND the final PID→session-label mapping (one
+    lslocks pass with the PIDs looked up in ``/proc/<pid>/environ``).
+    Consolidating into a single roundtrip avoids double-charging Slack's
+    3-second slash-command budget when the saturated per-session view is
+    also needed for the readout.
+    """
     try:
         out = ssm_run(
             ssm,
@@ -454,29 +510,88 @@ def _format_slots_line(ssm) -> str | None:
             # silently report "all free" — so bail to NODATA instead of lying.
             f"command -v lslocks >/dev/null 2>&1 || {{ echo NODATA; exit 0; }}; "
             f'echo "TOTAL $(ls "$D" 2>/dev/null | wc -l)"; '
-            f"for i in 1 2 3 4; do lslocks 2>/dev/null | grep -c sdc-sync-worker-slots; sleep 1; done",
+            # Three quick count-only samples for median smoothing (transient
+            # all-held/all-free blips are common on churn). The final
+            # sample also emits per-PID session-label lines so callers can
+            # attribute holds to rows under saturation.
+            f"SLOT_RE='{_SLOT_DIR_BASENAME_RE}'; "
+            f"for i in 1 2 3; do "
+            f'  lslocks 2>/dev/null | grep -cE "$SLOT_RE"; '
+            f"  sleep 1; "
+            f"done; "
+            f"HOLDERS=$(lslocks -n -o PID,PATH 2>/dev/null "
+            f'  | grep -E "$SLOT_RE" || true); '
+            f'echo "$HOLDERS" | grep -c . '
+            f"  | (read -r n; echo COUNT $n); "
+            f'echo "$HOLDERS" | awk "{{print \\$1}}" | while read pid; do '
+            f'  [ -z "$pid" ] && continue; '
+            # Each pipeline process (uploader, sdc-sync main and its pool
+            # workers, drain) inherits WIKIMEDIA_SESSION_LABEL from the tmux
+            # environ set by the launcher — a robust per-target signal that
+            # survives multiprocessing.Pool forks.
+            f"  label=$(tr '\\0' '\\n' < /proc/$pid/environ 2>/dev/null "
+            f"    | grep -m1 '^WIKIMEDIA_SESSION_LABEL=' | cut -d= -f2-); "
+            f'  [ -n "$label" ] && echo "HOLDER $label"; '
+            f"done",
         )
     except Exception as e:
-        logging.warning("Could not read slot headroom: %s", e)
+        logging.warning("Could not read slot snapshot: %s", e)
         return None
-    # Parse "TOTAL <n>" followed by the integer held-count samples.
-    total = None
+
+    total: int | None = None
     held_samples: list[int] = []
+    holds_by_label: dict[str, int] = {}
+    final_holder_count: int | None = None
     for ln in (out or "").splitlines():
         ln = ln.strip()
         if ln in ("NODIR", "NODATA"):
             return None
         if ln.startswith("TOTAL "):
             total = int(ln.split()[1])
+        elif ln.startswith("COUNT "):
+            final_holder_count = int(ln.split()[1])
+        elif ln.startswith("HOLDER "):
+            label = ln[len("HOLDER ") :]
+            holds_by_label[label] = holds_by_label.get(label, 0) + 1
         elif ln.isdigit():
             held_samples.append(int(ln))
     if not total or not held_samples:
         return None
-    # Median of the samples: slot ownership churns every few seconds, so this
-    # smooths a transient all-held/all-free blip into a representative reading.
+    # Feed the final structured pass into the median alongside the count-only
+    # samples so a run that transiently drops between samples still smooths.
+    if final_holder_count is not None:
+        held_samples.append(final_holder_count)
     held = round(statistics.median(held_samples))
     free = max(0, total - held)
-    return f"Worker slots: ~{free} free of {total} ({held} held)"
+    line = f"Worker slots: ~{free} free of {total} ({held} held)"
+    return SlotSnapshot(line=line, free=free, holds_by_label=holds_by_label)
+
+
+def _slot_suffix_for_row(
+    display_id: str, phase: str, holds_by_label: dict[str, int]
+) -> str:
+    """Return the ``[Slots: N]`` / ``[Awaiting slot]`` suffix (with leading
+    space) to append to a row's phase text, or an empty string when the
+    row is not in a slot-consuming phase.
+
+    Only called when the pool is fully saturated — see the ``free == 0``
+    gate at the caller. In the headroom regime every slot-phase session
+    trivially holds its full allotment, so surfacing the number is noise.
+
+    Suppresses ``[Awaiting slot]`` when the row's phase text already
+    carries the ``⏸ waiting on slots`` marker (appended earlier by
+    :func:`get_phase_and_progress` when the session's last log line is
+    ``SLOTS_BUSY_LOG_MARKER``). Otherwise a fully-blocked uploader would
+    render both indicators back-to-back — same signal, twice.
+    """
+    if not any(phase.startswith(p) for p in _SLOT_CONSUMING_PHASE_PREFIXES):
+        return ""
+    held = holds_by_label.get(display_id, 0)
+    if held > 0:
+        return f" [Slots: {held}]"
+    if "waiting on slots" in phase:
+        return ""
+    return " [Awaiting slot]"
 
 
 def _format_rows_into_blocks(rows: list[tuple[str, str]]) -> list[dict]:
@@ -704,7 +819,7 @@ def main() -> None:
     # phase resolution rather than serializing after it.
     with ThreadPoolExecutor(max_workers=min(len(sessions) + 2, 8)) as executor:
         memory_future = executor.submit(fetch_memory_snapshot, ssm)
-        slots_future = executor.submit(_format_slots_line, ssm)
+        slots_future = executor.submit(_fetch_slot_snapshot, ssm)
         futures = {executor.submit(fetch, s): s for s in sessions}
         for future in as_completed(futures):
             session = futures[future]
@@ -712,9 +827,24 @@ def main() -> None:
             results[session] = (display_id, phase)
             print(f"{display_id}: {phase}")
         memory_line = _format_memory_line(memory_future.result())
-        slots_line = slots_future.result()
+        slot_snapshot = slots_future.result()
 
     rows = [results[s] for s in sessions if s in results]
+    slots_line = slot_snapshot.line if slot_snapshot is not None else None
+    # Under saturation (0 shared slots free), attach a per-session [Slots: N]
+    # or [Awaiting slot] suffix so an operator can see at a glance which
+    # sessions are actually holding the pool vs. blocked on acquire. Skipped
+    # in the headroom regime because every session in a slot-consuming phase
+    # trivially holds its full allotment there.
+    if slot_snapshot is not None and slot_snapshot.free == 0:
+        rows = [
+            (
+                display_id,
+                phase
+                + _slot_suffix_for_row(display_id, phase, slot_snapshot.holds_by_label),
+            )
+            for display_id, phase in rows
+        ]
     post_to_slack(token, rows, memory_line=memory_line, slots_line=slots_line)
     print("Posted to Slack.")
 

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -1151,12 +1151,28 @@ def test_main_appends_slot_suffixes_when_pool_is_saturated():
     section_text = "\n".join(
         b["text"]["text"] for b in payload["blocks"] if b.get("type") == "section"
     )
-    # jimmy-carter holds 4 slots → [Slots: 4]
-    assert "nara+jimmy-carter-library" in section_text
-    assert "[Slots: 4]" in section_text
+
+    # Each status row renders as a single line (``\`display_id\` phase{suffix}``),
+    # so locate each session's own row and assert the suffix is attached to *that*
+    # row — not merely present somewhere in the concatenated block. This pins
+    # attribution: swapping the suffixes between rows must fail the test.
+    def _row_for(display_id: str) -> str:
+        matches = [ln for ln in section_text.splitlines() if display_id in ln]
+        assert len(matches) == 1, (
+            f"expected exactly one row for {display_id!r}, got {matches!r}"
+        )
+        return matches[0]
+
+    # jimmy-carter holds 4 slots → [Slots: 4] on its own row, and it must not
+    # be the one flagged as awaiting.
+    jimmy_row = _row_for("nara+jimmy-carter-library")
+    assert "[Slots: 4]" in jimmy_row, jimmy_row
+    assert "[Awaiting slot]" not in jimmy_row, jimmy_row
     # state-library-of-ohio is in an upload phase but holds zero → [Awaiting slot]
-    assert "ohio+state-library-of-ohio" in section_text
-    assert "[Awaiting slot]" in section_text
+    # on its own row, and it must not claim any held slots.
+    ohio_row = _row_for("ohio+state-library-of-ohio")
+    assert "[Awaiting slot]" in ohio_row, ohio_row
+    assert "[Slots:" not in ohio_row, ohio_row
 
 
 def test_fetch_slot_snapshot_returns_none_on_malformed_output():

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -631,6 +631,52 @@ def test_fetch_slot_snapshot_none_when_lslocks_absent():
         assert _fetch_slot_snapshot(object()) is None
 
 
+def test_fetch_slot_snapshot_aggregate_scopes_to_shared_pool_only():
+    """Regression (CR flagged on PR #366): ``held`` / ``free`` / ``line``
+    must reflect ONLY the shared 24-slot pool — the ``TOTAL`` line is
+    ``ls DEFAULT_SLOT_DIR | wc -l`` = shared pool size, so mixing in
+    uploader-priority-pool holds would let ``held`` exceed ``TOTAL``
+    and clamp ``free`` to zero even when the shared pool has headroom.
+
+    ``holds_by_label`` MUST still cover both pools — a Case-2 uploader
+    holding a priority slot should surface in its row's ``[Slots: 1]``
+    readout regardless of whether the shared pool is saturated.
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import _fetch_slot_snapshot
+
+    # TOTAL 24. Three shared-pool-only count samples all say 22.
+    # Final structured pass: shared-pool COUNT is 22 (median stays 22 →
+    # held = 22, free = 2), but the HOLDER lines include a
+    # priority-pool uploader whose slot is NOT in that 22.
+    out = (
+        "TOTAL 24\n"
+        "22\n"
+        "22\n"
+        "22\n"
+        "COUNT 22\n"
+        "HOLDER nara+franklin-d-roosevelt-library\n"  # priority-pool uploader
+        "HOLDER nara+jimmy-carter-library\n"
+        "HOLDER nara+jimmy-carter-library\n"
+        "HOLDER nara+jimmy-carter-library\n"
+        "HOLDER nara+jimmy-carter-library\n"
+        "HOLDER nara+jimmy-carter-library\n"
+        "HOLDER nara+jimmy-carter-library\n"
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", return_value=out):
+        snap = _fetch_slot_snapshot(object())
+    assert snap is not None
+    # Aggregate is shared-pool only: 22 held of 24 → 2 free.
+    assert snap.line == "Worker slots: ~2 free of 24 (22 held)"
+    assert snap.free == 2
+    # But per-session attribution still includes the priority-pool holder.
+    assert snap.holds_by_label == {
+        "nara+franklin-d-roosevelt-library": 1,
+        "nara+jimmy-carter-library": 6,
+    }
+
+
 def test_fetch_slot_snapshot_tolerates_no_holders():
     """Some polls will legitimately catch a moment with zero holders
     (transient slack). ``holds_by_label`` is empty and the aggregate
@@ -676,6 +722,26 @@ def test_slot_suffix_marks_awaiting_when_slot_phase_holds_zero():
         {"nara+franklin-d-roosevelt-library": 1},
     )
     assert suffix == " [Awaiting slot]"
+
+
+def test_slot_suffix_strips_batch_suffix_before_lookup():
+    """Regression (CR flagged on PR #366): multi-target sessions render
+    with a ``[n/m]`` batch-position annotation on their display id
+    (via ``_with_batch_suffix``), but ``WIKIMEDIA_SESSION_LABEL`` — the
+    key in ``holds_by_label`` — carries only the raw slug. The suffix
+    helper must strip the ``[n/m]`` before lookup, otherwise every
+    multi-target row would miss its own hold count and render
+    ``[Awaiting slot]`` while its workers are actively uploading.
+    """
+    from scripts.wikimedia_upload_status import _slot_suffix_for_row
+
+    # Batch-annotated display_id, holds are keyed by the raw label.
+    suffix = _slot_suffix_for_row(
+        "texas+baylor-county-free-library [17/54]",
+        "SDC syncing (11 / 4,452 files, ~0.2%)",
+        {"texas+baylor-county-free-library": 6},
+    )
+    assert suffix == " [Slots: 6]"
 
 
 def test_slot_suffix_suppressed_when_phase_already_shows_waiting_marker():

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -569,39 +569,149 @@ def test_post_to_slack_omits_memory_block_when_none():
     assert not any(b.get("type") == "context" for b in payload["blocks"])
 
 
-def test_format_slots_line_reports_free_headroom():
-    """Median of the held-count samples → free = total − held; reports the
-    stable headroom count, not who holds what."""
+def test_fetch_slot_snapshot_reports_free_headroom_and_holds_by_label():
+    """The snapshot returns median-smoothed headroom PLUS a per-session
+    map of holds derived from the final ``HOLDER <label>`` block. Both
+    pieces travel in a single SSM roundtrip because the saturated
+    per-session view is only ever useful with the aggregate — sending
+    them separately would double-charge Slack's 3-second ack budget."""
     from unittest.mock import patch
 
-    from scripts.wikimedia_upload_status import _format_slots_line
+    from scripts.wikimedia_upload_status import SlotSnapshot, _fetch_slot_snapshot
 
-    # TOTAL 24, held samples [16,14,17,15] → median 15.5 → 16 held → 8 free.
-    out = "TOTAL 24\n16\n14\n17\n15\n"
+    # TOTAL 24; three count-only samples [22, 24, 23]; final structured
+    # pass reports COUNT 24 + six HOLDER labels (one uploader + a
+    # 6-worker sdc-sync would look like this in the wild).
+    out = (
+        "TOTAL 24\n"
+        "22\n"
+        "24\n"
+        "23\n"
+        "COUNT 24\n"
+        "HOLDER nara+franklin-d-roosevelt-library\n"
+        "HOLDER nara+jimmy-carter-library\n"
+        "HOLDER nara+jimmy-carter-library\n"
+        "HOLDER nara+jimmy-carter-library\n"
+        "HOLDER nara+jimmy-carter-library\n"
+        "HOLDER nara+jimmy-carter-library\n"
+        "HOLDER nara+jimmy-carter-library\n"
+        "HOLDER ohio+state-library-of-ohio\n"
+    )
     with patch("scripts.wikimedia_upload_status.ssm_run", return_value=out):
-        line = _format_slots_line(object())
-    assert line == "Worker slots: ~8 free of 24 (16 held)"
+        snap = _fetch_slot_snapshot(object())
+    assert isinstance(snap, SlotSnapshot)
+    # Median of [22, 24, 23, 24] = 23.5 → 24 held → 0 free.
+    assert snap.line == "Worker slots: ~0 free of 24 (24 held)"
+    assert snap.free == 0
+    assert snap.holds_by_label == {
+        "nara+franklin-d-roosevelt-library": 1,
+        "nara+jimmy-carter-library": 6,
+        "ohio+state-library-of-ohio": 1,
+    }
 
 
-def test_format_slots_line_none_when_no_slot_dir():
-    """No slot dir (no budget-enabled session has run) → no line."""
+def test_fetch_slot_snapshot_none_when_no_slot_dir():
+    """No slot dir (no budget-enabled session has run) → no snapshot."""
     from unittest.mock import patch
 
-    from scripts.wikimedia_upload_status import _format_slots_line
+    from scripts.wikimedia_upload_status import _fetch_slot_snapshot
 
     with patch("scripts.wikimedia_upload_status.ssm_run", return_value="NODIR\n"):
-        assert _format_slots_line(object()) is None
+        assert _fetch_slot_snapshot(object()) is None
 
 
-def test_format_slots_line_none_when_lslocks_absent():
-    """lslocks missing → NODATA → no line (rather than a misleading "all
-    free" from grep -c on empty stdin)."""
+def test_fetch_slot_snapshot_none_when_lslocks_absent():
+    """lslocks missing → NODATA → no snapshot (rather than a misleading
+    "all free" from grep -c on empty stdin)."""
     from unittest.mock import patch
 
-    from scripts.wikimedia_upload_status import _format_slots_line
+    from scripts.wikimedia_upload_status import _fetch_slot_snapshot
 
     with patch("scripts.wikimedia_upload_status.ssm_run", return_value="NODATA\n"):
-        assert _format_slots_line(object()) is None
+        assert _fetch_slot_snapshot(object()) is None
+
+
+def test_fetch_slot_snapshot_tolerates_no_holders():
+    """Some polls will legitimately catch a moment with zero holders
+    (transient slack). ``holds_by_label`` is empty and the aggregate
+    still renders."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import _fetch_slot_snapshot
+
+    out = "TOTAL 24\n0\n0\n0\nCOUNT 0\n"
+    with patch("scripts.wikimedia_upload_status.ssm_run", return_value=out):
+        snap = _fetch_slot_snapshot(object())
+    assert snap is not None
+    assert snap.line == "Worker slots: ~24 free of 24 (0 held)"
+    assert snap.free == 24
+    assert snap.holds_by_label == {}
+
+
+def test_slot_suffix_appends_slots_when_session_holds_slots():
+    """Under saturation, a slot-consuming row that holds N slots gets a
+    ``[Slots: N]`` suffix so the reader can attribute pool usage
+    without SSM-ing in."""
+    from scripts.wikimedia_upload_status import _slot_suffix_for_row
+
+    suffix = _slot_suffix_for_row(
+        "nara+jimmy-carter-library",
+        "SDC syncing (1,359 / 11,011 files, ~12.3%)",
+        {"nara+jimmy-carter-library": 4, "ohio+state-library-of-ohio": 1},
+    )
+    assert suffix == " [Slots: 4]"
+
+
+def test_slot_suffix_marks_awaiting_when_slot_phase_holds_zero():
+    """Under saturation, a session that IS in a slot-consuming phase
+    but appears in zero holders gets ``[Awaiting slot]`` — every worker
+    in that session is blocked on acquire (or transiently between
+    items, which under 0-free-slot conditions is dominated by the
+    acquire wait)."""
+    from scripts.wikimedia_upload_status import _slot_suffix_for_row
+
+    suffix = _slot_suffix_for_row(
+        "ohio+toledo-lucas-county-public-library",
+        "Uploading (10,747 / 142,392 files, ~7.5%)",
+        {"nara+franklin-d-roosevelt-library": 1},
+    )
+    assert suffix == " [Awaiting slot]"
+
+
+def test_slot_suffix_suppressed_when_phase_already_shows_waiting_marker():
+    """A phase text that already ends with the ``⏸ waiting on slots``
+    marker (appended by ``get_phase_and_progress`` when the session's
+    last log line is ``SLOTS_BUSY_LOG_MARKER``) must NOT ALSO get a
+    ``[Awaiting slot]`` suffix. The two indicators mean the same
+    thing; rendering both produces phrasing like
+    ``Uploading (…) ⏸ waiting on slots [Awaiting slot]`` which reads
+    like a compound state. When the log-tail marker is already there
+    we defer to it and add nothing.
+    """
+    from scripts.wikimedia_upload_status import _slot_suffix_for_row
+
+    suffix = _slot_suffix_for_row(
+        "ohio+state-library-of-ohio",
+        "Uploading (75 / 17,349 files, ~0.4%) ⏸ waiting on slots",
+        {},  # zero holds for this session
+    )
+    assert suffix == ""
+
+
+def test_slot_suffix_empty_for_non_slot_phase():
+    """A session in a phase that doesn't touch the slot pool
+    (downloading, generating IDs, complete, error) gets NO slot
+    suffix — the pool line is irrelevant to it."""
+    from scripts.wikimedia_upload_status import _slot_suffix_for_row
+
+    for phase in (
+        "Downloading (500 / 1000 items, ~50.0%)",
+        "Generating IDs",
+        "Upload complete (1200 items)",
+        "Unknown (error)",
+        "Starting...",
+    ):
+        assert _slot_suffix_for_row("anything", phase, {}) == "", phase
 
 
 # ---------------------------------------------------------------------------
@@ -873,7 +983,7 @@ def test_main_rows_use_display_id_from_fetch_not_session_name():
             return_value=None,
         ),
         patch(
-            "scripts.wikimedia_upload_status._format_slots_line",
+            "scripts.wikimedia_upload_status._fetch_slot_snapshot",
             return_value=None,
         ),
         patch(
@@ -1266,7 +1376,9 @@ def test_fetch_position_annotation_for_multi_label_batch():
         patch(
             "scripts.wikimedia_upload_status.fetch_memory_snapshot", return_value=None
         ),
-        patch("scripts.wikimedia_upload_status._format_slots_line", return_value=None),
+        patch(
+            "scripts.wikimedia_upload_status._fetch_slot_snapshot", return_value=None
+        ),
         # Active label is the 3rd of 4 (texas+c).
         patch(
             "scripts.wikimedia_upload_status.find_active_label",
@@ -1311,7 +1423,9 @@ def test_fetch_no_position_annotation_for_single_label_session():
         patch(
             "scripts.wikimedia_upload_status.fetch_memory_snapshot", return_value=None
         ),
-        patch("scripts.wikimedia_upload_status._format_slots_line", return_value=None),
+        patch(
+            "scripts.wikimedia_upload_status._fetch_slot_snapshot", return_value=None
+        ),
         patch(
             "scripts.wikimedia_upload_status.find_active_label",
             return_value=("bpl+phillips-academy", 1700000000),

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -1083,6 +1083,102 @@ def test_main_rows_use_display_id_from_fetch_not_session_name():
 # Upload-phase file-level progress (PR: file progress + position-in-chain)
 
 
+def test_main_appends_slot_suffixes_when_pool_is_saturated():
+    """CR nitpick on PR #366: prior ``main()`` tests all mock
+    ``_fetch_slot_snapshot`` to ``None``, leaving the saturated-suffix
+    wiring untested end-to-end. This exercise it: snapshot reports
+    ``free == 0`` with a populated ``holds_by_label`` covering one
+    session's SDC-sync worker pool + a second session that holds zero
+    slots. Assertions verify that the final Slack section text carries
+    ``[Slots: 4]`` and ``[Awaiting slot]`` on the appropriate rows.
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import SlotSnapshot, main
+
+    sessions_out = (
+        "wikimedia-nara+jimmy-carter-library: 1 windows\n"
+        "wikimedia-ohio+state-library-of-ohio: 1 windows\n"
+    )
+    captured, fake_post = _capture_slack_post()
+
+    # Deterministic per-session phase results. jimmy-carter is
+    # SDC-syncing with 4 workers currently holding slots (2 waiting).
+    # state-library-of-ohio is an uploader that holds zero slots
+    # (saturation blocked it before it could grab one).
+    def fake_get_phase_and_progress(client, session, hub, label):
+        if label == "nara+jimmy-carter-library":
+            return ("SDC syncing (1,359 / 11,011 files, ~12.3%)", 1700000000)
+        if label == "ohio+state-library-of-ohio":
+            return ("Uploading (75 / 17,349 files, ~0.4%)", 1700000000)
+        return (None, 0)
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"DPLA_SLACK_BOT_TOKEN": "tok", "NOTIFY_IF_IDLE": "false"},
+        ),
+        patch("scripts.wikimedia_upload_status.boto3.client", return_value=object()),
+        patch("scripts.wikimedia_upload_status.ssm_run", return_value=sessions_out),
+        patch(
+            "scripts.wikimedia_upload_status.fetch_memory_snapshot",
+            return_value=None,
+        ),
+        patch(
+            "scripts.wikimedia_upload_status._fetch_slot_snapshot",
+            return_value=SlotSnapshot(
+                line="Worker slots: ~0 free of 24 (24 held)",
+                free=0,
+                holds_by_label={"nara+jimmy-carter-library": 4},
+            ),
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.find_active_label",
+            side_effect=lambda ssm, labels: (labels[0], 1700000000),
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.get_phase_and_progress",
+            side_effect=fake_get_phase_and_progress,
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.requests.post",
+            side_effect=fake_post,
+        ),
+    ):
+        main()
+
+    payload = captured["payload"]
+    section_text = "\n".join(
+        b["text"]["text"] for b in payload["blocks"] if b.get("type") == "section"
+    )
+    # jimmy-carter holds 4 slots → [Slots: 4]
+    assert "nara+jimmy-carter-library" in section_text
+    assert "[Slots: 4]" in section_text
+    # state-library-of-ohio is in an upload phase but holds zero → [Awaiting slot]
+    assert "ohio+state-library-of-ohio" in section_text
+    assert "[Awaiting slot]" in section_text
+
+
+def test_fetch_slot_snapshot_returns_none_on_malformed_output():
+    """CR nitpick on PR #366: the parse block must degrade to ``None``
+    rather than letting a malformed ``TOTAL``/``COUNT`` line propagate
+    out of ``slots_future.result()`` and abort the whole status post.
+    Matches :func:`fetch_memory_snapshot`'s own graceful-degradation
+    contract — the slot line is optional context, not load-bearing.
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import _fetch_slot_snapshot
+
+    # ``TOTAL`` line with a non-integer value → ``int(...)`` raises;
+    # helper must swallow and return ``None``.
+    with patch(
+        "scripts.wikimedia_upload_status.ssm_run",
+        return_value="TOTAL nope\n1\n1\n1\nCOUNT 1\n",
+    ):
+        assert _fetch_slot_snapshot(object()) is None
+
+
 def test_upload_progress_reports_file_level_when_download_log_available():
     """When the downloader has finished and the per-item `Item <id>: N
     ordinals` summary lines are present in the download log, the Upload


### PR DESCRIPTION
## Summary

When all 24 shared slots are held, the current status post ends with `Worker slots: ~0 free of 24 (24 held)` but gives no attribution — an operator has to SSM in to see which sessions actually hold the pool vs. which are stalled waiting.

This PR appends a `[Slots: N]` suffix to each row when the pool is saturated. Uploader = 1 expected slot; sdc-sync = 6 expected slots (the `--workers` default); a session in a slot-consuming phase that holds zero slots renders `[Awaiting slot]`.

Suffix is only rendered under saturation (`free == 0`). Under headroom every slot-consuming session trivially holds its full allotment, so surfacing the number is noise.

## Live demo

Sampled from EC2 right at PR-writing time (28 holders total; 24 shared + 4 priority):

```
nara+franklin-d-roosevelt-library Uploading (…) [Slots: 1]
nara+jimmy-carter-library SDC syncing (…) [Slots: 3]
nara+…+kennedy SDC syncing (…) [Slots: 4]
nara+…+washington-dc… Uploading (…) [Slots: 1]
nara+ronald-reagan-library Uploading (…) [Slots: 1]
northwest-heritage+oregon-state-archives SDC syncing (…) [Slots: 5]
ohio+ohio-university-libraries SDC syncing (…) [Slots: 5]
ohio+state-library-of-ohio Uploading (…) [Awaiting slot]
ohio+toledo-lucas-county-public-library Uploading (…) [Slots: 1]
texas+…+baylor-county-free-library SDC syncing (…) [Slots: 6]
Worker slots: ~0 free of 24 (24 held) …
```

Clear read: `jimmy-carter` sdc-sync has 3 of 6 workers waiting; `state-library-of-ohio` upload can't get a slot at all; `baylor-county-free-library` is fully productive.

## Mechanism

- `_format_slots_line` renamed to `_fetch_slot_snapshot`; now returns a `SlotSnapshot` NamedTuple with `line`, `free`, and `holds_by_label` (dict mapping `WIKIMEDIA_SESSION_LABEL` → held count).
- Same SSM roundtrip shape — 3 count-only `lslocks` polls (median-smoothed for churn) + 1 structured pass that emits `HOLDER <label>` per holder PID. Label pulled from `/proc/<pid>/environ`; the launcher's per-target `WIKIMEDIA_SESSION_LABEL` export survives through `multiprocessing.Pool` forks so worker PIDs inherit the right label with no additional bookkeeping.
- `main()` augments rows via a new `_slot_suffix_for_row` helper gated on the phase prefix (`Uploading` / `SDC syncing` / `Draining`) — download and id-generation rows never get the suffix. It also suppresses `[Awaiting slot]` when the phase already ends with the existing `⏸ waiting on slots` marker, so a fully-blocked uploader doesn't render both indicators back-to-back.
- The bash regex for slot-dir basenames is now built from `os.path.basename()` of `DEFAULT_SLOT_DIR` and `UPLOADER_PRIORITY_SLOT_DIR` imported from `ingest_wikimedia.worker_slots`, so a rename of either dir can't leave this file silently wrong.

## Test plan

- [x] `ruff check` + `ruff format` clean
- [x] Full pytest suite green (1085 passed, up from 1080 — six new tests added; existing `_format_slots_line` tests renamed for the new symbol)
- [x] `simplify` skill (reuse + quality + efficiency) — all three passes clean after addressing the quality reviewer's two findings (double-suffix suppression + slot-dir basenames as constants)
- [x] Verified against live EC2 snapshot; captured output matches the format above

## Notes

- No change to SSM budget under headroom (rows aren't augmented → same wall-time as before).
- Under saturation the SSM call grows by ~100-200ms for the extra `lslocks` + `~30 environ reads`, still well under Slack's 3-second slash-command ack budget.
- The efficiency reviewer noted a potential micro-optimization (single `awk` over all environ files instead of a per-PID pipeline). Not applied — current cost is a small fraction of the mandatory 3s of `sleep 1` between polls; the pipeline is easier to read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Replaced the previous slot headroom formatter with a slot-snapshot model: `_fetch_slot_snapshot` returns a `SlotSnapshot` containing the formatted shared-pool “Worker slots” line, shared-pool free slot count, and per-session held-slot attribution keyed by `WIKIMEDIA_SESSION_LABEL`.
- When the shared slot pool is fully saturated (`free == 0`), upload/SDC-sync/draining status rows are augmented with a per-session suffix: `[Slots: N]` when that session holds slots, or `[Awaiting slot]` for slot-consuming phases with zero held slots—while suppressing duplicate awaiting indicators if the phase text already contains the waiting marker.
- Kept normal (non-saturated) output effectively unchanged by only emitting the per-row slot suffixes under saturation (the top “slots line” uses the snapshot’s formatted aggregate).
- Updated slot-dir matching to derive basenames from `ingest_wikimedia.worker_slots` constants, so directory renames don’t break detection.
- Fixed slot aggregation/attribution edge cases: aggregate held/free/line are scoped to the shared pool, while `holds_by_label` can still include holders attributed via `HOLDER <label>` lines; display IDs are normalized by stripping trailing `[n/m]` before matching to `WIKIMEDIA_SESSION_LABEL`.
- Updated `main()` to fetch the slot snapshot concurrently with the memory snapshot, and to tolerate malformed/missing `lslocks` output by degrading to `None` for the slot snapshot rather than aborting the Slack status post.
- Expanded and updated tests for `_fetch_slot_snapshot` parsing and edge cases, saturation suffix rendering (including suppression/normalization behaviors), and `main()` end-to-end behavior.

## Notes
- No manual pipeline trigger or ECS redeployment required for this change to take effect.
- No environment variable or AWS Secrets Manager key additions/renames.
- No database migrations.
- No changes to shared infrastructure configuration (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No changes to public-facing API responses or endpoints.
- No security-impacting changes (no auth/credential-handling changes and no new external data inputs introduced).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->