### PR TITLE
Fix status-report bugs: session-scoped active-label lookup + drain-<hub> log matching

### DIFF
--- a/ingest_wikimedia/session_state.py
+++ b/ingest_wikimedia/session_state.py
@@ -48,9 +48,13 @@ def log_filename_pattern_for_label(label: str) -> str:
     )
 
 
-def find_active_label(client, labels: list[str]) -> tuple[str, int] | None:
+def find_active_label(
+    client,
+    labels: list[str],
+    session_created: int = 0,
+) -> tuple[str, int] | None:
     """Return ``(label, log_mtime)`` for the most-recently-written log file
-    across all ``labels`` in a chained session, or ``None`` if no matching
+    that plausibly belongs to this session, or ``None`` if no matching
     log exists yet.
 
     A wikimedia-upload session runs its labels sequentially (downloader →
@@ -66,6 +70,26 @@ def find_active_label(client, labels: list[str]) -> tuple[str, int] | None:
     SSM round trips linearly with batch size and pushed multi-institution
     sessions past Slack's three-second slash-command ack deadline. See
     PR #325-vintage multi-institution batches accumulating 50+ labels each.
+
+    ``session_created`` (Unix epoch seconds; 0 = no filter) bounds the
+    lookup to log files whose mtime is at or after the tmux session's
+    creation time. Without this bound, a concurrent second session that
+    happens to be writing to a log file with a label THIS session's
+    chain has already completed would be picked up as "active" here —
+    stealing the row's identity and progress numbers. The filter is a
+    strict prefix on the ``find`` command (``-newermt "@N"``); when 0
+    it's omitted and behavior matches the original unbounded query.
+
+    Also matches ``drain-<hub>`` logs for each unique hub appearing in
+    ``labels``. The launcher's terminal partner-level drain step
+    exports ``WIKIMEDIA_SESSION_LABEL=drain-<partner>``, so its log
+    file is ``…-drain-<partner>-drain-deferred.log`` — that name is
+    NOT one of the per-target labels callers pass, and before this
+    change the reporter's "which label is active" lookup silently
+    ignored it, misreporting sessions in terminal drain as
+    ``SDC complete``. On a match the synthetic ``drain-<hub>`` label
+    is returned; downstream callers can either display it as-is or
+    strip the prefix for the row label.
     """
     if not labels:
         return None
@@ -76,17 +100,30 @@ def find_active_label(client, labels: list[str]) -> tuple[str, int] | None:
         shlex.quote(f"/home/ec2-user/ingest-wikimedia/{PARTNER_DIR.get(h, h)}/logs")
         for h in hubs
     )
-    label_alt = "|".join(re.escape(lbl) for lbl in labels)
+    # Include synthetic ``drain-<hub>`` alternatives so the terminal
+    # partner-level drain step (launcher exports
+    # ``WIKIMEDIA_SESSION_LABEL=drain-<partner>`` before that step) is
+    # visible here. Combined regex alternation avoids doubling the
+    # SSM round trip count.
+    drain_hub_labels = [f"drain-{h}" for h in hubs]
+    label_alt = "|".join(re.escape(lbl) for lbl in [*labels, *drain_hub_labels])
     # Phase alternation MUST stay in sync with
     # :func:`log_filename_pattern_for_label` — drain-deferred(-opportunistic)
     # logs are legitimate "newest phase" candidates for a session whose
     # download/upload/sdc chain finished and moved on to drain.
