### PR TITLE
Recognize multi-value description subsets as DPLA-originated

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -455,6 +455,51 @@ def _extract_institution_qid(value: str) -> str | None:
     return None
 
 
+_MULTI_VALUE_DELIMITER = "; "
+
+
+def _multi_value_subset_of_canonical(value: str, canonical: str) -> bool:
+    """True when ``value`` and ``canonical`` are both ``; ``-joined
+    string lists AND every casefolded entry in ``value`` also appears
+    in ``canonical``.
+
+    Legacy ``{{Artwork}}`` uploads concatenated multi-valued DPLA
+    fields (``sourceResource.description`` is often a list) into a
+    single template parameter with ``; `` separators;
+    :func:`ingest_wikimedia.wikimedia.extract_strings` — the source of
+    ``canonical_params['description']`` — joins with the same
+    ``VALUE_JOIN_DELIMITER = "; "`` shape. Byte-comparing the two
+    concatenations misses the case where DPLA has drifted between
+    upload and migration (adding a value, dropping a value,
+    reordering) even though every value the wikitext carries is still
+    part of the DPLA-authored set. In that case the wikitext content
+    is DPLA-originated, not community-contributed, and no
+    ``inferred-from-Wikitext`` import should fire.
+
+    Subset — not equal — because the wikitext-side list at migration
+    time reflects DPLA data as of upload; DPLA canonical may have
+    added values since. The migrated ``{{DPLA metadata}}`` template
+    will render the current (superset) canonical from SDC anyway.
+    """
+    if _MULTI_VALUE_DELIMITER not in value or _MULTI_VALUE_DELIMITER not in canonical:
+        return False
+    value_parts = {
+        folded
+        for folded in (
+            casefold_for_compare(p) for p in value.split(_MULTI_VALUE_DELIMITER)
+        )
+        if folded
+    }
+    canonical_parts = {
+        folded
+        for folded in (
+            casefold_for_compare(p) for p in canonical.split(_MULTI_VALUE_DELIMITER)
+        )
+        if folded
+    }
+    return bool(value_parts) and value_parts.issubset(canonical_parts)
+
+
 def _value_equivalent_to_canonical(key: str, value: str, canonical: str) -> bool:
     """Return True when ``value`` (from wikitext) and ``canonical`` (from
     DPLA) are the same fact for the purpose of migration-planning.
@@ -468,14 +513,18 @@ def _value_equivalent_to_canonical(key: str, value: str, canonical: str) -> bool
     semantic date-equivalence check runs first — an override like
     ``19 November 1902`` collapses cleanly against ``1902-11-19``.
 
+    A ``; ``-joined multi-value subset check widens equivalence for
+    keys whose canonical form is a semicolon-joined list (notably
+    ``description``): if every value in the wikitext concatenation
+    also appears in DPLA canonical's concatenation after casefold,
+    the wikitext content is DPLA-originated and no community import
+    fires — DPLA-side drift (an extra value added, one dropped, or a
+    reorder) between upload and migration doesn't matter.
+
     For ``institution`` the wikitext value may be a bare Q-ID (flat
     ``{{DPLA metadata}}`` shape) or the legacy sub-template
     ``{{Institution|wikidata=Q...}}`` shape; both extract to a plain
     Q-ID that is byte-compared to the canonical DPLA institution Q-ID.
-    This closes the case where a legacy NARA file's ``Institution``
-    sub-template holds the (custodial-unit) Q-ID that DPLA now emits as
-    ``institution`` in canonical params, but where a wrap difference
-    prevents plain equality from firing.
 
     Keys outside those sets (other sub-template shapes) fall back to
     strict equality.
@@ -493,6 +542,8 @@ def _value_equivalent_to_canonical(key: str, value: str, canonical: str) -> bool
         folded_value = casefold_for_compare(value)
         folded_canonical = casefold_for_compare(canonical)
         if folded_value and folded_value == folded_canonical:
+            return True
+        if _multi_value_subset_of_canonical(value, canonical):
             return True
     return False
 

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -481,7 +481,12 @@ def _multi_value_subset_of_canonical(value: str, canonical: str) -> bool:
     added values since. The migrated ``{{DPLA metadata}}`` template
     will render the current (superset) canonical from SDC anyway.
     """
