### PR TITLE
Pin pywikibot socket_timeout to bound hung-recv worst-case

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -641,8 +641,27 @@ def get_page(site: BaseSite, title: str) -> FilePage:
         raise RuntimeError(f"Unable to create page {title}: {str(e)}") from e
 
 
+# HTTP (connect, read) timeouts pinned on every ``pywikibot.Site`` this
+# module hands out. Prevents an in-the-wild pattern (NPRC sdc-sync,
+# 2026-07-06) where a socket in kernel CLOSE-WAIT sat 80 minutes with
+# no per-recv deadline enforced — one hung descriptor stalled the whole
+# session's worker pool. A 60s read timeout means a stuck socket
+# surfaces as a ``requests.exceptions.ReadTimeout`` promptly and
+# pywikibot's retry loop takes over.
+PYWIKIBOT_SOCKET_TIMEOUT: tuple[float, float] = (10, 60)
+
+
+def _pin_socket_timeout() -> None:
+    """Set ``pywikibot.config.socket_timeout`` process-wide. Idempotent;
+    safe to call from every ``get_site``/``get_wikidata_site`` entry
+    so callers that never go through ``sdc-sync``'s ``_initialize()``
+    still get the bounded timeout."""
+    pywikibot.config.socket_timeout = PYWIKIBOT_SOCKET_TIMEOUT
+
+
 def get_site() -> BaseSite:
     """Returns the Site object for Wikimedia Commons."""
+    _pin_socket_timeout()
     site = pywikibot.Site(COMMONS_SITE_NAME)
     site.login()
     return site
@@ -650,6 +669,7 @@ def get_site() -> BaseSite:
 
 def get_wikidata_site() -> BaseSite:
     """Returns the Site object for Wikidata."""
+    _pin_socket_timeout()
     site = pywikibot.Site("wikidata", "wikidata")
     site.login()
     return site

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -2167,6 +2167,7 @@ def test_initialize_pins_pywikibot_retry_budget(monkeypatch, tmp_path):
     monkeypatch.setattr(pywikibot.config, "max_retries", 15)
     monkeypatch.setattr(pywikibot.config, "retry_wait", 5)
     monkeypatch.setattr(pywikibot.config, "retry_max", 120)
+    monkeypatch.setattr(pywikibot.config, "socket_timeout", None)
 
     # _initialize() reads config.toml + rights.json from _REPO_ROOT; stub both.
     (tmp_path / "config.toml").write_text('dpla_api_key = "stub"\n')
@@ -2191,6 +2192,7 @@ def test_initialize_pins_pywikibot_retry_budget(monkeypatch, tmp_path):
     assert pywikibot.config.max_retries == sdc_sync._PYWIKIBOT_MAX_RETRIES
     assert pywikibot.config.retry_wait == sdc_sync._PYWIKIBOT_RETRY_WAIT
     assert pywikibot.config.retry_max == sdc_sync._PYWIKIBOT_RETRY_MAX
+    assert pywikibot.config.socket_timeout == sdc_sync._PYWIKIBOT_SOCKET_TIMEOUT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -38,6 +38,37 @@ def test_get_site(mock_site):
     mock_site_instance.login.assert_called_once()
 
 
