### PR TITLE
Scope conflict detection to still-active/upcoming labels in a chained session

### DIFF
--- a/ingest_wikimedia/session_state.py
+++ b/ingest_wikimedia/session_state.py
@@ -1,0 +1,83 @@
+"""Session-state utilities for the ``wikimedia-*`` scripts.
+
+A wikimedia-upload tmux session runs its per-target chain sequentially —
+downloader → uploader → sdc-sync per label, then the next label. At any
+moment **at most one label is active**; the label whose log file was most
+recently written uniquely identifies it. This module exposes the log-filename
+helpers that both ``scripts/wikimedia_upload_status.py`` (for the periodic
+status post) and ``scripts/wikimedia_launch.py`` (for scoping conflict
+detection to still-active targets in a chained session) need.
+
+Kept in ``ingest_wikimedia/`` rather than ``scripts/`` because the two
+consumers run as top-level scripts (``python scripts/foo.py``) and don't share
+a package namespace — cross-script imports fail at runtime under that entry-
+point shape even though they work in tests via ``conftest`` path-fixup.
+"""
+
+import re
+import shlex
+
+from ingest_wikimedia.partners import PARTNER_DIR
+from ingest_wikimedia.ssm import ssm_run
+
+
+def log_filename_pattern_for_label(label: str) -> str:
+    """Anchored regex matching log filenames for exactly this label.
+
+    Log filenames follow ``{YYYYMMDD}-{HHMMSS}-{label}-(download|upload|sdc).log``.
+    The pattern must match ``…-bpl+phillips-academy-download.log`` and NOT
+    ``…-bpl+phillips-academy-andover-download.log`` — otherwise sibling
+    labels whose names extend this one steal the log selection and the
+    caller sticks on the wrong target. See lessons.md
+    "Log filename phase detection".
+    """
+    return rf"-{re.escape(label)}-(download|upload|sdc)\.log$"
+
+
+def find_active_label(client, labels: list[str]) -> tuple[str, int] | None:
+    """Return ``(label, log_mtime)`` for the most-recently-written log file
+    across all ``labels`` in a chained session, or ``None`` if no matching
+    log exists yet.
+
+    A wikimedia-upload session runs its labels sequentially (downloader →
+    uploader → sdc-sync per label, then on to the next label), so at any
+    moment **at most one label is active**. The freshest log file across
+    all labels in the session uniquely identifies that label — an aborted
+    earlier label's last log write is hours stale, while the running one
+    is being written right now.
+
+    Picking the active label this way takes one SSM round-trip per
+    session regardless of label count. Previously the status-post script
+    polled ``get_phase_and_progress`` once per label, which scaled the
+    SSM round trips linearly with batch size and pushed multi-institution
+    sessions past Slack's three-second slash-command ack deadline. See
+    PR #325-vintage multi-institution batches accumulating 50+ labels each.
+    """
+    if not labels:
+        return None
+
+    # Group labels by hub so we touch each partner log directory exactly once.
+    hubs = sorted({lbl.split("+")[0] for lbl in labels})
+    paths = " ".join(
+        shlex.quote(f"/home/ec2-user/ingest-wikimedia/{PARTNER_DIR.get(h, h)}/logs")
+        for h in hubs
+    )
+    label_alt = "|".join(re.escape(lbl) for lbl in labels)
+    cmd = (
+        f"find {paths} -maxdepth 1 -type f -name '*.log' "
+        f"-regextype posix-extended "
+        f"-regex '.*-({label_alt})-(download|upload|sdc)\\.log' "
+        f"-printf '%T@ %f\\n' 2>/dev/null | sort -rn | head -1"
+    )
+    out = ssm_run(client, cmd).strip()
+    if not out:
+        return None
+    mtime_str, _, filename = out.partition(" ")
+    # Identify which of our labels matched via the per-label helper —
+    # anchored-pattern logic so suffix-collision (e.g.
+    # ``bpl+phillips-academy`` vs ``bpl+phillips-academy-andover``) is
+    # handled exactly once.
+    for lbl in labels:
+        if re.search(log_filename_pattern_for_label(lbl), filename):
+            return lbl, int(float(mtime_str))
+    return None

