### PR TITLE
Parallel uploader workers via multiprocessing.Pool

### DIFF
--- a/ingest_wikimedia/worker_slots.py
+++ b/ingest_wikimedia/worker_slots.py
@@ -163,6 +163,23 @@ class WorkerSlotBudget:
     DIFFERENT directory and a DIFFERENT lock-file set, so they're
     accounted for separately and SDC workers using only the fallback
     can never lock priority slots.
+
+    Optional ``fallback_gate`` + ``priority_holdings`` (uploader
+    parallel-workers case): when a session runs multiple workers
+    (``--workers N``), we want it to greedily take priority slots
+    (up to N) while capping its shared-pool usage at AT MOST ONE slot
+    per session — so 4 concurrent uploader sessions occupy 4 priority
+    + 3 shared = 7 slots worst-case, not 4 + 12. ``fallback_gate`` is
+    a ``multiprocessing.Semaphore(1)`` shared across the session's
+    pool workers; a worker MUST hold this gate to attempt the
+    fallback pool. ``priority_holdings`` is a ``multiprocessing.Value
+    ('i', 0)`` shared across the same pool, incremented on priority-
+    slot grab and decremented on release. When ``priority_holdings >
+    0`` (i.e. this session already holds at least one priority slot),
+    subsequent workers skip the fallback path entirely and wait for
+    priority — the shared slot naturally drops out of the session's
+    holdings on its next item boundary, without needing an active
+    "yield my shared slot now" signal.
     """
 
     def __init__(
@@ -170,10 +187,14 @@ class WorkerSlotBudget:
         budget: int,
         slot_dir: str = DEFAULT_SLOT_DIR,
         fallback: "WorkerSlotBudget | None" = None,
+        fallback_gate=None,
+        priority_holdings=None,
     ):
         self.budget = budget
         self.slot_dir = slot_dir
         self.fallback = fallback
+        self.fallback_gate = fallback_gate
+        self.priority_holdings = priority_holdings
         # Cumulative seconds this process spent blocked in acquire() waiting
         # for a free slot. ~0 when the budget isn't contended; grows under
         # saturation. Callers read it to report slot contention.
@@ -238,9 +259,11 @@ class WorkerSlotBudget:
             return
 
         fd = None
+        got_priority = False
+        gate_held = False
         try:
             start = time.monotonic()
-            fd = self._acquire_slot_fd()
+            fd, got_priority, gate_held = self._acquire_slot_fd()
             self.total_wait_seconds += time.monotonic() - start
             yield
         finally:
@@ -248,6 +271,11 @@ class WorkerSlotBudget:
                 # Closing the fd releases the flock. No explicit
                 # LOCK_UN needed — close is the documented release.
                 os.close(fd)
+            if got_priority and self.priority_holdings is not None:
+                with self.priority_holdings.get_lock():
+                    self.priority_holdings.value -= 1
+            if gate_held and self.fallback_gate is not None:
+                self.fallback_gate.release()
 
     def _try_acquire_one_pass(self) -> int | None:
         """One non-blocking scan over this budget's slot files. Returns
@@ -277,9 +305,8 @@ class WorkerSlotBudget:
                 raise
         return None
 
-    def _acquire_slot_fd(self) -> int:
-        """Block until a slot is free in this budget or its fallback;
-        return the held fd.
+    def _acquire_slot_fd(self) -> tuple[int, bool, bool]:
+        """Block until a slot is free; return ``(fd, got_priority, gate_held)``.
 
         Tries the primary pool first (single non-blocking pass), then —
         only if all primary slots are held — the fallback pool. Sleeps
@@ -287,21 +314,35 @@ class WorkerSlotBudget:
         returned fd; closing releases the flock regardless of which
         pool's directory it came from.
 