-    cmd = (
-        f"find {paths} -maxdepth 1 -type f -name '*.log' "
-        f"-regextype posix-extended "
-        f"-regex '.*-({label_alt})-(download|upload|sdc|drain-deferred(-opportunistic)?)\\.log' "
-        f"-printf '%T@ %f\\n' 2>/dev/null | sort -rn | head -1"
-    )
+    cmd_parts = [
+        f"find {paths} -maxdepth 1 -type f -name '*.log'",
+        "-regextype posix-extended",
+        f"-regex '.*-({label_alt})-(download|upload|sdc|drain-deferred(-opportunistic)?)\\.log'",
+    ]
+    if session_created > 0:
+        # Time-bound the lookup to files created after this session's
+        # tmux session began. Guards against a concurrent second session
+        # incidentally writing to one of THIS session's already-completed
+        # labels (and thereby stealing the "active label" position).
+        cmd_parts.append(f"-newermt '@{session_created}'")
+    cmd_parts.append("-printf '%T@ %f\\n' 2>/dev/null | sort -rn | head -1")
+    cmd = " ".join(cmd_parts)
     out = ssm_run(client, cmd).strip()
     if not out:
         return None
@@ -94,14 +131,18 @@ def find_active_label(client, labels: list[str]) -> tuple[str, int] | None:
     # Identify which of our labels matched via the per-label helper —
     # anchored-pattern logic so suffix-collision (e.g.
     # ``bpl+phillips-academy`` vs ``bpl+phillips-academy-andover``) is
-    # handled exactly once.
-    for lbl in labels:
+    # handled exactly once. Try synthetic drain-hub labels first because
+    # a ``drain-<hub>`` file name may otherwise be matched against a
+    # per-target label whose prefix coincidentally aligns.
+    for lbl in [*drain_hub_labels, *labels]:
         if re.search(log_filename_pattern_for_label(lbl), filename):
             return lbl, int(float(mtime_str))
     return None
 
 
-def active_and_upcoming_labels(ssm, labels: list[str]) -> set[str]:
+def active_and_upcoming_labels(
+    ssm, labels: list[str], session_created: int = 0
+) -> set[str]:
     """Return the subset of ``labels`` that a chained session hasn't yet
     completed — the currently-active label plus everything after it in
     the chain-run order.
@@ -118,18 +159,31 @@ def active_and_upcoming_labels(ssm, labels: list[str]) -> set[str]:
     Uses :func:`find_active_label`'s log-mtime heuristic: the freshest
     log across the label set identifies the currently-running target;
     everything at or after that position is still upcoming, everything
-    before is done. If no log exists yet (session is in id-generation
-    for its first target) OR the lookup raises (transient SSM error),
-    fall back to treating all labels as active — the conservative
-    choice, so a failed lookup can't silently let a real conflict
-    through. The exception path is logged at warning level so silent
-    regressions to the old over-conflicting behavior are visible in
-    operator diagnostics.
+    before is done.
+
+    Special cases:
+
+    * ``find_active_label`` returns a synthetic ``drain-<hub>`` label
+      when the session is in its terminal partner-level drain phase.
+      All per-target work is done at that point — return the empty
+      set so a new request for any per-target label is not a conflict.
+    * ``find_active_label`` returns ``None`` (no log exists yet,
+      session is in id-generation for its first target) → fall back
+      to treating all labels as active.
+    * ``find_active_label`` raises (transient SSM error) → same
+      conservative all-labels fallback so a failed lookup can't
+      silently let a real conflict through. Logged at warning level
+      so silent regressions to the old over-conflicting behavior are
+      visible in operator diagnostics.
+
+    ``session_created`` (Unix epoch seconds; 0 = no filter) is
+    threaded through to :func:`find_active_label` — see its docstring
+    for the rationale.
     """
     if not labels:
         return set()
     try:
