### PR TITLE
Fix sidecar path double-nesting + subprocess-based active label + drain-hub row attribution

### DIFF
--- a/ingest_wikimedia/drain_sidecar.py
+++ b/ingest_wikimedia/drain_sidecar.py
@@ -25,19 +25,35 @@ import os
 import tempfile
 from pathlib import Path
 
+from ingest_wikimedia.partners import PARTNER_DIR
+
 SIDECAR_FILENAME = "deferred-drain.json"
+
+# Absolute anchor for the sidecar path — CWD-independent, so
+# uploader/sdc-sync/drain-deferred callers (which ``cd`` into
+# ``<root>/<partner_dir>/`` before executing) all resolve to the same
+# flat ``<root>/<partner_dir>/deferred-drain.json`` rather than a
+# doubly-nested variant. Tests monkeypatch this to a tmp dir.
+INGEST_WIKI_ROOT = Path("/home/ec2-user/ingest-wikimedia")
+
+
+def partner_dir_path(partner: str) -> Path:
+    """Absolute path to the partner's working directory under
+    :data:`INGEST_WIKI_ROOT`. Resolves ``si`` → ``smithsonian`` via
+    :data:`PARTNER_DIR`; other slugs pass through unchanged.
+    """
+    return INGEST_WIKI_ROOT / PARTNER_DIR.get(partner, partner)
 
 
 def sidecar_path(partner: str) -> Path:
     """Absolute path to the deferred-drain sidecar for ``partner``.
 
-    Uses the same per-partner working directory the uploader / sdc-sync
-    CLI commands run from (their CWD when launched by the tmux
-    pipeline). Callers may pass either the canonical partner slug
-    (``nara``) or a directory-name variant (``smithsonian`` for the ``si``
-    slug); resolution belongs on the caller side.
+    Anchored at :data:`INGEST_WIKI_ROOT` so it's independent of the
+    caller's CWD. The partner slug is resolved through
+    :data:`PARTNER_DIR` to handle slugs whose on-disk directory name
+    differs (``si`` → ``smithsonian``).
     """
-    return Path(partner) / SIDECAR_FILENAME
+    return partner_dir_path(partner) / SIDECAR_FILENAME
 
 
 def read_sidecar(partner: str) -> list[str]:

--- a/ingest_wikimedia/session_state.py
+++ b/ingest_wikimedia/session_state.py
@@ -43,15 +43,17 @@ def snapshot_running_active_labels(client) -> dict[str, str]:
     tell which session's subprocess is writing the log; env-var reads
     directly attribute the write.
 
-    ``sort -k2 -r`` on ``lstart`` picks the newest child as a tie-
-    breaker when a step has transient helper forks alongside the main
-    step.
+    Sorted numerically by ``etimes`` (elapsed seconds) ascending — the
+    smallest value is the most recently started direct child, which
+    is the correct pick when a step has transient helper forks
+    alongside the main step. ``lstart`` output is calendar text and
+    doesn't sort chronologically.
     """
     out = ssm_run(
         client,
         r"""tmux list-panes -aF '#{session_name}|#{pane_pid}' 2>/dev/null | while IFS='|' read name pane_pid; do
   case "$name" in wikimedia-*) : ;; *) continue ;; esac
-  child_pid=$(ps --ppid "$pane_pid" -o pid=,lstart= 2>/dev/null | sort -k2 -r | head -1 | awk '{print $1}')
+  child_pid=$(ps --ppid "$pane_pid" -o pid=,etimes= 2>/dev/null | sort -k2 -n | head -1 | awk '{print $1}')
   [ -z "$child_pid" ] && continue
   label=$(tr '\0' '\n' < /proc/"$child_pid"/environ 2>/dev/null | grep -m1 '^WIKIMEDIA_SESSION_LABEL=' | cut -d= -f2-)
   [ -n "$label" ] && echo "$name|$label"

--- a/ingest_wikimedia/session_state.py
+++ b/ingest_wikimedia/session_state.py
@@ -22,6 +22,53 @@ from ingest_wikimedia.partners import PARTNER_DIR
 from ingest_wikimedia.ssm import ssm_run
 
 
