### PR TITLE
Preserve DPLA-prefixed description extensions during legacy migration

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -143,9 +143,20 @@ class MigrationPlan:
     every action Phase 3b's executor needs to perform.
 
     ``community_imports`` carries the field-by-field values that must
-    survive the migration. Each entry is keyed by canonical-params key
-    so Phase 3b can dispatch to the right SDC property without
-    re-doing the parsing work.
+    survive the migration as SDC statements. Each entry is keyed by
+    canonical-params key so Phase 3b can dispatch to the right SDC
+    property without re-doing the parsing work.
+
+    ``wikitext_preserved_extras`` carries values whose community
+    contribution is structural wikitext (galleries, wikitables,
+    bulleted lists, horizontal rules) that Wikibase can't hold — its
+    monolingual-text validator rejects vertical whitespace. These
+    values stay on the migrated ``{{DPLA metadata}}`` template's own
+    parameter instead, so the yellow-box renderer picks them up. The
+    dict value is the FULL extension remainder verbatim (with any
+    leading newline / HR / heading the user wrote) — preserving
+    whatever structural marker they chose without treating any single
+    one as a canonical signal.
 
     ``source_permalink`` is the value that gets stamped onto every
     imported claim's P4656 reference. It points at the revision *that
@@ -157,6 +168,7 @@ class MigrationPlan:
     source_permalink: str
     community_imports: dict[str, str] = field(default_factory=dict)
     dpla_originated_params: dict[str, str] = field(default_factory=dict)
+    wikitext_preserved_extras: dict[str, str] = field(default_factory=dict)
     artwork_template_name: str = ""
 
 