+def test_get_site_pins_pywikibot_socket_timeout(monkeypatch):
+    """Every ``get_site`` handout must pin ``pywikibot.config.socket_timeout``
+    so a hung socket surfaces as a ``requests.exceptions.ReadTimeout``
+    rather than blocking indefinitely at kernel recv (in-the-wild
+    NPRC sdc-sync stall of 80 min against a CLOSE-WAIT socket)."""
+    import pywikibot
+
+    from ingest_wikimedia.wikimedia import PYWIKIBOT_SOCKET_TIMEOUT, get_site
+
+    monkeypatch.setattr(pywikibot.config, "socket_timeout", None)
+    monkeypatch.setattr("ingest_wikimedia.wikimedia.pywikibot.Site", MagicMock())
+    get_site()
+    assert pywikibot.config.socket_timeout == PYWIKIBOT_SOCKET_TIMEOUT
+
+
+def test_get_wikidata_site_pins_pywikibot_socket_timeout(monkeypatch):
+    """Same invariant on the Wikidata handout — the same failure mode
+    exists whenever pywikibot's HTTP layer is used against any wiki."""
+    import pywikibot
+
+    from ingest_wikimedia.wikimedia import (
+        PYWIKIBOT_SOCKET_TIMEOUT,
+        get_wikidata_site,
+    )
+
+    monkeypatch.setattr(pywikibot.config, "socket_timeout", None)
+    monkeypatch.setattr("ingest_wikimedia.wikimedia.pywikibot.Site", MagicMock())
+    get_wikidata_site()
+    assert pywikibot.config.socket_timeout == PYWIKIBOT_SOCKET_TIMEOUT
+
+
 def test_check_content_type_valid():
     content_type = "image/jpeg"
     assert check_content_type(content_type)

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -562,6 +562,7 @@ def _initialize() -> None:
     pywikibot.config.max_retries = _PYWIKIBOT_MAX_RETRIES
     pywikibot.config.retry_wait = _PYWIKIBOT_RETRY_WAIT
     pywikibot.config.retry_max = _PYWIKIBOT_RETRY_MAX
+    pywikibot.config.socket_timeout = _PYWIKIBOT_SOCKET_TIMEOUT
 
     site = pywikibot.Site()
     site.login()
@@ -709,10 +710,20 @@ def formattedclaim(prop, value, value_type, dpla_id):
 
 # Pywikibot retry budget — applied process-wide in ``_initialize()``.
 # Worst-case single-call stall ≈ max_retries × (read_timeout + retry_max)
-# = 5 × (45s + 60s) ≈ 9 min, vs pywikibot's ~30-min default.
+# = 5 × (60s + 60s) ≈ 10 min, vs pywikibot's ~30-min default.
 _PYWIKIBOT_MAX_RETRIES = 5
 _PYWIKIBOT_RETRY_WAIT = 5
 _PYWIKIBOT_RETRY_MAX = 60
+
+# HTTP (connect, read) timeouts for every request pywikibot makes. Set
+# explicitly rather than trusting the pywikibot default — an in-the-
+# wild sdc-sync stall (NPRC, 2026-07-06) sat 80 minutes on a socket
+# that was in kernel CLOSE-WAIT, indicating no per-recv deadline was
+# enforced. A 60s read timeout means a hung socket surfaces as a
+# ``requests.exceptions.ReadTimeout`` promptly and pywikibot's retry
+# loop picks up rather than the whole pool stalling behind one
+# blocked descriptor. Applies to reads AND writes.
+_PYWIKIBOT_SOCKET_TIMEOUT: tuple[float, float] = (10, 60)
 
 
 # Per-file cache for wbgetentities. Populated at the start of process_one()