+# Valid launcher-exported ``WIKIMEDIA_SESSION_LABEL`` shapes:
+# ``<hub>+<institution>`` (per-target), ``drain-<hub>`` (terminal
+# partner drain), ``retry-<hub>`` (retry pipeline).
+def _valid_session_label(label: str) -> bool:
+    return bool(label) and ("+" in label or label.startswith(("drain-", "retry-")))
+
+
+def snapshot_running_active_labels(client) -> dict[str, str]:
+    """One SSM roundtrip: for every ``wikimedia-*`` tmux session, return
+    the active session label read from its currently-running direct-
+    child subprocess's ``WIKIMEDIA_SESSION_LABEL`` env var. Sessions
+    with no running child are omitted; callers should fall back to
+    :func:`find_active_label` for those.
+
+    Direct-evidence signal: the launcher exports
+    ``WIKIMEDIA_SESSION_LABEL`` on every step, so every pipeline
+    subprocess inherits it. Beats :func:`find_active_label`'s log-mtime
+    heuristic when two sessions share a target label — mtime can't
+    tell which session's subprocess is writing the log; env-var reads
+    directly attribute the write.
+
+    ``sort -k2 -r`` on ``lstart`` picks the newest child as a tie-
+    breaker when a step has transient helper forks alongside the main
+    step.
+    """
+    out = ssm_run(
+        client,
+        r"""tmux list-panes -aF '#{session_name}|#{pane_pid}' 2>/dev/null | while IFS='|' read name pane_pid; do
+  case "$name" in wikimedia-*) : ;; *) continue ;; esac
+  child_pid=$(ps --ppid "$pane_pid" -o pid=,lstart= 2>/dev/null | sort -k2 -r | head -1 | awk '{print $1}')
+  [ -z "$child_pid" ] && continue
+  label=$(tr '\0' '\n' < /proc/"$child_pid"/environ 2>/dev/null | grep -m1 '^WIKIMEDIA_SESSION_LABEL=' | cut -d= -f2-)
+  [ -n "$label" ] && echo "$name|$label"
+done""",
+    )
+    result: dict[str, str] = {}
+    for line in (out or "").splitlines():
+        name, sep, label = line.partition("|")
+        if not sep:
+            continue
+        name = name.strip()
+        label = label.strip()
+        if name and _valid_session_label(label):
+            result[name] = label
+    return result
+
+
 def log_filename_pattern_for_label(label: str) -> str:
     """Anchored regex matching log filenames for exactly this label.
 
@@ -141,72 +188,54 @@ def find_active_label(
 
 
 def active_and_upcoming_labels(
-    ssm, labels: list[str], session_created: int = 0
+    ssm,
+    labels: list[str],
+    session_created: int = 0,
+    active_label: str | None = None,
 ) -> set[str]:
-    """Return the subset of ``labels`` that a chained session hasn't yet
-    completed — the currently-active label plus everything after it in
-    the chain-run order.
+    """Return the subset of ``labels`` a chained session hasn't yet
+    completed — the currently-active label plus everything after it
+    in chain-run order.
 
-    A wikimedia-upload tmux session runs its targets sequentially. Once
-    a target's ``sdc-sync`` phase finishes and the ``&&`` chain moves on,
-    that target is done; a new incoming request naming that same target
-    is NOT a conflict and should be allowed to run alongside the ongoing
-    session. Pre-fix, the launcher's conflict check naively compared
-    against **every** label in the tmux session name, causing a 54-target
-    chained session to block every new request naming any of its 54
-    institutions — even institutions whose target completed hours ago.
+    A wikimedia-upload session runs its targets sequentially, so a
+    target the session has passed cannot conflict with a new request
+    naming that same target. Pre-fix, the launcher's conflict check
+    naively compared against every label in the tmux session name,
+    causing a 54-target chained session to block every new request
+    naming any of its 54 institutions — even institutions whose target
+    completed hours ago.
 
-    Uses :func:`find_active_label`'s log-mtime heuristic: the freshest
-    log across the label set identifies the currently-running target;
-    everything at or after that position is still upcoming, everything
-    before is done.
-
-    Special cases:
-
-    * ``find_active_label`` returns a synthetic ``drain-<hub>`` label
-      when the session is in its terminal partner-level drain phase.
-      All per-target work is done at that point — return the empty
-      set so a new request for any per-target label is not a conflict.
-    * ``find_active_label`` returns ``None`` (no log exists yet,
-      session is in id-generation for its first target) → fall back
-      to treating all labels as active.
-    * ``find_active_label`` raises (transient SSM error) → same
-      conservative all-labels fallback so a failed lookup can't
-      silently let a real conflict through. Logged at warning level
-      so silent regressions to the old over-conflicting behavior are
-      visible in operator diagnostics.
-
-    ``session_created`` (Unix epoch seconds; 0 = no filter) is
-    threaded through to :func:`find_active_label` — see its docstring
-    for the rationale.
+    ``active_label`` (from
+    :func:`snapshot_running_active_labels`) is the direct-evidence
+    signal — one ``WIKIMEDIA_SESSION_LABEL`` env-var read from the
+    session's running child. When ``None``, falls back to
+    :func:`find_active_label`'s log-mtime heuristic
+    (``session_created``-bounded so a concurrent session's write can't
+    steal identity). Both a ``drain-<hub>`` active label and a lookup
+    that finds no log yet return the empty and all-labels sets
+    respectively; a transient SSM error is logged and treated as the
+    latter so a lookup failure can't silently let a real conflict
+    through.
     """
     if not labels:
         return set()
