### PR TITLE
Sanitize wikitext values during legacy migration + SDC-sync reconciliation

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -42,6 +42,7 @@ from ingest_wikimedia.sdc import (
     dates_semantically_equal,
     parse_date_range,
     parse_dpla_date,
+    unescape_wikitext_magic_words,
 )
 
 # DPLA's Commons-bot account names. Revisions authored by these accounts
@@ -188,10 +189,18 @@ def parse_artwork_params(wikitext: str) -> dict[str, str]:
 
     Returns ``{}`` when no legacy template is found, or when one is
     present but carries no recognised params. Values are whitespace-
-    stripped (matching the renderer's behavior); the unrecognised
-    param names are dropped silently — those don't have a canonical
-    target and the wikitext-rewrite step preserves them by leaving
-    the template untouched if the param wasn't migrated.
+    stripped (matching the renderer's behavior) and character-escape
+    magic words (``{{!}}`` / ``{{=}}`` / …) are un-escaped to the
+    literal characters they render as — a community editor's AWB pass
+    that swapped ``|`` for ``{{!}}`` inside a param value is a display
+    no-op and must be treated as one by both the provenance walk
+    (crediting the AWB edit for a real content change would misclassify
+    the value as community-contributed) and by downstream SDC-storage
+    paths (a stored value that literally contains ``{{!}}`` is nonsense
+    outside a template context). Unrecognised param names are dropped
+    silently — those don't have a canonical target and the wikitext-
+    rewrite step preserves them by leaving the template untouched if
+    the param wasn't migrated.
     """
     template = find_legacy_template(wikitext)
     if template is None:
@@ -201,7 +210,7 @@ def parse_artwork_params(wikitext: str) -> dict[str, str]:
         canonical = ARTWORK_PARAM_TO_CANONICAL_KEY.get(_normalize_param_name(param))
         if canonical is None:
             continue
-        value = str(param.value).strip()
+        value = unescape_wikitext_magic_words(str(param.value).strip())
         if value:
             # On duplicate canonical keys (e.g. both ``author`` and
             # ``creator`` set), the *last* wins — matches the renderer

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -40,6 +40,7 @@ from ingest_wikimedia.sdc import (
     CASEFOLD_COMPARE_KEYS,
     casefold_for_compare,
     dates_semantically_equal,
+    is_wikitext_junk_value,
     parse_date_range,
     parse_dpla_date,
     unescape_wikitext_magic_words,
@@ -211,12 +212,18 @@ def parse_artwork_params(wikitext: str) -> dict[str, str]:
         if canonical is None:
             continue
         value = unescape_wikitext_magic_words(str(param.value).strip())
-        if value:
-            # On duplicate canonical keys (e.g. both ``author`` and
-            # ``creator`` set), the *last* wins — matches the renderer
-            # behavior under MediaWiki, where the later assignment
-            # overrides the earlier.
-            parsed[canonical] = value
+        if not value or is_wikitext_junk_value(value):
+            # Empty values and wikitext-extraction junk (a stray ``;`` in
+            # a date field, ``--`` in a title, etc. — see
+            # :func:`is_wikitext_junk_value`) aren't useful provenance
+            # to import. Skip them same as we skip missing params so
+            # the migrator doesn't preserve markup errors as SDC.
+            continue
+        # On duplicate canonical keys (e.g. both ``author`` and
+        # ``creator`` set), the *last* wins — matches the renderer
+        # behavior under MediaWiki, where the later assignment
+        # overrides the earlier.
+        parsed[canonical] = value
     return parsed
 
 

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1226,10 +1226,50 @@ CASEFOLD_COMPARE_KEYS: frozenset[str] = frozenset(
 )
 
 
+# MediaWiki character-escape magic words. When a literal ``|`` or ``=``
+# would confuse the template parser (`|` separates params, `=`
+# separates key from value), community editors escape it with the
+# builtin magic-word form on the LEFT — which the parser expands back
+# to the character on the RIGHT before rendering. Docs:
+# https://www.mediawiki.org/wiki/Help:Magic_words
+#
+# When we read a value OUT of a template parameter position — either to
+# store it as an SDC statement or to compare it against DPLA canonical
+# — we must undo the escape or the value carries the meaningless magic-
+# word text into a context where it doesn't mean anything (the SDC
+# value ends up literally containing "{{!}}", and the comparator against
+# DPLA's canonical "|" fails).
+_WIKITEXT_MAGIC_WORD_UNESCAPES: tuple[tuple[str, str], ...] = (
+    ("{{!}}", "|"),
+    ("{{=}}", "="),
+    ("{{((}}", "{{"),
+    ("{{))}}", "}}"),
+    ("{{!(}}", "|["),
+    ("{{)!}}", "]|"),
+)
+
+
+def unescape_wikitext_magic_words(s: str) -> str:
+    """Replace MediaWiki character-escape magic words with the literal
+    characters they render as. Non-string / empty input returns as-is.
+
+    Applied when moving a value from wikitext (where these escapes are
+    required inside template parameters) to any other context (SDC
+    storage, comparator keys, log messages) where the magic-word form
+    is meaningless literal text.
+    """
+    if not isinstance(s, str) or not s:
+        return s
+    for magic, literal in _WIKITEXT_MAGIC_WORD_UNESCAPES:
+        s = s.replace(magic, literal)
+    return s
+
+
 def casefold_for_compare(s: str) -> str:
     """Fold ``s`` to a comparable form for equivalence checks against
-    another display string. Strips leading/trailing whitespace and
-    punctuation, collapses internal whitespace runs, and casefolds.
+    another display string. Unescapes MediaWiki character-escape magic
+    words (``{{!}}``, ``{{=}}``, …), strips leading/trailing whitespace
+    and punctuation, collapses internal whitespace runs, and casefolds.
 
     Used ONLY as a comparator key — never to rewrite stored or rendered
     values. DPLA-authored SDC and rendered wikitext must continue to
@@ -1244,6 +1284,7 @@ def casefold_for_compare(s: str) -> str:
     """
     if not isinstance(s, str) or not s:
         return ""
+    s = unescape_wikitext_magic_words(s)
     s = _LEADING_TRIM_RE.sub("", s)
     s = _TRAILING_TRIM_RE.sub("", s)
     s = _INTERNAL_WS_RE.sub(" ", s)

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1239,13 +1239,16 @@ CASEFOLD_COMPARE_KEYS: frozenset[str] = frozenset(
 # word text into a context where it doesn't mean anything (the SDC
 # value ends up literally containing "{{!}}", and the comparator against
 # DPLA's canonical "|" fails).
-_WIKITEXT_MAGIC_WORD_UNESCAPES: tuple[tuple[str, str], ...] = (
-    ("{{!}}", "|"),
-    ("{{=}}", "="),
-    ("{{((}}", "{{"),
-    ("{{))}}", "}}"),
-    ("{{!(}}", "|["),
-    ("{{)!}}", "]|"),
+_WIKITEXT_MAGIC_WORD_TABLE: dict[str, str] = {
+    "{{!}}": "|",
+    "{{=}}": "=",
+    "{{((}}": "{{",
+    "{{))}}": "}}",
+    "{{!(}}": "|[",
+    "{{)!}}": "]|",
+}
+_WIKITEXT_MAGIC_WORD_RE = re.compile(
+    "|".join(re.escape(k) for k in _WIKITEXT_MAGIC_WORD_TABLE)
 )
 
 
@@ -1257,12 +1260,19 @@ def unescape_wikitext_magic_words(s: str) -> str:
     required inside template parameters) to any other context (SDC
     storage, comparator keys, log messages) where the magic-word form
     is meaningless literal text.
+
+    Single-pass — regex substitution walks the original string once,
+    so the output of one un-escape can't be rescanned as input to
+    another. Sequential ``str.replace()`` would over-un-escape
+    ``{{((}}))}}`` (the community idiom for a literal ``{{}}``) all
+    the way to ``}}`` because ``{{((}}`` → ``{{`` leaves ``{{))}}``
+    on the tape, which the next pass would then match.
     """
     if not isinstance(s, str) or not s:
         return s
-    for magic, literal in _WIKITEXT_MAGIC_WORD_UNESCAPES:
-        s = s.replace(magic, literal)
-    return s
+    return _WIKITEXT_MAGIC_WORD_RE.sub(
+        lambda m: _WIKITEXT_MAGIC_WORD_TABLE[m.group(0)], s
+    )
 
 
 def casefold_for_compare(s: str) -> str:

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1226,6 +1226,28 @@ CASEFOLD_COMPARE_KEYS: frozenset[str] = frozenset(
 )
 
 
+def is_wikitext_junk_value(value: str) -> bool:
+    """True when ``value`` looks like a wikitext-extraction artifact —
+    1–2 characters after strip, all punctuation/whitespace (no
+    alphanumerics). Almost always a markup / regex / human error in
+    the source template rather than a genuine metadata contribution
+    worth preserving.
+
+    Motivating cases: ``| date = ;`` (stray semicolon left over from
+    a template rewrite), ``| title = --``, ``| creator = .``. Values
+    of 3+ characters, or values containing a letter or digit, are
+    treated as potentially legitimate — a single-character title
+    like ``A`` (film) or a date like ``1`` (unlikely but syntactically
+    parseable) is not filtered here.
+    """
+    if not isinstance(value, str):
+        return False
+    stripped = value.strip()
+    if not (1 <= len(stripped) <= 2):
+        return False
+    return not any(c.isalnum() for c in stripped)
+
+
 # MediaWiki character-escape magic words. When a literal ``|`` or ``=``
 # would confuse the template parser (`|` separates params, `=`
 # separates key from value), community editors escape it with the

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1266,8 +1266,13 @@ _WIKITEXT_MAGIC_WORD_TABLE: dict[str, str] = {
     "{{=}}": "=",
     "{{((}}": "{{",
     "{{))}}": "}}",
-    "{{!(}}": "|[",
-    "{{)!}}": "]|",
+    # ``{{!(}}`` / ``{{)!}}`` are community templates (Template:!( and
+    # Template:)!) that render as ``{|`` and ``|}`` — the MediaWiki
+    # table-start and table-end markers. Used inside template params
+    # to keep a nested wikitable's opening/closing tokens from being
+    # consumed by the outer template's argument parser.
+    "{{!(}}": "{|",
+    "{{)!}}": "|}",
 }
 _WIKITEXT_MAGIC_WORD_RE = re.compile(
     "|".join(re.escape(k) for k in _WIKITEXT_MAGIC_WORD_TABLE)

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -110,6 +110,38 @@ def test_parse_artwork_params_drops_empty_values():
     assert params == {"title": "A"}
 
 
+def test_parse_artwork_params_unescapes_magic_words_in_values():
+    """A community AWB pass sometimes rewrites literal ``|`` inside a
+    template param to the ``{{!}}`` magic word (parser expands it back
+    to ``|`` at render time — display-invariant). Extraction must
+    un-escape so:
+
+    (a) the value stored downstream as an SDC statement is the literal
+        text a reader sees, not the magic-word form that has no meaning
+        outside a template context, and
+    (b) the migration provenance walker doesn't credit the AWB pass for
+        a content change that didn't actually change display.
+
+    Motivating example: File:Block_Card_6_E._Bancroft_Street_-_DPLA_-
+    _307d98570261183ed48eb3b1880fce14.jpg — 2020-06-04 AWB pass
+    replaced ``|`` with ``{{!}}`` in the description; the July 2026
+    legacy-Artwork migrator then stored the escaped form as a P10358
+    SDC statement, permanently diverging from DPLA canonical.
+    """
+    wikitext = (
+        "{{Artwork\n"
+        "| title = A {{=}} B\n"
+        "| description = terms include: buildings {{!}} Italianate "
+        "{{!}} one story\n"
+        "}}"
+    )
+    params = parse_artwork_params(wikitext)
+    assert params == {
+        "title": "A = B",
+        "description": ("terms include: buildings | Italianate | one story"),
+    }
+
+
 # ---------------------------------------------------------------------------
 # trace_param_provenance — revision-history walker
 # ---------------------------------------------------------------------------

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -110,6 +110,39 @@ def test_parse_artwork_params_drops_empty_values():
     assert params == {"title": "A"}
 
 
+def test_parse_artwork_params_drops_wikitext_junk_values():
+    """A 1-2-character punctuation-only value (``| date = ;``,
+    ``| title = --``) is a wikitext-extraction artifact — parser or
+    editor error, not real metadata. Extraction drops it the same way
+    it drops empty values, so the migrator doesn't preserve markup
+    junk as an SDC statement.
+
+    Motivating example: File:A_Toledo_Symphony_Orchestra_---_why%3F_
+    -_DPLA_-_640c3941bd35b12a39cb3820e9f778b2_(page_6).jpg — legacy
+    template carried ``| date = ;`` and the 2026-06-25 migrator
+    dutifully wrote a P571 = somevalue statement with the ``;`` as
+    its P1932 stated-as qualifier.
+    """
+    wikitext = (
+        "{{Artwork\n"
+        "| title = --\n"
+        "| description = A real description here\n"
+        "| date = ; \n"
+        "| creator = .\n"
+        "}}"
+    )
+    params = parse_artwork_params(wikitext)
+    assert params == {"description": "A real description here"}
+
+
+def test_parse_artwork_params_keeps_single_alnum_values():
+    """A single-letter title (film title ``A``) or single-digit value
+    passes through — the junk filter targets only punctuation-only
+    shorts."""
+    wikitext = "{{Artwork|title=A|date=1}}"
+    assert parse_artwork_params(wikitext) == {"title": "A", "date": "1"}
+
+
 def test_parse_artwork_params_unescapes_magic_words_in_values():
     """A community AWB pass sometimes rewrites literal ``|`` inside a
     template param to the ``{{!}}`` magic word (parser expands it back

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -659,6 +659,44 @@ def test_unescape_wikitext_magic_words_leaves_regular_text_alone():
     assert unescape_wikitext_magic_words(None) is None  # type: ignore[arg-type]
 
 
+def test_is_wikitext_junk_value_flags_short_punctuation_only():
+    """1-2 characters that are all punctuation/whitespace read as a
+    wikitext-extraction artifact rather than metadata worth keeping."""
+    from ingest_wikimedia.sdc import is_wikitext_junk_value
+
+    assert is_wikitext_junk_value(";")
+    assert is_wikitext_junk_value(" ; ")
+    assert is_wikitext_junk_value("--")
+    assert is_wikitext_junk_value(".")
+    assert is_wikitext_junk_value(",,")
+    assert is_wikitext_junk_value("()")
+
+
+def test_is_wikitext_junk_value_lets_content_through():
+    """Anything with a letter or digit — or 3+ characters — is
+    considered potentially-legitimate and passes through unfiltered."""
+    from ingest_wikimedia.sdc import is_wikitext_junk_value
+
+    # Single letters / digits are legitimate values (title "A", etc.).
+    assert not is_wikitext_junk_value("A")
+    assert not is_wikitext_junk_value("1")
+    assert not is_wikitext_junk_value("1.")
+    # 3+ punctuation is likely a stylistic choice / ellipsis proxy —
+    # not caught by this narrow filter.
+    assert not is_wikitext_junk_value("---")
+    assert not is_wikitext_junk_value("...")
+    assert not is_wikitext_junk_value("1937")
+    assert not is_wikitext_junk_value("A Title")
+
+
+def test_is_wikitext_junk_value_handles_falsy_input():
+    from ingest_wikimedia.sdc import is_wikitext_junk_value
+
+    assert not is_wikitext_junk_value("")
+    assert not is_wikitext_junk_value("   ")
+    assert not is_wikitext_junk_value(None)  # type: ignore[arg-type]
+
+
 def test_unescape_wikitext_magic_words_covers_documented_forms():
     """All the character-escape magic words documented on
     https://www.mediawiki.org/wiki/Help:Magic_words expand to the

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -617,6 +617,60 @@ def test_casefold_for_compare_handles_falsy_input():
     assert casefold_for_compare("   .,  ") == ""
 
 
+def test_casefold_for_compare_unescapes_wikitext_magic_words():
+    """A community AWB pass sometimes rewrites literal ``|`` inside a
+    template param to the ``{{!}}`` magic word (the parser expands it
+    back to ``|`` at render time). If the escaped form leaks into
+    stored SDC and DPLA's canonical carries the literal, byte- and
+    casefold-comparison fail on a display-invariant transform. The
+    comparator must un-escape.
+
+    Motivating example: File:Block_Card_6_E._Bancroft_Street_-_DPLA_-
+    _307d98570261183ed48eb3b1880fce14.jpg — description migrated to
+    P10358 with literal ``{{!}}`` between terms, but DPLA canonical
+    description carries ``|``.
+    """
+    from ingest_wikimedia.sdc import casefold_for_compare
+
+    dpla = (
+        "Descriptive terms related to this photograph include: "
+        "commercial buildings | Italianate | one story"
+    )
+    community = (
+        "Descriptive terms related to this photograph include: "
+        "commercial buildings {{!}} Italianate {{!}} one story"
+    )
+    assert casefold_for_compare(dpla) == casefold_for_compare(community)
+
+    # ``{{=}}`` and the bracket variants land the same way.
+    assert casefold_for_compare("a = b") == casefold_for_compare("a {{=}} b")
+    assert casefold_for_compare("{{x}}") == casefold_for_compare("{{((}}x{{))}}")
+
+
+def test_unescape_wikitext_magic_words_leaves_regular_text_alone():
+    """The helper is pure substitution of the documented magic words —
+    ordinary text (including stray braces that aren't part of a magic-
+    word) passes through unchanged."""
+    from ingest_wikimedia.sdc import unescape_wikitext_magic_words
+
+    assert unescape_wikitext_magic_words("plain text") == "plain text"
+    assert unescape_wikitext_magic_words("{{cite}}") == "{{cite}}"
+    assert unescape_wikitext_magic_words("") == ""
+    assert unescape_wikitext_magic_words(None) is None  # type: ignore[arg-type]
+
+
+def test_unescape_wikitext_magic_words_covers_documented_forms():
+    """All the character-escape magic words documented on
+    https://www.mediawiki.org/wiki/Help:Magic_words expand to the
+    literal char they render as."""
+    from ingest_wikimedia.sdc import unescape_wikitext_magic_words
+
+    assert unescape_wikitext_magic_words("a{{!}}b") == "a|b"
+    assert unescape_wikitext_magic_words("a{{=}}b") == "a=b"
+    assert unescape_wikitext_magic_words("{{((}}x{{))}}") == "{{x}}"
+    assert unescape_wikitext_magic_words("{{!(}}x{{)!}}") == "|[x]|"
+
+
 # ---------------------------------------------------------------------------
 # dates_semantically_equal — semantic date equivalence for
 # ``{{DPLA metadata}}`` ``date =`` overrides that reformat DPLA's own

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -671,6 +671,25 @@ def test_unescape_wikitext_magic_words_covers_documented_forms():
     assert unescape_wikitext_magic_words("{{!(}}x{{)!}}") == "|[x]|"
 
 
+def test_unescape_wikitext_magic_words_is_single_pass():
+    """``{{((}}))}}`` is the community idiom for a literal ``{{}}``:
+    the ``{{((}}`` token expands to ``{{`` and the trailing ``))}}``
+    stays literal because it's not a magic-word token on its own —
+    ``{{))}}`` (with the leading ``{{``) is, but the tail alone is
+    not. A sequential-replace implementation would first swap
+    ``{{((}}`` for ``{{`` and then rescan its own output, matching a
+    spurious ``{{))}}`` and collapsing the whole thing to ``}}``.
+    Single-pass regex substitution matches each source token exactly
+    once against the original string.
+    """
+    from ingest_wikimedia.sdc import unescape_wikitext_magic_words
+
+    assert unescape_wikitext_magic_words("{{((}}))}}") == "{{))}}"
+    # Adjacent magic words unescape independently — sequential replace
+    # would still get this right, but the case pins the intent.
+    assert unescape_wikitext_magic_words("{{!}}{{!}}") == "||"
+
+
 # ---------------------------------------------------------------------------
 # dates_semantically_equal — semantic date equivalence for
 # ``{{DPLA metadata}}`` ``date =`` overrides that reformat DPLA's own

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -706,7 +706,10 @@ def test_unescape_wikitext_magic_words_covers_documented_forms():
     assert unescape_wikitext_magic_words("a{{!}}b") == "a|b"
     assert unescape_wikitext_magic_words("a{{=}}b") == "a=b"
     assert unescape_wikitext_magic_words("{{((}}x{{))}}") == "{{x}}"
-    assert unescape_wikitext_magic_words("{{!(}}x{{)!}}") == "|[x]|"
+    # {{!(}} and {{)!}} are the community table-start / table-end
+    # escapes used to keep a nested wikitable's `{|` / `|}` tokens
+    # from being consumed by the outer template's argument parser.
+    assert unescape_wikitext_magic_words("{{!(}}row{{)!}}") == "{|row|}"
 
 
 def test_unescape_wikitext_magic_words_is_single_pass():

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -5176,6 +5176,125 @@ def test_inferred_dupe_cleanup_skips_property_with_no_dpla_claim():
 
 
 # ---------------------------------------------------------------------------
+# _reconcile_inferred_from_wikitext_junk — sweeps out inferred-from-Wikitext
+# claims whose stored display text is a 1-2-character punctuation-only
+# wikitext-extraction artifact (a stray ``;`` in a date, ``--`` in a title).
+# Only touches the migration's own imports (P887 → Q131783016 reference);
+# third-party community claims are never removed.
+# ---------------------------------------------------------------------------
+
+
+def _string_stmt(stmt_id, prop, value, references=None):
+    """Build a value-typed string-datavalue statement — the shape used
+    for description (P10358), page counts, and other free-text
+    claims. ``_stmt`` above defaults to wikibase-entityid; this helper
+    fills the string-typed gap for the junk-cleanup tests."""
+    return {
+        "id": stmt_id,
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": prop,
+            "datavalue": {"type": "string", "value": value},
+        },
+        "references": references or [],
+    }
+
+
+def test_inferred_junk_cleanup_removes_p571_somevalue_with_punctuation_p1932():
+    """Toledo Symphony repro — a legacy ``| date = ;`` extracted to a
+    P571 somevalue+P1932=";" inferred claim. The stated-as qualifier
+    is punctuation only; the pass drops the whole statement."""
+    from tools import sdc_sync
+
+    junk_claim = _p571_somevalue_with_p1932(
+        "M640$JUNK",
+        ";",
+        references=[_inferred_from_wikitext_reference()],
+        p459=False,
+    )
+    entity = {"pageid": 640, "statements": {"P571": [junk_claim]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_junk("M640")
+    assert sdc_sync.removals == ["M640$JUNK"]
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_junk_cleanup_removes_string_mainsnak_junk():
+    """A string-typed inferred claim whose stored value is ``--`` (or
+    any 1-2-char punctuation-only run) is a wikitext extraction
+    artifact; drop it."""
+    from tools import sdc_sync
+
+    junk = _string_stmt(
+        "M111$JUNK",
+        "P10358",
+        "--",
+        references=[_inferred_from_wikitext_reference()],
+    )
+    entity = {"pageid": 111, "statements": {"P10358": [junk]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_junk("M111")
+    assert sdc_sync.removals == ["M111$JUNK"]
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_junk_cleanup_preserves_real_content():
+    """Non-junk inferred claims (real dates, real strings) are never
+    touched — this pass only removes markup-error shapes."""
+    from tools import sdc_sync
+
+    real = _p571_somevalue_with_p1932(
+        "M111$REAL",
+        "1937",
+        references=[_inferred_from_wikitext_reference()],
+        p459=False,
+    )
+    entity = {"pageid": 111, "statements": {"P571": [real]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_junk("M111")
+    assert sdc_sync.removals == []
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_inferred_junk_cleanup_skips_non_inferred_claims():
+    """DPLA-authored claims and third-party community claims (no
+    P887→Q131783016 reference) are never removed even when their
+    value shape is coincidentally junk-like. This pass strictly
+    unwrites the legacy migrator's imports."""
+    from tools import sdc_sync
+
+    dpla_junk = _p571_somevalue_with_p1932(
+        "M111$DPLA",
+        ";",  # coincidentally junk-shaped — untouchable regardless
+        references=[_dpla_reference()],
+    )
+    third_party = _string_stmt(
+        "M111$3P",
+        "P10358",
+        "--",
+        references=[],
+    )
+    entity = {
+        "pageid": 111,
+        "statements": {"P571": [dpla_junk], "P10358": [third_party]},
+    }
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._reconcile_inferred_from_wikitext_junk("M111")
+    assert sdc_sync.removals == []
+    sdc_sync._reset_per_file_accumulators()
+
+
+# ---------------------------------------------------------------------------
 # _find_existing_commons_files_by_dpla_id — Commons-side discovery primitive
 # that decouples SDC eligibility from the upload phase's per-ordinal status.
 # Lets a file already on Commons get its SDC re-synced when the current

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -20,6 +20,7 @@ from ingest_wikimedia.sdc import (
     NARA_PROVIDER_NAME,
     casefold_for_compare,
     ingest_date_from_doc,
+    is_wikitext_junk_value,
     parse_date_range,
     parse_dpla_date,
     parse_nara_access_level,
@@ -2989,6 +2990,7 @@ def dpla_claims(
         mediaid, dpla_id, expected, protected_props=CHUNKABLE_PROPS
     )
     _reconcile_inferred_from_wikitext_dupes(mediaid)
+    _reconcile_inferred_from_wikitext_junk(mediaid)
 
 
 def _build_expected_from_parsed(
@@ -3474,6 +3476,75 @@ def _reconcile_inferred_from_wikitext_dupes(mediaid):
         for stmt in inferred_stmts:
             comp = _statement_comparable_value(stmt)
             if comp is not None and comp in dpla_comparables:
+                removals.append(stmt["id"])
+
+
+def _inferred_stored_text(stmt) -> str | None:
+    """Return the raw display text stored on an inferred-from-Wikitext
+    claim, or ``None`` when the statement carries no plain-text
+    display value.
+
+    ``value`` mainsnaks of type ``string`` return the string directly.
+    ``monolingualtext`` returns the inner ``text`` field. ``somevalue``
+    claims (the shape the migrator falls back to when
+    :func:`parse_dpla_date` rejects the input) return the raw
+    ``P1932`` stated-as qualifier — that's where a junk date like
+    ``;`` actually lives, since the mainsnak has no string of its
+    own.
+
+    Non-text mainsnaks (structured time, wikibase-entityid, quantity)
+    return ``None`` — the junk sweep skips them; if a time-typed
+    claim parsed successfully, the underlying value can't be markup
+    junk by construction.
+    """
+    ms = stmt.get("mainsnak") or {}
+    if ms.get("snaktype") == "value":
+        dv = ms.get("datavalue") or {}
+        dtype = dv.get("type")
+        v = dv.get("value")
+        if dtype == "string" and isinstance(v, str):
+            return v
+        if dtype == "monolingualtext" and isinstance(v, dict):
+            text = v.get("text")
+            return text if isinstance(text, str) else None
+        return None
+    if ms.get("snaktype") == "somevalue":
+        for q in (stmt.get("qualifiers") or {}).get("P1932", []):
+            qv = q.get("datavalue") or {}
+            if qv.get("type") == "string":
+                s = qv.get("value")
+                if isinstance(s, str):
+                    return s
+    return None
+
+
+def _reconcile_inferred_from_wikitext_junk(mediaid):
+    """Remove inferred-from-Wikitext claims whose stored display text
+    is a wikitext-extraction artifact — a stray ``;`` in a date field,
+    ``--`` in a title, and other 1-2-character punctuation-only values
+    that :func:`ingest_wikimedia.sdc.is_wikitext_junk_value` flags.
+    These are markup / regex / human errors in the source template,
+    never real metadata worth preserving as SDC.
+
+    Pushes statement IDs onto the module-level ``removals`` accumulator
+    so the per-file dispatcher flushes them alongside DPLA-drift and
+    dupe removals in one wbeditentity.
+
+    Safety: only touches claims carrying the ``P887 → Q131783016``
+    (inferred-from-Wikitext) reference fingerprint — the migration's
+    own imports. Third-party community claims are never removed even
+    when they happen to be punctuation-only; this pass strictly
+    unwrites the legacy migrator's mistakes.
+    """
+    entity = get_entity(mediaid)
+    statements = entity.get("statements") or {}
+    for stmts in statements.values():
+        for stmt in stmts:
+            refs = stmt.get("references") or []
+            if not any(_is_inferred_from_wikitext_reference(ref) for ref in refs):
+                continue
+            text = _inferred_stored_text(stmt)
+            if text is not None and is_wikitext_junk_value(text):
                 removals.append(stmt["id"])
 
 


### PR DESCRIPTION
Two closely-related fixes for wikitext-extraction sanity, both landing at the same seam (`parse_artwork_params` extraction + `casefold_for_compare` / SDC reconciler comparators).

## 1 · Un-escape MediaWiki magic words

Community AWB passes sometimes rewrite a literal `|` inside a template parameter value to the `{{!}}` magic word — the parser expands it back to `|` at render time, so it's display-invariant. But the escape survives as literal text in any context that reads the raw wikitext without expanding it: the legacy-Artwork → SDC migrator stored the escaped form as a P10358 statement, permanently diverging from DPLA canonical which carries the literal `|`.

**Motivating example:** [File:Block_Card_6_E._Bancroft_Street_-_DPLA_-_307d98570261183ed48eb3b1880fce14.jpg](https://commons.wikimedia.org/wiki/File:Block_Card_6_E._Bancroft_Street_-_DPLA_-_307d98570261183ed48eb3b1880fce14.jpg) — 2020-06-04 AWB pass rewrote every `|` in template params to `{{!}}`; 2026-07-06 legacy-Artwork migrator preserved the escaped form as a P10358 SDC statement.

New helper `unescape_wikitext_magic_words` in `ingest_wikimedia/sdc.py` covers all six documented forms from https://www.mediawiki.org/wiki/Help:Magic_words: `{{!}}` `{{=}}` `{{((}}` `{{))}}` `{{!(}}` `{{)!}}`. Implemented as a single-pass `re.sub` — sequential `str.replace` rescans its own output and over-unescapes cases like `{{((}}))}}`.

Applied at two seams: `parse_artwork_params` (prevents new dirty writes + fixes the provenance walker's misclassification of AWB's display-invariant edits as content changes) and inside `casefold_for_compare` (belt-and-suspenders for the already-stored dirty SDC values — the two comparator paths `_statement_comparable_value` and `_value_matches` both route through this helper).

## 2 · Refuse to preserve 1-2-char punctuation-only values

A stray `;` in a `date =` field, `--` in a title, `.` in a creator — all wikitext-extraction artifacts (markup / regex / human error in the source template), never real metadata worth preserving as SDC.

**Motivating example:** [File:A_Toledo_Symphony_Orchestra_---_why%3F_-_DPLA_-_640c3941bd35b12a39cb3820e9f778b2_(page_6).jpg](https://commons.wikimedia.org/wiki/File:A_Toledo_Symphony_Orchestra_---_why%3F_-_DPLA_-_640c3941bd35b12a39cb3820e9f778b2_(page_6).jpg) — legacy template carried `| date = ;` and the 2026-06-25 migrator dutifully wrote a P571 = somevalue + P1932=";" inferred claim.

New helper `is_wikitext_junk_value(s)` in `sdc.py`: True when `s` is 1-2 chars after strip and contains no alphanumerics. Single-letter titles (`A`) and single-digit values (`1`) pass through unfiltered — the filter targets punctuation-only shapes specifically.

Applied at two seams:
- `parse_artwork_params` — filter at extraction, same behavior as the existing empty-value skip. Prevents new junk SDC writes.
- New `_reconcile_inferred_from_wikitext_junk` in `tools/sdc_sync.py` — sweep pass that removes existing inferred-from-Wikitext claims whose stored display text (string mainsnak, monolingual `text`, or P1932 stated-as qualifier) is junk-shaped. Scoped strictly to the migration's own imports (P887→Q131783016 reference); DPLA-authored and third-party claims are never touched even when their value shape is coincidentally junk-like.

## Test plan

- [ ] `python -m pytest -q` — 1154 passing locally
- [ ] New tests: unescape / junk value helper coverage, `parse_artwork_params` extraction filters, `_reconcile_inferred_from_wikitext_junk` cleanup pass (positive + preservation + third-party safety)
- [ ] After merge: legacy-Artwork migrations no longer write junk-shaped or magic-word-escaped values; next SDC-sync pass over already-migrated files sweeps existing dirt out.

## Follow-up (out of scope)

Broader data-repair of already-stored dirty SDC values (rewriting `{{!}}`-carrying descriptions to clean text, etc.) beyond the junk-only sweep — separate one-off script if the next SDC-sync deduplication pass doesn't clean them up naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR teaches wikitext↔SDC reconciliation to treat MediaWiki “magic word” escape templates as display-equivalent to their rendered characters (via a single-pass unescape to avoid incorrect collapsing in adjacent-token cases).

- Added `unescape_wikitext_magic_words()` in `ingest_wikimedia/sdc.py` and updated `casefold_for_compare()` to unescape `{{!}}`, `{{=}}`, `{{((}}`, `{{))}}`, `{{!(}}`, and `{{)!}}` before the existing normalization/comparison steps.
- Updated legacy `{{Artwork}}` param parsing in `ingest_wikimedia/legacy_artwork.py` to unescape these forms during extraction, preventing escaped template artifacts from being written into SDC and improving provenance tracing.
- Introduced `is_wikitext_junk_value()` to detect short punctuation/whitespace-only “wikitext junk” and filter it during extraction/reconciliation so existing junk-shaped values don’t get (re)written.
- Updated `tools/sdc_sync.py` reconciliation to add `_reconcile_inferred_from_wikitext_junk()`, removing existing inferred-from-Wikitext claims only when the stored inferred text is junk-shaped and the claim matches the migration’s own inferred-from-Wikitext fingerprint/scope—while preserving non-junk content and skipping DPLA-authored and unrelated third-party/community inferred claims.

No database migration (reversible or otherwise), public API/endpoint shape change, environment variable/AWS Secrets change, shared infrastructure configuration change (CodePipeline/CodeBuild/ECS/IAM), security/auth change, or manual pipeline trigger/ECS redeployment is required beyond deploying the updated code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->