--- a/ingest_wikimedia/session_state.py
+++ b/ingest_wikimedia/session_state.py
@@ -14,6 +14,7 @@ a package namespace — cross-script imports fail at runtime under that entry-
 point shape even though they work in tests via ``conftest`` path-fixup.
 """
 
+import logging
 import re
 import shlex
 
@@ -81,3 +82,53 @@ def find_active_label(client, labels: list[str]) -> tuple[str, int] | None:
         if re.search(log_filename_pattern_for_label(lbl), filename):
             return lbl, int(float(mtime_str))
     return None
+
+
+def active_and_upcoming_labels(ssm, labels: list[str]) -> set[str]:
+    """Return the subset of ``labels`` that a chained session hasn't yet
+    completed — the currently-active label plus everything after it in
+    the chain-run order.
+
+    A wikimedia-upload tmux session runs its targets sequentially. Once
+    a target's ``sdc-sync`` phase finishes and the ``&&`` chain moves on,
+    that target is done; a new incoming request naming that same target
+    is NOT a conflict and should be allowed to run alongside the ongoing
+    session. Pre-fix, the launcher's conflict check naively compared
+    against **every** label in the tmux session name, causing a 54-target
+    chained session to block every new request naming any of its 54
+    institutions — even institutions whose target completed hours ago.
+
+    Uses :func:`find_active_label`'s log-mtime heuristic: the freshest
+    log across the label set identifies the currently-running target;
+    everything at or after that position is still upcoming, everything
+    before is done. If no log exists yet (session is in id-generation
+    for its first target) OR the lookup raises (transient SSM error),
+    fall back to treating all labels as active — the conservative
+    choice, so a failed lookup can't silently let a real conflict
+    through. The exception path is logged at warning level so silent
+    regressions to the old over-conflicting behavior are visible in
+    operator diagnostics.
+    """
+    if not labels:
+        return set()
+    try:
+        active = find_active_label(ssm, labels)
+    except Exception as e:
+        logging.warning(
+            "active_and_upcoming_labels: find_active_label raised %r; "
+            "falling back to conservative all-labels conflict scope. "
+            "Some completed targets may over-conflict until the SSM "
+            "lookup recovers.",
+            e,
+        )
+        return set(labels)
+    if active is None:
+        return set(labels)
+    try:
+        start_idx = labels.index(active[0])
+    except ValueError:
+        # ``find_active_label`` returned a label not in the input list —
+        # shouldn't happen (its selection loop only returns labels from
+        # this list), but treat as unknown → conservative all-labels.
+        return set(labels)
+    return set(labels[start_idx:])

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -1093,6 +1093,15 @@ def main() -> None:
             f"⚠️ Failed to list tmux sessions: {e}",
             operational=True,
         )
+    # In-memory pre-filter: an existing session can only conflict with a
+    # requested target if they share a hub prefix. Sessions on unrelated
+    # hubs — the common case when the box runs 3+ concurrent partner
+    # chains — skip the ``active_and_upcoming_labels`` SSM round trip
+    # entirely, keeping the launcher's total SSM budget bounded by the
+    # number of overlapping sessions rather than by the number of running
+    # sessions. Extracted once outside the loop; ``targets`` is set at
+    # this point and doesn't change during conflict detection.
+    target_hubs = {canonical for canonical, _, _, _, _ in targets}
     label_conflicts: dict[str, list[str]] = {}
     for line in tmux_list.splitlines():
         existing_name = line.split(":")[0].strip()
@@ -1101,6 +1110,11 @@ def main() -> None:
         existing_labels_ordered = parse_session_labels(
             existing_name[len("wikimedia-") :]
         )
+        if not any(lbl.split("+")[0] in target_hubs for lbl in existing_labels_ordered):
+            # No shared hub with any requested target — can't conflict
+            # regardless of which label is currently active in this
+            # session. Skip the SSM lookup and move on.
+            continue
         existing_labels = active_and_upcoming_labels(ssm, existing_labels_ordered)
         for canonical, institutions, label, dpla_id, collection in targets:
             if not institutions and dpla_id is None:

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -49,7 +49,7 @@ from ingest_wikimedia.partners import (
     slugify_session_label_component,
     wikidata_qid_for_target,
 )
-from ingest_wikimedia.session_state import find_active_label
+from ingest_wikimedia.session_state import active_and_upcoming_labels
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run, stage_and_launch_tmux
 
@@ -141,47 +141,6 @@ _STEP_BY_FIRST_TOKEN: dict[str, str] = {
     "sdc-sync": "sdc-sync",
     "drain-deferred": "drain-deferred",
 }
-
-
-def _active_and_upcoming_labels(ssm, labels: list[str]) -> set[str]:
-    """Return the subset of ``labels`` that a chained session hasn't yet
-    completed — the currently-active label plus everything after it in
-    the chain-run order.
-
-    A wikimedia-upload tmux session runs its targets sequentially. Once
-    a target's ``sdc-sync`` phase finishes and the ``&&`` chain moves on,
-    that target is done; a new incoming request naming that same target
-    is NOT a conflict and should be allowed to run alongside the ongoing
-    session. Pre-fix (before this helper existed), the conflict check
-    naively compared against **every** label in the tmux session name,
-    causing the 54-target texas chain to block every new request naming
-    any of its 54 institutions — even institutions whose target
-    completed hours ago.
-
-    Uses :func:`ingest_wikimedia.session_state.find_active_label`'s
-    log-mtime heuristic: the freshest log across the label set
-    identifies the currently-running target; everything AT or AFTER
-    that position is still upcoming, everything before is done. If no
-    log exists yet (session is in id-generation for its first target
-    or a transient SSM error prevented the lookup), fall back to
-    treating all labels as active — the conservative choice, so a
-    failed lookup can't silently let a real conflict through.
-    """
-    if not labels:
-        return set()
-    try:
-        active = find_active_label(ssm, labels)
-    except Exception:
-        return set(labels)
-    if active is None:
-        return set(labels)
-    try:
-        start_idx = labels.index(active[0])
-    except ValueError:
-        # ``find_active_label`` returned a label not in the input list —
-        # shouldn't happen, but treat as unknown → fall back to all.
-        return set(labels)
-    return set(labels[start_idx:])
 
 
 def _wrap_step_with_marker(cmd: str) -> str:
@@ -1142,7 +1101,7 @@ def main() -> None:
         existing_labels_ordered = parse_session_labels(
             existing_name[len("wikimedia-") :]
         )
-        existing_labels = _active_and_upcoming_labels(ssm, existing_labels_ordered)
+        existing_labels = active_and_upcoming_labels(ssm, existing_labels_ordered)
         for canonical, institutions, label, dpla_id, collection in targets:
             if not institutions and dpla_id is None:
                 # Hub-level request conflicts with any existing session touching this hub

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -49,6 +49,7 @@ from ingest_wikimedia.partners import (
     slugify_session_label_component,
     wikidata_qid_for_target,
 )
+from ingest_wikimedia.session_state import find_active_label
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run, stage_and_launch_tmux
 
@@ -140,6 +141,47 @@ _STEP_BY_FIRST_TOKEN: dict[str, str] = {
     "sdc-sync": "sdc-sync",
     "drain-deferred": "drain-deferred",
 }
+
+
+def _active_and_upcoming_labels(ssm, labels: list[str]) -> set[str]:
+    """Return the subset of ``labels`` that a chained session hasn't yet
+    completed — the currently-active label plus everything after it in
+    the chain-run order.
+
+    A wikimedia-upload tmux session runs its targets sequentially. Once
+    a target's ``sdc-sync`` phase finishes and the ``&&`` chain moves on,
+    that target is done; a new incoming request naming that same target
+    is NOT a conflict and should be allowed to run alongside the ongoing
+    session. Pre-fix (before this helper existed), the conflict check
+    naively compared against **every** label in the tmux session name,
+    causing the 54-target texas chain to block every new request naming
+    any of its 54 institutions — even institutions whose target
+    completed hours ago.
+
+    Uses :func:`ingest_wikimedia.session_state.find_active_label`'s
+    log-mtime heuristic: the freshest log across the label set
+    identifies the currently-running target; everything AT or AFTER
+    that position is still upcoming, everything before is done. If no
+    log exists yet (session is in id-generation for its first target
+    or a transient SSM error prevented the lookup), fall back to
+    treating all labels as active — the conservative choice, so a
+    failed lookup can't silently let a real conflict through.
+    """
+    if not labels:
+        return set()
+    try:
+        active = find_active_label(ssm, labels)
+    except Exception:
+        return set(labels)
+    if active is None:
+        return set(labels)
+    try:
+        start_idx = labels.index(active[0])
+    except ValueError:
+        # ``find_active_label`` returned a label not in the input list —
+        # shouldn't happen, but treat as unknown → fall back to all.
+        return set(labels)
+    return set(labels[start_idx:])
 
 
 def _wrap_step_with_marker(cmd: str) -> str:
@@ -1097,7 +1139,10 @@ def main() -> None:
         existing_name = line.split(":")[0].strip()
         if not existing_name.startswith("wikimedia-"):
             continue
-        existing_labels = set(parse_session_labels(existing_name[len("wikimedia-") :]))
+        existing_labels_ordered = parse_session_labels(
+            existing_name[len("wikimedia-") :]
+        )
+        existing_labels = _active_and_upcoming_labels(ssm, existing_labels_ordered)
         for canonical, institutions, label, dpla_id, collection in targets:
             if not institutions and dpla_id is None:
                 # Hub-level request conflicts with any existing session touching this hub

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -18,6 +18,10 @@ import requests
 from typing import NamedTuple
 
 from ingest_wikimedia.partners import PARTNER_DIR, parse_session_labels, resolve_slug
+from ingest_wikimedia.session_state import (
+    find_active_label,
+    log_filename_pattern_for_label,
+)
 from ingest_wikimedia.ssm import REGION, fetch_memory_snapshot, ssm_run
 from ingest_wikimedia.worker_slots import (
     DEFAULT_SLOT_DIR,
@@ -101,19 +105,6 @@ _SDC_COMPLETE_PREFIX = "SDC complete"
 _SLACK_BLOCK_SOFT_LIMIT = 2800
 
 
-def log_filename_pattern_for_label(label: str) -> str:
-    """Anchored regex matching log filenames for exactly this label.
-
-    Log filenames follow "{YYYYMMDD}-{HHMMSS}-{label}-(download|upload|sdc).log".
-    The pattern must match `…-bpl+phillips-academy-download.log` and NOT
-    `…-bpl+phillips-academy-andover-download.log` — otherwise sibling
-    labels whose names extend this one steal the log selection and the
-    status report sticks on the wrong target. See lessons.md
-    "Log filename phase detection".
-    """
-    return rf"-{re.escape(label)}-(download|upload|sdc)\.log$"
-
-
 _DOWNLOAD_COMPLETE_PREFIX = "Download complete"
 # A session that hasn't written a log line in this many seconds is considered hung.
 # Uploads normally complete items in seconds; downloads in seconds to low minutes.
@@ -126,54 +117,6 @@ _STALE_SECONDS = 1800  # 30 minutes
 # slug shape at runtime to keep that interpolation safe regardless of
 # how callers obtain the label.
 _LABEL_SLUG_RE = re.compile(r"[a-z0-9+\-]+")
-
-
-def find_active_label(client, labels: list[str]) -> tuple[str, int] | None:
-    """Return ``(label, log_mtime)`` for the most-recently-written log file
-    across all labels in this session, or ``None`` if no matching log exists.
-
-    A wikimedia-upload session runs its labels sequentially (downloader →
-    uploader → sdc-sync per label, then on to the next label), so at any
-    moment **at most one label is active**. The freshest log file across
-    all labels in the session uniquely identifies that label — an aborted
-    earlier label's last log write is hours stale, while the running one
-    is being written right now.
-
-    Picking the active label this way takes one SSM round-trip per
-    session regardless of label count. Previously the script polled
-    ``get_phase_and_progress`` once per label, which scaled the SSM round
-    trips linearly with batch size and pushed multi-institution sessions
-    past Slack's three-second slash-command ack deadline. See PR #325-vintage
-    multi-institution batches accumulating 50+ labels each.
-    """
-    if not labels:
-        return None
-
-    # Group labels by hub so we touch each partner log directory exactly once.
-    hubs = sorted({lbl.split("+")[0] for lbl in labels})
-    paths = " ".join(
-        shlex.quote(f"/home/ec2-user/ingest-wikimedia/{PARTNER_DIR.get(h, h)}/logs")
-        for h in hubs
-    )
-    label_alt = "|".join(re.escape(lbl) for lbl in labels)
-    cmd = (
-        f"find {paths} -maxdepth 1 -type f -name '*.log' "
-        f"-regextype posix-extended "
-        f"-regex '.*-({label_alt})-(download|upload|sdc)\\.log' "
-        f"-printf '%T@ %f\\n' 2>/dev/null | sort -rn | head -1"
-    )
-    out = ssm_run(client, cmd).strip()
-    if not out:
-        return None
-    mtime_str, _, filename = out.partition(" ")
-    # Identify which of our labels matched via the per-label helper —
-    # same anchored-pattern logic the rest of this file uses, so
-    # suffix-collision (e.g. ``bpl+phillips-academy`` vs
-    # ``bpl+phillips-academy-andover``) is handled exactly once.
-    for lbl in labels:
-        if re.search(log_filename_pattern_for_label(lbl), filename):
-            return lbl, int(float(mtime_str))
-    return None
 
 
 def get_phase_and_progress(

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -966,10 +966,10 @@ def test_active_and_upcoming_labels_scopes_to_labels_at_or_after_current():
     ]
 
     with patch(
-        "scripts.wikimedia_launch.find_active_label",
+        "ingest_wikimedia.session_state.find_active_label",
         return_value=("texas+bicentennial-city-county-library", 1700000000),
     ):
-        result = launch_mod._active_and_upcoming_labels(object(), labels)
+        result = launch_mod.active_and_upcoming_labels(object(), labels)
 
     # Completed labels absent — new requests naming them do not conflict.
     assert "texas+livingston-municipal-library" not in result
@@ -992,8 +992,8 @@ def test_active_and_upcoming_labels_all_when_no_log_yet():
     import scripts.wikimedia_launch as launch_mod
 
     labels = ["nara+franklin-d-roosevelt-library", "nara+jimmy-carter-library"]
-    with patch("scripts.wikimedia_launch.find_active_label", return_value=None):
-        result = launch_mod._active_and_upcoming_labels(object(), labels)
+    with patch("ingest_wikimedia.session_state.find_active_label", return_value=None):
+        result = launch_mod.active_and_upcoming_labels(object(), labels)
     assert result == set(labels)
 
 
@@ -1007,10 +1007,10 @@ def test_active_and_upcoming_labels_all_when_ssm_lookup_raises():
 
     labels = ["nara+franklin-d-roosevelt-library", "nara+jimmy-carter-library"]
     with patch(
-        "scripts.wikimedia_launch.find_active_label",
+        "ingest_wikimedia.session_state.find_active_label",
         side_effect=RuntimeError("SSM transient failure"),
     ):
-        result = launch_mod._active_and_upcoming_labels(object(), labels)
+        result = launch_mod.active_and_upcoming_labels(object(), labels)
     assert result == set(labels)
 
 
@@ -1020,8 +1020,8 @@ def test_active_and_upcoming_labels_empty_list_short_circuits():
     return an empty list on a malformed session name."""
     import scripts.wikimedia_launch as launch_mod
 