-    try:
-        active = find_active_label(ssm, labels, session_created=session_created)
-    except Exception as e:
-        logging.warning(
-            "active_and_upcoming_labels: find_active_label raised %r; "
-            "falling back to conservative all-labels conflict scope. "
-            "Some completed targets may over-conflict until the SSM "
-            "lookup recovers.",
-            e,
-        )
-        return set(labels)
-    if active is None:
-        return set(labels)
-    if active[0].startswith("drain-"):
-        # Session is in the terminal partner-level drain phase — all
-        # per-target chain steps finished. No per-target label is a
-        # conflict candidate; the drain is per-partner and doesn't
-        # exclude a new institution-scoped request.
+    if active_label is None:
+        try:
+            found = find_active_label(ssm, labels, session_created=session_created)
+        except Exception as e:
+            logging.warning(
+                "active_and_upcoming_labels: find_active_label raised %r; "
+                "falling back to conservative all-labels conflict scope.",
+                e,
+            )
+            return set(labels)
+        if found is None:
+            return set(labels)
+        active_label = found[0]
+    if active_label.startswith("drain-"):
         return set()
     try:
-        start_idx = labels.index(active[0])
+        start_idx = labels.index(active_label)
     except ValueError:
-        # ``find_active_label`` returned a label not in the input list —
-        # shouldn't happen (its selection loop only returns labels from
-        # this list or synthetic drain-hub labels, and drain-hub is
-        # handled above), but treat as unknown → conservative all-labels.
         return set(labels)
     return set(labels[start_idx:])

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -49,7 +49,10 @@ from ingest_wikimedia.partners import (
     slugify_session_label_component,
     wikidata_qid_for_target,
 )
-from ingest_wikimedia.session_state import active_and_upcoming_labels
+from ingest_wikimedia.session_state import (
+    active_and_upcoming_labels,
+    snapshot_running_active_labels,
+)
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run, stage_and_launch_tmux
 
@@ -1086,9 +1089,13 @@ def main() -> None:
     # Maps each requested label to the existing session name(s) it conflicts with.
     # ``tmux ls -F`` returns ``name|epoch`` per line — the epoch is fed to
     # ``active_and_upcoming_labels`` so :func:`find_active_label` can bound its
-    # log-mtime lookup to files created after each session began, keeping a
+    # log-mtime fallback to files created after each session began, keeping a
     # concurrent second session's writes from stealing "which label is active"
-    # for the wrong session.
+    # for the wrong session. The active-label snapshot below is the primary
+    # (direct-evidence) signal — one SSM roundtrip covers every session, so
+    # the per-session loop can look up ``active_label`` in a dict rather than
+    # firing its own ``find_active_label_via_subprocess`` SSM roundtrip per
+    # candidate.
     print(f"Checking for existing sessions that overlap with {session_name}...")
     try:
         tmux_list = ssm_run(
@@ -1101,6 +1108,14 @@ def main() -> None:
             f"⚠️ Failed to list tmux sessions: {e}",
             operational=True,
         )
+    try:
+        active_label_snapshot = snapshot_running_active_labels(ssm)
+    except Exception as e:
+        # Fall through to the mtime heuristic per session on failure —
+        # conservative correctness is more important than the shared-
+        # label edge case when the snapshot roundtrip is broken.
+        print(f"Failed to snapshot active labels; falling back to mtime: {e}")
+        active_label_snapshot = {}
     # In-memory pre-filter: an existing session can only conflict with a
     # requested target if they share a hub prefix. Sessions on unrelated
     # hubs — the common case when the box runs 3+ concurrent partner
@@ -1132,7 +1147,10 @@ def main() -> None:
             # session. Skip the SSM lookup and move on.
             continue
         existing_labels = active_and_upcoming_labels(
-            ssm, existing_labels_ordered, session_created=existing_created
+            ssm,
+            existing_labels_ordered,
+            session_created=existing_created,
+            active_label=active_label_snapshot.get(existing_name),
         )
         for canonical, institutions, label, dpla_id, collection in targets:
             if not institutions and dpla_id is None:

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -10,7 +10,7 @@ import os
 import re
 import shlex
 import statistics
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 
 import boto3
 import requests
