### PR TITLE
status: report drain-deferred phase (sidecar queue + lock state + throttle)

### DIFF
--- a/ingest_wikimedia/session_state.py
+++ b/ingest_wikimedia/session_state.py
@@ -25,14 +25,27 @@ from ingest_wikimedia.ssm import ssm_run
 def log_filename_pattern_for_label(label: str) -> str:
     """Anchored regex matching log filenames for exactly this label.
 
-    Log filenames follow ``{YYYYMMDD}-{HHMMSS}-{label}-(download|upload|sdc).log``.
+    Log filenames follow ``{YYYYMMDD}-{HHMMSS}-{label}-<phase>.log`` where
+    ``<phase>`` is one of ``download``, ``upload``, ``sdc``,
+    ``drain-deferred``, or ``drain-deferred-opportunistic``.
     The pattern must match ``…-bpl+phillips-academy-download.log`` and NOT
     ``…-bpl+phillips-academy-andover-download.log`` — otherwise sibling
     labels whose names extend this one steal the log selection and the
     caller sticks on the wrong target. See lessons.md
     "Log filename phase detection".
+
+    ``drain-deferred`` is included so the status reporter can see the
+    post-SDC deferred-tagging phase — a session that has completed
+    upload+SDC and moved on to draining its Case-2 duplicate-tag
+    sidecar was previously invisible here and misreported as
+    ``SDC complete`` while actually holding a host-level flock and
+    polling ``Category:Duplicate`` capacity.
     """
-    return rf"-{re.escape(label)}-(download|upload|sdc)\.log$"
+    return (
+        rf"-{re.escape(label)}-"
+        r"(download|upload|sdc|drain-deferred(?:-opportunistic)?)"
+        r"\.log$"
+    )
 
 
 def find_active_label(client, labels: list[str]) -> tuple[str, int] | None:
@@ -64,10 +77,14 @@ def find_active_label(client, labels: list[str]) -> tuple[str, int] | None:
         for h in hubs
     )
     label_alt = "|".join(re.escape(lbl) for lbl in labels)
