### PR TITLE
Tighten Category:Duplicate throttle per Commons admins (ceiling 190)

### DIFF
--- a/ingest_wikimedia/dup_throttle.py
+++ b/ingest_wikimedia/dup_throttle.py
@@ -31,9 +31,17 @@ from collections.abc import Callable
 
 import pywikibot
 
-DEFAULT_THRESHOLD = 1000
-DEFAULT_RESUME_BELOW = 900
-DEFAULT_RECHECK_CAP = 100
+# Commons admins asked us (2026-07) to keep Category:Duplicate lean. Defer new
+# hash-drift {{duplicate}} tags once the category reaches DEFAULT_THRESHOLD, and
+# don't resume draining the deferred backlog until it falls back below
+# DEFAULT_RESUME_BELOW — a 50-member hysteresis band so the drain works a real
+# batch each cycle instead of thrashing at the ceiling.
+DEFAULT_THRESHOLD = 190
+DEFAULT_RESUME_BELOW = 140
+# Max tags emitted per cached size reading. Kept <= the hysteresis band so
+# concurrent partner runs can't overshoot the ceiling by much before
+# re-querying (worst case ~= recheck_cap x concurrent sessions).
+DEFAULT_RECHECK_CAP = 50
 # Category:Duplicate drains on human-admin timescales — days, not
 # minutes — so polling every 5 minutes is fast enough that we won't sit
 # idle after a batch clears while still being a good API citizen. The


### PR DESCRIPTION
Per Commons admins' instruction, keep `Category:Duplicate` lean. Adjust the three `DuplicateCategoryThrottle` defaults in `ingest_wikimedia/dup_throttle.py`:

| constant | old | new | role |
|---|---:|---:|---|
| `DEFAULT_THRESHOLD` | 1000 | **190** | Defer ceiling — the live upload pass stops emitting hash-drift `{{duplicate}}` tags and defers them to the per-partner sidecar once the category reaches this. This is the real "keep it under ~190" cap. |
| `DEFAULT_RESUME_BELOW` | 900 | **140** | Drain resume mark — the deferred-drain phase waits until the category falls below this before pushing queued tags back in. The 50-member gap under the ceiling is the hysteresis band (drain a real batch each cycle, no thrashing). This is the number surfaced in the Slack "needs < N" message. |
| `DEFAULT_RECHECK_CAP` | 100 | **50** | Max tags emitted per cached size reading. A single session can't overshoot the ceiling (budget is `min(threshold − size, recheck_cap)`), but **concurrent** partner runs banking off the same stale read can — worst case ≈ `recheck_cap × sessions`. Halving it (and keeping it ≤ the band) bounds that at the lower ceiling. |

## Scope

This is the whole change — one constants block:
- **Reporting** (`scripts/wikimedia_upload_status.py`) derives the `"needs < N"` number by regex-parsing the throttle's own runtime log line, so it follows automatically.
- **Docs/docstrings** reference the params by name, not value.
- **Tests**: every construction passes `threshold`/`resume_below` explicitly (or exercises the ValueError guards); the four that use the default `recheck_cap` assert poll counts / cache-ride behavior, not an exact headroom value — so no test asserts these defaults and CI is unaffected. Verified `resume_below ≤ threshold` (140 ≤ 190) and `recheck_cap ≥ 1`.

## Note

`Category:Duplicate` currently sits well above 190 (~1,000 total members), so once this ships the uploader's live hash-drift tagging goes into full "defer to sidecar" mode until admins (and the moving-window releases) draw it down under 190/140. That's the intended lean behavior and lines up with prioritizing the 40K `{{DPLA duplicate}}` backlog first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adjusted `DuplicateCategoryThrottle` hysteresis defaults in `ingest_wikimedia/dup_throttle.py` per Commons admins: reduced `DEFAULT_THRESHOLD` (defer ceiling) from `1000` to `190`, reduced `DEFAULT_RESUME_BELOW` (resume/drain trigger) from `900` to `140`, and reduced `DEFAULT_RECHECK_CAP` from `100` to `50`. Updated the module/header comments to document the “keep Category:Duplicate lean” behavior and ensure the invariant `resume_below <= threshold` (140 <= 190) still holds.

No database migrations, environment variable/Secrets Manager changes, shared infrastructure configuration updates, or public API/endpoint shape changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->