@@ -21,6 +21,7 @@ from ingest_wikimedia.partners import PARTNER_DIR, parse_session_labels, resolve
 from ingest_wikimedia.session_state import (
     find_active_label,
     log_filename_pattern_for_label,
+    snapshot_running_active_labels,
 )
 from ingest_wikimedia.ssm import REGION, fetch_memory_snapshot, ssm_run
 from ingest_wikimedia.worker_slots import (
@@ -857,6 +858,11 @@ def main() -> None:
     results: dict[str, tuple[str, str]] = {}
 
     session_created_by_name = dict(sessions_with_created)
+    # ``fetch`` waits on this future for the subprocess-based active-
+    # label signal (see :func:`snapshot_running_active_labels`). Assigned
+    # inside the executor block below; declared here so the closure
+    # captures the name and can be mutated at runtime.
+    active_labels_future: Future[dict[str, str]] | None = None
 
     def fetch(session: str) -> tuple[str, str]:
         suffix = session.removeprefix("wikimedia-")
@@ -920,15 +926,23 @@ def main() -> None:
             return session, "Unknown (unrecognised session name)"
         multi = len(labels) > 1
 
-        # See find_active_label's docstring. ``session_created`` bounds
-        # the log-mtime lookup so a concurrent session writing to one of
-        # this session's completed labels can't steal the active-row
-        # identity (see PR bug 1).
+        # Prefer the subprocess-based active-label snapshot; fall back
+        # to the log-mtime lookup only when no running child was found
+        # (id-generation cold start, between steps, or chain finished).
         try:
-            active = find_active_label(ssm, labels, session_created=session_created)
+            snapshot = active_labels_future.result() if active_labels_future else {}
         except Exception:
-            logging.exception("Failed to find active label for %s", session)
-            return labels[0], "Unknown (error)"
+            logging.exception("Snapshot future failed for %s", session)
+            snapshot = {}
+        subprocess_label = snapshot.get(session)
+        if subprocess_label is not None:
+            active: tuple[str, int] | None = (subprocess_label, 0)
+        else:
+            try:
+                active = find_active_label(ssm, labels, session_created=session_created)
+            except Exception:
+                logging.exception("Failed to find active label for %s", session)
+                return labels[0], "Unknown (error)"
 
         # For multi-label batches, suffix a `[<pos>/<total>]` position
         # annotation so the reader can tell at a glance how far along
@@ -953,18 +967,15 @@ def main() -> None:
             return _with_batch_suffix(labels[0]), "Generating IDs"
 
         label, _ = active
-        # ``find_active_label`` may return a synthetic ``drain-<hub>``
-        # label when the session is in its terminal partner-level drain
-        # phase. Its log file (``…-drain-<hub>-drain-deferred.log``) is
-        # NOT indexed by any per-target label, so the reporter would
-        # previously miss it and misreport the session as ``SDC complete``
-        # (PR bug 2). For those, the ``hub`` is the suffix after
-        # ``drain-`` (not ``label.split("+")[0]``, which would return
-        # the whole ``drain-<hub>`` string), and no batch suffix is
-        # meaningful since the drain is a partner-level post-chain step.
+        # Terminal partner-level drain: attribute the row to the batch's
+        # identity + a ``(drain: <hub>)`` annotation rather than
+        # displaying the raw ``drain-<hub>`` label as a standalone row.
         if label.startswith("drain-"):
             hub = label[len("drain-") :]
-            display_label = label
+            if multi:
+                display_label = f"{labels[0]} +{len(labels) - 1} more (drain: {hub})"
+            else:
+                display_label = f"{labels[0]} (drain: {hub})"
         else:
             hub = label.split("+")[0]
             display_label = _with_batch_suffix(label)
@@ -977,8 +988,13 @@ def main() -> None:
 
     # Memory snapshot is independent of every per-session fetch — submit it
     # to the same executor so the SSM round-trip overlaps with the session
-    # phase resolution rather than serializing after it.
-    with ThreadPoolExecutor(max_workers=min(len(sessions) + 2, 8)) as executor:
+    # phase resolution rather than serializing after it. Same treatment
+    # for the active-label snapshot: submitted first so it can overlap
+    # with memory/slots/per-session lookups; each ``fetch`` blocks on
+    # its result only if the snapshot hasn't landed by the time the
+    # thread needs it.
+    with ThreadPoolExecutor(max_workers=min(len(sessions) + 3, 8)) as executor:
+        active_labels_future = executor.submit(snapshot_running_active_labels, ssm)
         memory_future = executor.submit(fetch_memory_snapshot, ssm)
         slots_future = executor.submit(_fetch_slot_snapshot, ssm)
         futures = {executor.submit(fetch, s): s for s in sessions}

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -14,8 +14,11 @@ from tools import drain_deferred
 
 
 @pytest.fixture(autouse=True)
-def chdir_tmp(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
+def override_root(tmp_path, monkeypatch):
+    """Redirect ``drain_sidecar``'s absolute-anchor root into ``tmp_path``
+    so tests don't touch (or depend on) the real
+    ``/home/ec2-user/ingest-wikimedia/`` tree."""
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path)
     return tmp_path
 
 

--- a/tests/test_drain_sidecar.py
+++ b/tests/test_drain_sidecar.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 
 import pytest
 
@@ -11,11 +10,13 @@ from ingest_wikimedia import drain_sidecar
 
 
 @pytest.fixture(autouse=True)
-def chdir_tmp(tmp_path, monkeypatch):
-    """Every test runs in an isolated tmp directory so the sidecar
-    path (``<partner>/deferred-drain.json``) doesn't collide with any
-    real partner tree or between tests."""
-    monkeypatch.chdir(tmp_path)
+def override_root(tmp_path, monkeypatch):
+    """Every test runs against an isolated tmp root so the (absolute)
+    sidecar path doesn't collide with any real partner tree or between
+    tests. Anchoring at ``INGEST_WIKI_ROOT`` (not CWD) is what the
+    production code does — see the module docstring on ``drain_sidecar``.
+    """
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path)
     return tmp_path
 
 
