### PR TITLE
Defer pywikibot login in scheduled metrics jobs to stop new-device emails

### DIFF
--- a/metrics/cim-pageviews/CIMviews.py
+++ b/metrics/cim-pageviews/CIMviews.py
@@ -37,9 +37,17 @@ arg = parse.parse_args()
 if arg.cat and arg.mode == 'categories':
     parse.error('--cat is only valid with --mode data')
 
-# Connect and authenticate to Wikimedia Commons
+# Connect to Wikimedia Commons. Do not log in eagerly: most of this script is
+# reads, and many scheduled runs (especially daily categories mode) make no
+# edits at all. Logging in only when we first write avoids a Wikimedia "login
+# from a new device" email on every no-op run — each CI runner has a fresh IP.
+# ensure_login() is called immediately before every write and logs in once.
 site = pywikibot.Site()
-site.login()
+
+
+def ensure_login():
+    if not site.logged_in():
+        site.login()
 
 # Counters for the summary report
 updated = 0      # data pages written/updated
@@ -91,6 +99,7 @@ if arg.mode == 'categories':
         category = pywikibot.Page(site, cimreq_title)
         if cimreq_title in cimlist:
             print(cimreq_title)
+            ensure_login()
             category.change_category(cimcat, None, 'Remove category: [[Category:Category requested for Commons Impact Metrics]]')
             print('Removed request for ' + cimreq_title)
             fulfilled += 1
@@ -152,6 +161,7 @@ for cat in cats:
         if cat not in cimlist:
             if cimcat not in category.categories():
                 category.text += '\n[[Category:Category requested for Commons Impact Metrics]]'
+                ensure_login()
                 category.save(summary='Adding category: [[Category:Category requested for Commons Impact Metrics]]')
                 print('   Category requested for Commons Impact Metrics!')
                 requested += 1
@@ -197,6 +207,7 @@ for cat in cats:
             print(f'   Request error, skipping: {e}')
             continue
         pagename.text = json.dumps(datapage, indent=4)
+        ensure_login()
         pagename.save('Adding tabular data for category page views from Commons Impact Metrics.')
         updated += 1
 
@@ -214,6 +225,7 @@ for cat in cats:
         print(chartpage)
         chartpagename.text = json.dumps(chartpage, indent=4, ensure_ascii=False)
         print(chartpagename.text)
+        ensure_login()
         chartpagename.save('   Creating chart page for category page views from Commons Impact Metrics.')
 
 print("""

--- a/metrics/dpla-dup-window/release_window.py
+++ b/metrics/dpla-dup-window/release_window.py
@@ -303,7 +303,11 @@ def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
     site = pywikibot.Site()
-    site.login()
+    # Do not log in eagerly. Every read below (window value, category count,
+    # backlog fetch) works anonymously; we log in only if we actually write.
+    # Otherwise every scheduled run — almost always a no-op, since the category
+    # sits at/above target — would log in from a fresh CI-runner IP and trigger
+    # a Wikimedia "login from a new device" email for nothing.
 
     window_page = pywikibot.Page(site, WINDOW_PAGE)
     current_window = parse_window_value(
@@ -345,6 +349,7 @@ def main() -> int:
         logging.info("Dry run: no edits or purges made.")
         return 0
 
+    site.login()  # only reached when actually releasing — never on no-op runs
     window_page.text = render_window_value(plan.new_window)
     window_page.save(
         summary=(


### PR DESCRIPTION
## Problem

The hourly **dpla-dup-window** and daily **cim-pageviews** GitHub Actions each call `site.login()` eagerly at startup. Every scheduled run executes on a fresh CI runner with a new (Azure) IP and no saved session, so Wikimedia's **LoginNotify** emails a *"Login to Wikimedia Commons as DPLA bot from a device you have not recently used"* alert on **every run** — currently one per hour. That noise also destroys the signal: a genuinely suspicious login is indistinguishable from the CI churn.

The EC2 uploader/recovery jobs don't trigger this because they run from a stable, long-since-"known" IP.

## Fix

Both jobs are read-dominated and usually make **no edits**:
- `dpla-dup-window` is a no-op whenever `Category:Duplicate` is at/above target (the normal state).
- `cim-pageviews` categories mode writes only when a CIM request is added or fulfilled.

So defer login until just before the first actual write. All reads (window value, category counts, backlog fetch, data-page freshness checks) work anonymously.

- **`release_window.py`** — move the single `site.login()` to immediately before the window-page `save()`, after the no-op and dry-run early returns.
- **`CIMviews.py`** — replace the eager login with `ensure_login()`, called before each of the four write sites; runs with zero writes never authenticate.

## Effect

- No-op runs no longer log in → no email. Since dpla-dup-window stays a no-op until admins draw `Category:Duplicate` under target, this eliminates essentially all of the hourly noise.
- **LoginNotify stays fully enabled** — a real login from an unknown device still emails, so no genuine alert is lost. This is strictly better than muting the notification.
- Login now happens only on runs that actually write (rare, and legitimately the bot acting).

`tools/sdc_sync.py` was intentionally left unchanged: it always writes (partner SDC sync), so its login is unavoidable and deferral wouldn't help.

## Testing

- `ruff check` passes on both files; `release_window.py` already `ruff format`-clean (CIMviews left unformatted to avoid unrelated churn — added lines are ruff-clean).
- `py_compile` clean on both.
- No behavior change to the tested pure functions in `release_window.py`; `main()`'s login placement isn't covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR defers Wikimedia login in the scheduled `dpla-dup-window` and `cim-pageviews` jobs so no-op or read-only runs no longer trigger LoginNotify emails from fresh CI runners.

Security impact: authentication is now delayed until just before the first write operation, while anonymous reads remain unchanged. Real write-bearing runs still authenticate normally, so LoginNotify remains enabled for suspicious logins.

Changes:
- `metrics/dpla-dup-window/release_window.py`
  - Removed eager `site.login()` at startup.
  - Logs in only after the script has determined there is work to do and it is not a dry run.
  - Keeps initial reads anonymous; write/save and purge steps still run after login.
- `metrics/cim-pageviews/CIMviews.py`
  - Replaced startup login with `ensure_login()`.
  - Authenticates only before write paths, including request cleanup, saving updated tab data, and saving newly created chart pages.
  - Read-only execution now stays anonymous.

Testing:
- `ruff check`
- `py_compile` on both files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->