### PR TITLE
Repair literal-pipe truncation in parse_artwork_params

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -202,16 +202,50 @@ def parse_artwork_params(wikitext: str) -> dict[str, str]:
     silently — those don't have a canonical target and the wikitext-
     rewrite step preserves them by leaving the template untouched if
     the param wasn't migrated.
+
+    Repairs literal-``|`` truncation of named-param values. Legacy
+    ``{{Artwork}}`` uploads sometimes wrote pipe-separated subject
+    lists directly into ``| description = ... buildings | 633 Evesham
+    | Dwellings | ...`` without escaping. ``mwparserfromhell`` treats
+    each such ``|`` as a parameter separator and truncates the named
+    ``description`` value at the first pipe, spilling the rest into
+    anonymous positional params (``1``, ``2``, ``3``, …). The legacy
+    ``{{Artwork}}`` / ``{{Information}}`` / ``{{Photograph}}``
+    templates take only named params by convention, so any anonymous
+    positional at the top level is overflow from an earlier named
+    value; we stitch each back onto the preceding named param with a
+    literal ``|`` rejoin. Without this repair, a later AWB pass that
+    rewrote the raw ``|`` to ``{{!}}`` looks like a content change to
+    the provenance walker (Rev N-1 parse ends at first pipe; Rev N
+    parse gets the full value), and the description gets misattributed
+    as community-contributed on migration.
     """
     template = find_legacy_template(wikitext)
     if template is None:
         return {}
-    parsed: dict[str, str] = {}
+    # Stitch: iterate template params, accumulating overflow positional
+    # values into the preceding named param's raw value. Track whether
+    # the last named param was RECOGNISED so overflow from an
+    # unrecognised param (e.g. ``| Other fields 1 = X | Y | title = …``)
+    # is dropped rather than misattributed to the previous recognised
+    # named entry earlier in the template.
+    stitched: list[list[str]] = []
+    last_named_recognised = False
     for param in template.params:
+        if not param.showkey:
+            if last_named_recognised and stitched:
+                stitched[-1][1] += "|" + str(param.value)
+            continue
         canonical = ARTWORK_PARAM_TO_CANONICAL_KEY.get(_normalize_param_name(param))
         if canonical is None:
+            last_named_recognised = False
             continue
-        value = unescape_wikitext_magic_words(str(param.value).strip())
+        stitched.append([canonical, str(param.value)])
+        last_named_recognised = True
+
+    parsed: dict[str, str] = {}
+    for canonical, raw in stitched:
+        value = unescape_wikitext_magic_words(raw.strip())
         if not value or is_wikitext_junk_value(value):
             # Empty values and wikitext-extraction junk (a stray ``;`` in
             # a date field, ``--`` in a title, etc. — see

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -219,6 +219,20 @@ def parse_artwork_params(wikitext: str) -> dict[str, str]:
     the provenance walker (Rev N-1 parse ends at first pipe; Rev N
     parse gets the full value), and the description gets misattributed
     as community-contributed on migration.
+
+    Known limitation: only ANONYMOUS positional overflow is stitched.
+    An overflow fragment that itself happens to contain ``=`` (e.g.
+    ``| description = A | region=north | date = …``) is parsed by
+    ``mwparserfromhell`` as a NAMED parameter (``region=north``) and
+    the current logic drops it — the literal-pipe form's parse then
+    diverges from the corresponding ``{{!}}`` form (which would keep
+    the whole ``A | region=north`` as one description value). In
+    practice DPLA metadata values rarely contain ``key=value`` shapes
+    (typical subject lists are noun phrases like ``Ranch houses`` or
+    ``Dwellings``), and none of the migration incidents observed to
+    date hit this shape. See
+    :func:`test_parse_artwork_params_pipe_overflow_with_equals_fragment_is_dropped`
+    for the pinned current behaviour.
     """
     template = find_legacy_template(wikitext)
     if template is None:

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -143,6 +143,89 @@ def test_parse_artwork_params_keeps_single_alnum_values():
     assert parse_artwork_params(wikitext) == {"title": "A", "date": "1"}
 
 