@@ -176,10 +177,33 @@ def test_sidecar_path_is_partner_scoped():
     assert p.parent.name == "nara"
 
 
+def test_sidecar_path_is_absolute_and_ignores_cwd(tmp_path, monkeypatch):
+    """Path is anchored at ``INGEST_WIKI_ROOT``, independent of CWD."""
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path)
+    partner_dir = tmp_path / "nara"
+    partner_dir.mkdir()
+    monkeypatch.chdir(partner_dir)  # simulate the uploader's CWD
+    p = drain_sidecar.sidecar_path("nara")
+    assert p.is_absolute()
+    assert p == tmp_path / "nara" / "deferred-drain.json"
+    assert p != partner_dir / "nara" / "deferred-drain.json"
+
+
+def test_sidecar_path_uses_partner_dir_mapping_for_smithsonian(monkeypatch, tmp_path):
+    """The ``si`` slug maps to the ``smithsonian/`` directory on disk
+    (see :data:`ingest_wikimedia.partners.PARTNER_DIR`). Sidecar_path
+    must honor that so the drain finds the file at the same location
+    the launcher's ``cd`` targets."""
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path)
+    p = drain_sidecar.sidecar_path("si")
+    assert p == tmp_path / "smithsonian" / "deferred-drain.json"
+
+
 def test_write_creates_partner_directory_if_missing():
     """A drain phase that starts before any partner-dir files exist
     still gets a working sidecar."""
-    assert not os.path.isdir("nara")
+    partner_dir = drain_sidecar.sidecar_path("nara").parent
+    assert not partner_dir.exists()
     drain_sidecar.write_sidecar("nara", ["abc"])
-    assert os.path.isdir("nara")
+    assert partner_dir.is_dir()
     assert drain_sidecar.read_sidecar("nara") == ["abc"]

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -1253,6 +1253,148 @@ def test_find_active_label_rejects_filename_not_in_label_list():
     assert result is None
 
 