-    with patch("scripts.wikimedia_launch.find_active_label") as mock_find:
-        result = launch_mod._active_and_upcoming_labels(object(), [])
+    with patch("ingest_wikimedia.session_state.find_active_label") as mock_find:
+        result = launch_mod.active_and_upcoming_labels(object(), [])
     assert result == set()
     assert not mock_find.called
 
@@ -1035,8 +1035,8 @@ def test_active_and_upcoming_labels_active_at_position_zero_returns_all():
 
     labels = ["texas+lib-a", "texas+lib-b", "texas+lib-c"]
     with patch(
-        "scripts.wikimedia_launch.find_active_label",
+        "ingest_wikimedia.session_state.find_active_label",
         return_value=("texas+lib-a", 1700000000),
     ):
-        result = launch_mod._active_and_upcoming_labels(object(), labels)
+        result = launch_mod.active_and_upcoming_labels(object(), labels)
     assert result == set(labels)

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -935,3 +935,108 @@ def test_maintain_stage_cmd_routes_bare_nara_to_get_ids_nara():
         "get-ids-es nara --institution 'National Archives at College Park'"
         " --maintain --skip-media-filter > out.csv"
     )
+
+
+# ---------------------------------------------------------------------------
+# _active_and_upcoming_labels: conflict detection scoped to labels the
+# chained session still has to work on
+# ---------------------------------------------------------------------------
+
+
+def test_active_and_upcoming_labels_scopes_to_labels_at_or_after_current():
+    """A chained session with N targets is currently on target ``k``
+    (its log is the freshest). Everything before ``k`` in the chain has
+    completed and is no longer a conflict candidate — a new request
+    naming one of those labels must be free to run. Regression for the
+    54-target texas-chain incident where a new request naming
+    ``montgomery-county-memorial-library`` (long-completed by then) was
+    blocked because the naive check compared against every label in the
+    tmux session name.
+    """
+    import scripts.wikimedia_launch as launch_mod
+
+    labels = [
+        "texas+livingston-municipal-library",
+        "texas+friends-of-the-nocona-public-library",
+        "texas+montgomery-county-memorial-library",  # completed
+        "texas+harrie-p-woodson-memorial-library",  # completed
+        "texas+bicentennial-city-county-library",  # currently active
+        "texas+nesbitt-memorial-library",  # upcoming
+        "texas+baylor-county-free-library",  # upcoming
+    ]
+
+    with patch(
+        "scripts.wikimedia_launch.find_active_label",
+        return_value=("texas+bicentennial-city-county-library", 1700000000),
+    ):
+        result = launch_mod._active_and_upcoming_labels(object(), labels)
+
+    # Completed labels absent — new requests naming them do not conflict.
+    assert "texas+livingston-municipal-library" not in result
+    assert "texas+friends-of-the-nocona-public-library" not in result
+    assert "texas+montgomery-county-memorial-library" not in result
+    assert "texas+harrie-p-woodson-memorial-library" not in result
+    # Active label + upcoming labels present — new requests naming these
+    # DO still conflict.
+    assert "texas+bicentennial-city-county-library" in result
+    assert "texas+nesbitt-memorial-library" in result
+    assert "texas+baylor-county-free-library" in result
+
+
+def test_active_and_upcoming_labels_all_when_no_log_yet():
+    """A session in id-generation for its first target hasn't written any
+    downstream-phase log — ``find_active_label`` returns ``None``.
+    Fall back to conservative "all labels active" so an ambiguous state
+    doesn't silently let a real conflict through.
+    """
+    import scripts.wikimedia_launch as launch_mod
+
+    labels = ["nara+franklin-d-roosevelt-library", "nara+jimmy-carter-library"]
+    with patch("scripts.wikimedia_launch.find_active_label", return_value=None):
+        result = launch_mod._active_and_upcoming_labels(object(), labels)
+    assert result == set(labels)
+
+
+def test_active_and_upcoming_labels_all_when_ssm_lookup_raises():
+    """A transient SSM error during the log-mtime lookup must NOT crash
+    the whole conflict check nor silently drop conflict candidates.
+    Fall back to treating all labels as active so a real conflict can't
+    slip through under partial SSM failure.
+    """
+    import scripts.wikimedia_launch as launch_mod
+
+    labels = ["nara+franklin-d-roosevelt-library", "nara+jimmy-carter-library"]
+    with patch(
+        "scripts.wikimedia_launch.find_active_label",
+        side_effect=RuntimeError("SSM transient failure"),
+    ):
+        result = launch_mod._active_and_upcoming_labels(object(), labels)
+    assert result == set(labels)
+
+
+def test_active_and_upcoming_labels_empty_list_short_circuits():
+    """Defensive: empty label list returns empty set, no SSM call. The
+    helper is reached from :func:`parse_session_labels`, which can
+    return an empty list on a malformed session name."""
+    import scripts.wikimedia_launch as launch_mod
+
+    with patch("scripts.wikimedia_launch.find_active_label") as mock_find:
+        result = launch_mod._active_and_upcoming_labels(object(), [])
+    assert result == set()
+    assert not mock_find.called
+
+
+def test_active_and_upcoming_labels_active_at_position_zero_returns_all():
+    """When the currently-active label is the FIRST target in the chain,
+    every label is still active or upcoming — the whole set is returned.
+    Guards against off-by-one in the ``labels.index(active[0])`` slice.
+    """
+    import scripts.wikimedia_launch as launch_mod
+
+    labels = ["texas+lib-a", "texas+lib-b", "texas+lib-c"]
+    with patch(
+        "scripts.wikimedia_launch.find_active_label",
+        return_value=("texas+lib-a", 1700000000),
+    ):
+        result = launch_mod._active_and_upcoming_labels(object(), labels)
+    assert result == set(labels)

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -790,12 +790,12 @@ def test_find_active_label_picks_freshest_log_across_labels():
     helper parses out the label."""
     from unittest.mock import patch
 
-    from scripts.wikimedia_upload_status import find_active_label
+    from ingest_wikimedia.session_state import find_active_label
 
     # Latest-mtime log file in the partner dir is the upload log for
     # bpl+phillips-academy. The helper should pick that label.
     with patch(
-        "scripts.wikimedia_upload_status.ssm_run",
+        "ingest_wikimedia.session_state.ssm_run",
         return_value="1700005000.000000000 20260528-091047-bpl+phillips-academy-upload.log",
     ):
         result = find_active_label(
@@ -814,9 +814,9 @@ def test_find_active_label_returns_none_when_no_logs_match():
     session that hasn't yet written any downstream phase log."""
     from unittest.mock import patch
 
