### PR TITLE
Preserve creator community contributions during legacy migration

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -262,7 +262,24 @@ def parse_artwork_params(wikitext: str) -> dict[str, str]:
             if last_named_recognised and stitched:
                 stitched[-1][1] += "|" + str(param.value)
             continue
-        canonical = ARTWORK_PARAM_TO_CANONICAL_KEY.get(_normalize_param_name(param))
+        param_name = _normalize_param_name(param)
+        canonical = ARTWORK_PARAM_TO_CANONICAL_KEY.get(param_name)
+        # ``Other fields`` / ``Other fields N`` — the legacy shape
+        # for creator (and historically other rows) wrapped in
+        # ``{{InFi | Creator | <inner>}}`` bot scaffolding. Unwrap the
+        # InFi and route the inner value to its canonical key when
+        # the label is one we can migrate. Non-Creator InFi wrappers
+        # (Description, Photographer, etc.) fall through as
+        # unrecognised — a later phase can widen the set.
+        if canonical is None and _OTHER_FIELDS_PARAM_RE.match(param_name):
+            inner = _unwrap_infi_creator(str(param.value))
+            if inner is None:
+                last_named_recognised = False
+                continue
+            canonical = "creator"
+            stitched.append([canonical, inner])
+            last_named_recognised = True
+            continue
         if canonical is None:
             last_named_recognised = False
             continue
@@ -279,6 +296,20 @@ def parse_artwork_params(wikitext: str) -> dict[str, str]:
             # to import. Skip them same as we skip missing params so
             # the migrator doesn't preserve markup errors as SDC.
             continue
+        # Creator has multiple wikitext shapes: plain stated-as name,
+        # ``{{creator|Wikidata=Q…}}`` with a direct QID,
+        # ``{{Creator:Foo}}`` with a Creator: page transclusion, or
+        # ``{{NARA-Author|…}}`` legacy-bot scaffolding. Classify and
+        # tag with a sentinel; downstream comparator + claim-builder
+        # branch on the sentinel. ``None`` from the classifier means
+        # strip-only (never preserve) — the value is dropped from the
+        # parse output entirely, indistinguishable from an absent
+        # param, so no community-import fires.
+        if canonical == "creator":
+            classified = _parse_creator_shape(value)
+            if classified is None:
+                continue
+            value = classified
         # On duplicate canonical keys (e.g. both ``author`` and
         # ``creator`` set), the *last* wins — matches the renderer
         # behavior under MediaWiki, where the later assignment