+def test_snapshot_running_active_labels_parses_multiple_sessions():
+    """Ground-truth signal for active-label detection: one SSM
+    roundtrip parses tmux+ps+/proc/<pid>/environ output into
+    ``{session_name: label}``. Each pipe-delimited line comes from a
+    running child of a distinct tmux session's bash pipeline; the
+    label field is that child's ``WIKIMEDIA_SESSION_LABEL`` env var.
+    """
+    from unittest.mock import patch
+
+    from ingest_wikimedia.session_state import snapshot_running_active_labels
+
+    with patch(
+        "ingest_wikimedia.session_state.ssm_run",
+        return_value=(
+            "wikimedia-texas+livingston-and-53-more"
+            "|texas+botanical-research-institute-of-texas\n"
+            "wikimedia-texas+montgomery-plus-2"
+            "|texas+harrie-p-woodson-memorial-library\n"
+            "wikimedia-ohio-and-3-more|drain-ohio\n"
+        ),
+    ):
+        snap = snapshot_running_active_labels(client=None)
+    assert snap == {
+        "wikimedia-texas+livingston-and-53-more": (
+            "texas+botanical-research-institute-of-texas"
+        ),
+        "wikimedia-texas+montgomery-plus-2": (
+            "texas+harrie-p-woodson-memorial-library"
+        ),
+        "wikimedia-ohio-and-3-more": "drain-ohio",
+    }
+
+
+def test_snapshot_running_active_labels_disambiguates_shared_labels():
+    """The core defect the subprocess signal fixes: two concurrent
+    sessions have the SAME target label (e.g. both texas chains include
+    harrie-p-woodson). The mtime heuristic can't distinguish which
+    session's subprocess is writing the log right now, so it mis-
+    attributes. The subprocess signal (reading each session's running
+    child's ``WIKIMEDIA_SESSION_LABEL``) resolves that unambiguously.
+    """
+    from unittest.mock import patch
+
+    from ingest_wikimedia.session_state import snapshot_running_active_labels
+
+    # Big chain is on 'botanical', small chain is on 'harrie-p-woodson'.
+    # A pure-mtime heuristic would have picked harrie-p-woodson for
+    # BOTH sessions because the small chain is writing that log right
+    # now (highest mtime across the big chain's label set too).
+    with patch(
+        "ingest_wikimedia.session_state.ssm_run",
+        return_value=(
+            "wikimedia-texas+livingston-and-53-more"
+            "|texas+botanical-research-institute-of-texas\n"
+            "wikimedia-texas+montgomery-plus-2"
+            "|texas+harrie-p-woodson-memorial-library\n"
+        ),
+    ):
+        snap = snapshot_running_active_labels(client=None)
+    assert (
+        snap["wikimedia-texas+livingston-and-53-more"]
+        == "texas+botanical-research-institute-of-texas"
+    )
+    assert (
+        snap["wikimedia-texas+montgomery-plus-2"]
+        == "texas+harrie-p-woodson-memorial-library"
+    )
+
+
+def test_snapshot_running_active_labels_empty_output():
+    """No sessions with a running child (all sessions in id-generation
+    cold start, or no sessions at all) → empty dict, callers fall back
+    to :func:`find_active_label`."""
+    from unittest.mock import patch
+
+    from ingest_wikimedia.session_state import snapshot_running_active_labels
+
+    with patch("ingest_wikimedia.session_state.ssm_run", return_value=""):
+        assert snapshot_running_active_labels(client=None) == {}
+
+
+def test_active_and_upcoming_labels_uses_provided_active_label_over_mtime():
+    """Passing a pre-resolved ``active_label`` skips the mtime lookup —
+    load-bearing property: callers pre-fetch the snapshot once, then
+    invoke this helper per-session as a pure decision over the
+    resolved label."""
+    from unittest.mock import patch
+
+    from ingest_wikimedia.session_state import active_and_upcoming_labels
+
+    labels = ["ohio+a", "ohio+b", "ohio+c"]
+    with patch(
+        "ingest_wikimedia.session_state.find_active_label",
+        side_effect=AssertionError("mtime path must not run"),
+    ) as mtime:
+        upcoming = active_and_upcoming_labels(
+            ssm=None,
+            labels=labels,
+            session_created=1700000000,
+            active_label="ohio+b",
+        )
+    mtime.assert_not_called()
+    assert upcoming == {"ohio+b", "ohio+c"}
+
+
+def test_active_and_upcoming_labels_falls_back_to_mtime_when_active_label_none():
+    """No pre-resolved active_label → fall through to the mtime
+    heuristic (id-generation cold start, between steps, chain
+    finished)."""
+    from unittest.mock import patch
+
+    from ingest_wikimedia.session_state import active_and_upcoming_labels
+
+    labels = ["ohio+a", "ohio+b", "ohio+c"]
+    with patch(
+        "ingest_wikimedia.session_state.find_active_label",
+        return_value=("ohio+c", 1700009999),
+    ) as mtime:
+        upcoming = active_and_upcoming_labels(
+            ssm=None,
+            labels=labels,
+            session_created=1700000000,
+            active_label=None,
+        )
+    mtime.assert_called_once()
+    assert upcoming == {"ohio+c"}
+
+
+def test_active_and_upcoming_labels_empty_set_for_drain_hub_active_label():
+    """``drain-<hub>`` means the terminal partner-level drain phase —
+    all per-target work is done → empty set so a new request for any
+    per-target label is not a conflict."""
+    from ingest_wikimedia.session_state import active_and_upcoming_labels
+
+    upcoming = active_and_upcoming_labels(
+        ssm=None,
+        labels=["ohio+a", "nwh+b"],
+        active_label="drain-ohio",
+    )
+    assert upcoming == set()
+
+
 # ---------------------------------------------------------------------------
 # Slack output safety — multi-block splitting
 
@@ -1344,6 +1486,158 @@ def test_post_to_slack_payload_contains_multiple_section_blocks_for_busy_day():
     for block in section_blocks:
         assert block["text"]["text"].strip(), "Empty section block emitted"
     assert json.dumps(payload)