+def test_parse_artwork_params_stitches_literal_pipe_truncation():
+    """A legacy upload that writes pipe-separated subject terms directly
+    into a named value (``| description = A | B | C``) gets truncated
+    by ``mwparserfromhell`` — the ``|`` reads as a parameter separator
+    and ``B`` / ``C`` land as anonymous positional args. Left
+    unrepaired, a later AWB pass rewriting ``|`` → ``{{!}}`` looks like
+    a content change (short truncated value → full value), causing the
+    provenance walker to misattribute description authorship to the
+    AWB editor and the migration to preserve DPLA-authored text as a
+    spurious ``inferred-from-Wikitext`` SDC claim.
+
+    Regression: Block_Card_633_Evesham_Avenue-DPLA-
+    ccb2717b29309f0ef0e58a8221e75019 — 2020 DPLA_bot upload with
+    literal ``|`` in description; 2020-06-04 JarektBot AWB pass
+    swapped for ``{{!}}``; the pre-fix migration misattributed the
+    description to JarektBot and wrote a P10358 statement preserving
+    the AWB form of the wikitext.
+    """
+    literal_pipe_form = (
+        "{{Artwork\n"
+        "| title = A Title\n"
+        "| description = terms: houses | 633 Evesham | Dwellings | Norwood\n"
+        "| date = 1937\n"
+        "}}"
+    )
+    magic_word_form = (
+        "{{Artwork\n"
+        "| title = A Title\n"
+        "| description = terms: houses {{!}} 633 Evesham {{!}} Dwellings {{!}} Norwood\n"
+        "| date = 1937\n"
+        "}}"
+    )
+    a = parse_artwork_params(literal_pipe_form)
+    b = parse_artwork_params(magic_word_form)
+    # Both revs parse to the same description — the AWB rewrite is
+    # display-invariant and must produce a display-invariant parse too.
+    assert a == b
+    assert a["description"] == "terms: houses | 633 Evesham | Dwellings | Norwood"
+    assert a["date"] == "1937"
+
+
+def test_parse_artwork_params_pipe_overflow_from_unrecognised_param_dropped():
+    """Overflow positional args from an unrecognised named param
+    (``| Other fields 1 = X | Y | title = …``) must NOT be misattributed
+    to a previous recognised named entry. ``Y`` is overflow from
+    ``Other fields 1``; dropping it is correct because we can't route
+    it to any canonical target."""
+    wikitext = (
+        "{{Artwork\n"
+        "| title = T\n"
+        "| Other fields 1 = X | Y | Z\n"
+        "| description = A real description\n"
+        "| date = 1937\n"
+        "}}"
+    )
+    p = parse_artwork_params(wikitext)
+    assert p == {
+        "title": "T",
+        "description": "A real description",
+        "date": "1937",
+    }
+
+
+def test_parse_artwork_params_stitching_ignores_pipes_inside_nested_templates():
+    """A nested ``{{Institution|wikidata=Q…}}`` inside a param value
+    keeps its own ``|`` scoped to the nested template — the outer
+    Artwork param value is one whole string, not truncated. The
+    stitching pass must not double-count or damage this case."""
+    wikitext = (
+        "{{Artwork\n"
+        "| title = T\n"
+        "| institution = {{Institution|wikidata=Q7814140}}\n"
+        "| date = 1937\n"
+        "}}"
+    )
+    p = parse_artwork_params(wikitext)
+    assert p == {
+        "title": "T",
+        "institution": "{{Institution|wikidata=Q7814140}}",
+        "date": "1937",
+    }
+
+
 def test_parse_artwork_params_unescapes_magic_words_in_values():
     """A community AWB pass sometimes rewrites literal ``|`` inside a
     template param to the ``{{!}}`` magic word (parser expands it back

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -226,6 +226,42 @@ def test_parse_artwork_params_stitching_ignores_pipes_inside_nested_templates():
     }
 
 
+def test_parse_artwork_params_pipe_overflow_with_equals_fragment_is_dropped():
+    """Known limitation of the stitching heuristic: an overflow fragment
+    that contains ``=`` (e.g. ``| description = A | region=north | …``)
+    is parsed by ``mwparserfromhell`` as a NAMED parameter
+    (``region=north``) rather than as an anonymous positional. Only
+    anonymous positional overflow is stitched, so the ``region=north``
+    fragment is dropped and the literal-pipe form's parse diverges
+    from the corresponding ``{{!}}`` form for the same source text.
+
+    Pinned here as a regression test — the shape is rare in real DPLA
+    metadata (typical subject lists don't contain ``key=value``) and
+    handling it would require a wider allowlist-based heuristic. If
+    we ever fix this, the test flips to assert successful stitching.
+    """
+    literal_pipe_form = (
+        "{{Artwork\n"
+        "| description = A | region=north\n"
+        "| date = 1937\n"
+        "}}"
+    )
+    p = parse_artwork_params(literal_pipe_form)
+    # Current behavior: ``region=north`` is dropped because mwparserfromhell
+    # parses it as a named param and stitching only rejoins positional
+    # overflow. Description ends at the truncation point.
+    assert p == {"description": "A", "date": "1937"}
+    # For contrast, the {{!}} form keeps the whole value:
+    magic_word_form = (
+        "{{Artwork\n"
+        "| description = A {{!}} region=north\n"
+        "| date = 1937\n"
+        "}}"
+    )
+    q = parse_artwork_params(magic_word_form)
+    assert q == {"description": "A | region=north", "date": "1937"}
+
+
 def test_parse_artwork_params_unescapes_magic_words_in_values():
     """A community AWB pass sometimes rewrites literal ``|`` inside a
     template param to the ``{{!}}`` magic word (parser expands it back


### PR DESCRIPTION
## Summary

The `_reconcile_inferred_from_wikitext_dupes` pass added in #375 correctly compares SDC values through `casefold_for_compare` (which un-escapes `{{!}}`). But on [File:Block Card 633 Evesham Avenue -- DPLA -- ccb2717b…](https://commons.wikimedia.org/wiki/File:Block_Card_633_Evesham_Avenue_-_DPLA_-_ccb2717b29309f0ef0e58a8221e75019.jpg) a fresh post-#375 sync still no-oped: the DPLA-attributed P10358 says "Dwelling" and the inferred-from-Wikitext P10358 says "Dwellings" — one legitimate character of difference, so the reconciler correctly did NOT merge them.

The wrong thing isn't the reconciler; it's that the inferred statement ever existed. Traced to its cause:

1. **2020-05-17** DPLA_bot uploaded the file with `| description = ... Ranch houses | 633 Evesham | Dwellings | ...` — literal `|` inside the description value.
2. `mwparserfromhell` treats each `|` as a parameter separator. `parse_artwork_params` on Rev 1 returned `description = "...Ranch houses"` (199 chars, truncated). The rest of the pipe-separated subject terms landed as anonymous positional params (`1=633 Evesham`, `2=Dwellings`, `3=…`).
3. **2020-06-04** JarektBot ran an AWB pass rewriting the literal `|` to `{{!}}`. Now mwparserfromhell keeps the whole description as one value; `parse_artwork_params` (with the #375 magic-word un-escape) returns the full 331 chars.
4. **Migration's provenance walker sees a "content change"** from Rev 1's 199-char parse to Rev 2's 331-char parse, attributes description authorship to JarektBot (community), and imports the description as an `inferred-from-Wikitext` P10358 statement — even though the AWB rewrite was display-invariant.
5. Downstream, DPLA-side canonical drifted "Dwellings" → "Dwelling" over the years. The reconciler compares the still-preserved community value against DPLA's current value; they legitimately differ; nothing gets merged.

The upstream defect is step 2/3: the AWB rewrite must produce a display-invariant parse to keep the provenance walker honest.

## Fix

`parse_artwork_params` now stitches overflow positional args back onto the preceding named param's value with a literal `|` rejoin. Legacy `{{Artwork}}` / `{{Information}}` / `{{Photograph}}` templates take only named params by convention, so any anonymous positional at the top level is overflow from an earlier named value that mwparserfromhell truncated.

Also tracks whether the last named param was RECOGNISED — overflow from an unrecognised param (`| Other fields 1 = X | Y | title = …`) is dropped rather than misattributed to an earlier recognised entry.

Verified against the real file: Rev 1 (literal-pipe) and Rev 2 (`{{!}}`-form) both now parse to the identical 331-char description. Provenance walker will attribute description to Rev 1's DPLA_bot → classified as DPLA-originated → no spurious community import.

## Test plan

- [ ] `python -m pytest -q` — 1159 passing locally
- [ ] New tests: `test_parse_artwork_params_stitches_literal_pipe_truncation`, `test_parse_artwork_params_pipe_overflow_from_unrecognised_param_dropped`, `test_parse_artwork_params_stitching_ignores_pipes_inside_nested_templates`
- [ ] After merge: next legacy-Artwork migration pass on a literal-pipe file classifies the description as DPLA-originated instead of community, no spurious P10358 write.

## Follow-up (out of scope)

Data-repair sweep for existing inferred-from-Wikitext SDC statements minted by this misattribution before the fix. Deferred per discussion — needs its own scoping around revision-history inspection vs. bulk-value-drift detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixed legacy `{{Artwork}}`-family template parsing to repair `mwparserfromhell` literal-pipe (`|`) truncation in `parse_artwork_params`. When a recognized named parameter value contains `|`, any overflow that `mwparserfromhell` incorrectly places into anonymous positional parameters is now stitched back onto the preceding recognized named parameter using a literal `|` rejoin. The repair stops when overflow follows an unrecognized named parameter, so overflow from unknown keys is dropped instead of being misattributed. Pipes inside nested templates within parameter values are preserved as part of the outer value.

Added regression tests covering:
- stitching literal-pipe truncation back into the correct named parameter (including parity with `{{!}}`),
- dropping overflow originating from unrecognized named parameters,
- preserving nested templates containing pipes,
- documented heuristic limitation: if the overflow fragment contains `=`, it may be parsed as a named parameter and is not stitched today (asserted via a regression test).

No manual pipeline trigger or ECS redeployment required, and no environment/secret, database migration, shared infrastructure (CodePipeline/CodeBuild/ECS/IAM), public API shape, endpoints, or security-relevant credential/input handling changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->