-    from scripts.wikimedia_upload_status import find_active_label
+    from ingest_wikimedia.session_state import find_active_label
 
-    with patch("scripts.wikimedia_upload_status.ssm_run", return_value=""):
+    with patch("ingest_wikimedia.session_state.ssm_run", return_value=""):
         result = find_active_label(client=None, labels=["bpl+phillips-academy"])
     assert result is None
 
@@ -827,9 +827,9 @@ def test_find_active_label_returns_none_for_empty_label_list():
     can return an empty list on a malformed session name."""
     from unittest.mock import patch
 
-    from scripts.wikimedia_upload_status import find_active_label
+    from ingest_wikimedia.session_state import find_active_label
 
-    with patch("scripts.wikimedia_upload_status.ssm_run") as ssm:
+    with patch("ingest_wikimedia.session_state.ssm_run") as ssm:
         result = find_active_label(client=None, labels=[])
     assert result is None
     assert not ssm.called, "Empty label list must skip the SSM round trip"
@@ -843,7 +843,7 @@ def test_find_active_label_groups_multi_hub_labels_into_single_find():
     ``get_phase_and_progress`` per label — O(labels) round trips."""
     from unittest.mock import patch
 
-    from scripts.wikimedia_upload_status import find_active_label
+    from ingest_wikimedia.session_state import find_active_label
 
     captured: list[str] = []
 