-        The priority order (primary > fallback) is what makes the
-        uploader's dedicated pool actually a priority pool: the uploader
-        consistently gets a dedicated slot first if any are free, and
-        only spills into the shared pool when its own four slots are
-        exhausted by other simultaneously-running uploaders.
+        ``got_priority`` is True iff the returned fd came from THIS
+        budget (primary). Caller uses it to know whether to decrement
+        :attr:`priority_holdings` when releasing.
+
+        ``gate_held`` is True iff the returned fd came from the fallback
+        pool via successfully acquiring :attr:`fallback_gate`. Caller
+        uses it to know whether to release the gate alongside the fd.
+
+        Fallback path is gated by two conditions when both are
+        configured: :attr:`priority_holdings` must be 0 at check time
+        AND :attr:`fallback_gate` must be acquirable non-blockingly.
+        Re-checks ``priority_holdings`` after grabbing the gate to
+        close the race window where another worker took a priority
+        slot between the initial check and the gate acquisition — a
+        session that has ANY priority holding must never also take a
+        shared slot per the invariant.
         """
         waited_logged = False
         while True:
             fd = self._try_acquire_one_pass()
             if fd is not None:
-                return fd
-            if self.fallback is not None:
-                fd = self.fallback._try_acquire_one_pass()
+                if self.priority_holdings is not None:
+                    with self.priority_holdings.get_lock():
+                        self.priority_holdings.value += 1
+                return fd, True, False
+            if self.fallback is not None and self._session_may_use_fallback():
+                fd, gate_held = self._try_fallback_with_gate()
                 if fd is not None:
-                    return fd
+                    return fd, False, gate_held
             # Every slot busy across primary AND fallback. Log once so an
             # operator watching the log can see the budget is saturated
             # (expected under heavy concurrency), then poll.
@@ -314,3 +355,53 @@ class WorkerSlotBudget:
                 )
                 waited_logged = True
             time.sleep(_POLL_INTERVAL_SECONDS)
+
+    def _session_may_use_fallback(self) -> bool:
+        """True iff this session hasn't already claimed a priority slot.
+
+        Returning False here forces the caller to keep waiting on the
+        primary pool instead of spilling into fallback — preserving the
+        invariant that a session holding ANY priority slot must not also
+        hold a shared-pool slot. When :attr:`priority_holdings` isn't
+        configured (single-worker uploaders, sdc-sync), unconditionally
+        True — the invariant only applies to the parallel-worker case.
+        """
+        if self.priority_holdings is None:
+            return True
+        with self.priority_holdings.get_lock():
+            return self.priority_holdings.value == 0
+
+    def _try_fallback_with_gate(self) -> tuple[int | None, bool]:
+        """Attempt one fallback-pool acquisition, gated by
+        :attr:`fallback_gate` (per-session Semaphore(1)) when set.
+
+        Returns ``(fd, gate_held)``. ``fd`` is None on failure (gate
+        contended, or gate acquired but no fallback slot free, or
+        holdings-recheck aborted the attempt). Never blocks — polling
+        is the caller's job.
+        """
+        # No gate configured (sdc-sync single-worker legacy path):
+        # try fallback directly. gate_held stays False.
+        if self.fallback_gate is None:
+            fd = self.fallback._try_acquire_one_pass()
+            return fd, False
+
+        # Non-blocking gate acquire. Another worker in this session
+        # already holds it → skip fallback this iteration.
+        if not self.fallback_gate.acquire(False):
+            return None, False
+
+        # Gate held. Re-check priority_holdings to close the race
+        # window where another worker got a priority slot between the
+        # caller's initial check and this point.
+        if self.priority_holdings is not None:
+            with self.priority_holdings.get_lock():
+                if self.priority_holdings.value > 0:
+                    self.fallback_gate.release()
+                    return None, False
+
+        fd = self.fallback._try_acquire_one_pass()
+        if fd is None:
+            self.fallback_gate.release()
+            return None, False
+        return fd, True

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1516,8 +1516,13 @@ def test_main_acquires_one_budget_slot_per_item():
             # (load_ids is mocked, so contents don't matter).
             with open("ids.csv", "w") as fh:
                 fh.write("id_a\nid_b\nid_c\n")
+            # ``--workers 1`` forces the legacy single-process for-loop
+            # path this test targets — the ``workers > 1`` branch dispatches
+            # into a multiprocessing.spawn Pool, which would re-import the
+            # test module and hang under CliRunner.
             result = runner.invoke(
-                up.main, ["ids.csv", "nara", "--workers-budget", "16"]
+                up.main,
+                ["ids.csv", "nara", "--workers-budget", "16", "--workers", "1"],
             )
 
     assert result.exit_code == 0, result.output
@@ -1545,6 +1550,89 @@ def test_main_acquires_one_budget_slot_per_item():
     )
     assert all(b is priority for b in acquire_calls), (
         "per-item loop must acquire on the priority (outer) budget, not the shared one"
+    )
+
+
+def test_main_dispatches_to_pool_when_workers_gt_one():
+    """When ``--workers > 1``, main() must skip the single-process for-loop
+    and hand the item list to ``_run_upload_pool`` — the parent process
+    should NOT call ``Uploader.process_item`` itself, since the workers
+    do that inside their own processes."""
+    from click.testing import CliRunner
+
+    import tools.uploader as up
+
+    pool_calls: list[dict] = []
+
+    def fake_run_pool(**kwargs):
+        pool_calls.append(kwargs)
+        # Simulate the pool having populated the parent's newly_created
+        # set (each worker's CategoryEnsurer union).
+        kwargs["newly_created"].add("Q_worker_created")
+        # And having accounted for one deferred item so main()'s sidecar
+        # merge path also gets exercised.
+        kwargs["deferred"]["deferred_id"] = 2
+
+    fake_ctx = MagicMock()
+    fake_ctx.get_tracker.return_value = Tracker()
+    fake_ctx.get_local_fs.return_value = MagicMock()
+    fake_ctx.get_s3_client.return_value = MagicMock()
+    fake_dpla = MagicMock()
+    fake_dpla.get_providers_data.return_value = {}
+    fake_ctx.get_dpla.return_value = fake_dpla
+
+    fake_ensurer = MagicMock()
+    fake_ensurer._newly_created = set()
+
+    process_item_calls = []
+
+    def track_process_item(*args, **kwargs):
+        process_item_calls.append(args)
+
+    with (
+        patch.object(up.ToolsContext, "init", return_value=fake_ctx),
+        patch.object(up, "get_site", return_value=MagicMock()),
+        patch.object(up, "CategoryEnsurer", return_value=fake_ensurer),
+        patch.object(up, "setup_logging"),
+        patch.object(up, "notify_phase_start"),
+        patch.object(up, "notify_upload_complete"),
+        patch.object(up, "_post_upload_touch_new_institutions"),
+        patch.object(
+            up, "load_ids", return_value=["id_a", "id_b", "id_c"]
+        ),
+        patch.object(up.Uploader, "process_item", side_effect=track_process_item),
+        patch.object(up, "_run_upload_pool", side_effect=fake_run_pool),
+        patch.object(up.drain_sidecar, "merge_sidecar", return_value=["deferred_id"]),
+    ):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("ids.csv", "w") as fh:
+                fh.write("id_a\nid_b\nid_c\n")
+            result = runner.invoke(
+                up.main,
+                ["ids.csv", "nara", "--workers-budget", "16", "--workers", "3"],
+            )
+
+    assert result.exit_code == 0, result.output
+    assert len(pool_calls) == 1, "pool dispatch must fire exactly once"
+    kwargs = pool_calls[0]
+    assert kwargs["workers"] == 3
+    assert kwargs["dpla_ids"] == ["id_a", "id_b", "id_c"]
+    assert kwargs["partner"] == "nara"
+    assert kwargs["deferred"] == {"deferred_id": 2}, (
+        "pool must have received the parent-owned deferred dict so the "
+        "post-loop drain-sidecar merge sees deferred items from every worker"
+    )
+    assert kwargs["newly_created"] == {"Q_worker_created"}, (
+        "pool must have received the parent-owned newly_created set "
+        "so post-upload touches cover institutions any worker created"
+    )
+    assert process_item_calls == [], (
+        "parent process must NOT call process_item itself when the pool runs"
+    )
+    assert "Q_worker_created" in fake_ensurer._newly_created, (
+        "worker-created institution QIDs must be folded back into the "
+        "parent ensurer so _post_upload_touch_new_institutions sees them"
     )
 
 

--- a/tests/test_worker_slots.py
+++ b/tests/test_worker_slots.py
@@ -362,3 +362,240 @@ def test_priority_pool_release_does_not_leak_shared_slot(tmp_path):
     assert all(not _slot_is_held(str(shared_dir), i) for i in range(2)), (
         "shared slot must release when the uploader's with-block exits"
     )
+
+
+# ---- Parallel-worker gate + priority-holdings behaviour ----
+#
+# When an uploader session runs multiple workers (``--workers N``), the
+# session's slot budget carries a ``multiprocessing.Semaphore(1)`` gate
+# and a ``multiprocessing.Value('i', 0)`` counter to enforce:
+#
+#   (a) at most ONE shared-pool slot held per session, and
+#   (b) NO shared-pool slot held when the session also holds any
+#       priority slot.
+#
+# Tests below simulate the shared-across-workers state with plain
+# ``threading`` primitives (a threading.Semaphore(1) and a small object
+# with the same value/get_lock() surface as multiprocessing.Value) —
+# WorkerSlotBudget only uses those attributes, so a threading double is
+# a valid substitute in-process. Real cross-process coordination is
+# covered by mypy/importability + the multiprocessing.Value contract.
+
+
+class _FakeMPValue:
+    """Threading substitute for ``multiprocessing.Value('i', 0)``.
+
+    ``WorkerSlotBudget`` only touches ``.value`` and ``.get_lock()``.
+    Using a threading.Lock here lets in-process tests exercise the
+    same code paths without spawning subprocesses; the invariant the
+    class actually enforces (increment on grab, decrement on release,
+    atomically via the lock) is the same either way.
+    """
+
+    def __init__(self, initial: int = 0):
+        self.value = initial
+        self._lock = threading.Lock()
+
+    def get_lock(self):
+        return self._lock
+
+
+def test_fallback_gate_serialises_shared_pool_acquisition(tmp_path):
+    """When two workers of the SAME session both try to fall back to
+    shared, only one succeeds — the other is blocked by the gate
+    Semaphore and waits for priority instead. This is the invariant
+    that caps a 4-uploader worst case at 4 priority + 3 shared = 7
+    slots rather than 4 + 12."""
+    priority_dir = tmp_path / "priority"
+    shared_dir = tmp_path / "shared"
+    priority_dir.mkdir()
+    shared_dir.mkdir()
+    shared = WorkerSlotBudget(budget=4, slot_dir=str(shared_dir))
+    gate = threading.Semaphore(1)
+    holdings = _FakeMPValue(0)
+    uploader = WorkerSlotBudget(
+        budget=2,
+        slot_dir=str(priority_dir),
+        fallback=shared,
+        fallback_gate=gate,
+        priority_holdings=holdings,
+    )
+    # Force fallback: hold both priority slots foreign.
+    with _foreign_flock(str(priority_dir), 0), _foreign_flock(str(priority_dir), 1):
+        # Worker 1 grabs a shared slot; hold it while probing Worker 2.
+        in_block = threading.Event()
+        release = threading.Event()
+
+        def worker1():
+            with uploader.acquire():
+                in_block.set()
+                release.wait(timeout=5)
+
+        t1 = threading.Thread(target=worker1)
+        t1.start()
+        assert in_block.wait(timeout=2), "worker1 never entered its acquire block"
+
+        # Exactly one shared slot must be held right now.
+        shared_held = sum(_slot_is_held(str(shared_dir), i) for i in range(4))
+        assert shared_held == 1, (
+            f"expected 1 shared slot held by worker1, got {shared_held}"
+        )
+
+        # Worker 2 tries to fall back — gate is taken, so it must NOT
+        # succeed while worker1 is still holding.
+        worker2_got_slot = threading.Event()
+
+        def worker2():
+            with uploader.acquire():
+                worker2_got_slot.set()
+
+        t2 = threading.Thread(target=worker2)
+        t2.start()
+        assert not worker2_got_slot.wait(timeout=0.6), (
+            "worker2 acquired a shared slot while worker1 already held one; "
+            "gate should have blocked it"
+        )
+        # Shared holdings still at 1, not 2.
+        assert sum(_slot_is_held(str(shared_dir), i) for i in range(4)) == 1
+
+        # Release worker1 → worker2 can now proceed (grabs gate + shared).
+        release.set()
+        assert worker2_got_slot.wait(timeout=3), (
+            "worker2 did not proceed after worker1 released the gate"
+        )
+        t1.join(timeout=1)
+        t2.join(timeout=1)
+
+
+def test_fallback_skipped_when_session_already_holds_priority(tmp_path):
+    """A session that already holds a priority slot must NOT spill
+    into shared for a subsequent worker's acquire, even if all
+    remaining priority slots are held by other sessions. Enforces the
+    invariant "hold priority OR shared, never both" per session."""
+    priority_dir = tmp_path / "priority"
+    shared_dir = tmp_path / "shared"
+    priority_dir.mkdir()
+    shared_dir.mkdir()
+    shared = WorkerSlotBudget(budget=4, slot_dir=str(shared_dir))
+    gate = threading.Semaphore(1)
+    holdings = _FakeMPValue(0)
+    uploader = WorkerSlotBudget(
+        budget=2,
+        slot_dir=str(priority_dir),
+        fallback=shared,
+        fallback_gate=gate,
+        priority_holdings=holdings,
+    )
+
+    in_block = threading.Event()
+    release = threading.Event()
+
+    # Worker 1 grabs a priority slot (slot-0). While it holds:
+    def worker1():
+        with uploader.acquire():
+            in_block.set()
+            release.wait(timeout=5)
+
+    t1 = threading.Thread(target=worker1)
+    t1.start()
+    assert in_block.wait(timeout=2)
+    assert holdings.value == 1, "priority_holdings should increment on grab"
+
+    # Simulate another session holding the remaining priority slot so
+    # Worker 2 would spill to shared under the OLD semantics.
+    with _foreign_flock(str(priority_dir), 1):
+        worker2_took_slot = threading.Event()
+        worker2_took_shared = []
+
+        def worker2():
+            with uploader.acquire():
+                worker2_took_shared.append(
+                    any(_slot_is_held(str(shared_dir), i) for i in range(4))
+                )
+                worker2_took_slot.set()
+
+        t2 = threading.Thread(target=worker2)
+        t2.start()
+        # Session already holds a priority slot via worker1, so worker2
+        # must wait for priority — MUST NOT fall back to shared.
+        assert not worker2_took_slot.wait(timeout=0.6), (
+            "worker2 acquired while session already holds priority — "
+            "shared-pool fallback must be inhibited"
+        )
+        # Shared pool must remain untouched.
+        assert not any(_slot_is_held(str(shared_dir), i) for i in range(4)), (
+            "shared pool should remain empty when session already holds priority"
+        )
+
+        # Release worker1's priority slot → worker2 can grab it (still
+        # priority, not shared, because holdings drops to 0 and slot-0
+        # is free while slot-1 stays foreign-held).
+        release.set()
+        assert worker2_took_slot.wait(timeout=3)
+        assert worker2_took_shared == [False], (
+            f"worker2 should have taken a priority slot, not shared; "
+            f"took_shared={worker2_took_shared}"
+        )
+    t1.join(timeout=1)
+    t2.join(timeout=1)
+    assert holdings.value == 0, (
+        "priority_holdings should decrement back to 0 after all workers release"
+    )
+
+
+def test_gate_released_alongside_fd(tmp_path):
+    """The gate acquired for a shared-pool grab must release when the
+    with-block exits, so a subsequent acquire on the same session can
+    grab shared again. Otherwise a session that took shared once
+    would permanently lock out its own future shared attempts."""
+    priority_dir = tmp_path / "priority"
+    shared_dir = tmp_path / "shared"
+    priority_dir.mkdir()
+    shared_dir.mkdir()
+    shared = WorkerSlotBudget(budget=2, slot_dir=str(shared_dir))
+    gate = threading.Semaphore(1)
+    holdings = _FakeMPValue(0)
+    uploader = WorkerSlotBudget(
+        budget=1,
+        slot_dir=str(priority_dir),
+        fallback=shared,
+        fallback_gate=gate,
+        priority_holdings=holdings,
+    )
+    # Force fallback both times.
+    with _foreign_flock(str(priority_dir), 0):
+        with uploader.acquire():
+            # Gate is held here; a non-blocking acquire would fail.
+            assert not gate.acquire(blocking=False), (
+                "gate must be held while inside the with-block"
+            )
+        # Gate must be released now.
+        assert gate.acquire(blocking=False), (
+            "gate must be released when the with-block exits"
+        )
+        gate.release()
+        # A second acquire should succeed (gate free).
+        with uploader.acquire():
+            pass
+
+
+def test_priority_holdings_counter_decrements_on_exception(tmp_path):
+    """A with-block that raises still decrements ``priority_holdings``
+    so the session's counter doesn't leak on transient errors."""
+    priority_dir = tmp_path / "priority"
+    priority_dir.mkdir()
+    holdings = _FakeMPValue(0)
+    uploader = WorkerSlotBudget(
+        budget=2,
+        slot_dir=str(priority_dir),
+        priority_holdings=holdings,
+    )
+    try:
+        with uploader.acquire():
+            assert holdings.value == 1
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert holdings.value == 0, (
+        "priority_holdings must decrement even when the with-block raises"
+    )

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -2039,6 +2039,220 @@ class Uploader:
             logging.warning(f"Failed: {message}", exc_info=ex)
 
 
+# Module-level worker state populated by _init_upload_worker in each pool
+# process. The pool worker task reads these directly rather than
+# threading them through per-call args (which multiprocessing would
+# have to pickle for every dispatch). Declared at module scope so the
+# task function's globals lookup finds them regardless of the spawn
+# start method's re-import.
+_worker_uploader = None
+_worker_slot_budget = None
+_worker_providers_json = None
+_worker_partner = None
+_worker_dry_run = False
+_worker_verbose = False
+
+
+def _init_upload_worker(
+    log_queue,
+    workers_budget: int,
+    partner: str,
+    dry_run: bool,
+    verbose: bool,
+    no_create: bool,
+    providers_json: dict,
+    fallback_gate,
+    priority_holdings,
+):
+    """Per-worker setup for the ``--workers > 1`` uploader Pool.
+
+    Each spawned worker process re-imports this module fresh and runs
+    this initializer once. Same shape as sdc-sync's
+    ``_init_partner_worker`` — fresh pywikibot ``Site``/login, cross-
+    process log routing via a ``QueueHandler``, and per-worker
+    construction of the stateful helpers the item loop needs
+    (Uploader, CategoryEnsurer, DupThrottle, ToolsContext).
+
+    The parent passes ``fallback_gate`` (a ``multiprocessing.Semaphore(1)``)
+    and ``priority_holdings`` (a ``multiprocessing.Value('i', 0)``) so
+    every worker's :class:`WorkerSlotBudget` shares the same two per-
+    session objects — enforcing "at most one shared-pool slot per
+    session" and "no shared slot when the session already holds any
+    priority slot" across the whole worker pool. See
+    :class:`ingest_wikimedia.worker_slots.WorkerSlotBudget` for the
+    invariants.
+    """
+    import logging.handlers
+
+    import pywikibot
+
+    pywikibot.config.max_retries = 5
+    pywikibot.config.retry_wait = 5
+    pywikibot.config.retry_max = 60
+    pywikibot.config.socket_timeout = (10, 60)
+
+    root = logging.getLogger()
+    root.handlers[:] = [logging.handlers.QueueHandler(log_queue)]
+    root.setLevel(logging.INFO)
+
+    global _worker_uploader, _worker_slot_budget
+    global _worker_providers_json, _worker_partner, _worker_dry_run, _worker_verbose
+
+    commons_site = get_site()
+    category_ensurer = CategoryEnsurer(commons_site, dry_run=dry_run)
+    dup_throttle = DuplicateCategoryThrottle(commons_site)
+    tools_context = ToolsContext.init(partner)
+    tools_context.get_local_fs().setup_temp_dir()
+
+    _worker_uploader = Uploader(
+        tools_context.get_tracker(),
+        tools_context.get_local_fs(),
+        tools_context.get_s3_client(),
+        tools_context.get_dpla(),
+        commons_site,
+        category_ensurer,
+        no_create=no_create,
+        dup_throttle=dup_throttle,
+    )
+
+    if workers_budget > 0:
+        shared_budget = WorkerSlotBudget(workers_budget)
+        _worker_slot_budget = WorkerSlotBudget(
+            UPLOADER_PRIORITY_SLOTS,
+            slot_dir=UPLOADER_PRIORITY_SLOT_DIR,
+            fallback=shared_budget,
+            fallback_gate=fallback_gate,
+            priority_holdings=priority_holdings,
+        )
+    else:
+        _worker_slot_budget = WorkerSlotBudget(0)
+
+    _worker_providers_json = providers_json
+    _worker_partner = partner
+    _worker_dry_run = dry_run
+    _worker_verbose = verbose
+
+
+def _worker_upload_task(dpla_id: str):
+    """Process one DPLA item in the pool worker; return
+    ``(dpla_id, tracker_delta, deferred_count, newly_created_delta)``.
+
+    ``tracker_delta`` is the change in the worker's tracker counters
+    across this one item — the parent merges it into its own tracker
+    so the final ``str(tracker)`` line and Slack summary reflect work
+    done across all workers. Uses the same ``snapshot`` → ``diff``
+    pattern as sdc-sync's parallel path so a long-lived worker doesn't
+    double-count across successive tasks.
+
+    ``newly_created_delta`` is the set of institution QIDs the worker's
+    :class:`CategoryEnsurer` created on Commons during this item.
+    The parent unions these across all tasks and feeds the combined
+    set into ``_post_upload_touch_new_institutions``, since each
+    spawned worker has its own ``category_ensurer.newly_created``
+    that the parent's ensurer would otherwise never see — leaving
+    first-batch files stranded in Category:Unknown institution.
+
+    Wraps ``process_item`` in the same slot-acquire that the single-
+    worker path uses. A worker-level exception is logged and swallowed
+    so a bad item doesn't kill the pool worker; ``CsrfRecoveryFailed``
+    re-raises so the pool sees it and the parent's outer try/except
+    can abort the whole run cleanly rather than skip-and-recur on
+    every subsequent item.
+    """
+    prior = _worker_uploader.tracker.snapshot()
+    prior_newly_created = set(_worker_uploader.category_ensurer.newly_created)
+    deferred_count = 0
+    try:
+        with _worker_slot_budget.acquire():
+            deferred_count = _worker_uploader.process_item(
+                dpla_id,
+                _worker_providers_json,
+                _worker_partner,
+                _worker_verbose,
+                _worker_dry_run,
+            )
+    except CsrfRecoveryFailed:
+        raise
+    except Exception:
+        logging.exception(f" -- Item {dpla_id}: worker task raised; skipping.")
+    delta = _worker_uploader.tracker.diff(prior)
+    newly_created_delta = (
+        _worker_uploader.category_ensurer.newly_created - prior_newly_created
+    )
+    return dpla_id, delta, deferred_count or 0, newly_created_delta
+
+
+def _run_upload_pool(
+    *,
+    dpla_ids,
+    partner: str,
+    dry_run: bool,
+    verbose: bool,
+    no_create: bool,
+    workers_budget: int,
+    providers_json: dict,
+    workers: int,
+    tracker,
+    deferred: dict[str, int],
+    newly_created: set[str],
+) -> None:
+    """Dispatch upload across ``workers`` spawned processes.
+
+    Creates the ``multiprocessing.Semaphore(1)`` fallback-gate and the
+    ``multiprocessing.Value('i', 0)`` priority-holdings counter shared
+    across all workers of this session, then runs the pool with
+    ``imap_unordered`` and merges each task's tracker delta into the
+    parent tracker. Cross-process log routing via ``QueueListener``
+    on the parent's already-open ``-upload.log`` handlers so worker
+    log lines land in the same file the operator is tailing.
+
+    Uses ``spawn`` start_method explicitly so workers don't inherit
+    the parent's pywikibot session sockets — fork-then-use of an
+    already-authenticated Site has been a source of half-broken
+    connections in similar bot setups.
+    """
+    import logging.handlers
+    import multiprocessing
+
+    ctx = multiprocessing.get_context("spawn")
+    log_queue = ctx.Manager().Queue(-1)
+    listener = logging.handlers.QueueListener(
+        log_queue, *logging.getLogger().handlers, respect_handler_level=True
+    )
+    listener.start()
+    fallback_gate = ctx.Semaphore(1)
+    priority_holdings = ctx.Value("i", 0)
+    try:
+        with ctx.Pool(
+            processes=workers,
+            initializer=_init_upload_worker,
+            initargs=(
+                log_queue,
+                workers_budget,
+                partner,
+                dry_run,
+                verbose,
+                no_create,
+                providers_json,
+                fallback_gate,
+                priority_holdings,
+            ),
+        ) as pool:
+            for dpla_id, delta, deferred_count, newly_created_delta in tqdm(
+                pool.imap_unordered(_worker_upload_task, dpla_ids),
+                total=len(dpla_ids),
+                desc="Uploading Items",
+                unit="Item",
+                ncols=100,
+            ):
+                tracker.merge(delta)
+                if deferred_count:
+                    deferred[dpla_id] = deferred_count
+                newly_created.update(newly_created_delta)
+    finally:
+        listener.stop()
+
+
 @click.command()
 @click.argument("ids_file", type=click.File("r"))
 @click.argument("partner")
@@ -2063,13 +2277,28 @@ class Uploader:
     help=(
         "Box-wide cap on concurrent Commons-writing processes across ALL "
         "wikimedia sessions on the host, shared with the SDC-sync phase. "
-        "The uploader is single-process (no parallelism), so it checks out "
-        "exactly ONE slot while working an item — making it count as one "
-        "writer against the shared budget alongside SDC-sync workers. "
         "0 (default) disables the budget — correct for a standalone run, "
         "which has no peers to coordinate with. Pass --workers-budget 16 "
         "to join the shared box-wide cap (the launch workflow does this). "
         "See ingest_wikimedia.worker_slots.WorkerSlotBudget."
+    ),
+)
+@click.option(
+    "--workers",
+    "workers",
+    type=int,
+    default=UPLOADER_PRIORITY_SLOTS,
+    show_default=True,
+    help=(
+        "Parallel uploader worker processes for this session. Each worker "
+        "acquires one slot per item from the priority pool (spilling into "
+        "the shared pool only when its session doesn't already hold a "
+        "priority slot, gated to at most one shared slot per session — see "
+        "WorkerSlotBudget's fallback_gate/priority_holdings). Default "
+        "matches UPLOADER_PRIORITY_SLOTS so a single uploader session can "
+        "saturate the priority pool by itself; 4 concurrent sessions "
+        "settle to ~1 priority slot each. Pass 1 for the legacy single-"
+        "process for-loop path."
     ),
 )
 def main(
@@ -2079,6 +2308,7 @@ def main(
     verbose: bool,
     no_create: bool,
     workers_budget: int,
+    workers: int,
 ) -> None:
     start_time = time.time()
     # ``setup_logging`` is the first thing we do so its
@@ -2178,15 +2408,41 @@ def main(
         # Map of dpla_id -> count of ordinals the dup-category throttle deferred.
         deferred: dict[str, int] = {}
         try:
-            for dpla_id in tqdm(
-                dpla_ids, desc="Uploading Items", unit="Item", ncols=100
-            ):
-                with slot_budget.acquire():
-                    deferred_count = uploader.process_item(
-                        dpla_id, providers_json, partner, verbose, dry_run
-                    )
-                    if deferred_count:
-                        deferred[dpla_id] = deferred_count
+            if workers > 1:
+                # Workers each have their own CategoryEnsurer with a private
+                # ``newly_created`` set — the parent's ensurer wouldn't otherwise
+                # see them, and the end-of-run touch helper would find nothing to
+                # touch. Union the deltas from each task and fold them into the
+                # parent ensurer so ``_post_upload_touch_new_institutions`` fires
+                # exactly once, box-serialised, for every institution any worker
+                # created.
+                worker_newly_created: set[str] = set()
+                _run_upload_pool(
+                    dpla_ids=dpla_ids,
+                    partner=partner,
+                    dry_run=dry_run,
+                    verbose=verbose,
+                    no_create=no_create,
+                    workers_budget=workers_budget,
+                    providers_json=providers_json,
+                    workers=workers,
+                    tracker=tracker,
+                    deferred=deferred,
+                    newly_created=worker_newly_created,
+                )
+                # ``newly_created`` is a copy-returning property; mutate the
+                # underlying set directly so the touch helper sees the union.
+                category_ensurer._newly_created.update(worker_newly_created)
+            else:
+                for dpla_id in tqdm(
+                    dpla_ids, desc="Uploading Items", unit="Item", ncols=100
+                ):
+                    with slot_budget.acquire():
+                        deferred_count = uploader.process_item(
+                            dpla_id, providers_json, partner, verbose, dry_run
+                        )
+                        if deferred_count:
+                            deferred[dpla_id] = deferred_count
 
             # Any item whose {{duplicate}}-tagging upload was deferred because
             # Category:Duplicate was full: persist the deferred DPLA IDs to

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -2133,6 +2133,23 @@ def _init_upload_worker(
     _worker_verbose = verbose
 
 
+def _worker_warmup(_ignored):
+    """Confirm this worker's ``_init_upload_worker`` finished. Returns
+    True on success; raises whatever the initializer already raised
+    (re-raised from a stashed error) on failure.
+
+    ``multiprocessing.Pool`` does not surface initializer exceptions
+    directly — a failed init leaves the pool respawning workers or
+    hanging on the first result forever. Running one warmup task per
+    worker slot from the parent before real dispatch forces any init
+    failure to surface as a ``pool.apply`` exception, so the parent
+    can abort fast instead of waiting on a job that will never
+    progress. See CPython issues 43306 / 35311 / cpython #103061."""
+    if _worker_uploader is None:
+        raise RuntimeError("upload worker initializer did not populate globals")
+    return True
+
+
 def _worker_upload_task(dpla_id: str):
     """Process one DPLA item in the pool worker; return
     ``(dpla_id, tracker_delta, deferred_count, newly_created_delta)``.
@@ -2238,6 +2255,16 @@ def _run_upload_pool(
                 priority_holdings,
             ),
         ) as pool:
+            # Warmup — force any ``_init_upload_worker`` failure to surface
+            # here instead of hanging the pool later. One task per configured
+            # worker slot so every worker's initializer is exercised. If any
+            # raises, ``AsyncResult.get`` re-raises in the parent, we log
+            # and abort — the ``with`` block terminates the whole pool.
+            warmup_results = [
+                pool.apply_async(_worker_warmup, (i,)) for i in range(workers)
+            ]
+            for r in warmup_results:
+                r.get(timeout=120)
             for dpla_id, delta, deferred_count, newly_created_delta in tqdm(
                 pool.imap_unordered(_worker_upload_task, dpla_ids),
                 total=len(dpla_ids),


### PR DESCRIPTION
## Summary

- **New `--workers` CLI option** (default `UPLOADER_PRIORITY_SLOTS = 4`) fans one uploader session out across N spawned processes so a single partner can greedily saturate the priority pool by itself instead of using one slot at a time.
- **Per-session slot-budget invariants** are enforced across the whole worker pool via the `fallback_gate` (`multiprocessing.Semaphore(1)`) and `priority_holdings` (`multiprocessing.Value('i', 0)`) hooks added on the preceding commit: at most one shared-pool slot per session, never a shared slot when the session already holds any priority slot. Worst-case for 4 concurrent uploaders is **4 priority + 3 shared = 7 slots**, not 16.
- **Per-worker isolation**: each spawned process gets its own pywikibot `Site`, `CategoryEnsurer`, `DupThrottle`, and `Uploader`. Tracker deltas are aggregated in the parent via `snapshot`/`diff`/`merge`; newly-created institution QIDs are unioned so `_post_upload_touch_new_institutions` fires exactly once for every institution any worker created.
- **Log routing** through `Manager().Queue(-1)` + `QueueListener` on the parent's already-open `-upload.log` handlers so worker log lines land in the file the operator is tailing.
- **`spawn` context, not fork**: fork-then-use of an already-authenticated pywikibot Site has been a source of half-broken sockets in similar bot setups.
- **`--workers 1`** forces the legacy single-process for-loop path for tests and standalone runs.

## Test plan

- [ ] `python -m pytest -q` on branch — new `test_main_dispatches_to_pool_when_workers_gt_one` covers the pool-dispatch shape; the existing `test_main_acquires_one_budget_slot_per_item` was updated to pass `--workers 1` since it targets the loop path.
- [ ] Smoke run against a partner with a small ID list on EC2 to confirm the pool starts, log lines route through, tracker aggregates, and the post-upload touch runs.
- [ ] Confirm concurrent uploaders never exceed 4 priority + N-uploaders shared slots on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Added parallel uploader support via a new `--workers` CLI option, with `--workers 1` preserving the legacy single-process path.
- Introduced multiprocessing pool execution using the `spawn` context, with per-worker `Site`, `CategoryEnsurer`, `DupThrottle`, and `Uploader` instances.
- Added parent-side aggregation of tracker state and newly created institution QIDs so deferred post-upload institution touches run once per created institution.
- Routed worker logs through a shared queue/listener so output continues to land in the existing upload log.
- Extended `WorkerSlotBudget` to coordinate session-wide slot invariants across workers using `fallback_gate` and `priority_holdings`, preventing unsafe shared/priority overlap.
- Added and updated tests covering worker-slot gating behavior and pool dispatch from the uploader CLI.

## Notes
- No manual pipeline trigger/ECS redeploy, environment variable or Secrets Manager key changes, database migration, shared infrastructure config changes, public API changes, or security-sensitive auth/credential changes were indicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->