@@ -5021,6 +5032,7 @@ def _init_partner_worker(
     pywikibot.config.max_retries = _PYWIKIBOT_MAX_RETRIES
     pywikibot.config.retry_wait = _PYWIKIBOT_RETRY_WAIT
     pywikibot.config.retry_max = _PYWIKIBOT_RETRY_MAX
+    pywikibot.config.socket_timeout = _PYWIKIBOT_SOCKET_TIMEOUT
 
     global site, hubs, rights, subject_ids, _normalize_wikitext_enabled
     global _worker_slot_budget
@@ -5539,6 +5551,7 @@ def _init_maintain_worker(
     pywikibot.config.max_retries = _PYWIKIBOT_MAX_RETRIES
     pywikibot.config.retry_wait = _PYWIKIBOT_RETRY_WAIT
     pywikibot.config.retry_max = _PYWIKIBOT_RETRY_MAX
+    pywikibot.config.socket_timeout = _PYWIKIBOT_SOCKET_TIMEOUT
 
     global site, hubs, _s3_partner, _s3_client
     global _normalize_wikitext_enabled, _worker_slot_budget


### PR DESCRIPTION
## Summary

Bound the worst-case per-recv wait on every pywikibot HTTP call by pinning `pywikibot.config.socket_timeout = (10, 60)` (10s connect, 60s read) at every process-wide setup site.

## Motivating incident

The NARA National Personnel Records Center sdc-sync run on 2026-07-06 stalled for 80 minutes on a socket in kernel `CLOSE-WAIT` — the Wikimedia peer had sent FIN and 25 bytes were queued in the recv buffer, but the application was still blocked in `read()`. Diagnostic from `ss -tp`:

```
CLOSE-WAIT 25 0  172.30.0.239:45350  208.80.154.224:https  users:(("sdc-sync",pid=550499,fd=3))
```

Kernel stack of the offending thread was in `__skb_wait_for_more_packets` — a raw socket recv with no timeout being enforced. The whole session's worker pool stalled behind the main process's blocked descriptor (`⚠ idle 59m` in the status readout). The eventual unblock came from a lower-layer TCP/SSL timeout much later, not from any HTTP-level deadline. This was a **no-op run** (`SDC_ITEMS_SYNCED: 143` with all other counters zero) — it stalled on a GET, not a write.

## Fix

Pin `pywikibot.config.socket_timeout` explicitly rather than trusting the pywikibot default. Applied at four places so every pywikibot-using code path picks it up:

- `ingest_wikimedia.wikimedia.get_site` / `get_wikidata_site` — covers uploader, drain-deferred, retirer, fix-unknown-categories, and anything else that goes through the shared helper.
- Three `tools/sdc_sync.py` initialisation entry points (`_initialize`, worker-fork init, and the pywikibot-only init variant) — the same block that already sets `max_retries` / `retry_wait` / `retry_max` now also sets `socket_timeout`.

Also updated the retry-budget math comment in `sdc_sync.py` (worst-case single-call stall was calculated against pywikibot's assumed 45s default; now bounded explicitly at 60s → worst-case stall ≈ 10 min instead of 30 min or unbounded).

## Test plan

- [ ] `python -m pytest -q` — 1156 passing locally
- [ ] New tests: `test_get_site_pins_pywikibot_socket_timeout`, `test_get_wikidata_site_pins_pywikibot_socket_timeout`, plus the existing `_initialize` retry-config test extended to also assert `socket_timeout`.
- [ ] After merge: next long-running sdc-sync run that hits a stuck socket should error out within ~60s and retry rather than stalling silently for tens of minutes.

## Skipped from earlier scope

I originally floated a reporter slot-count "cross-session attribution" fix. On closer look I don't have evidence of an actual leak — the `[Slots: 3]` reading at 3:41pm was probably legitimately 3 NPRC PIDs holding locks at that moment (my later 1-lock check was 5+ min after main exited, i.e. after cleanup). Not going to fix what isn't demonstrably broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR pins `pywikibot.config.socket_timeout` to `(10, 60)` everywhere pywikibot is initialized, bounding stalled HTTP requests to a 10s connect timeout and 60s read timeout.

Changed paths:
- `ingest_wikimedia/wikimedia.py`: added a shared socket-timeout constant and helper, and now applies it before creating/logging into both Commons and Wikidata sites.
- `tools/sdc_sync.py`: applies the same timeout during main initialization and both multiprocessing worker initializers, alongside the existing retry tuning.
- Tests were updated/added to verify the timeout is pinned in both the Wikimedia site helpers and `sdc_sync` initialization.

Also updated the retry-budget comment to reflect the explicit 60-second read timeout.

No manual pipeline trigger, redeployment, env var/secret, database, shared infrastructure, API shape, or security changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->