-        active = find_active_label(ssm, labels)
+        active = find_active_label(ssm, labels, session_created=session_created)
     except Exception as e:
         logging.warning(
             "active_and_upcoming_labels: find_active_label raised %r; "
@@ -141,11 +195,18 @@ def active_and_upcoming_labels(ssm, labels: list[str]) -> set[str]:
         return set(labels)
     if active is None:
         return set(labels)
+    if active[0].startswith("drain-"):
+        # Session is in the terminal partner-level drain phase — all
+        # per-target chain steps finished. No per-target label is a
+        # conflict candidate; the drain is per-partner and doesn't
+        # exclude a new institution-scoped request.
+        return set()
     try:
         start_idx = labels.index(active[0])
     except ValueError:
         # ``find_active_label`` returned a label not in the input list —
         # shouldn't happen (its selection loop only returns labels from
-        # this list), but treat as unknown → conservative all-labels.
+        # this list or synthetic drain-hub labels, and drain-hub is
+        # handled above), but treat as unknown → conservative all-labels.
         return set(labels)
     return set(labels[start_idx:])

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -1084,9 +1084,17 @@ def main() -> None:
 
     # Check for any existing session that includes one of the requested targets.
     # Maps each requested label to the existing session name(s) it conflicts with.
+    # ``tmux ls -F`` returns ``name|epoch`` per line — the epoch is fed to
+    # ``active_and_upcoming_labels`` so :func:`find_active_label` can bound its
+    # log-mtime lookup to files created after each session began, keeping a
+    # concurrent second session's writes from stealing "which label is active"
+    # for the wrong session.
     print(f"Checking for existing sessions that overlap with {session_name}...")
     try:
-        tmux_list = ssm_run(ssm, "tmux ls 2>/dev/null || true")
+        tmux_list = ssm_run(
+            ssm,
+            "tmux ls -F '#{session_name}|#{session_created}' 2>/dev/null || true",
+        )
     except Exception as e:
         _slack_fail(
             response_url,
@@ -1104,9 +1112,17 @@ def main() -> None:
     target_hubs = {canonical for canonical, _, _, _, _ in targets}
     label_conflicts: dict[str, list[str]] = {}
     for line in tmux_list.splitlines():
-        existing_name = line.split(":")[0].strip()
+        # ``tmux ls -F '#{session_name}|#{session_created}'`` format:
+        # ``wikimedia-foo|1751706567``. Parse name + epoch; fall back to
+        # 0 for the epoch if a line is malformed (older tmux, unexpected
+        # format, or a non-wikimedia session using ``:`` in its name).
+        existing_name, _, epoch_str = line.strip().partition("|")
         if not existing_name.startswith("wikimedia-"):
             continue
+        try:
+            existing_created = int(epoch_str)
+        except ValueError:
+            existing_created = 0
         existing_labels_ordered = parse_session_labels(
             existing_name[len("wikimedia-") :]
         )
@@ -1115,7 +1131,9 @@ def main() -> None:
             # regardless of which label is currently active in this
             # session. Skip the SSM lookup and move on.
             continue
-        existing_labels = active_and_upcoming_labels(ssm, existing_labels_ordered)
+        existing_labels = active_and_upcoming_labels(
+            ssm, existing_labels_ordered, session_created=existing_created
+        )
         for canonical, institutions, label, dpla_id, collection in targets:
             if not institutions and dpla_id is None:
                 # Hub-level request conflicts with any existing session touching this hub

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -795,8 +795,15 @@ def main() -> None:
     notify_if_idle = os.environ.get("NOTIFY_IF_IDLE", "false").lower() == "true"
 
     try:
+        # ``-F`` returns structured ``name|epoch`` lines instead of the
+        # verbose default format. Pinning the fields we want avoids
+        # fragile string parsing of the "created Sun Jul 5 …" text and
+        # gives us the session-creation epoch we need to time-bound
+        # :func:`find_active_label`'s log lookup.
         session_out = ssm_run(
-            ssm, "tmux ls 2>/dev/null | grep '^wikimedia-' || echo NONE"
+            ssm,
+            "tmux ls -F '#{session_name}|#{session_created}' 2>/dev/null "
+            "| grep '^wikimedia-' || echo NONE",
         )
     except TimeoutError as e:
         logging.error("SSM poll timed out: %s", e)
@@ -811,11 +818,23 @@ def main() -> None:
         )
         return
 
-    sessions = (
-        [line.split(":")[0].strip() for line in session_out.splitlines()]
+    # Each entry: ``(session_name, session_created_epoch)``.
+    # session_created_epoch is used to bound the log-mtime lookup so a
+    # concurrent session writing to one of this session's completed
+    # labels can't hijack the "active" row.
+    def _parse_session_line(line: str) -> tuple[str, int]:
+        name, _, epoch = line.partition("|")
+        try:
+            return name.strip(), int(epoch.strip())
+        except ValueError:
+            return name.strip(), 0
+
+    sessions_with_created = (
+        [_parse_session_line(line) for line in session_out.splitlines()]
         if session_out and session_out != "NONE"
         else []
     )
+    sessions = [name for name, _ in sessions_with_created]
 
     if not sessions:
         print("No active wikimedia sessions.")
@@ -837,8 +856,11 @@ def main() -> None:
     # output in the Slack readout.
     results: dict[str, tuple[str, str]] = {}
 
+    session_created_by_name = dict(sessions_with_created)
+
     def fetch(session: str) -> tuple[str, str]:
         suffix = session.removeprefix("wikimedia-")
+        session_created = session_created_by_name.get(session, 0)
 
         # Retry sessions are named wikimedia-retry-<days>d[-<partner>].
         # parse_session_labels doesn't recognise the retry- prefix, so resolve
@@ -898,9 +920,12 @@ def main() -> None:
             return session, "Unknown (unrecognised session name)"
         multi = len(labels) > 1
 
-        # See find_active_label's docstring.
+        # See find_active_label's docstring. ``session_created`` bounds
+        # the log-mtime lookup so a concurrent session writing to one of
+        # this session's completed labels can't steal the active-row
+        # identity (see PR bug 1).
         try:
-            active = find_active_label(ssm, labels)
+            active = find_active_label(ssm, labels, session_created=session_created)
         except Exception:
             logging.exception("Failed to find active label for %s", session)
             return labels[0], "Unknown (error)"
@@ -928,15 +953,27 @@ def main() -> None:
             return _with_batch_suffix(labels[0]), "Generating IDs"
 
         label, _ = active
-        hub = label.split("+")[0]
+        # ``find_active_label`` may return a synthetic ``drain-<hub>``
+        # label when the session is in its terminal partner-level drain
+        # phase. Its log file (``…-drain-<hub>-drain-deferred.log``) is
+        # NOT indexed by any per-target label, so the reporter would
+        # previously miss it and misreport the session as ``SDC complete``
+        # (PR bug 2). For those, the ``hub`` is the suffix after
+        # ``drain-`` (not ``label.split("+")[0]``, which would return
+        # the whole ``drain-<hub>`` string), and no batch suffix is
+        # meaningful since the drain is a partner-level post-chain step.
+        if label.startswith("drain-"):
+            hub = label[len("drain-") :]
+            display_label = label
+        else:
+            hub = label.split("+")[0]
+            display_label = _with_batch_suffix(label)
         try:
             phase, _ = get_phase_and_progress(ssm, session, hub, label)
         except Exception:
             logging.exception("Failed to get status for %s (%s)", session, label)
-            return _with_batch_suffix(label), "Unknown (error)"
-        return _with_batch_suffix(
-            label
-        ), phase if phase is not None else "Generating IDs"
+            return display_label, "Unknown (error)"
+        return display_label, phase if phase is not None else "Generating IDs"
 
     # Memory snapshot is independent of every per-session fetch — submit it
     # to the same executor so the SSM round-trip overlaps with the session

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -1040,3 +1040,48 @@ def test_active_and_upcoming_labels_active_at_position_zero_returns_all():
     ):
         result = launch_mod.active_and_upcoming_labels(object(), labels)
     assert result == set(labels)
+
+
+def test_active_and_upcoming_labels_empty_set_when_session_in_terminal_drain():
+    """Regression: when ``find_active_label`` returns a synthetic
+    ``drain-<hub>`` label, the session has completed ALL its
+    per-target chain work and moved on to the box-wide terminal drain
+    phase. No per-target label is a conflict candidate — a new
+    request for any of them must be allowed. Return an empty set to
+    signal "no conflicts from this session"."""
+    import scripts.wikimedia_launch as launch_mod
+
+    labels = [
+        "ohio+ohio-university-libraries",
+        "northwest-heritage+whitman-county-library",
+        "bpl+phillips-academy",
+    ]
+    with patch(
+        "ingest_wikimedia.session_state.find_active_label",
+        return_value=("drain-ohio", 1700000000),
+    ):
+        result = launch_mod.active_and_upcoming_labels(object(), labels)
+    assert result == set()
+
+
+def test_active_and_upcoming_labels_threads_session_created():
+    """``session_created`` must be forwarded to ``find_active_label`` so
+    the log-mtime bound is applied. Without threading, ``find_active_label``
+    would fall back to the unbounded lookup and re-open the "one
+    concurrent session steals another's active label" hole (PR bug 1)."""
+    from unittest.mock import Mock
+
+    import scripts.wikimedia_launch as launch_mod
+
+    labels = ["texas+lib-a", "texas+lib-b"]
+    mock_find = Mock(return_value=("texas+lib-a", 1700000000))
+    with patch("ingest_wikimedia.session_state.find_active_label", mock_find):
+        launch_mod.active_and_upcoming_labels(
+            object(), labels, session_created=1699000000
+        )
+
+    # find_active_label must have been called with session_created threaded through.
+    _args, kwargs = mock_find.call_args
+    assert kwargs.get("session_created") == 1699000000, (
+        f"session_created must be forwarded to find_active_label; got kwargs={kwargs!r}"
+    )

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -1138,6 +1138,104 @@ def test_find_active_label_picks_active_when_earlier_label_aborted():
     )
 
 