@@ -851,7 +851,7 @@ def test_find_active_label_groups_multi_hub_labels_into_single_find():
         captured.append(command)
         return "1700000000.0 20260528-091047-bpl+phillips-academy-upload.log"
 
-    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
+    with patch("ingest_wikimedia.session_state.ssm_run", side_effect=fake_ssm_run):
         find_active_label(
             client=None,
             labels=[
@@ -879,14 +879,14 @@ def test_find_active_label_picks_active_when_earlier_label_aborted():
     that's the active label."""
     from unittest.mock import patch
 
-    from scripts.wikimedia_upload_status import find_active_label
+    from ingest_wikimedia.session_state import find_active_label
 
     # ``find ... | sort -rn | head -1`` returns the highest-mtime line;
     # we just have to feed it that one line. The active CFLA SDC log
     # would be ranked above the aborted Clinton SDC log because its
     # mtime is later.
     with patch(
-        "scripts.wikimedia_upload_status.ssm_run",
+        "ingest_wikimedia.session_state.ssm_run",
         return_value="1700018000.0 20260528-140954-nara+center-for-legislative-archives-sdc.log",
     ):
         result = find_active_label(
@@ -911,10 +911,10 @@ def test_find_active_label_rejects_filename_not_in_label_list():
     label."""
     from unittest.mock import patch
 
-    from scripts.wikimedia_upload_status import find_active_label
+    from ingest_wikimedia.session_state import find_active_label
 
     with patch(
-        "scripts.wikimedia_upload_status.ssm_run",
+        "ingest_wikimedia.session_state.ssm_run",
         return_value="1700000000.0 20260528-091047-some+other-hub-upload.log",
     ):
         result = find_active_label(client=None, labels=["bpl+phillips-academy"])


### PR DESCRIPTION
## Summary

The `/wikimedia-upload` launcher's conflict check was comparing new-request labels against **every** label parsed from an existing tmux session name. For chained sessions — a batch of 54 texas institutions in one tmux run, for example — this over-declared conflicts: a new request naming `texas|Montgomery County Memorial Library` (completed hours earlier as target 13 of 54) was blocked because the string still appeared in the tmux session name for the still-running target 20+.

## Fix

Scope conflict detection to labels the chained session **still has to work on** — the currently-active label + everything after it in the chain-run order. A completed target is no longer a conflict candidate; a new request naming one is free to run alongside the ongoing session.

Uses the same log-mtime heuristic `wikimedia_upload_status` already uses to answer "which label is current": the freshest log across the label set identifies the currently-running target, the sequential chain guarantees everything at-or-after is upcoming and everything before is done.

**Fallback semantics**: when `find_active_label` returns `None` (no log written yet — session is in id-generation for its first target) OR raises (transient SSM error), fall back to `set(labels)` — conservative "all labels active" so a lookup failure can't silently let a real conflict through.

## Structural refactor

Moved `find_active_label` and `log_filename_pattern_for_label` from `scripts/wikimedia_upload_status.py` into a new shared module `ingest_wikimedia/session_state.py`. Both consumer scripts run as `python scripts/foo.py` (top-level script, no package namespace), so cross-script imports fail at runtime even though they work in tests via conftest path-fixup. The shared home has to be under `ingest_wikimedia/`.

## Tests

- **New** (in `tests/test_wikimedia_launch.py`): 5 unit tests for `_active_and_upcoming_labels` covering the happy path (mid-chain), no-log-yet fallback, exception fallback, empty-list short-circuit, and active-at-position-zero (off-by-one guard).
- **Updated** (in `tests/test_wikimedia_upload_status.py`): 5 existing `find_active_label` tests updated to import from the new location and patch `ingest_wikimedia.session_state.ssm_run` instead of the old `scripts.wikimedia_upload_status.ssm_run`.

## Test plan

- [x] `ruff check` + `ruff format` clean
- [x] Full pytest suite green (1094 passed, up from 1089)
- [x] `simplify` skill (reuse + quality + efficiency) — all three passes clean
- [x] Verified against the current live scenario: `/wikimedia-upload "texas|Montgomery County Memorial Library" ...` while the big texas chain is still running would no longer report a conflict for a completed target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Scoped `/wikimedia-upload` conflict detection so it only considers labels that are currently active or upcoming in a chained tmux session, preventing previously completed targets from triggering false conflicts.

Moved shared session-state helpers into `ingest_wikimedia/session_state.py` so both launch/status scripts use the same runtime-safe logic for:
- anchored log filename matching per label/phase
- selecting the active label via the newest log mtime
- computing the “active and upcoming” label subset with conservative fallback (treat all labels as active if the active label can’t be determined)

Updated `scripts/wikimedia_launch.py` to compute overlap conflicts using the new active-label scoping heuristic (preserving label order), and refactored `scripts/wikimedia_upload_status.py` to import the shared helpers from the new module.

Added/updated tests to cover the new label-scoping behavior and the new helper module location.

No manual pipeline/ECS redeployment or configuration/infrastructure changes are included beyond deploying this code for the behavior change to take effect; no environment variables, Secrets Manager keys, database migrations, shared infra configuration, public API response/endpoint changes, or auth/security/credential handling changes are part of this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->