+
+
+def test_main_uses_subprocess_snapshot_over_mtime_for_active_label():
+    """When ``snapshot_running_active_labels`` returns an active label
+    for a session, ``fetch`` must use it — NOT fall through to
+    :func:`find_active_label`'s log-mtime heuristic. This is the fix
+    for the two-sessions-share-a-label bug: mtime can't distinguish
+    which session's subprocess is writing a shared log, but the
+    ``WIKIMEDIA_SESSION_LABEL`` env var of each session's running
+    child does.
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import main
+
+    sessions_out = "wikimedia-texas+livingston-and-1-more|1700000000\n"
+    captured, fake_post = _capture_slack_post()
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"DPLA_SLACK_BOT_TOKEN": "tok-xxx", "NOTIFY_IF_IDLE": "false"},
+        ),
+        patch("scripts.wikimedia_upload_status.boto3.client", return_value=object()),
+        patch(
+            "scripts.wikimedia_upload_status.ssm_run",
+            return_value=sessions_out,
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.fetch_memory_snapshot",
+            return_value=None,
+        ),
+        patch(
+            "scripts.wikimedia_upload_status._fetch_slot_snapshot",
+            return_value=None,
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.parse_session_labels",
+            return_value=[
+                "texas+livingston-municipal-library",
+                "texas+botanical-research-institute-of-texas",
+            ],
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.snapshot_running_active_labels",
+            return_value={
+                "wikimedia-texas+livingston-and-1-more": (
+                    "texas+botanical-research-institute-of-texas"
+                ),
+            },
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.find_active_label",
+            side_effect=AssertionError(
+                "find_active_label (mtime) must not be consulted when "
+                "the subprocess snapshot has a label for the session"
+            ),
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.get_phase_and_progress",
+            return_value=("Uploading (100 / 500 files, ~20.0%)", 1700009999),
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.requests.post",
+            side_effect=fake_post,
+        ),
+    ):
+        main()
+
+    payload = captured["payload"]
+    section_blocks = [b for b in payload["blocks"] if b.get("type") == "section"]
+    text = section_blocks[0]["text"]["text"]
+    # The subprocess signal (botanical) wins over any mtime latch onto
+    # a shared label. Row is positioned [2/2] because botanical is
+    # position 2 of the batch.
+    assert "texas+botanical-research-institute-of-texas [2/2]" in text
+    assert "Uploading (100 / 500 files, ~20.0%)" in text
+
+
+def test_main_drain_hub_row_attributes_to_parent_chain():
+    """When a chained session is in its terminal partner-level drain
+    phase (subprocess signal reports
+    ``WIKIMEDIA_SESSION_LABEL=drain-<hub>``), the row must be
+    attributed to the parent multi-target session — ``<first-target>
+    +N more (drain: <hub>)`` — not displayed as a standalone
+    ``drain-<hub>`` identity, which reads as a whole new session to
+    operators.
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import main
+
+    sessions_out = "wikimedia-ohio+ohio-uni-and-3-more|1700000000\n"
+    captured, fake_post = _capture_slack_post()
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"DPLA_SLACK_BOT_TOKEN": "tok-xxx", "NOTIFY_IF_IDLE": "false"},
+        ),
+        patch("scripts.wikimedia_upload_status.boto3.client", return_value=object()),
+        patch(
+            "scripts.wikimedia_upload_status.ssm_run",
+            return_value=sessions_out,
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.fetch_memory_snapshot",
+            return_value=None,
+        ),
+        patch(
+            "scripts.wikimedia_upload_status._fetch_slot_snapshot",
+            return_value=None,
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.parse_session_labels",
+            return_value=[
+                "ohio+ohio-university-libraries",
+                "northwest-heritage+whitman-county-library",
+                "minnesota+minnesota-legislative-reference-library",
+                "bpl+phillips-academy",
+            ],
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.snapshot_running_active_labels",
+            return_value={"wikimedia-ohio+ohio-uni-and-3-more": "drain-ohio"},
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.get_phase_and_progress",
+            return_value=(
+                "Draining (drain: 0 queued, Category:Duplicate at 1,004, needs < 900)",
+                1700009999,
+            ),
+        ),
+        patch(
+            "scripts.wikimedia_upload_status.requests.post",
+            side_effect=fake_post,
+        ),
+    ):
+        main()
+
+    payload = captured["payload"]
+    section_blocks = [b for b in payload["blocks"] if b.get("type") == "section"]
+    text = section_blocks[0]["text"]["text"]
+    # Row identifies the parent chain (first target + count of remaining
+    # targets) with a `(drain: ohio)` phase annotation, NOT the raw
+    # synthetic `drain-ohio` label as a standalone session identity.
+    assert "ohio+ohio-university-libraries +3 more (drain: ohio)" in text
+    assert "drain: 0 queued" in text
+    # And critically, the raw `drain-ohio` string is not the row's
+    # identity (the phase annotation still contains "drain: ohio" but
+    # not as the label — the assertion above pins that).
+    assert "`drain-ohio`" not in text
 
 
 def test_main_rows_use_display_id_from_fetch_not_session_name():

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -94,9 +94,10 @@ def _run_deferred_items(partner: str, dpla_ids: list[str]) -> None:
     sidecar for the next loop iteration, which is the intended
     behaviour.
     """
+    partner_base = drain_sidecar.partner_dir_path(partner)
     with tempfile.NamedTemporaryFile(
         "w",
-        dir=partner,
+        dir=partner_base,
         prefix=".drain-ids-",
         suffix=".csv",
         delete=False,
@@ -112,7 +113,7 @@ def _run_deferred_items(partner: str, dpla_ids: list[str]) -> None:
         )
         result = subprocess.run(
             ["uploader", os.path.basename(csv_path), partner],
-            cwd=partner,
+            cwd=partner_base,
             check=False,
         )
         if result.returncode != 0:
@@ -135,7 +136,7 @@ def _run_deferred_items(partner: str, dpla_ids: list[str]) -> None:
                 "--ids-file",
                 os.path.basename(csv_path),
             ],
-            cwd=partner,
+            cwd=partner_base,
             check=False,
         )
         if result.returncode != 0:


### PR DESCRIPTION
## Summary

Three related status-report defects, bundled.

**1. `drain_sidecar.sidecar_path()` double-nesting.** The helper returned a CWD-relative `Path(partner)/deferred-drain.json`. Every caller runs with CWD=`<partner_dir>/` (from the launcher's `cd {base}`), so writes landed at `<partner_dir>/<partner_dir>/deferred-drain.json` — invisible to the status reporter and to anything else expecting the flat shape (this is the false-zero "drain: 0 queued" on `northwest-heritage+oregon-state-archives` in the last status post). Fixed by anchoring at `INGEST_WIKI_ROOT` and resolving through `PARTNER_DIR`. Also fixed `_run_deferred_items` in `tools/drain_deferred.py`, which had the same CWD-relative bug for its temp CSV dir and `subprocess.run(cwd=)`.

**2. `find_active_label` mtime heuristic mis-attributes shared labels.** When two chained sessions share a target label (e.g. both texas chains include `texas+harrie-p-woodson-memorial-library`), the mtime signal can't tell which session's subprocess is writing the log — so the completed-hours-ago target in one chain gets falsely picked as the "active" row because the other chain is running that target right now. Added `snapshot_running_active_labels(client)`: one SSM roundtrip reads `WIKIMEDIA_SESSION_LABEL` from each session's running child's `/proc/<pid>/environ` — direct evidence of which subprocess is producing the writes.

- Reporter uses it as primary signal (submitted to the `ThreadPoolExecutor` so it overlaps with memory/slots/per-session lookups, no serial extra roundtrip).
- Launcher takes one snapshot upfront and passes `active_label` per-session, collapsing N SSM roundtrips into 1 for the conflict-check loop.

**3. `drain-<hub>` orphan row.** When a chained session enters its terminal partner-level drain, the reporter previously displayed the raw `drain-<hub>` synthetic label as a standalone row (reading as a whole new session identity to operators). Now attributes it as `<first-target> +N more (drain: <hub>)`.

## Follow-up (out of scope)

- On-EC2 migration: `mv <partner>/<partner>/deferred-drain.json <partner>/deferred-drain.json` for `bpl`, `ohio`, `northwest-heritage`; remove empty `mwdl/mwdl/`. Left for after this deploys so the fix and the migration land as a clean pair.
- The `INGEST_WIKI_ROOT` + `partner_dir_path` helper is a candidate for promotion to `ingest_wikimedia/partners.py` and reuse across the ~15 other partner-dir path construction sites — separate refactor PR.

## Test plan

- [ ] `python -m pytest -q` (1139 passing locally)
- [ ] After merge and deploy: watch a `/wikimedia-status` post for the two texas chains — should show `botanical-research-institute-of-texas [21/54]` and `harrie-p-woodson-memorial-library [2/3]` distinctly, not two identical rows
- [ ] After migration: same `/wikimedia-status` post should show `drain: 8 queued` for the nwh row (was `drain: 0 queued`)
- [ ] The ohio multi-partner chain should render as `ohio+ohio-university-libraries +3 more (drain: ohio)`, not `drain-ohio` alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Fixed sidecar/deferred-drain path resolution so partner files are anchored under the ingest root (via `INGEST_WIKI_ROOT`/`PARTNER_DIR`) instead of the current working directory, preventing accidental double-nesting; aligned `tools/drain_deferred.py` temp dirs/subprocess `cwd` to the same anchored layout.
- Added direct active-label detection by snapshotting `WIKIMEDIA_SESSION_LABEL` from running tmux child processes via SSM (`snapshot_running_active_labels`), updated conflict attribution to prefer this snapshot over the previous mtime heuristic, and switched the “newest child” tie-breaker to a numeric elapsed-time (`etimes`) strategy.
- Improved drain-hub reporting so terminal partner-level drains are attributed to the originating chain as `<first-target> +N more (drain: <hub>)` instead of showing `drain-<hub>` as a standalone row.
- Updated launcher/upload-status reporting and the drain tooling/tests to use the new root-anchored partner directory layout and the new active-label attribution behavior.

Infra/env/secrets/API/migrations notes:
- No manual pipeline trigger or ECS redeployment changes required (code-level behavior only).
- No new/replaced environment variables, AWS Secrets Manager keys, IAM policies, or shared infrastructure configuration.
- No database migrations/endpoints/API response shape changes.

Security note: this PR increases reliance on SSM to read running child-process environment variables (`WIKIMEDIA_SESSION_LABEL`) from `/proc/<pid>/environ` for status attribution; it does not introduce new secrets or credentials handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->