+    # Phase alternation MUST stay in sync with
+    # :func:`log_filename_pattern_for_label` — drain-deferred(-opportunistic)
+    # logs are legitimate "newest phase" candidates for a session whose
+    # download/upload/sdc chain finished and moved on to drain.
     cmd = (
         f"find {paths} -maxdepth 1 -type f -name '*.log' "
         f"-regextype posix-extended "
-        f"-regex '.*-({label_alt})-(download|upload|sdc)\\.log' "
+        f"-regex '.*-({label_alt})-(download|upload|sdc|drain-deferred(-opportunistic)?)\\.log' "
         f"-printf '%T@ %f\\n' 2>/dev/null | sort -rn | head -1"
     )
     out = ssm_run(client, cmd).strip()

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -134,19 +134,33 @@ def _drain_deferred_phase(
     log_path: str,
     log_file: str,
     session_created: int,
-) -> tuple[str, int]:
+) -> tuple[str | None, int]:
     """Report the drain-deferred phase's live state.
+
+    Returns ``(None, 0)`` for the "no usable log yet" case (log predates
+    this session), matching :func:`get_phase_and_progress`'s sentinel so
+    the caller's ``phase is None`` fallback fires instead of rendering a
+    blank phase string.
 
     Sidecar queue length comes from ``<partner>/deferred-drain.json``
     (the file the drain loop rewrites atomically after each round —
     reading it gives the live count, not the initial count from the
     log's "N item(s) queued" line, which grows stale as items drain).
 
-    Lock state and throttle numbers come from the log itself: presence
-    of ``Drain-phase host lock acquired.`` distinguishes lock-holder
-    from lock-waiter, and the most recent
-    ``Category:Duplicate at N (>= resume threshold M)`` line gives the
-    current throttle position.
+    Lock state and throttle numbers come from the log: whether the
+    ``Drain-phase host lock acquired.`` marker is present ANYWHERE in
+    the file distinguishes lock-holder from lock-waiter, and the most
+    recent ``Category:Duplicate at N (>= resume threshold M)`` line
+    gives the current throttle position.
+
+    The lock marker is grepped from the WHOLE file, not the tail: a
+    patient drain emits one throttle-poll line every poll interval
+    (5 min), so after ~8 polls the one-shot "lock acquired" line
+    scrolls out of any fixed-size tail window. Reading it from the tail
+    alone would make a session that has held the lock for hours
+    misreport as "waiting for host lock". Terminal markers and the
+    throttle poll are still read from the tail (they recur / live at
+    the end).
 
     ``opportunistic`` mode is a one-shot best-effort drain that exits
     fast — its logs are terminal by design, so the phase string
@@ -160,15 +174,21 @@ def _drain_deferred_phase(
     # pretty-printed shape). Counting `[0-9a-f]{32}` matches is more
     # robust than parsing JSON through a here-python (no dependency on
     # shell quoting the interpreter body correctly).
+    #
+    # The lock-marker grep runs over the FULL log (see docstring) and
+    # emits its own count in a dedicated section so tail-window
+    # eviction can't hide a long-held lock.
     out = ssm_run(
         client,
         f"stat -c %Y {log_path} 2>/dev/null || echo 0; "
         f"echo {sep}; "
         f"tail -8 {log_path} 2>/dev/null; "
         f"echo {sep}; "
-        f"grep -oE '[0-9a-f]{{32}}' {sidecar} 2>/dev/null | wc -l",
+        f"grep -oE '[0-9a-f]{{32}}' {sidecar} 2>/dev/null | wc -l; "
+        f"echo {sep}; "
+        f"grep -cF 'Drain-phase host lock acquired.' {log_path} 2>/dev/null || echo 0",
     )
-    sections = out.split(f"{sep}\n", 2)
+    sections = out.split(f"{sep}\n", 3)
 
     def _int(s: str) -> int:
         try:
@@ -179,9 +199,10 @@ def _drain_deferred_phase(
     log_mtime = _int(sections[0]) if sections else 0
     tail = sections[1] if len(sections) > 1 else ""
     queued = _int(sections[2]) if len(sections) > 2 else 0
+    lock_acquired = (_int(sections[3]) if len(sections) > 3 else 0) > 0
 
     if session_created > 0 and log_mtime > 0 and log_mtime < session_created:
-        return "", 0
+        return None, 0
 
     mode = "opportunistic drain" if is_opportunistic else "drain"
 
@@ -195,8 +216,8 @@ def _drain_deferred_phase(
             log_mtime,
         )
 
-    # Non-terminal: determine lock state.
-    if "Drain-phase host lock acquired." not in tail:
+    # Non-terminal: determine lock state from the full-log marker count.
+    if not lock_acquired:
         # Still waiting on the flock — another partner's drain is
         # holding it.
         return (

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -118,6 +118,108 @@ _STALE_SECONDS = 1800  # 30 minutes
 # how callers obtain the label.
 _LABEL_SLUG_RE = re.compile(r"[a-z0-9+\-]+")
 
+# The drain-deferred phase emits its `Category:Duplicate at N (>= resume
+# threshold M); waiting Ss…` line every poll interval. Extract N and M
+# so the status readout can show both the current queue size and how
+# close it is to the resume gate.
+_DRAIN_THROTTLE_RE = re.compile(
+    r"Category:Duplicate at (\d+) \(>= resume threshold (\d+)\)"
+)
+
+
+def _drain_deferred_phase(
+    *,
+    client,
+    pdir: str,
+    log_path: str,
+    log_file: str,
+    session_created: int,
+) -> tuple[str, int]:
+    """Report the drain-deferred phase's live state.
+
+    Sidecar queue length comes from ``<partner>/deferred-drain.json``
+    (the file the drain loop rewrites atomically after each round —
+    reading it gives the live count, not the initial count from the
+    log's "N item(s) queued" line, which grows stale as items drain).
+
+    Lock state and throttle numbers come from the log itself: presence
+    of ``Drain-phase host lock acquired.`` distinguishes lock-holder
+    from lock-waiter, and the most recent
+    ``Category:Duplicate at N (>= resume threshold M)`` line gives the
+    current throttle position.
+
+    ``opportunistic`` mode is a one-shot best-effort drain that exits
+    fast — its logs are terminal by design, so the phase string
+    reflects that final state rather than "still working".
+    """
+    is_opportunistic = log_file.endswith("-drain-deferred-opportunistic.log")
+    sidecar = shlex.quote(f"/home/ec2-user/ingest-wikimedia/{pdir}/deferred-drain.json")
+    sep = "__WM_DRAIN_SEP__"
+    # Live sidecar count: each DPLA ID is a 32-hex-char string on its
+    # own line in the JSON array (the drain sidecar writer emits a
+    # pretty-printed shape). Counting `[0-9a-f]{32}` matches is more
+    # robust than parsing JSON through a here-python (no dependency on
+    # shell quoting the interpreter body correctly).
+    out = ssm_run(
+        client,
+        f"stat -c %Y {log_path} 2>/dev/null || echo 0; "
+        f"echo {sep}; "
+        f"tail -8 {log_path} 2>/dev/null; "
+        f"echo {sep}; "
+        f"grep -oE '[0-9a-f]{{32}}' {sidecar} 2>/dev/null | wc -l",
+    )
+    sections = out.split(f"{sep}\n", 2)
+
+    def _int(s: str) -> int:
+        try:
+            return int(s.strip())
+        except ValueError:
+            return 0
+
+    log_mtime = _int(sections[0]) if sections else 0
+    tail = sections[1] if len(sections) > 1 else ""
+    queued = _int(sections[2]) if len(sections) > 2 else 0
+
+    if session_created > 0 and log_mtime > 0 and log_mtime < session_created:
+        return "", 0
+
+    mode = "opportunistic drain" if is_opportunistic else "drain"
+
+    # Terminal states first — a completed / capacity-declined drain
+    # doesn't need lock / throttle qualifiers.
+    if "Drain-deferred: complete." in tail:
+        return f"Drain complete ({queued:,} still queued)", log_mtime
+    if "at capacity; " in tail and is_opportunistic:
+        return (
+            f"Drain (opportunistic) skipped ({queued:,} deferred to terminal drain)",
+            log_mtime,
+        )
+
+    # Non-terminal: determine lock state.
+    if "Drain-phase host lock acquired." not in tail:
+        # Still waiting on the flock — another partner's drain is
+        # holding it.
+        return (
+            f"Draining ({mode}: {queued:,} queued, ⏸ waiting for host lock)",
+            log_mtime,
+        )
+
+    # Lock held. Try to surface the most recent throttle poll.
+    m = None
+    for line in reversed(tail.splitlines()):
+        m = _DRAIN_THROTTLE_RE.search(line)
+        if m:
+            break
+    if m:
+        cat_size, threshold = int(m.group(1)), int(m.group(2))
+        return (
+            f"Draining ({mode}: {queued:,} queued, "
+            f"Category:Duplicate at {cat_size:,}, needs < {threshold:,})",
+            log_mtime,
+        )
+    # Lock acquired but no throttle poll yet — first tick of the loop.
+    return f"Draining ({mode}: {queued:,} queued, host lock acquired)", log_mtime
+
 
 def get_phase_and_progress(
     client, session: str, hub: str, label: str
@@ -193,6 +295,22 @@ def get_phase_and_progress(
         return None, 0
 
     log_path = shlex.quote(f"{base}/logs/{log_file}")
+
+    # Drain-deferred phase has its own tight state machine: sidecar queue
+    # size + host-lock state + throttle poll number are what matter, not
+    # the download/upload/sdc markers the awk pass below counts. Short-
+    # circuit before the heavier SSM call — one round-trip, direct
+    # signals.
+    if log_file.endswith("-drain-deferred.log") or log_file.endswith(
+        "-drain-deferred-opportunistic.log"
+    ):
+        return _drain_deferred_phase(
+            client=client,
+            pdir=pdir,
+            log_path=log_path,
+            log_file=log_file,
+            session_created=session_created,
+        )
     # Resolve the CSV(s) backing this label so `wc -l` returns a meaningful
     # "items in scope" denominator.
     #

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -483,23 +483,37 @@ def _fake_ssm_for_drain(
     log_filename: str,
     tail: str,
     queued: int,
+    lock_acquired_count: int | None = None,
     mtime: int = 1700000000,
     session_created: int = 0,
 ):
     """Two-call SSM fake for the drain-deferred phase code path.
 
     Call 1 (precheck): ``session_created\\nlog_filename\\n``.
-    Call 2 (drain state): ``{mtime}\\n<SEP>\\n{tail}\\n<SEP>\\n{queued}``
-    where SEP is ``__WM_DRAIN_SEP__``.
+    Call 2 (drain state): four SEP-delimited sections —
+    ``{mtime}<SEP>{tail}<SEP>{queued}<SEP>{lock_acquired_count}`` where
+    SEP is ``__WM_DRAIN_SEP__``. The 4th section is the whole-file
+    ``grep -c`` of the lock-acquired marker (decoupled from ``tail`` so
+    the reporter can't be fooled by tail-window eviction on long
+    drains).
+
+    ``lock_acquired_count`` defaults to being derived from ``tail`` —
+    mirroring the common case where the marker is still in-window — but
+    can be set explicitly to exercise the tail-eviction regression
+    (marker present in the full file, absent from the tail).
     """
     call = [0]
     sep = "__WM_DRAIN_SEP__"
+    if lock_acquired_count is None:
+        lock_acquired_count = 1 if "Drain-phase host lock acquired." in tail else 0
 
     def fake(_client, _cmd, **_kw):
         call[0] += 1
         if call[0] == 1:
             return f"{session_created}\n{log_filename}\n"
-        return f"{mtime}\n{sep}\n{tail}\n{sep}\n{queued}\n"
+        return (
+            f"{mtime}\n{sep}\n{tail}\n{sep}\n{queued}\n{sep}\n{lock_acquired_count}\n"
+        )
 
     return fake
 
@@ -622,6 +636,72 @@ def test_drain_deferred_reports_complete_when_sidecar_drained():
             label="ohio",
         )
     assert phase.startswith("Drain complete")
+
+
+def test_drain_deferred_lock_marker_read_from_full_log_not_tail():
+    """Regression (CR #368): a patient drain that has held the lock for
+    hours has scrolled the one-shot ``Drain-phase host lock acquired.``
+    line out of the tail window — the tail is now all throttle-poll
+    lines. The lock state must come from the FULL-log grep count (4th
+    SSM section), so this session still reports its throttle state, NOT
+    a false 'waiting for host lock'."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_drain(
+        log_filename="20260705-092303-drain-ohio-drain-deferred.log",
+        # Tail is ONLY throttle polls — lock-acquired line evicted.
+        tail=(
+            "[INFO] 14:53:17: Category:Duplicate at 958 (>= resume "
+            "threshold 900); waiting 300s before retrying deferred "
+            "duplicate-tags.\n"
+            "[INFO] 14:58:17: Category:Duplicate at 954 (>= resume "
+            "threshold 900); waiting 300s before retrying deferred "
+            "duplicate-tags."
+        ),
+        queued=42,
+        # But the full-file grep still finds the marker.
+        lock_acquired_count=1,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _mtime = get_phase_and_progress(
+            client=None,
+            session="wikimedia-ohio",
+            hub="ohio",
+            label="ohio",
+        )
+    assert "waiting for host lock" not in phase, (
+        "lock marker evicted from tail must not be misread as lock-waiting"
+    )
+    assert "954" in phase and "900" in phase
+
+
+def test_drain_deferred_returns_none_for_stale_log_predating_session():
+    """Regression (CR #368): when the drain log predates the current
+    session (log_mtime < session_created), the helper must return the
+    ``None`` sentinel — matching every other branch of
+    get_phase_and_progress — so the caller's fallback fires instead of
+    rendering a blank phase string."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_drain(
+        log_filename="20260705-092303-drain-ohio-drain-deferred.log",
+        tail="[INFO] 09:23:02: Drain-phase host lock acquired.",
+        queued=5,
+        mtime=1700000000,
+        session_created=1700000000 + 3600,  # session started AFTER this log
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        result = get_phase_and_progress(
+            client=None,
+            session="wikimedia-ohio",
+            hub="ohio",
+            label="ohio",
+        )
+    assert result == (None, 0)
 
 
 def test_get_phase_and_progress_returns_none_tuple_when_no_log_exists():

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -35,16 +35,24 @@ def test_log_filename_pattern_matches_only_exact_label():
 
 
 def test_log_filename_pattern_matches_only_phase_suffixes():
-    """Only -download.log, -upload.log, and -sdc.log are valid phase logs."""
+    """The five recognised phase suffixes: download, upload, sdc,
+    drain-deferred, drain-deferred-opportunistic. Anything else (e.g.
+    legacy retirer logs) must not match."""
     from scripts.wikimedia_upload_status import log_filename_pattern_for_label
 
     pattern = re.compile(log_filename_pattern_for_label("nara"))
     assert pattern.search("20260522-100000-nara-download.log")
     assert pattern.search("20260522-100000-nara-upload.log")
     assert pattern.search("20260522-100000-nara-sdc.log")
+    assert pattern.search("20260522-100000-nara-drain-deferred.log")
+    assert pattern.search("20260522-100000-nara-drain-deferred-opportunistic.log")
     # Other phases (e.g. legacy retirer logs) must NOT match
     assert not pattern.search("20251220-012010-nara-retirer.log")
     assert not pattern.search("20260522-100000-nara-fix.log")
+    # Guard against a partial-match footgun: the pattern must be anchored
+    # so that "nara-drain-deferred-oops.log" is NOT interpreted as a
+    # valid drain-deferred variant.
+    assert not pattern.search("20260522-100000-nara-drain-deferred-oops.log")
 
 
 def test_log_filename_pattern_handles_regex_metachars_in_label():
@@ -468,6 +476,152 @@ def test_main_picks_latest_active_label_by_mtime_when_earlier_label_aborted():
     chosen_label, chosen_phase, _ = max(active_labels, key=lambda t: t[2])
     assert chosen_label == "nara+center-for-legislative-archives"
     assert chosen_phase == active_phase
+
+
+def _fake_ssm_for_drain(
+    *,
+    log_filename: str,
+    tail: str,
+    queued: int,
+    mtime: int = 1700000000,
+    session_created: int = 0,
+):
+    """Two-call SSM fake for the drain-deferred phase code path.
+
+    Call 1 (precheck): ``session_created\\nlog_filename\\n``.
+    Call 2 (drain state): ``{mtime}\\n<SEP>\\n{tail}\\n<SEP>\\n{queued}``
+    where SEP is ``__WM_DRAIN_SEP__``.
+    """
+    call = [0]
+    sep = "__WM_DRAIN_SEP__"
+
+    def fake(_client, _cmd, **_kw):
+        call[0] += 1
+        if call[0] == 1:
+            return f"{session_created}\n{log_filename}\n"
+        return f"{mtime}\n{sep}\n{tail}\n{sep}\n{queued}\n"
+
+    return fake
+
+
+def test_drain_deferred_reports_waiting_for_lock():
+    """Session queued behind another partner's drain: no
+    ``Drain-phase host lock acquired.`` line yet — must be flagged as
+    lock-waiting rather than as SDC-complete-and-idle."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_drain(
+        log_filename="20260705-120631-northwest-heritage+oregon-state-archives-drain-deferred.log",
+        tail=(
+            "[INFO] 12:06:31: Drain-deferred: sidecar for partner "
+            "northwest-heritage has 8 item(s) queued; acquiring host lock "
+            "(mode: patient).\n"
+            "[INFO] 12:06:31: Acquiring drain-phase host lock at "
+            "/home/ec2-user/ingest-wikimedia/.drain-lock (blocking until "
+            "available)…"
+        ),
+        queued=8,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _mtime = get_phase_and_progress(
+            client=None,
+            session="wikimedia-northwest-heritage+oregon-state-archives",
+            hub="northwest-heritage",
+            label="northwest-heritage+oregon-state-archives",
+        )
+    assert "waiting for host lock" in phase
+    assert "8 queued" in phase
+
+
+def test_drain_deferred_reports_throttle_state_when_holding_lock():
+    """Session holding the lock and polling ``Category:Duplicate``:
+    surface the live throttle numbers so operators can gauge how
+    close the resume gate is to opening."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_drain(
+        log_filename="20260705-092303-drain-ohio-drain-deferred.log",
+        tail=(
+            "[INFO] 14:58:16: Drain-phase host lock acquired.\n"
+            "[INFO] 14:58:16: Category:Duplicate at 979 (>= resume "
+            "threshold 900); waiting 300s before retrying deferred "
+            "duplicate-tags.\n"
+            "[INFO] 15:03:17: Category:Duplicate at 954 (>= resume "
+            "threshold 900); waiting 300s before retrying deferred "
+            "duplicate-tags."
+        ),
+        queued=42,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _mtime = get_phase_and_progress(
+            client=None,
+            session="wikimedia-ohio",
+            hub="ohio",
+            label="ohio",
+        )
+    assert "42 queued" in phase
+    # Uses the MOST RECENT throttle poll (954), not the earliest (979).
+    assert "954" in phase
+    assert "900" in phase
+
+
+def test_drain_deferred_reports_opportunistic_capacity_skip():
+    """Opportunistic drain that hit ``at capacity`` and exited fast is
+    terminal — surface how many items remain deferred to the
+    batch-terminal patient drain, not a still-working state."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_drain(
+        log_filename="20260705-092302-bpl+phillips-academy-drain-deferred-opportunistic.log",
+        tail=(
+            "[INFO] 09:23:02: Drain-phase host lock acquired.\n"
+            "[INFO] 09:23:03: Drain-deferred (opportunistic): "
+            "Category:Duplicate at capacity; 7 item(s) remain in sidecar "
+            "for the batch's terminal drain."
+        ),
+        queued=7,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _mtime = get_phase_and_progress(
+            client=None,
+            session="wikimedia-bpl+phillips-academy",
+            hub="bpl",
+            label="bpl+phillips-academy",
+        )
+    assert "opportunistic" in phase
+    assert "7" in phase
+
+
+def test_drain_deferred_reports_complete_when_sidecar_drained():
+    """Sidecar drained to empty + ``Drain-deferred: complete.`` marker
+    → the phase is terminal and reports completion so the walker can
+    move on."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_drain(
+        log_filename="20260705-092303-drain-ohio-drain-deferred.log",
+        tail=(
+            "[INFO] 15:00:00: Drain-deferred: complete. Emitted "
+            "42 item(s) over 3600 seconds."
+        ),
+        queued=0,
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _mtime = get_phase_and_progress(
+            client=None,
+            session="wikimedia-ohio",
+            hub="ohio",
+            label="ohio",
+        )
+    assert phase.startswith("Drain complete")
 
 
 def test_get_phase_and_progress_returns_none_tuple_when_no_log_exists():


### PR DESCRIPTION
## Summary

Sessions whose download/upload/sdc chain has finished and moved on to draining their deferred-tagging sidecar were previously invisible to `/wikimedia-status` — the log-filename phase regex only knew `download|upload|sdc`, so the reporter stopped at the SDC log and posted `SDC complete` even while the tmux session was still very much alive: either holding the host flock and polling Category:Duplicate for capacity, or queued behind another partner's drain.

Observed on 2026-07-05: seven `wikimedia-*` tmux sessions posting `SDC complete` while actually spread across the drain-deferred lock chain (ohio holding, northwest-heritage / bpl / etc. waiting).

## What this adds

- `drain-deferred(-opportunistic)?` added to the phase alternation in both `log_filename_pattern_for_label` and `find_active_label`'s SSM query.
- A dedicated `_drain_deferred_phase` helper in `scripts/wikimedia_upload_status.py` that issues one drain-specific SSM call and returns a live phase string based on three signals:
  1. **Sidecar queue length** — live count from `<partner>/deferred-drain.json` (grep for 32-hex DPLA IDs; robust to schema drift, no jq dep).
  2. **Lock state** — presence of `Drain-phase host lock acquired.` in the log tail distinguishes lock-holder from lock-waiter.
  3. **Throttle position** — most recent `Category:Duplicate at N (>= resume threshold M)` line pulled by regex.

## Sample outputs

| State | Phase string |
|---|---|
| Queued behind another partner's drain | `Draining (drain: 8 queued, ⏸ waiting for host lock)` |
| Holding lock, throttled at capacity | `Draining (drain: 42 queued, Category:Duplicate at 954, needs < 900)` |
| Opportunistic drain skipped due to capacity | `Drain (opportunistic) skipped (7 deferred to terminal drain)` |
| Sidecar drained to empty | `Drain complete (0 still queued)` |

## Test plan

- [x] 4 new tests covering each drain-phase state + updated pattern coverage (56 status-script tests total)
- [x] Full suite passes (1,098 / 1,098)
- [ ] Trigger `/wikimedia-status` after merge; expect the currently-stuck `SDC complete` sessions to correctly render as `Draining (...)` with live queue/throttle numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated Wikimedia upload status reporting to recognize and track `drain-deferred` and `drain-deferred-opportunistic` session phases, so chained sessions that have finished download/upload/SDC but are still draining deferred-tagging work are no longer misreported as complete.

Key changes:
- Expanded log filename/active-label matching to include the new drain-deferred phase suffixes.
- Added drain-specific phase computation in `wikimedia_upload_status.py` using sidecar queue state, log-tail lock status, and the latest throttle position.
- Introduced new status outputs for queued, lock-waiting, throttled, opportunistic-skip, and drained-to-empty cases.
- Added tests covering the new phase matching and drain-deferred status scenarios.

No pipeline trigger, ECS redeploy, env var/Secrets changes, database migration, shared infrastructure changes, API shape changes, or security-impacting changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->