-    if _MULTI_VALUE_DELIMITER not in value or _MULTI_VALUE_DELIMITER not in canonical:
+    # Only ``canonical`` needs the delimiter — a single-value wikitext
+    # (``| description = A``) can still be a subset of a multi-value
+    # canonical (``A; B; C``) when DPLA expanded the field after
+    # upload. Gating on both sides would reproduce the exact
+    # false-positive this helper exists to catch, just for N=1.
+    if _MULTI_VALUE_DELIMITER not in canonical:
         return False
     value_parts = {
         folded

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1841,19 +1841,23 @@ def test_plan_migration_still_imports_substantively_different_title():
 
 
 def test_plan_migration_skips_description_that_is_multi_value_subset_of_canonical():
-    """A multi-valued DPLA description field renders in wikitext as a
-    single ``; ``-joined string. If DPLA later added a value that
-    wasn't in the wikitext concatenation at upload time, byte- and
-    casefold-comparison fail but the wikitext content is still every
-    bit DPLA-originated. Subset check must recognise the wikitext
-    list as a subset of DPLA canonical and NOT flag it as
-    community-contributed.
+    """A community editor reduces a multi-valued DPLA description
+    (removes one entry) — the remaining values are all still DPLA-
+    authored, so the wikitext content is a subset of DPLA canonical
+    and no ``inferred-from-Wikitext`` import should fire. Subset
+    check widens equivalence to catch this case; without it, the
+    community edit gets preserved forever as a spurious P10358.
 
     Regression: File:%22Principles_of_Causality%22_essay_by_Sarah_..._-_DPLA_-_b3f489f90ebb903b961500c0cf71edfc
     — DPLA has 6 description values, wikitext concatenation had 5;
     the pre-fix migration wrote an inferred-from-Wikitext P10358
     with the 5-value concatenation preserved as a bogus community
     contribution.
+
+    Test forces the community classification with a real editor
+    revision (removing one value) — without a non-bot revision the
+    provenance walker attributes the value to DPLA_bot and skips the
+    equivalence check entirely.
     """
     canonical_description = "; ".join(
         [
@@ -1862,10 +1866,12 @@ def test_plan_migration_skips_description_that_is_multi_value_subset_of_canonica
             "Sallie M. Field",
             "Phillips Academy Archives received the collection.",
             "From The Trustees of Phillips Academy.",
-            "This date is inferred.",  # 6th value not in wikitext
+            "This date is inferred.",
         ]
     )
-    wikitext_description = "; ".join(
+    # Rev 1 matches full DPLA (6 values). Editor removed one value.
+    initial_wikitext_description = canonical_description
+    edited_wikitext_description = "; ".join(
         [
             "Eight page essay with markings made by teacher in pencil.",
             "Date supplied by cataloger.",
@@ -1875,7 +1881,16 @@ def test_plan_migration_skips_description_that_is_multi_value_subset_of_canonica
         ]
     )
     revs = _make_revs(
-        (1, "DPLA_bot", f"{{{{Artwork|description={wikitext_description}}}}}"),
+        (
+            1,
+            "DPLA_bot",
+            f"{{{{Artwork|description={initial_wikitext_description}}}}}",
+        ),
+        (
+            2,
+            "Editor1",
+            f"{{{{Artwork|description={edited_wikitext_description}}}}}",
+        ),
     )
     plan = plan_migration(
         "File:Foo.jpg",
@@ -1883,9 +1898,55 @@ def test_plan_migration_skips_description_that_is_multi_value_subset_of_canonica
         _canonical_params(description=canonical_description),
     )
     assert plan is not None
+    # Editor last touched description → classified community → equivalence
+    # check runs. Subset check widens to say the 5-value wikitext ⊆
+    # 6-value canonical, so no community_import.
     assert plan.community_imports == {}, (
-        f"description whose values are all in DPLA canonical should not "
-        f"be a community import; got community_imports={plan.community_imports}"
+        f"community edit whose values are all in DPLA canonical should "
+        f"not be an import; got community_imports={plan.community_imports}"
+    )
+
+
+def test_plan_migration_subset_handles_single_value_wikitext_vs_multi_canonical():
+    """N=1 boundary of the subset check: wikitext has a single value
+    (no ``; `` delimiter) but canonical is multi-value. Still a
+    subset — the wikitext value appears in the canonical set — and
+    must not classify as community. Pre-fix, the guard required the
+    delimiter on both sides, short-circuiting this case to False and
+    forcing an inferred-from-Wikitext import for what is really a
+    single-value-at-upload-then-DPLA-expanded record."""
+    canonical_description = "; ".join(["only value", "later addition"])
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|description=only value}}"),
+        (2, "Editor1", "{{Artwork|description=only value}}"),
+    )
+    # Rev 2 didn't change description content, so provenance walker
+    # keeps attribution with DPLA_bot; force a change by having Rev 2
+    # touch a different field. Description then stays classified as
+    # dpla, and this test verifies the subset check doesn't over-fire
+    # (i.e., single-value wikitext isn't the community path). To
+    # actually exercise the subset check on N=1, we need a real
+    # community reduction to N=1:
+    revs = _make_revs(
+        (
+            1,
+            "DPLA_bot",
+            "{{Artwork|description=only value; later addition}}",
+        ),
+        (2, "Editor1", "{{Artwork|description=only value}}"),
+    )
+    plan = plan_migration(
+        "File:Foo.jpg",
+        revs,
+        _canonical_params(description=canonical_description),
+    )
+    assert plan is not None
+    # Wikitext value = "only value" (no delim). Canonical = "only value;
+    # later addition". Subset check: {"only value"} ⊆ {"only value",
+    # "later addition"} → True → not community_import.
+    assert plan.community_imports == {}, (
+        f"single-value wikitext that's a subset of multi-value canonical "
+        f"should not be an import; got community_imports={plan.community_imports}"
     )
 
 

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1840,6 +1840,88 @@ def test_plan_migration_still_imports_substantively_different_title():
     assert plan.community_imports == {"title": "A Completely Different Title"}
 
 
+def test_plan_migration_skips_description_that_is_multi_value_subset_of_canonical():
+    """A multi-valued DPLA description field renders in wikitext as a
+    single ``; ``-joined string. If DPLA later added a value that
+    wasn't in the wikitext concatenation at upload time, byte- and
+    casefold-comparison fail but the wikitext content is still every
+    bit DPLA-originated. Subset check must recognise the wikitext
+    list as a subset of DPLA canonical and NOT flag it as
+    community-contributed.
+
+    Regression: File:%22Principles_of_Causality%22_essay_by_Sarah_..._-_DPLA_-_b3f489f90ebb903b961500c0cf71edfc
+    — DPLA has 6 description values, wikitext concatenation had 5;
+    the pre-fix migration wrote an inferred-from-Wikitext P10358
+    with the 5-value concatenation preserved as a bogus community
+    contribution.
+    """
+    canonical_description = "; ".join(
+        [
+            "Eight page essay with markings made by teacher in pencil.",
+            "Date supplied by cataloger.",
+            "Sallie M. Field",
+            "Phillips Academy Archives received the collection.",
+            "From The Trustees of Phillips Academy.",
+            "This date is inferred.",  # 6th value not in wikitext
+        ]
+    )
+    wikitext_description = "; ".join(
+        [
+            "Eight page essay with markings made by teacher in pencil.",
+            "Date supplied by cataloger.",
+            "Sallie M. Field",
+            "Phillips Academy Archives received the collection.",
+            "From The Trustees of Phillips Academy.",
+        ]
+    )
+    revs = _make_revs(
+        (1, "DPLA_bot", f"{{{{Artwork|description={wikitext_description}}}}}"),
+    )
+    plan = plan_migration(
+        "File:Foo.jpg",
+        revs,
+        _canonical_params(description=canonical_description),
+    )
+    assert plan is not None
+    assert plan.community_imports == {}, (
+        f"description whose values are all in DPLA canonical should not "
+        f"be a community import; got community_imports={plan.community_imports}"
+    )
+
+
+def test_plan_migration_still_imports_description_with_extra_community_value():
+    """Guard against overshoot — a community editor appended a value
+    NOT in DPLA canonical to the description concatenation. Subset
+    check correctly says the wikitext isn't a subset of canonical, so
+    the community edit is preserved as an inferred-from-Wikitext SDC
+    statement rather than silently dropped as an equivalent."""
+    canonical_description = "; ".join(["DPLA one.", "DPLA two."])
+    wikitext_description = "; ".join(
+        ["DPLA one.", "DPLA two.", "Community-added extra value."]
+    )
+    original_description = "; ".join(["DPLA one.", "DPLA two."])
+    revs = _make_revs(
+        (
+            1,
+            "DPLA_bot",
+            f"{{{{Artwork|description={original_description}}}}}",
+        ),
+        (
+            2,
+            "Editor1",
+            f"{{{{Artwork|description={wikitext_description}}}}}",
+        ),
+    )
+    plan = plan_migration(
+        "File:Foo.jpg",
+        revs,
+        _canonical_params(description=canonical_description),
+    )
+    assert plan is not None
+    assert "description" in plan.community_imports
+    assert "Community-added extra value" in plan.community_imports["description"]
+
+
 # ---------------------------------------------------------------------------
 # plan_migration — institution Q-ID equivalence (this commit).
 # For NARA files in particular, the legacy `{{Artwork}}` template wrote

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1916,17 +1916,11 @@ def test_plan_migration_subset_handles_single_value_wikitext_vs_multi_canonical(
     forcing an inferred-from-Wikitext import for what is really a
     single-value-at-upload-then-DPLA-expanded record."""
     canonical_description = "; ".join(["only value", "later addition"])
-    revs = _make_revs(
-        (1, "DPLA_bot", "{{Artwork|description=only value}}"),
-        (2, "Editor1", "{{Artwork|description=only value}}"),
-    )
-    # Rev 2 didn't change description content, so provenance walker
-    # keeps attribution with DPLA_bot; force a change by having Rev 2
-    # touch a different field. Description then stays classified as
-    # dpla, and this test verifies the subset check doesn't over-fire
-    # (i.e., single-value wikitext isn't the community path). To
-    # actually exercise the subset check on N=1, we need a real
-    # community reduction to N=1:
+    # Rev 1 has two values; Rev 2 (community editor) reduces to one.
+    # Reduction changes the parsed value, so provenance walker attributes
+    # description to Editor1 → classified as community → subset check
+    # runs on the (now single-value) wikitext against the multi-value
+    # canonical.
     revs = _make_revs(
         (
             1,


### PR DESCRIPTION
## Summary

Third failure mode of the same class as #375 / #377: the legacy-Artwork migration writes an `inferred-from-Wikitext` P10358 statement for values that are actually all DPLA-authored content, just in a different multi-value shape than DPLA canonical carries now.

## Motivating example

[File:%22Principles_of_Causality%22_essay_by_Sarah_(Sallie)_M._Field,_Abbot_Academy,_class_of_1904_-_DPLA_-_b3f489f90ebb903b961500c0cf71edfc_(page_5).jpg](https://commons.wikimedia.org/wiki/File:%22Principles_of_Causality%22_essay_by_Sarah_(Sallie)_M._Field,_Abbot_Academy,_class_of_1904_-_DPLA_-_b3f489f90ebb903b961500c0cf71edfc_(page_5).jpg) — DPLA `sourceResource.description` has 6 values, the legacy `{{Artwork}}` template concatenated 5 of them into a single `| description = A; B; C; D; E` string. `dpla_metadata_params` joins with the same `VALUE_JOIN_DELIMITER = "; "`, so canonical is `A; B; C; D; E; F`. Pre-fix migration byte-compared → not equal → community-import → wrote a P10358 statement whose value is the 5-value concatenation, permanently preserved as a spurious "community contribution."

## Fix

Extend `_value_equivalent_to_canonical` with a `; `-split subset check: if every value in the wikitext concatenation (after `casefold_for_compare`) also appears in DPLA canonical's concatenation, the wikitext content is DPLA-originated and no community import fires.

Subset — not equal — because at migration time the wikitext-side list reflects DPLA data as of *upload*, and DPLA-side may have added values since. Any wikitext value that ISN'T in current canonical still classifies as community-contributed (existing behavior preserved).

## Verified locally

Simulated the file's real values: the 5-value wikitext subset of DPLA's 6-value canonical now returns True from the subset check. A community-added extra value that isn't in DPLA returns False (correctly preserved as an import). A completely community-authored value returns False (correctly preserved).

## Test plan

- [ ] `python -m pytest -q` — 1158 passing locally
- [ ] New tests: `test_plan_migration_skips_description_that_is_multi_value_subset_of_canonical`, `test_plan_migration_still_imports_description_with_extra_community_value`
- [ ] After merge: next legacy-Artwork migration on a file with multi-value description whose values are all in DPLA canonical won't write a spurious P10358 statement; DPLA-side drift (values added since upload) no longer forces community-import.

## Follow-up (out of scope, per prior discussion)

Data-repair sweep for the inferred-from-Wikitext SDC statements already minted under this pattern. Same shape as #377's follow-up — needs revision-history inspection to distinguish real community contributions from DPLA-drift-preserved artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated legacy `{{Artwork}}` migration equivalence for multi-value (semicolon-delimited) wikitext `description` fields so they’re treated as DPLA-originated when the wikitext values form a case-insensitive subset of the current canonical DPLA description values. This prevents spurious `inferred-from-Wikitext` (P10358) statements when canonical sets drift (added/dropped/reordered values) but the wikitext-authored subset still matches.

Added regression coverage for: (1) subset/removal where migration must not classify as `community_imports["description"]`, (2) the boundary where wikitext has a single value while canonical has multiple, and (3) the overshoot case where an extra community-added value not present in canonical must still be imported as a community contribution.

No manual pipeline/ECS redeploy, no environment variable/AWS Secrets Manager key changes, no database migrations, no shared infrastructure/IAM configuration changes, no security/auth changes, and no public API/endpoint shape changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->