@@ -394,6 +406,7 @@ def plan_migration(
 
     community_imports: dict[str, str] = {}
     dpla_originated: dict[str, str] = {}
+    wikitext_preserved_extras: dict[str, str] = {}
 
     for key, value in wikitext_params.items():
         canonical_value = _canonical_value_for_key(canonical_params, key)
@@ -409,6 +422,22 @@ def plan_migration(
             # punctuation-trim for the display-string keys — so a
             # community edit that reformatted DPLA's own value is not
             # imported as a spurious community contribution.
+            #
+            # DPLA-prefixed extension: if the wikitext value is the
+            # canonical value with additional structural content
+            # appended (gallery, wikitable, HR, list, embedded
+            # template — anything that introduces vertical
+            # whitespace), split it. The DPLA prefix already lives in
+            # DPLA-attributed SDC so no ``community_import`` is
+            # emitted for it (that would fail Wikibase's
+            # monolingual-text validator anyway). The remainder is
+            # preserved verbatim on the migrated template's
+            # parameter, where the yellow-box renderer picks it up.
+            extras = _split_extension_extras(value, canonical_value)
+            if extras is not None:
+                wikitext_preserved_extras[key] = extras
+                dpla_originated[key] = value
+                continue
             community_imports[key] = value
         else:
             dpla_originated[key] = value
@@ -418,6 +447,7 @@ def plan_migration(
         source_permalink=_build_permalink(file_title, latest.revid),
         community_imports=community_imports,
         dpla_originated_params=dpla_originated,
+        wikitext_preserved_extras=wikitext_preserved_extras,
         artwork_template_name=_template_name(legacy_template),
     )
 
@@ -456,6 +486,67 @@ def _extract_institution_qid(value: str) -> str | None:
 
 
 _MULTI_VALUE_DELIMITER = "; "
+
+# Any of these characters would trip Wikibase's monolingual-text
+# validator (``wikibase-validator-illegal-string-chars``: "String
+# should not start or end with whitespace nor include vertical
+# whitespace or tabs"). Used to detect the "extension" pattern where
+# a user's wikitext contribution carries structural markup (gallery
+# blocks, wikitables, bulleted lists, horizontal rules) after the
+# DPLA-authored text — a shape that can't survive as-is in SDC and
+# needs a different preservation strategy than the default
+# community-import path. See :func:`_split_extension_extras`.
+_VERTICAL_WHITESPACE_RE = re.compile(r"[\n\r\t]")
+
+
+def _split_extension_extras(value: str, canonical: str) -> str | None:
+    """When ``value`` is a DPLA-prefixed extension, return the verbatim
+    remainder; otherwise return None.
+
+    An "extension" is the shape a Commons editor produces when they
+    add structural wikitext (gallery, wikitable, bulleted list, HR,
+    embedded template, etc.) to a DPLA-authored value by continuing
+    the template parameter past the DPLA text. Since Wikibase's
+    monolingual-text validator rejects vertical whitespace, values in
+    this shape can't be submitted as SDC monolingualtext claims — but
+    they're not community *divergence* either, they're community
+    *addition*. The DPLA-authored prefix is still intact and should
+    keep its DPLA-attributed SDC representation; only the remainder
+    needs to live on the migrated template as a wikitext-only
+    contribution.
+
+    Detection is deliberately structure-agnostic: any vertical
+    whitespace (``\\n``/``\\r``/``\\t``) marks the boundary between
+    the DPLA prefix and the community remainder. HRs, galleries, and
+    templates all imply vertical whitespace but so does plain
+    multi-line prose — none is treated as a canonical signal. The
+    substring up to the first vertical-whitespace character must
+    casefold-match the canonical value (same normalisation chain used
+    elsewhere in this module: magic-word unescape → strip
+    leading/trailing punctuation → collapse whitespace → casefold);
+    otherwise it's a scalar divergence (e.g. ``"1949"`` →
+    ``"1949-02-01"``) and falls through to the ordinary
+    community-import path.
+
+    Returns the verbatim remainder from the boundary character onward
+    (including the boundary itself) so the caller can inject it into
+    the migrated template's parameter byte-identical to what the user
+    wrote. Returns None when the value doesn't fit the extension
+    shape or when ``canonical`` is empty (nothing to prefix-match).
+    """
+    if not value or not canonical:
+        return None
+    match = _VERTICAL_WHITESPACE_RE.search(value)
+    if match is None:
+        return None
+    boundary = match.start()
+    prefix = value[:boundary]
+    remainder = value[boundary:]
+    folded_prefix = casefold_for_compare(prefix)
+    folded_canonical = casefold_for_compare(canonical)
+    if not folded_prefix or folded_prefix != folded_canonical:
+        return None
+    return remainder
 
 
 def _multi_value_subset_of_canonical(value: str, canonical: str) -> bool:
@@ -634,6 +725,49 @@ def _reference_snaks(permalink: str) -> dict:
     }
 
 
+class InvalidWikibaseTextValue(ValueError):
+    """Raised when a value can't be safely submitted to Wikibase.
+
+    Client-side pre-flight for values that would trip Wikibase's
+    ``wikibase-validator-illegal-string-chars`` — the validator
+    rejects vertical whitespace (``\\n``/``\\r``/``\\t``) and
+    leading/trailing whitespace on monolingualtext + string values.
+    A dedicated exception (as opposed to letting the API raise
+    :class:`pywikibot.exceptions.APIError`) gives operators a clear
+    "value X for property Y didn't pass local validation" message
+    instead of a Wikibase traceback the reader has to decode; the
+    migration executor catches it with the same per-file boundary
+    that catches API errors, so behavior on the wire is unchanged.
+    """
+
+
+def _validate_wikibase_text(text: str, prop: str, canonical_key: str) -> None:
+    """Raise :class:`InvalidWikibaseTextValue` if ``text`` can't be
+    safely submitted as a monolingualtext / string claim value.
+
+    The migration pipeline's plan-time extension-detection routes
+    values containing vertical whitespace to the wikitext-preserved
+    path instead of the SDC-import path — so this check should never
+    fire on a healthy code path. It exists as belt-and-suspenders: a
+    new user-contribution shape the extraction heuristic hasn't been
+    taught yet would previously reach Wikibase and get rejected as a
+    generic ``APIError``. Failing loud, distinctly, and *before* the
+    wire trip keeps future incidents legible in the log.
+    """
+    if _VERTICAL_WHITESPACE_RE.search(text):
+        raise InvalidWikibaseTextValue(
+            f"legacy-artwork import claim for {canonical_key!r} → {prop} "
+            f"contains vertical whitespace (newline/tab/CR); Wikibase's "
+            f"monolingual-text validator would reject it. Value: {text!r}"
+        )
+    if text != text.strip():
+        raise InvalidWikibaseTextValue(
+            f"legacy-artwork import claim for {canonical_key!r} → {prop} "
+            f"has leading/trailing whitespace; Wikibase's monolingual-text "
+            f"validator would reject it. Value: {text!r}"
+        )
+
+
 def _monolingualtext_datavalue(text: str, language: str = "en") -> dict:
     return {
         "type": "monolingualtext",
@@ -669,9 +803,11 @@ def format_legacy_import_claim(
         return None
     prop, kind = mapping
     if kind == "monolingualtext":
+        _validate_wikibase_text(value, prop, canonical_key)
         datavalue = _monolingualtext_datavalue(value)
         datatype = "monolingualtext"
     elif kind == "string":
+        _validate_wikibase_text(value, prop, canonical_key)
         datavalue = _string_datavalue(value)
         datatype = "string"
     elif kind == "time":
@@ -1207,6 +1343,57 @@ def render_migrated_wikitext(
     return str(wikicode)
 
 
+def _inject_preserved_extras(text: str, extras: dict[str, str]) -> str:
+    """Inject each ``key = value`` extension remainder into the
+    ``{{DPLA metadata}}`` template inside ``text``.
+
+    Called after ``normalize``+``canonicalize`` have finished — at
+    that point the migrated template has already been stripped of
+    every DPLA-canonical param, so a preserved extras value (the
+    tail of a DPLA-prefixed extension: gallery, HR, wikitable, etc.)
+    lands on an otherwise-clean template. Verbatim insertion, no
+    whitespace normalisation — the user's structural markup is what
+    it is.
+
+    If the template's rendered form is the empty ``{{DPLA metadata}}``
+    the templates library folds it onto a single line; the injection
+    below places each ``| key = value`` on its own line for legibility
+    matching the ``get_wiki_text`` shape a fresh upload would produce.
+    Returns the original text unchanged when no ``{{DPLA metadata}}``
+    template can be found (defensive — the caller has already run
+    ``render_migrated_wikitext`` which guarantees it).
+    """
+    if not extras:
+        return text
+    wikicode = mwparserfromhell.parse(text)
+    target = None
+    for tpl in wikicode.filter_templates():
+        if _template_name(tpl) == "dpla metadata":
+            target = tpl
+            break
+    if target is None:
+        return text
+    # Add each param with a trailing newline on the value so the
+    # closing ``}}`` lands on its own line (mwparserfromhell defaults
+    # would jam it onto the last content line otherwise). Verbatim
+    # value preservation: don't touch the extras themselves; only the
+    # ``| key = `` surround gets shaped for readability.
+    for key, value in extras.items():
+        formatted_value = value if value.endswith("\n") else value + "\n"
+        target.add(
+            f" {key} ",
+            formatted_value,
+            preserve_spacing=False,
+        )
+    # Force a newline right after the opening ``{{DPLA metadata`` so
+    # the first ``| key = value`` starts on its own line, matching
+    # the multi-line shape a fresh ``get_wiki_text`` emits.
+    # mwparserfromhell doesn't expose that first-class; a targeted
+    # string replace is safe because ``{{DPLA metadata`` is a fixed
+    # sentinel and the empty template is a controlled shape.
+    return str(wikicode).replace("{{DPLA metadata|", "{{DPLA metadata\n|")
+
+
 # Edit summary the migration executor stamps on every wikitext save +
 # wbeditentity edit. Centralised so a future change to the wording
 # (e.g. linking to the Commons documentation page) doesn't need to be
@@ -1385,6 +1572,16 @@ def migrate_legacy_file(
 
     rewritten, _stripped = normalize(rewritten, canonical_params)
     rewritten = canonicalize(rewritten)
+    # Re-inject wikitext-preserved extension remainders (galleries,
+    # HRs, wikitables, etc. the user appended past the DPLA-authored
+    # text) onto the migrated ``{{DPLA metadata}}`` template. These
+    # can't live in SDC — Wikibase's monolingual-text validator
+    # rejects vertical whitespace — so the migration preserves them
+    # on the template's own parameter, where Module:DPLA's
+    # ``userValue`` renderer picks them up into the yellow row. See
+    # :func:`_split_extension_extras` for the detection rule.
+    if plan.wikitext_preserved_extras:
+        rewritten = _inject_preserved_extras(rewritten, plan.wikitext_preserved_extras)
     wikitext_changed = rewritten != file_page.text
     if wikitext_changed:
         file_page.text = rewritten

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -1387,11 +1387,16 @@ def _inject_preserved_extras(text: str, extras: dict[str, str]) -> str:
         )
     # Force a newline right after the opening ``{{DPLA metadata`` so
     # the first ``| key = value`` starts on its own line, matching
-    # the multi-line shape a fresh ``get_wiki_text`` emits.
-    # mwparserfromhell doesn't expose that first-class; a targeted
-    # string replace is safe because ``{{DPLA metadata`` is a fixed
-    # sentinel and the empty template is a controlled shape.
-    return str(wikicode).replace("{{DPLA metadata|", "{{DPLA metadata\n|")
+    # the multi-line shape a fresh ``get_wiki_text`` emits. Appending
+    # ``"\n"`` to the template's own ``name`` attribute scopes the
+    # change to this template node — a page-wide string replace
+    # would also rewrite the same literal if it appeared inside a
+    # preserved extra (e.g. a nested template inside a user's
+    # gallery caption).
+    name_str = str(target.name)
+    if not name_str.endswith("\n"):
+        target.name = name_str + "\n"
+    return str(wikicode)
 
 
 # Edit summary the migration executor stamps on every wikitext save +

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -2262,6 +2262,29 @@ def test_inject_preserved_extras_matches_fresh_upload_layout():
     assert "[[Category:Example]]" in injected
 
 
+def test_inject_preserved_extras_scoped_to_template_node_not_page_wide():
+    """Regression: newline-insertion must target the ``{{DPLA metadata}}``
+    template node only, not the whole serialised page. If a preserved
+    extra ever contains the literal ``{{DPLA metadata|`` (e.g. a nested
+    template inside a user's gallery caption, or an embedded example),
+    a page-wide string replace would rewrite that literal too and
+    corrupt the user's contribution."""
+    from ingest_wikimedia.legacy_artwork import _inject_preserved_extras
+
+    poisoned = (
+        "\nSee also the wrapper docs: <code>{{DPLA metadata|title=example}}</code>"
+    )
+    injected = _inject_preserved_extras("{{DPLA metadata}}", {"description": poisoned})
+    assert poisoned in injected, (
+        "extras value must survive verbatim — the newline insertion must "
+        f"not touch matches inside the value. Got: {injected!r}"
+    )
+    assert "{{DPLA metadata|title=example}}" in injected, (
+        "inline ``{{DPLA metadata|title=example}}`` inside the description "
+        f"extras was rewritten. Got: {injected!r}"
+    )
+
+
 def test_inject_preserved_extras_preserves_value_verbatim():
     """The extras value goes in byte-identical (aside from a trailing
     newline the layout helper appends when absent). No stripping of

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -240,12 +240,7 @@ def test_parse_artwork_params_pipe_overflow_with_equals_fragment_is_dropped():
     handling it would require a wider allowlist-based heuristic. If
     we ever fix this, the test flips to assert successful stitching.
     """
-    literal_pipe_form = (
-        "{{Artwork\n"
-        "| description = A | region=north\n"
-        "| date = 1937\n"
-        "}}"
-    )
+    literal_pipe_form = "{{Artwork\n| description = A | region=north\n| date = 1937\n}}"
     p = parse_artwork_params(literal_pipe_form)
     # Current behavior: ``region=north`` is dropped because mwparserfromhell
     # parses it as a named param and stitching only rejoins positional
@@ -253,10 +248,7 @@ def test_parse_artwork_params_pipe_overflow_with_equals_fragment_is_dropped():
     assert p == {"description": "A", "date": "1937"}
     # For contrast, the {{!}} form keeps the whole value:
     magic_word_form = (
-        "{{Artwork\n"
-        "| description = A {{!}} region=north\n"
-        "| date = 1937\n"
-        "}}"
+        "{{Artwork\n| description = A {{!}} region=north\n| date = 1937\n}}"
     )
     q = parse_artwork_params(magic_word_form)
     assert q == {"description": "A | region=north", "date": "1937"}
@@ -2072,3 +2064,214 @@ def test_plan_migration_preserves_question_marked_date_override():
     plan = plan_migration("File:Foo.jpg", revs, _canonical_params(date="1902"))
     assert plan is not None
     assert plan.community_imports == {"date": "1902?"}
+
+
+# ---------------------------------------------------------------------------
+# plan_migration — DPLA-prefixed extension (this commit).
+# A community editor extends a DPLA-authored template parameter by
+# appending structural wikitext (gallery, HR, wikitable, list, embedded
+# template) past the DPLA-authored text. Since Wikibase's monolingual-
+# text validator rejects vertical whitespace, the extras can't be
+# submitted as an SDC monolingualtext claim — but the DPLA prefix is
+# still intact and shouldn't be treated as community divergence.
+# The extras go to ``wikitext_preserved_extras`` for injection into
+# the migrated ``{{DPLA metadata}}`` template's own parameter; no SDC
+# import fires for that key.
+# ---------------------------------------------------------------------------
+
+
+_DPLA_SENTENCE = (
+    'Transcribed from photograph: "Portraits. Group. Faculty of Central '
+    'School. Opening day, May 7, 1883."'
+)
+
+
+def test_plan_migration_gallery_extension_preserves_extras_not_import():
+    """The mockup case: user appends ``----`` + ``<gallery>`` after the
+    DPLA sentence. The DPLA prefix stays DPLA-attributed (no
+    community-import for description), and the ``----\\n<gallery>``
+    block lands verbatim in ``wikitext_preserved_extras`` so the
+    migration executor can inject it onto the migrated template."""
+    extras = (
+        "\n----\n<gallery>\nFile:one.jpg|caption 1\nFile:two.jpg|caption 2\n</gallery>"
+    )
+    extended = _DPLA_SENTENCE + extras
+    revs = _make_revs(
+        (1, "DPLA_bot", f"{{{{Artwork|description={_DPLA_SENTENCE}}}}}"),
+        (2, "Editor1", f"{{{{Artwork|description={extended}}}}}"),
+    )
+    plan = plan_migration(
+        "File:Foo.jpg", revs, _canonical_params(description=_DPLA_SENTENCE)
+    )
+    assert plan is not None
+    assert "description" not in plan.community_imports, (
+        "extension case must not emit an inferred-from-Wikitext claim; "
+        "Wikibase would reject the vertical whitespace"
+    )
+    assert plan.wikitext_preserved_extras.get("description") == extras
+
+
+def test_plan_migration_hr_only_extension_preserves_extras():
+    """No gallery, just an HR + extra prose. The rule is structural-
+    marker-agnostic — presence of a vertical whitespace boundary plus a
+    matching DPLA prefix is all that's required."""
+    extras = "\n----\nAdditional context added by Commons editor."
+    extended = _DPLA_SENTENCE + extras
+    revs = _make_revs(
+        (1, "DPLA_bot", f"{{{{Artwork|description={_DPLA_SENTENCE}}}}}"),
+        (2, "Editor1", f"{{{{Artwork|description={extended}}}}}"),
+    )
+    plan = plan_migration(
+        "File:Foo.jpg", revs, _canonical_params(description=_DPLA_SENTENCE)
+    )
+    assert plan is not None
+    assert "description" not in plan.community_imports
+    assert plan.wikitext_preserved_extras.get("description") == extras
+
+
+def test_plan_migration_bulleted_list_extension_preserves_extras():
+    """A user-added bulleted list past the DPLA sentence — the shape
+    Ohio Cleveland Public Library used to link to related Wikipedia
+    entries (the class the log survey identified as the biggest
+    silent-skip source, 64 events / 3 unique DPLA IDs)."""
+    extras = (
+        "\n* [https://en.wikipedia.org/wiki/John_Doe John Doe]"
+        "\n* [https://en.wikipedia.org/wiki/Jane_Roe Jane Roe]"
+    )
+    extended = _DPLA_SENTENCE + extras
+    revs = _make_revs(
+        (1, "DPLA_bot", f"{{{{Artwork|description={_DPLA_SENTENCE}}}}}"),
+        (2, "Editor1", f"{{{{Artwork|description={extended}}}}}"),
+    )
+    plan = plan_migration(
+        "File:Foo.jpg", revs, _canonical_params(description=_DPLA_SENTENCE)
+    )
+    assert plan is not None
+    assert "description" not in plan.community_imports
+    assert plan.wikitext_preserved_extras.get("description") == extras
+
+
+def test_plan_migration_scalar_edit_stays_on_divergence_path():
+    """No vertical whitespace = not extension. A single-line reformat
+    like ``1949`` → ``1949-02-01`` is a genuine value replacement, not
+    an extension, and belongs on the ordinary community-import path so
+    the community's more-specific value gets an inferred-from-Wikitext
+    SDC claim."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|date=1949}}"),
+        (2, "Editor1", "{{Artwork|date=1949-02-01}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params(date="1949"))
+    assert plan is not None
+    assert plan.community_imports == {"date": "1949-02-01"}
+    assert "date" not in plan.wikitext_preserved_extras
+
+
+def test_plan_migration_extension_prefix_must_match_canonical():
+    """A wikitext value that CONTAINS vertical whitespace but whose
+    prefix doesn't match canonical is not extension — it's a full
+    replacement that happens to have multiple lines. Falls through to
+    the ordinary community-import path (which will hit the pre-flight
+    validator and raise ``InvalidWikibaseTextValue``, catching the
+    unhandled shape loudly instead of silently mis-classifying it as
+    an extension)."""
+    revs = _make_revs(
+        (1, "DPLA_bot", f"{{{{Artwork|description={_DPLA_SENTENCE}}}}}"),
+        (
+            2,
+            "Editor1",
+            "{{Artwork|description=Totally different first line.\n"
+            "Followed by a second line.}}",
+        ),
+    )
+    plan = plan_migration(
+        "File:Foo.jpg", revs, _canonical_params(description=_DPLA_SENTENCE)
+    )
+    assert plan is not None
+    assert "description" in plan.community_imports
+    assert "description" not in plan.wikitext_preserved_extras
+
+
+def test_format_legacy_import_claim_rejects_vertical_whitespace():
+    """Pre-flight validator refuses to build a monolingualtext claim
+    whose value contains vertical whitespace. This is belt-and-suspenders
+    — plan_migration should route such values to
+    ``wikitext_preserved_extras`` instead — but if a shape slips past
+    the extraction heuristic, the failure surfaces here with a clear
+    "value X for property Y failed local validation" message rather
+    than as a Wikibase APIError traceback."""
+    from ingest_wikimedia.legacy_artwork import InvalidWikibaseTextValue
+
+    with pytest.raises(InvalidWikibaseTextValue) as exc:
+        format_legacy_import_claim(
+            "description",
+            "line one\nline two",
+            "https://commons.wikimedia.org/w/index.php?title=X&oldid=1",
+        )
+    assert "description" in str(exc.value)
+    assert "P10358" in str(exc.value)
+
+
+def test_format_legacy_import_claim_rejects_leading_trailing_whitespace():
+    """Wikibase also rejects leading/trailing whitespace on monolingual
+    values (same validator, same rule). Same client-side pre-flight
+    behaviour."""
+    from ingest_wikimedia.legacy_artwork import InvalidWikibaseTextValue
+
+    with pytest.raises(InvalidWikibaseTextValue):
+        format_legacy_import_claim(
+            "description",
+            "   trailing space around a value   ",
+            "https://commons.wikimedia.org/w/index.php?title=X&oldid=1",
+        )
+
+
+def test_format_legacy_import_claim_accepts_clean_multiline_free_value():
+    """Sanity — a clean scalar description still passes and produces a
+    normal monolingualtext claim."""
+    claim = format_legacy_import_claim(
+        "description",
+        "Clean single-line description.",
+        "https://commons.wikimedia.org/w/index.php?title=X&oldid=1",
+    )
+    assert claim is not None
+    assert claim["mainsnak"]["datavalue"]["value"]["text"] == (
+        "Clean single-line description."
+    )
+
+
+def test_inject_preserved_extras_matches_fresh_upload_layout():
+    """Layout regression: injected extras must land in the same
+    multi-line ``{{DPLA metadata\\n| key = value\\n}}`` shape that a
+    fresh upload emits, not jammed onto the opening ``{{`` line. A
+    migrated file should read the same as a freshly-uploaded one so
+    operators reviewing diffs don't have to distinguish shapes."""
+    from ingest_wikimedia.legacy_artwork import _inject_preserved_extras
+
+    empty = "== {{int:filedesc}} ==\n\n{{DPLA metadata}}\n\n[[Category:Example]]\n"
+    extras = {"description": ("\n----\n<gallery>\nFile:one.jpg|front\n</gallery>")}
+    injected = _inject_preserved_extras(empty, extras)
+    assert "{{DPLA metadata\n| description =" in injected, (
+        f"expected first param on its own line; got: {injected!r}"
+    )
+    assert injected.rstrip().endswith("}}\n\n[[Category:Example]]".rstrip()) or (
+        "</gallery>\n}}" in injected
+    ), f"expected closing }} on its own line; got: {injected!r}"
+    # Category preservation — the injection must not disturb what comes
+    # after the template.
+    assert "[[Category:Example]]" in injected
+
+
+def test_inject_preserved_extras_preserves_value_verbatim():
+    """The extras value goes in byte-identical (aside from a trailing
+    newline the layout helper appends when absent). No stripping of
+    ``----``, ``<br />``, blank lines, headings, or any specific
+    marker — the user's structural markup is what it is."""
+    from ingest_wikimedia.legacy_artwork import _inject_preserved_extras
+
+    empty = "{{DPLA metadata}}"
+    weird = "\n\n<br />\n\n== Header ==\n{| \n| Cell \n|}"
+    injected = _inject_preserved_extras(empty, {"description": weird})
+    assert weird in injected, (
+        f"extras value must be preserved byte-identical; got: {injected!r}"
+    )

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -4533,6 +4533,13 @@ def _post_sdc_cleanup_for_page(
                 f" -- cleanup: legacy migration of '{file_page.title()}'"
                 f" for {dpla_id} failed; skipping."
             )
+            # Surface post-SDC migration failures in the Slack summary
+            # via the same counter the standalone migration-mode path
+            # uses. Previously this branch logged the traceback and
+            # returned False — the log line survived but the counter
+            # was never touched, so the summary reported zero problems
+            # even when every migration in the run had failed.
+            tracker.increment(Result.LEGACY_SKIPPED_ERROR)
             return False
         return bool(getattr(result, "wikitext_changed", False))
 


### PR DESCRIPTION
## Summary

Legacy `{{Artwork}}` → `{{DPLA metadata}}` migration failed when a community editor extended a DPLA-authored template parameter past the DPLA text with structural wikitext — galleries, HRs, wikitables, bulleted lists, embedded templates, or anything else that introduces vertical whitespace. Wikibase's monolingual-text validator rejected the extended value with `wikibase-validator-illegal-string-chars`, and the migration aborted for the whole file. Since the migration is what rewrites the wikitext from `{{Artwork}}` to `{{DPLA metadata}}`, the failing files stayed on the legacy template — so the SDC we'd just written never rendered in the yellow box.

The reporting side made this silent: `_post_sdc_cleanup_for_page` caught the exception and logged it but never bumped a counter, so the SDC Slack summary reported zero problems while **91 events / 22 distinct DPLA IDs** failed across ohio (64/3), nara (21/14), mwdl (3/3), and northwest-heritage (3/2). Ohio Cleveland Public Library alone was cycling through 3 items 64 times cumulatively across recurring syncs.

## Approach

Recognize the "extension" pattern semantically — a community contribution that extends the DPLA-authored value, not one that replaces it. Route the DPLA prefix to SDC unchanged (it was already valid); preserve the community extras in the migrated template's own parameter, where Module:DPLA's yellow-row renderer picks them up. Structure-agnostic: vertical whitespace triggers the check, not any specific marker like `----` or `<gallery>`. Same shape as PR #378's multi-value subset fix, extended to structural extension.

- `plan_migration` detects extension: any vertical whitespace in the wikitext value + the substring up to that boundary casefold-matches the canonical DPLA value = extension. The remainder (verbatim, from the boundary onward) lands in a new `MigrationPlan.wikitext_preserved_extras` dict instead of `community_imports`. No inferred-from-Wikitext SDC claim fires for the extras — SDC can't hold structural markup, and the DPLA prefix is already covered by DPLA-attributed SDC.
- `migrate_legacy_file` injects the preserved extras onto the migrated `{{DPLA metadata}}` template's own parameter after `normalize+canonicalize` finish. The layout matches what `get_wiki_text` emits for fresh uploads (multi-line `| key = value` per param).
- Scalar edits like `"1949"` → `"1949-02-01"` stay on the ordinary community-import path — no vertical whitespace, no extension trigger.
- Client-side pre-flight validator in `format_legacy_import_claim` raises `InvalidWikibaseTextValue` when a monolingualtext or string value contains vertical whitespace, so any shape the extraction heuristic hasn't been taught yet fails with a clear "value X for property Y" error instead of a Wikibase APIError traceback.
- `Result.LEGACY_SKIPPED_ERROR` now increments at the `_post_sdc_cleanup_for_page` catch site. The counter existed but was only bumped by the standalone `--migrate` mode.

## Live mockup

The PR has been run end-to-end against the motivating file to verify the shape. Before/after:

- **Before:** [rev 1105099064](https://commons.wikimedia.org/w/index.php?title=File:Faculty_of_Central_School,_May_7,_1883_-_DPLA_-_892257585be252969284e2c7de6c4081_(page_1).jpg&oldid=1105099064) — legacy `{{Artwork}}` with description extended by `----` + `<gallery>`.
- **After:** [current live page](https://commons.wikimedia.org/wiki/File:Faculty_of_Central_School,_May_7,_1883_-_DPLA_-_892257585be252969284e2c7de6c4081_(page_1).jpg) — migrated `{{DPLA metadata}}`, DPLA prefix in blue box (from SDC), gallery in yellow box (from preserved `description=`).

`imports_posted: 1`, `wikitext_changed: True`, no APIError.

## Test plan

- [ ] `python -m pytest -q` on branch — 1181 pass. New coverage: extend-with-gallery (mockup shape), extend-with-HR-only, extend-with-bulleted-list (Ohio Cleveland pattern), scalar-edit stays on divergence path, extension prefix must match canonical, pre-flight rejects vertical whitespace + leading/trailing whitespace, injection matches fresh-upload layout, extras preserved byte-verbatim.
- [ ] Deploy + one-shot migration of `892257585be252969284e2c7de6c4081` on wiki EC2 — done, live mockup above.
- [ ] Full NWDH batch run to confirm the previously-silent skips now surface in the tracker summary as `LEGACY_SKIPPED_ERROR: N` when they occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated legacy `{{Artwork}}` → `{{DPLA metadata}}` migration to preserve Commons community-added structural wikitext that follows a canonical DPLA-authored description. The migration now detects “extension” edits where the community value matches the canonical DPLA text up to the first vertical-whitespace boundary, keeps the DPLA prefix in SDC, and carries the remaining wikitext into the migrated `{{DPLA metadata}}` template by reinjecting it into the template parameter (instead of triggering migration failure).

Also added earlier client-side validation for `monolingualtext` and `string` claim values to reject vertical whitespace and leading/trailing whitespace with a clearer, dedicated validation error before Wikibase API submission.

Improved cleanup-time reporting: when legacy migration failures occur during SDC cleanup, the code increments `LEGACY_SKIPPED_ERROR` so skipped items are reflected in tracker/run summaries.

Tests were added/updated for gallery, HR, bulleted-list, scalar-edit, and preserved-extras injection formatting cases, including negative/edge coverage and a poisoned-caption regression scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->