@@ -456,10 +487,121 @@ def plan_migration(
 # Case-insensitive on the template name and param key so hand-typed
 # variants (``institution`` / ``Institution``, ``Wikidata`` / ``wikidata``)
 # both parse cleanly to the inner Q-ID.
+# Regexes for the legacy ``Other fields N`` creator shapes. Order-sensitive
+# only in that the most specific matcher runs first — NARA-Author's
+# name+id shape is distinct enough that it never collides with the
+# QID-bearing shapes. See :func:`_parse_creator_shape` for the dispatcher.
 _INSTITUTION_SUBTEMPLATE_RE = re.compile(
     r"^\s*\{\{\s*Institution\s*\|\s*wikidata\s*=\s*(Q\d+)\s*\}\}\s*$",
     re.IGNORECASE,
 )
+
+# ``Other fields 1 = {{InFi | Creator | <inner> | id=fileinfotpl_aut}}``
+# and variants. Case-insensitive on InFi and on the ``Creator`` label
+# so hand-typed variants (``infi`` / ``INFI``, ``creator`` / ``Creator``)
+# both parse cleanly.
+_INFI_CREATOR_LABEL_RE = re.compile(r"^\s*creator\s*$", re.IGNORECASE)
+
+# ``Other fields 1``, ``Other fields 2``, ..., or the bare ``Other fields``.
+# Case-folded param names since ``_normalize_param_name`` already lower-cases.
+_OTHER_FIELDS_PARAM_RE = re.compile(r"^other fields(?: \d+)?$")
+
+# ``{{creator|Wikidata=Q56159174}}`` — Commons Creator template with a
+# direct Wikidata QID. Case-insensitive on template name; the Wikidata
+# param name is conventionally capitalized ``Wikidata`` on Commons but
+# accepts any casing under MediaWiki's param-name rules.
+_CREATOR_WIKIDATA_RE = re.compile(
+    r"^\s*\{\{\s*creator\s*\|\s*[Ww]ikidata\s*=\s*(Q\d+)\s*\}\}\s*$",
+    re.IGNORECASE,
+)
+
+# ``{{Creator:Theodore E. Peiser}}`` — Commons Creator: namespace page
+# transclusion (no Wikidata= param, resolved later via Commons API).
+_CREATOR_PAGE_RE = re.compile(r"^\s*\{\{\s*Creator:([^}|]+?)\s*\}\}\s*$")
+
+# ``{{NARA-Author|Adams, Ansel, 1902-1984, Photographer|1332556}}`` —
+# legacy bot-authored NARA authorship template. Never a genuine
+# community contribution; strip without extracting either positional.
+_NARA_AUTHOR_RE = re.compile(r"^\s*\{\{\s*NARA-Author\s*\|", re.IGNORECASE)
+
+
+# Sentinel prefixes marking a creator value that carries structured
+# provenance beyond a plain stated-as name string. Downstream code
+# (comparator + claim-builder) branches on these; unrelated code paths
+# treat them as opaque strings that happen not to match anything.
+_CREATOR_QID_PREFIX = "__creator_qid__:"
+_CREATOR_PAGE_PREFIX = "__creator_page__:"
+
+
+def _unwrap_infi_creator(value: str) -> str | None:
+    """Return the inner value of ``{{InFi | Creator | <inner> …}}`` if
+    ``value`` is exactly that shape (any casing on ``InFi`` / ``Creator``,
+    any trailing ``id=`` or other kwargs), else ``None``.
+
+    Legacy uploads wrapped the creator row in ``Other fields N =
+    {{InFi|Creator|<value>|id=fileinfotpl_aut}}`` to attach the
+    machine-readable ``fileinfotpl_aut`` id. The inner value is what
+    a Commons editor actually contributed; the wrapper is bot
+    scaffolding that drops out on migration.
+    """
+    parsed = mwparserfromhell.parse(value)
+    templates = parsed.filter_templates(recursive=False)
+    if len(templates) != 1:
+        return None
+    tpl = templates[0]
+    if str(tpl.name).strip().casefold() != "infi":
+        return None
+    label_param = None
+    inner_param = None
+    for p in tpl.params:
+        if not p.showkey:
+            if label_param is None:
+                label_param = p
+            elif inner_param is None:
+                inner_param = p
+    if label_param is None or inner_param is None:
+        return None
+    if not _INFI_CREATOR_LABEL_RE.match(str(label_param.value)):
+        return None
+    return str(inner_param.value).strip()
+
+
+def _parse_creator_shape(value: str) -> str | None:
+    """Classify a raw wikitext creator value and return a comparable
+    representation.
+
+    Returns:
+
+    * ``None`` if the value is a strip-only shape that must NOT be
+      preserved as a community contribution (``{{NARA-Author|…}}`` —
+      bot-authored, never a real community edit).
+    * ``"__creator_qid__:Q…"`` sentinel when the value carries an
+      explicit Wikidata QID (``{{creator|Wikidata=Q…}}``). The QID
+      is stored as-is; the executor's comparator matches it directly
+      against DPLA-attributed P170 QIDs.
+    * ``"__creator_page__:<title>"`` sentinel when the value is a
+      Commons Creator: page transclusion (``{{Creator:Foo}}``). The
+      executor's QID resolver will call Commons ``pageprops`` to
+      find the linked Wikidata QID and either preserve it as
+      P170 QID or fall back to a P170 somevalue + P2093 stated-as
+      claim when the Creator: page has no Wikibase link.
+    * The unchanged ``value`` string for anything else — a plain
+      stated-as name (``Peiser, Theodore E``) or an unrecognised
+      shape. Passes through to the existing string-based comparator
+      + claim-builder path unchanged.
+    """
+    stripped = value.strip()
+    if not stripped:
+        return stripped
+    if _NARA_AUTHOR_RE.match(stripped):
+        return None
+    m = _CREATOR_WIKIDATA_RE.match(stripped)
+    if m:
+        return _CREATOR_QID_PREFIX + m.group(1)
+    m = _CREATOR_PAGE_RE.match(stripped)
+    if m:
+        return _CREATOR_PAGE_PREFIX + m.group(1).strip()
+    return stripped
 
 
 def _extract_institution_qid(value: str) -> str | None:
@@ -798,6 +940,31 @@ def format_legacy_import_claim(
     the signature so a later phase can decide whether to add a
     secondary P813 reference snak without changing call sites.
     """
+    # Creator has multiple wikitext shapes: a plain stated-as name
+    # (existing string-datavalue path) OR the sentinel-tagged QID /
+    # Creator: page shapes emitted by :func:`_parse_creator_shape`.
+    # The QID and page shapes need a P170 mainsnak (not the default
+    # P2093 stated-as claim); page-shape values also need a Commons
+    # API round-trip to resolve the linked Wikidata QID. Surface
+    # both as pending markers so :func:`materialize_import_claims`
+    # can do the SDC comparison + resolution in the executor's
+    # network-touching context, keeping :func:`plan_migration` pure.
+    if canonical_key == "creator":
+        if value.startswith(_CREATOR_QID_PREFIX):
+            return {
+                "type": "statement",
+                "rank": "normal",
+                "_phase3a_pending_creator_qid": value[len(_CREATOR_QID_PREFIX) :],
+                "_permalink": permalink,
+            }
+        if value.startswith(_CREATOR_PAGE_PREFIX):
+            return {
+                "type": "statement",
+                "rank": "normal",
+                "_phase3a_pending_creator_page": value[len(_CREATOR_PAGE_PREFIX) :],
+                "_permalink": permalink,
+            }
+
     mapping = LEGACY_IMPORT_PROPERTY.get(canonical_key)
     if mapping is None:
         return None
@@ -1213,33 +1380,214 @@ def materialize_pending_date_claim(
     }
 
 
+def _entity_p170_qids(existing_entity: dict | None) -> set[str]:
+    """Return the set of Wikidata QIDs already stated in ``existing_entity``'s
+    P170 (creator) mainsnaks, DPLA-attributed or otherwise.
+
+    Used by the creator claim materialiser to detect when a community-
+    contributed QID (from ``{{Creator:Foo}}`` / ``{{creator|Wikidata=Q…}}``)
+    duplicates a QID already on the entity — in which case the community
+    import is a no-op and gets dropped rather than emitted as a redundant
+    second P170 statement carrying the same fact. Reads only the
+    ``wikibase-entityid`` mainsnak shape; somevalue + P2093 stated-as
+    claims contribute no QID and are ignored here.
+    """
+    if not existing_entity:
+        return set()
+    statements = (
+        existing_entity.get("statements") or existing_entity.get("claims") or {}
+    )
+    qids: set[str] = set()
+    for stmt in statements.get("P170", []):
+        ms = stmt.get("mainsnak") or {}
+        if ms.get("snaktype") != "value":
+            continue
+        dv = ms.get("datavalue") or {}
+        if dv.get("type") != "wikibase-entityid":
+            continue
+        qid = (dv.get("value") or {}).get("id")
+        if qid:
+            qids.add(qid)
+    return qids
+
+
+def _resolve_commons_creator_qid(site, page_title: str) -> str | None:
+    """Look up the Wikidata QID linked from a Commons ``Creator:<title>``
+    page via the ``prop=pageprops`` API.
+
+    Returns the QID string (``"Q…"``) when the Creator page exists and
+    has a ``wikibase_item`` sitelink; ``None`` for missing pages,
+    orphaned Creator pages, or any API failure. Falling back to
+    ``None`` is intentional: the caller substitutes a P170 somevalue
+    + P2093 stated-as name claim so the community contribution is
+    preserved as a stated-as string even when the QID resolution
+    can't succeed — same outcome as a plain ``| creator = <name>``
+    parameter would produce.
+
+    Requires ``site`` to be a live pywikibot Site; test callers can
+    pass ``None`` to short-circuit to the name-only fallback path.
+    """
+    if site is None or not page_title:
+        return None
+    try:
+        response = site.simple_request(
+            action="query",
+            prop="pageprops",
+            titles=f"Creator:{page_title}",
+            format="json",
+        ).submit()
+    except Exception:
+        return None
+    pages = (response.get("query") or {}).get("pages") or {}
+    for page in pages.values():
+        pp = page.get("pageprops") or {}
+        qid = pp.get("wikibase_item")
+        if isinstance(qid, str) and qid.startswith("Q"):
+            return qid
+    return None
+
+
+def _build_creator_qid_claim(qid: str, permalink: str) -> dict:
+    """Build a P170 (creator) statement whose mainsnak is a
+    wikibase-entityid pointing at ``qid``, with the inferred-from-
+    Wikitext reference shape."""
+    return {
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": "P170",
+            "datatype": "wikibase-item",
+            "datavalue": {
+                "type": "wikibase-entityid",
+                "value": {"entity-type": "item", "id": qid},
+            },
+        },
+        "references": [_reference_snaks(permalink)],
+    }
+
+
+def _build_creator_stated_as_claim(name: str, permalink: str) -> dict:
+    """Build a P170 somevalue statement qualified by P2093 (stated as)
+    ``name``, matching the DPLA-bot's canonical creator shape for
+    files where the creator is a plain name string with no Wikidata
+    counterpart."""
+    return {
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "somevalue",
+            "property": "P170",
+            "datatype": "wikibase-item",
+        },
+        "qualifiers": {
+            "P2093": [
+                {
+                    "snaktype": "value",
+                    "property": "P2093",
+                    "datatype": "string",
+                    "datavalue": {"type": "string", "value": name},
+                }
+            ],
+        },
+        "qualifiers-order": ["P2093"],
+        "references": [_reference_snaks(permalink)],
+    }
+
+
+def materialize_pending_creator_claim(
+    placeholder: dict,
+    *,
+    site=None,
+    existing_entity: dict | None = None,
+) -> dict | None:
+    """Convert a Phase-3a creator placeholder into a real P170 statement.
+
+    Two placeholder shapes are supported, matching the sentinels
+    :func:`_parse_creator_shape` emits:
+
+    * ``_phase3a_pending_creator_qid``: the QID is already known
+      (came from ``{{creator|Wikidata=Q…}}``). Compare against
+      :func:`_entity_p170_qids`; return ``None`` to drop the claim
+      when the QID is already on the entity, else build a P170 QID
+      statement.
+    * ``_phase3a_pending_creator_page``: the value is a Commons
+      Creator: page title (came from ``{{Creator:Foo}}``). Resolve
+      to a Wikidata QID via :func:`_resolve_commons_creator_qid`;
+      apply the same duplicate check on success. On resolution
+      failure (page missing, orphaned Creator, or API error),
+      fall back to a P170 somevalue + P2093 stated-as ``<title>``
+      claim so the community contribution is preserved as a stated-as
+      string.
+
+    Returns ``None`` for placeholders missing the expected sentinel
+    keys (defensive — the caller drops such claims) or for the
+    duplicate-QID drop case.
+    """
+    permalink = placeholder.get("_permalink", "")
+    existing_qids = _entity_p170_qids(existing_entity)
+
+    qid = placeholder.get("_phase3a_pending_creator_qid")
+    if isinstance(qid, str) and qid:
+        if qid in existing_qids:
+            return None
+        return _build_creator_qid_claim(qid, permalink)
+
+    page_title = placeholder.get("_phase3a_pending_creator_page")
+    if isinstance(page_title, str) and page_title:
+        resolved = _resolve_commons_creator_qid(site, page_title)
+        if resolved is not None:
+            if resolved in existing_qids:
+                return None
+            return _build_creator_qid_claim(resolved, permalink)
+        # No Wikidata QID on the Creator: page. Preserve as a stated-as
+        # string using the page title as the name — best-effort
+        # fallback that mirrors what a plain ``| creator = <name>``
+        # param would produce.
+        return _build_creator_stated_as_claim(page_title, permalink)
+
+    return None
+
+
 def materialize_import_claims(
     claims: list[dict],
     *,
     site=None,
     existing_entity: dict | None = None,
 ) -> list[dict]:
-    """Walk an import-claim list and substitute every Phase-3a date
-    placeholder for a real P571 time statement.
+    """Walk an import-claim list and substitute every Phase-3a
+    placeholder for a real Wikibase statement.
 
-    Claims without a placeholder marker pass through unchanged.
-    Placeholders whose date can't be expanded (parser failure paired
-    with missing sentinel keys — should never happen for in-tree
-    callers) are dropped silently rather than crashing the migration.
+    Handles two placeholder shapes: date placeholders (P571 time
+    statements via :func:`materialize_pending_date_claim`) and
+    creator placeholders (P170 statements via
+    :func:`materialize_pending_creator_claim`). Claims without a
+    placeholder marker pass through unchanged. Placeholders whose
+    materialiser returns ``None`` — duplicate of existing SDC, or
+    an unparseable value — are dropped from the returned list.
 
-    ``site`` and ``existing_entity`` are forwarded to
-    :func:`materialize_pending_date_claim` so the date materialiser
-    can (a) expand wikitext templates server-side before parsing and
-    (b) drop a community-import claim whose parsed value already
-    exists DPLA-attributed on the entity. Both are optional — when
-    neither is supplied, the function preserves the historical
-    always-import behaviour. The original caller signature is also
-    preserved for tests that pass only the claims list.
+    ``site`` and ``existing_entity`` are forwarded to the
+    materialisers so they can (a) expand wikitext templates
+    server-side, (b) look up Commons Creator-page QIDs, and (c)
+    drop community-imports whose value already exists on the entity.
+    All optional — when none are supplied, the function preserves
+    the historical always-import behaviour. The original caller
+    signature is also preserved for tests that pass only the
+    claims list.
     """
     materialised: list[dict] = []
     for claim in claims:
         if "_phase3a_pending_date_parse" in claim:
             real = materialize_pending_date_claim(
+                claim, site=site, existing_entity=existing_entity
+            )
+            if real is not None:
+                materialised.append(real)
+        elif (
+            "_phase3a_pending_creator_qid" in claim
+            or "_phase3a_pending_creator_page" in claim
+        ):
+            real = materialize_pending_creator_claim(
                 claim, site=site, existing_entity=existing_entity
             )
             if real is not None:

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -517,7 +517,10 @@ _CREATOR_WIKIDATA_RE = re.compile(
 
 # ``{{Creator:Theodore E. Peiser}}`` — Commons Creator: namespace page
 # transclusion (no Wikidata= param, resolved later via Commons API).
-_CREATOR_PAGE_RE = re.compile(r"^\s*\{\{\s*Creator:([^}|]+?)\s*\}\}\s*$")
+# Case-insensitive on the ``Creator:`` prefix because MediaWiki auto-
+# capitalises the namespace on a template transclusion; both
+# ``{{Creator:Foo}}`` and ``{{creator:Foo}}`` resolve to the same page.
+_CREATOR_PAGE_RE = re.compile(r"^\s*\{\{\s*Creator:([^}|]+?)\s*\}\}\s*$", re.IGNORECASE)
 
 # ``{{NARA-Author|Adams, Ansel, 1902-1984, Photographer|1332556}}`` —
 # legacy bot-authored NARA authorship template. Never a genuine
@@ -585,10 +588,19 @@ def _parse_creator_shape(value: str) -> str | None:
       find the linked Wikidata QID and either preserve it as
       P170 QID or fall back to a P170 somevalue + P2093 stated-as
       claim when the Creator: page has no Wikibase link.
-    * The unchanged ``value`` string for anything else — a plain
-      stated-as name (``Peiser, Theodore E``) or an unrecognised
-      shape. Passes through to the existing string-based comparator
-      + claim-builder path unchanged.
+    * The unchanged ``value`` string for anything that is *not*
+      template-shaped — a plain stated-as name
+      (``Peiser, Theodore E``), an already-expanded creator string
+      from any source. Passes through to the existing string-based
+      comparator + claim-builder path unchanged.
+    * ``None`` for any template-shaped value that doesn't match one
+      of the recognised shapes above — e.g. an unknown ``{{Foo}}``
+      wrapper, or a shape we haven't taught the parser about. Preserves
+      the "strip when we can't safely preserve" invariant: submitting
+      literal ``{{…}}`` markup as a P2093 stated-as string would be
+      both wrong (SDC shouldn't store wikitext) and hard to unwind
+      later. Deferring to a later phase that widens the recognised
+      set is safer than emitting nonsense claims now.
     """
     stripped = value.strip()
     if not stripped:
@@ -601,6 +613,11 @@ def _parse_creator_shape(value: str) -> str | None:
     m = _CREATOR_PAGE_RE.match(stripped)
     if m:
         return _CREATOR_PAGE_PREFIX + m.group(1).strip()
+    # Any remaining ``{{…}}`` template-shaped value we don't recognise
+    # is dropped rather than passed through as a raw string. See the
+    # returns-``None`` clause of the docstring for the rationale.
+    if stripped.startswith("{{") and stripped.endswith("}}"):
+        return None
     return stripped
 
 

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -2554,3 +2554,52 @@ def test_plan_migration_extracts_infi_creator_with_wikidata_qid():
     )
     assert plan is not None
     assert plan.community_imports.get("creator") == (_CREATOR_QID_PREFIX + "Q56159174")
+
+
+def test_parse_creator_shape_matches_creator_page_case_insensitively():
+    """MediaWiki auto-capitalises the ``Creator:`` namespace on
+    template transclusions, so ``{{creator:Foo}}`` and ``{{Creator:Foo}}``
+    both resolve to the same page. The parser matches both."""
+    from ingest_wikimedia.legacy_artwork import (
+        _parse_creator_shape,
+        _CREATOR_PAGE_PREFIX,
+    )
+
+    assert _parse_creator_shape("{{creator:Theodore E. Peiser}}") == (
+        _CREATOR_PAGE_PREFIX + "Theodore E. Peiser"
+    )
+    assert _parse_creator_shape("{{CREATOR:Theodore E. Peiser}}") == (
+        _CREATOR_PAGE_PREFIX + "Theodore E. Peiser"
+    )
+
+
+def test_parse_creator_shape_strips_unknown_template_shapes():
+    """Any template-shaped value that doesn't match one of the
+    recognised creator shapes is dropped rather than passed through
+    as a literal string. Submitting raw ``{{…}}`` markup as a P2093
+    stated-as would be both wrong (SDC shouldn't store wikitext) and
+    a maintenance burden to reverse later. Deferring to a later phase
+    that widens the recognised set is safer than emitting nonsense
+    claims now."""
+    from ingest_wikimedia.legacy_artwork import _parse_creator_shape
+
+    # An unknown creator-authoring template shape.
+    assert _parse_creator_shape("{{some-unknown-creator-template|Foo Bar}}") is None
+    # A partially-typed Creator: shape that misses ``_CREATOR_PAGE_RE``
+    # (contains pipe → treated as a template with args rather than a
+    # bare page transclusion). Better to strip than to emit
+    # ``P2093="{{Creator:Foo|extra}}"``.
+    assert _parse_creator_shape("{{Creator:Foo|extra}}") is None
+
+
+def test_parse_creator_shape_passes_through_plain_names():
+    """Regression: plain-string creator names still pass through
+    unchanged. The unknown-template guard only fires on ``{{…}}``-
+    wrapped values."""
+    from ingest_wikimedia.legacy_artwork import _parse_creator_shape
+
+    assert _parse_creator_shape("Peiser, Theodore E") == "Peiser, Theodore E"
+    # A name that happens to contain balanced braces mid-string (not a
+    # template) must still pass through — the guard checks bounds, not
+    # substring occurrence.
+    assert _parse_creator_shape("Smith, John (author)") == "Smith, John (author)"

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -2298,3 +2298,259 @@ def test_inject_preserved_extras_preserves_value_verbatim():
     assert weird in injected, (
         f"extras value must be preserved byte-identical; got: {injected!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Creator community-contribution extraction (this commit).
+# Legacy ``Other fields N = {{InFi|Creator|<inner>}}`` uploads carried
+# community-contributed creator values in a wrapper that the previous
+# extractor didn't recognise. This commit adds:
+#   * InFi-wrapper unwrap in parse_artwork_params
+#   * Inner-shape dispatch for {{Creator:Foo}}, {{creator|Wikidata=Q…}},
+#     {{NARA-Author|<name>|<id>}}, and plain strings
+#   * Materialise-time QID resolution for Creator: pages via Commons
+#     pageprops
+#   * P170-QID and P170-somevalue+P2093-stated-as claim shapes,
+#     replacing the previous P2093 mainsnak that Module:DPLA didn't
+#     read as a creator statement
+# ---------------------------------------------------------------------------
+
+
+def test_parse_artwork_params_unwraps_infi_creator_with_creator_page():
+    """The ``Other fields 1 = {{InFi|Creator|{{Creator:Foo}}}}`` wrapper
+    must be unwrapped and its inner ``{{Creator:Foo}}`` routed to the
+    canonical ``creator`` key with a page-title sentinel so the
+    executor can resolve to a Wikidata QID via Commons pageprops."""
+    from ingest_wikimedia.legacy_artwork import (
+        parse_artwork_params,
+        _CREATOR_PAGE_PREFIX,
+    )
+
+    wt = (
+        "{{Artwork\n"
+        "| Other fields 1 = {{ InFi | Creator | "
+        "{{Creator:Theodore E. Peiser}} | id=fileinfotpl_aut }}\n"
+        "| title = A title\n"
+        "}}"
+    )
+    params = parse_artwork_params(wt)
+    assert params.get("creator") == (_CREATOR_PAGE_PREFIX + "Theodore E. Peiser"), (
+        f"got {params!r}"
+    )
+
+
+def test_parse_artwork_params_unwraps_infi_creator_with_wikidata_template():
+    """``{{creator|Wikidata=Q…}}`` inside the InFi wrapper is
+    dispatched with a QID sentinel so the executor doesn't need to
+    resolve anything — the community already supplied the QID."""
+    from ingest_wikimedia.legacy_artwork import (
+        parse_artwork_params,
+        _CREATOR_QID_PREFIX,
+    )
+
+    wt = (
+        "{{Artwork\n"
+        "| Other fields 1 = {{ InFi | Creator | "
+        "{{creator|Wikidata=Q56159174}} | id=fileinfotpl_aut }}\n"
+        "}}"
+    )
+    params = parse_artwork_params(wt)
+    assert params.get("creator") == _CREATOR_QID_PREFIX + "Q56159174"
+
+
+def test_parse_artwork_params_strips_nara_author_completely():
+    """``{{NARA-Author|<name>|<id>}}`` is bot-authored legacy
+    scaffolding, never a real community edit. It must be stripped
+    entirely — no community-import claim fires — so any drift between
+    its captured value and current DPLA SDC doesn't become permanently
+    attributed as an inferred-from-Wikitext contribution. Verified by
+    the creator key being absent from the parse output entirely,
+    matching the behaviour of an omitted param."""
+    from ingest_wikimedia.legacy_artwork import parse_artwork_params
+
+    wt = (
+        "{{Artwork\n"
+        "| Other fields 1 = {{ InFi | Creator | "
+        "{{NARA-Author|Adams, Ansel, 1902-1984, Photographer|1332556}} "
+        "| id=fileinfotpl_aut }}\n"
+        "| title = A title\n"
+        "}}"
+    )
+    params = parse_artwork_params(wt)
+    assert "creator" not in params, (
+        f"NARA-Author must be stripped without producing a creator "
+        f"entry; got {params!r}"
+    )
+
+
+def test_parse_artwork_params_plain_string_creator_in_infi_wrapper():
+    """A plain stated-as name inside the InFi wrapper still routes to
+    ``creator`` as a plain string — same path as the flat ``|creator=``
+    shape."""
+    from ingest_wikimedia.legacy_artwork import parse_artwork_params
+
+    wt = (
+        "{{Artwork\n"
+        "| Other fields 1 = {{ InFi | Creator | Peiser, Theodore E "
+        "| id=fileinfotpl_aut }}\n"
+        "}}"
+    )
+    params = parse_artwork_params(wt)
+    assert params.get("creator") == "Peiser, Theodore E"
+
+
+def test_parse_artwork_params_creator_wikidata_template_in_flat_param():
+    """``{{creator|Wikidata=Q…}}`` in the flat ``| creator = …``
+    param (post-migration Commons-editor shape) is also dispatched
+    with a QID sentinel — same downstream handling as the wrapped
+    legacy form."""
+    from ingest_wikimedia.legacy_artwork import (
+        parse_artwork_params,
+        _CREATOR_QID_PREFIX,
+    )
+
+    wt = "{{Artwork\n| creator = {{creator|Wikidata=Q56159174}}\n}}"
+    params = parse_artwork_params(wt)
+    assert params.get("creator") == _CREATOR_QID_PREFIX + "Q56159174"
+
+
+def test_materialize_creator_qid_placeholder_drops_when_qid_already_on_entity():
+    """``{{creator|Wikidata=Q…}}`` whose QID already matches a P170
+    QID on the entity is a no-op community import — drop the claim
+    from the materialised list rather than posting a redundant
+    second P170 statement."""
+    from ingest_wikimedia.legacy_artwork import materialize_import_claims
+
+    placeholder = {
+        "type": "statement",
+        "rank": "normal",
+        "_phase3a_pending_creator_qid": "Q56159174",
+        "_permalink": "https://commons.wikimedia.org/w/index.php?oldid=1",
+    }
+    entity = {
+        "statements": {
+            "P170": [
+                {
+                    "mainsnak": {
+                        "snaktype": "value",
+                        "property": "P170",
+                        "datavalue": {
+                            "type": "wikibase-entityid",
+                            "value": {"entity-type": "item", "id": "Q56159174"},
+                        },
+                    }
+                }
+            ]
+        }
+    }
+    materialised = materialize_import_claims([placeholder], existing_entity=entity)
+    assert materialised == [], (
+        "creator-QID placeholder whose QID is already on the entity's "
+        f"P170 must not produce a claim; got {materialised!r}"
+    )
+
+
+def test_materialize_creator_qid_placeholder_emits_when_qid_differs():
+    """When the community QID isn't already on the entity, emit a
+    proper P170 mainsnak QID statement with the inferred-from-
+    Wikitext reference shape — NOT the previous P2093 mainsnak that
+    Module:DPLA doesn't render as a creator row."""
+    from ingest_wikimedia.legacy_artwork import materialize_import_claims
+
+    placeholder = {
+        "type": "statement",
+        "rank": "normal",
+        "_phase3a_pending_creator_qid": "Q56159174",
+        "_permalink": "https://commons.wikimedia.org/w/index.php?oldid=1",
+    }
+    # Entity has only a somevalue P170 (DPLA's stated-as name shape),
+    # no QID — the community QID is genuinely new information.
+    entity = {
+        "statements": {
+            "P170": [
+                {
+                    "mainsnak": {
+                        "snaktype": "somevalue",
+                        "property": "P170",
+                    }
+                }
+            ]
+        }
+    }
+    materialised = materialize_import_claims([placeholder], existing_entity=entity)
+    assert len(materialised) == 1
+    claim = materialised[0]
+    assert claim["mainsnak"]["property"] == "P170"
+    assert claim["mainsnak"]["snaktype"] == "value"
+    dv = claim["mainsnak"]["datavalue"]
+    assert dv["type"] == "wikibase-entityid"
+    assert dv["value"]["id"] == "Q56159174"
+    # Inferred-from-Wikitext reference shape must be intact.
+    refs = claim["references"][0]["snaks"]
+    assert refs["P887"][0]["datavalue"]["value"]["id"] == "Q131783016"
+
+
+def test_materialize_creator_page_placeholder_falls_back_to_stated_as_when_no_qid():
+    """A ``{{Creator:Foo}}`` transclusion whose Creator: page has no
+    linked Wikidata item (orphaned page, or the page doesn't exist)
+    falls back to a P170 somevalue + P2093 stated-as claim using the
+    page title as the name. Preserves the community contribution as
+    a stated-as string rather than dropping it silently.
+
+    The resolver is stubbed to return None so the fallback path fires
+    without requiring a live Commons API call."""
+    from ingest_wikimedia.legacy_artwork import materialize_import_claims
+
+    placeholder = {
+        "type": "statement",
+        "rank": "normal",
+        "_phase3a_pending_creator_page": "Orphaned Person",
+        "_permalink": "https://commons.wikimedia.org/w/index.php?oldid=1",
+    }
+    # ``site=None`` short-circuits ``_resolve_commons_creator_qid`` to
+    # None, exercising the stated-as fallback without a network call.
+    materialised = materialize_import_claims([placeholder], site=None)
+    assert len(materialised) == 1
+    claim = materialised[0]
+    assert claim["mainsnak"]["property"] == "P170"
+    assert claim["mainsnak"]["snaktype"] == "somevalue"
+    stated_as = claim["qualifiers"]["P2093"][0]["datavalue"]["value"]
+    assert stated_as == "Orphaned Person", (
+        f"expected stated-as to fall back to the page title; got {stated_as!r}"
+    )
+    refs = claim["references"][0]["snaks"]
+    assert refs["P887"][0]["datavalue"]["value"]["id"] == "Q131783016"
+
+
+def test_plan_migration_extracts_infi_creator_with_wikidata_qid():
+    """Integration: a legacy Artwork upload with a community
+    contribution wrapped in ``Other fields 1 = {{InFi|Creator|
+    {{creator|Wikidata=Q…}}}}`` must produce a plan whose
+    community_imports carries the QID sentinel — which then
+    materialises into a P170 QID claim at execute time."""
+    from ingest_wikimedia.legacy_artwork import (
+        plan_migration,
+        _CREATOR_QID_PREFIX,
+    )
+
+    revs = _make_revs(
+        (
+            1,
+            "DPLA_bot",
+            "{{Artwork\n| Other fields 1 = {{ InFi | Creator | "
+            "Peiser, Theodore E | id=fileinfotpl_aut }}\n}}",
+        ),
+        (
+            2,
+            "Community_editor",
+            "{{Artwork\n| Other fields 1 = {{ InFi | Creator | "
+            "{{creator|Wikidata=Q56159174}} | id=fileinfotpl_aut }}\n}}",
+        ),
+    )
+    plan = plan_migration(
+        "File:Foo.jpg",
+        revs,
+        _canonical_params(creator="Peiser, Theodore E"),
+    )
+    assert plan is not None
+    assert plan.community_imports.get("creator") == (_CREATOR_QID_PREFIX + "Q56159174")


### PR DESCRIPTION
## Summary

Legacy `{{Artwork}}` uploads carried the creator row wrapped in `Other fields N = {{InFi|Creator|<inner>}}` — bot scaffolding around a value that a Commons editor may have curated to something more informative than DPLA's stated-as name: a Wikidata-linked `{{Creator:Foo}}` page, or a direct `{{creator|Wikidata=Q…}}` template. The previous `parse_artwork_params` only recognised the flat `|creator=` shape, so the wrapped community contribution was silently dropped — `render_migrated_wikitext` swapped the whole `{{Artwork}}` for a fresh `{{DPLA metadata}}` block, and the community creator link went with it. Users like Jmabel (Faculty of Central School photo) lost their curated Creator-page links to nothing.

## Changes

- **Extractor**: `parse_artwork_params` recognises `Other fields` / `Other fields N` and unwraps `{{InFi|Creator|<inner>}}`, routing the inner value to the canonical creator key.
- **Shape dispatch**: `_parse_creator_shape` classifies the inner value into one of:
  - `{{Creator:Foo}}` → `__creator_page__:<title>` sentinel (executor resolves QID via Commons `pageprops`).
  - `{{creator|Wikidata=Q…}}` → `__creator_qid__:Q…` sentinel (QID already known, no resolution needed).
  - `{{NARA-Author|<name>|<id>}}` → **stripped entirely**. Bot-authored legacy scaffolding, never a genuine community edit; preserving it as inferred-from-Wikitext would permanently attribute bot-drift to the community.
  - Plain string → unchanged, existing casefold comparator handles equivalence to DPLA stated-as name.
- **Claim materialisation**: `format_legacy_import_claim` emits Phase 3a pending markers for the sentinel-tagged shapes (matching the existing `_phase3a_pending_date_parse` pattern), so `plan_migration` stays pure. `materialize_import_claims` resolves them at the executor layer:
  - QID sentinel: compare against existing P170 QIDs on the entity; drop if duplicate, else build a P170 wikibase-entityid claim.
  - Page sentinel: call Commons `pageprops` for the Creator: page's `wikibase_item`; on success apply the same duplicate check; on failure fall back to `P170 somevalue + P2093 stated-as <page-title>`.
- **New claim shapes**: `_build_creator_qid_claim` (P170 mainsnak QID) and `_build_creator_stated_as_claim` (P170 somevalue + P2093 qualifier) with the inferred-from-Wikitext reference shape. Note that these differ from the previous creator import path which emitted a bare P2093 mainsnak — a shape Module:DPLA doesn't render as a creator row.

## Companion module change (already deployed)

Module:DPLA was updated in a companion Commons edit to render P170 QID mainsnaks via `{{creator|Wikidata=Q…}}` — the full Commons Creator infobox — matching hand-authored `{{Creator:Foo}}` wikitext. Without that render fix, any P170 QIDs this PR writes would show as bare plaintext labels. See the module edit's summary for context.

## Test plan

- [x] `python -m pytest -q` — 1191 pass. New coverage: 9 tests spanning InFi unwrap for all three community shapes, NARA-Author strip, plain-string InFi passthrough, flat `|creator=` with `{{creator|Wikidata=Q…}}`, QID materialisation with duplicate drop, QID materialisation with new-value emit, Creator: page fallback to stated-as when no linked QID, and end-to-end `plan_migration` integration.
- [ ] Batch test run against the 22 previously-affected DPLA IDs. Any file with `Other fields N = {{InFi|Creator|…}}` will exercise the new extractor path; NARA IDs (14 of the 22) will strip cleanly without emitting redundant inferred-from-Wikitext claims.
- [ ] Spot-check on Commons after the batch run to confirm yellow-box Creator infoboxes render as expected for files with newly-preserved P170 QIDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Preserves creator community contributions during legacy `{{Artwork}}` migration.

- Unwraps creator values wrapped in legacy “Other fields / Other fields N” bot scaffolding (`Other fields N = {{InFi|Creator|...}}`) and routes the inner value into the creator migration path (including acceptance of plain strings inside the `InFi` wrapper).
- Classifies creator wikitext via a new creator-shape parser:
  - `{{Creator:...}}` → Commons creator-page sentinel
  - `{{creator|Wikidata=Q...}}` (and flat `creator = {{creator|Wikidata=Q...}}`) → QID sentinel
  - `{{NARA-Author|...}}` → dropped
  - case-insensitive `Creator:` matching
  - any unrecognized/unsupported `{{...}}` template-shaped values → stripped (no raw wikitext stored)
- Updates claim materialization to resolve creator placeholders during execution:
  - during planning, emits Phase-3a pending markers for creator QID/page-title sentinels
  - during execution, resolves pending markers into real `P170` statements with deduping against existing entity `P170` QIDs
  - resolves Commons creator pages via `pageprops` when possible
  - falls back to a `P170` `somevalue` claim with a `P2093` “stated-as” qualifier (using the page title) when QID resolution fails
  - omits no-op claims when materialization determines they’re duplicates or unresolvable
- Adds Phase-3a/plan_migration tests covering creator parsing, placeholder dropping/emission, Commons page fallback behavior, and end-to-end extraction for wrapped creator contributions.
- Includes a note about a companion Commons `Module:DPLA` change so P170 QID mainsnaks render correctly in the Creator infobox.

No database migration, shared infrastructure change, environment variable change, or manual pipeline/ECS step is indicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->