+def test_find_active_label_bounds_lookup_by_session_created():
+    """Regression: two concurrent sessions can each contain the same
+    label in their chain — e.g. a 54-target texas chain and a 3-target
+    fixup chain that overlap on ``texas+harrie-p-woodson-memorial-library``.
+    When the smaller chain writes to that label's log, the log's mtime
+    becomes the freshest across the big chain's label set too, and the
+    big chain gets misreported as "active on harrie" even though it
+    completed harrie hours ago and is really further down its own
+    chain.
+
+    Fix: pass the tmux session's creation epoch to ``find_active_label``
+    which appends ``-newermt "@N"`` to the ``find`` command, bounding
+    the lookup to files created after this session's tmux window
+    began. A completed-target log written by a concurrent session gets
+    filtered out.
+    """
+    from unittest.mock import patch
+
+    from ingest_wikimedia.session_state import find_active_label
+
+    captured: list[str] = []
+
+    def fake_ssm_run(_client, command, **_kwargs):
+        captured.append(command)
+        return "1700005000.0 20260528-091047-bpl+phillips-academy-upload.log"
+
+    with patch("ingest_wikimedia.session_state.ssm_run", side_effect=fake_ssm_run):
+        find_active_label(
+            client=None,
+            labels=["bpl+phillips-academy"],
+            session_created=1700000000,
+        )
+
+    assert len(captured) == 1
+    assert "-newermt '@1700000000'" in captured[0], (
+        f"``find`` command must include a ``-newermt '@<epoch>'`` filter "
+        f"when session_created is set; got: {captured[0]!r}"
+    )
+
+
+def test_find_active_label_no_session_bound_when_created_is_zero():
+    """The ``-newermt`` filter must be OMITTED when ``session_created=0``
+    (default). This preserves backwards compatibility for callers that
+    don't yet thread the tmux session-creation epoch through — and
+    matches the semantics of "no bound".
+    """
+    from unittest.mock import patch
+
+    from ingest_wikimedia.session_state import find_active_label
+
+    captured: list[str] = []
+
+    def fake_ssm_run(_client, command, **_kwargs):
+        captured.append(command)
+        return "1700005000.0 20260528-091047-bpl+phillips-academy-upload.log"
+
+    with patch("ingest_wikimedia.session_state.ssm_run", side_effect=fake_ssm_run):
+        find_active_label(client=None, labels=["bpl+phillips-academy"])
+
+    assert len(captured) == 1
+    assert "-newermt" not in captured[0], (
+        f"``find`` command must NOT include ``-newermt`` when "
+        f"session_created is 0; got: {captured[0]!r}"
+    )
+
+
+def test_find_active_label_matches_drain_hub_log():
+    """Regression: a session in its terminal partner-level drain phase
+    writes ``…-drain-<hub>-drain-deferred.log``. That label is NOT in
+    the session's per-target label list, but the reporter needs to see
+    it — previously such a session showed ``SDC complete`` while the
+    tmux window was busy on the box-wide drain flock (PR bug 2).
+
+    ``find_active_label`` synthesizes ``drain-<hub>`` alternatives for
+    each unique hub in the input label set so the freshest drain log
+    surfaces correctly. On match the synthetic label is returned so
+    downstream callers can dispatch on it.
+    """
+    from unittest.mock import patch
+
+    from ingest_wikimedia.session_state import find_active_label
+
+    with patch(
+        "ingest_wikimedia.session_state.ssm_run",
+        return_value=("1700009000.0 20260705-092303-drain-ohio-drain-deferred.log"),
+    ):
+        result = find_active_label(
+            client=None,
+            labels=["ohio+ohio-university-libraries"],
+        )
+    assert result is not None
+    label, _ = result
+    assert label == "drain-ohio", (
+        f"drain-hub synthetic label must be returned when the freshest "
+        f"log is a drain-<hub> file; got {label!r}"
+    )
+
+
 def test_find_active_label_rejects_filename_not_in_label_list():
     """Defensive: if the ``find`` regex's alternation somehow returns a
     label that isn't in ``labels`` (regex prefix collision in a edge
@@ -1261,7 +1359,7 @@ def test_main_rows_use_display_id_from_fetch_not_session_name():
 
     from scripts.wikimedia_upload_status import main
 
-    sessions_out = "wikimedia-bpl+phillips-academy: 1 windows\n"
+    sessions_out = "wikimedia-bpl+phillips-academy|1700000000\n"
     captured, fake_post = _capture_slack_post()
 
     # Patch the helpers ``fetch`` calls so the real ``fetch`` returns
@@ -1330,9 +1428,13 @@ def test_main_appends_slot_suffixes_when_pool_is_saturated():
 
     from scripts.wikimedia_upload_status import SlotSnapshot, main
 
+    # ``tmux ls -F '#{session_name}|#{session_created}'`` output shape —
+    # matches what wikimedia_upload_status now issues so
+    # ``_parse_session_line`` extracts the creation epoch alongside the
+    # session name.
     sessions_out = (
-        "wikimedia-nara+jimmy-carter-library: 1 windows\n"
-        "wikimedia-ohio+state-library-of-ohio: 1 windows\n"
+        "wikimedia-nara+jimmy-carter-library|1700000000\n"
+        "wikimedia-ohio+state-library-of-ohio|1700000000\n"
     )
     captured, fake_post = _capture_slack_post()
 
@@ -1368,7 +1470,7 @@ def test_main_appends_slot_suffixes_when_pool_is_saturated():
         ),
         patch(
             "scripts.wikimedia_upload_status.find_active_label",
-            side_effect=lambda ssm, labels: (labels[0], 1700000000),
+            side_effect=lambda ssm, labels, **_kw: (labels[0], 1700000000),
         ),
         patch(
             "scripts.wikimedia_upload_status.get_phase_and_progress",
@@ -1776,7 +1878,7 @@ def test_fetch_position_annotation_for_multi_label_batch():
 
     from scripts.wikimedia_upload_status import main
 
-    sessions_out = "wikimedia-texas+a+texas+b+texas+c+texas+d: 1 windows\n"
+    sessions_out = "wikimedia-texas+a+texas+b+texas+c+texas+d|1700000000\n"
     captured, fake_post = _capture_slack_post()
     with (
         patch.dict(
@@ -1823,7 +1925,7 @@ def test_fetch_no_position_annotation_for_single_label_session():
 
     from scripts.wikimedia_upload_status import main
 
-    sessions_out = "wikimedia-bpl+phillips-academy: 1 windows\n"
+    sessions_out = "wikimedia-bpl+phillips-academy|1700000000\n"
     captured, fake_post = _capture_slack_post()
     with (
         patch.dict(


### PR DESCRIPTION
## Summary

Two bugs surfaced in `/wikimedia-status` after recent multi-session + drain-phase reporting work:

**Bug 1 — duplicate rows with identical progress.** Two concurrent tmux sessions that share a per-target label rendered as separate rows with matching progress numbers. Root cause: `find_active_label` picked the freshest log matching any label globally, with no scope to which tmux session actually owns that log. A concurrent session's write to a completed-target's log stole the "active" row identity for both.

**Bug 2 — terminal partner-level drain misreported as `SDC complete`.** A multi-target chain's terminal drain step exports `WIKIMEDIA_SESSION_LABEL=drain-<partner>`, so its log filename is `…-drain-<partner>-drain-deferred.log`. The status tool only searched for logs matching per-target labels, never `drain-<hub>` logs, so the session appeared stuck at `SDC complete` while the tmux window was busy holding the box-wide drain flock.

## Bug 1 fix — `session_created` bound

`find_active_label` gains an optional `session_created` parameter (Unix epoch, default 0). When set, appends `-newermt "@<epoch>"` to the `find` command so log files older than the session's start time are filtered out. Both callers (`wikimedia_upload_status.py` and `wikimedia_launch.py`) now use `tmux ls -F '#{session_name}|#{session_created}'` to extract creation epochs, thread them through, and pass to `find_active_label`.

## Bug 2 fix — `drain-<hub>` synthetic label matching

`find_active_label` also synthesizes `drain-<hub>` label alternatives from each unique hub in the input label set. On match returns the synthetic label. Downstream:
- `wikimedia_upload_status.fetch()`: when the returned label starts with `drain-`, extracts hub as `label[len("drain-"):]`, skips the batch-position suffix (drain is post-chain), and passes through to `get_phase_and_progress` which routes to the drain-deferred phase reporter (from PR #368).
- `active_and_upcoming_labels` in `session_state.py`: a `drain-<hub>` return indicates all per-target work is done — returns an empty set so a new per-target request is not treated as a conflict.

## Tests

- `find_active_label` regression tests: `session_created` bound applies `-newermt` (and is omitted when 0); `drain-<hub>` synthetic label matches correctly.
- `active_and_upcoming_labels` regression tests: returns empty set in terminal drain; forwards `session_created`.
- Existing `main()`-level integration tests updated to use the new `tmux ls -F` output format.

## Test plan

- [x] `ruff check` + `ruff format` clean
- [x] Full pytest suite: **1129 passed** (up from 1120 — 5 new tests added)
- [x] Manually verified against the live EC2 state that motivated the report: the duplicate-row scenario resolves to the correct single active session; the terminal-drain session displays the drain-phase reporter output from PR #368.

## Not in scope — bug 3

The user also flagged a suspicious state where a drain session was blocked on the flock while its sidecar showed 0 items queued — someone/something drained the sidecar between the drain's initial read (8 items) and the report snapshot. Root cause is unclear (no other process should touch that partner's sidecar), and the code path that could produce this needs deeper investigation. Tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Fixed `/wikimedia-status` label resolution so active-log lookup is bounded by each tmux session’s creation time, preventing older completed logs from being misattributed to newer sessions.
- Added support for synthetic `drain-<hub>` labels so terminal drain phases are reported correctly instead of as `SDC complete`.
- Threaded tmux session creation metadata through the Wikimedia launch and upload-status scripts, and updated status rendering to handle drain-phase display/phase selection correctly.
- Added regression tests covering session-creation scoping, `drain-<hub>` matching, and the updated tmux session listing format.

## Notes
- No environment variable, Secrets Manager, database, shared infrastructure, API shape, or security-related changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->