### PR TITLE
Split uploader upload()-returns-None into byte-drift skip + unhandled

### DIFF
--- a/ingest_wikimedia/tracker.py
+++ b/ingest_wikimedia/tracker.py
@@ -25,6 +25,16 @@ class Result(Enum):
     # in the drain pass); the number of items still deferred at run end is
     # logged separately. Not a skip: the work is retried, not abandoned.
     UPLOAD_DEFERRED_DUP_CATEGORY = auto()
+    # An upload attempt returned ``None`` from ``pywikibot.Site.upload()``
+    # AND the target title already holds a real file whose SHA1 does not
+    # match ours — the signature of Commons treating a subtly-different
+    # (typically 1-byte off) file as a duplicate of what it already has.
+    # Empirically dominates the "possible ID drift" error class (91k+ of
+    # the 109k events observed are Ohio PDFs with 1-byte S3-vs-Commons
+    # drift, not real ID drift); reporting them as FAILED inflates the
+    # counter and hides genuine drift-repair gaps in the same bucket.
+    # See the investigation notes on PR that introduced this counter.
+    UPLOAD_SKIPPED_COMMONS_DEDUP = auto()
     UPLOADED = auto()
     BYTES = auto()
     ITEM_NOT_PRESENT = auto()

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1597,9 +1597,7 @@ def test_main_dispatches_to_pool_when_workers_gt_one():
         patch.object(up, "notify_phase_start"),
         patch.object(up, "notify_upload_complete"),
         patch.object(up, "_post_upload_touch_new_institutions"),
-        patch.object(
-            up, "load_ids", return_value=["id_a", "id_b", "id_c"]
-        ),
+        patch.object(up, "load_ids", return_value=["id_a", "id_b", "id_c"]),
         patch.object(up.Uploader, "process_item", side_effect=track_process_item),
         patch.object(up, "_run_upload_pool", side_effect=fake_run_pool),
         patch.object(up.drain_sidecar, "merge_sidecar", return_value=["deferred_id"]),
@@ -2121,6 +2119,178 @@ def test_process_file_backend_fail_retry_exhaustion_counts_once():
 # — otherwise the fatal would be swallowed as "one FAILED ordinal" and
 # the main loop would keep going.
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Commons-dedup byte-drift skip + unhandled-drift-shape reporting.
+# When ``site.upload()`` returns None, process_file used to raise
+# ``RuntimeError("File linked to another page (possible ID drift)")`` and let
+# the catch-all report it as FAILED + "Failed: Unknown". Empirically this
+# was 91k+ Ohio PDFs with 1-byte S3-vs-Commons drift — Commons treats our
+# re-upload as a duplicate of what it already has, nothing to repair, but
+# every retry counted as FAILED. This suite pins the split:
+#
+#   * ``_detect_commons_dedup_skip`` returns SKIPPED when the target exists
+#     at the intended title with a different SHA1 (increments a dedicated
+#     ``UPLOAD_SKIPPED_COMMONS_DEDUP`` breakdown).
+#   * The RuntimeError still raises when the target is a redirect, missing,
+#     or has no readable SHA1 — genuine drift-repair gaps.
+#   * ``handle_upload_exception`` maps the RuntimeError to a distinct
+#     "unhandled drift shape" message so it doesn't collapse into
+#     "Failed: Unknown".
+# ---------------------------------------------------------------------------
+
+
+def _dedup_uploader(tracker: Tracker) -> Uploader:
+    return _process_file_uploader(tracker)
+
+
+def _fake_filepage(
+    *, exists: bool, is_redirect: bool, sha1: str | None, pageid: int = 42
+):
+    """Build a MagicMock that quacks like ``pywikibot.FilePage`` for the
+    narrow surface ``_detect_commons_dedup_skip`` reads: ``exists()``,
+    ``isRedirectPage()``, ``latest_file_info.sha1``, ``pageid``."""
+    page = MagicMock()
+    page.exists.return_value = exists
+    page.isRedirectPage.return_value = is_redirect
+    if sha1 is None:
+        # Simulate a fetch failure to read the SHA1.
+        type(page).latest_file_info = property(
+            lambda _self: (_ for _ in ()).throw(RuntimeError("no info"))
+        )
+    else:
+        page.latest_file_info.sha1 = sha1
+    page.pageid = pageid
+    return page
+
+
+def test_detect_commons_dedup_skip_fires_when_target_has_different_sha1():
+    """The observed 91k-event class: target exists at intended title with
+    a real file whose SHA1 differs from ours. Return SKIPPED and bump the
+    dedicated dedup counter (plus the generic SKIPPED, mirroring how
+    UPLOAD_SKIPPED_NOT_PRESENT / _INELIGIBLE are counted)."""
+    tracker = Tracker()
+    uploader = _dedup_uploader(tracker)
+    fake_page = _fake_filepage(exists=True, is_redirect=False, sha1="commons-sha1")
+    with patch("tools.uploader.get_page", return_value=fake_page):
+        result = uploader._detect_commons_dedup_skip(
+            page_title="File:Foo (page 2).pdf",
+            our_sha1="s3-sha1",
+            dpla_id="abc",
+            ordinal=2,
+        )
+    assert result is not None
+    assert result["status"] == "SKIPPED"
+    assert result["title"] == "File:Foo (page 2).pdf"
+    assert result["pageid"] == 42
+    assert tracker.count(Result.UPLOAD_SKIPPED_COMMONS_DEDUP) == 1
+    assert tracker.count(Result.SKIPPED) == 1
+
+
+def test_detect_commons_dedup_skip_returns_none_when_target_is_redirect():
+    """Target is a redirect — this is NOT the byte-drift class. Fall
+    through so the RuntimeError still raises and the shape stays
+    visible for future drift-resolution work."""
+    tracker = Tracker()
+    uploader = _dedup_uploader(tracker)
+    fake_page = _fake_filepage(exists=True, is_redirect=True, sha1="commons-sha1")
+    with patch("tools.uploader.get_page", return_value=fake_page):
+        result = uploader._detect_commons_dedup_skip(
+            page_title="File:Foo (page 2).pdf",
+            our_sha1="s3-sha1",
+            dpla_id="abc",
+            ordinal=2,
+        )
+    assert result is None
+    assert tracker.count(Result.UPLOAD_SKIPPED_COMMONS_DEDUP) == 0
+
+
+def test_detect_commons_dedup_skip_returns_none_when_target_missing():
+    """Target doesn't exist. Also NOT byte-drift — probably a real
+    upload-attempt failure. Fall through."""
+    tracker = Tracker()
+    uploader = _dedup_uploader(tracker)
+    fake_page = _fake_filepage(exists=False, is_redirect=False, sha1=None)
+    with patch("tools.uploader.get_page", return_value=fake_page):
+        result = uploader._detect_commons_dedup_skip(
+            page_title="File:Foo (page 2).pdf",
+            our_sha1="s3-sha1",
+            dpla_id="abc",
+            ordinal=2,
+        )
+    assert result is None
+    assert tracker.count(Result.UPLOAD_SKIPPED_COMMONS_DEDUP) == 0
+
+
+def test_detect_commons_dedup_skip_returns_none_when_sha1_matches():
+    """Target's SHA1 matches our S3 SHA1 — the pre-check should have
+    caught this earlier. This branch guards against the (theoretical)
+    case where the pre-check missed but the target genuinely holds
+    our bytes. Not byte-drift; fall through."""
+    tracker = Tracker()
+    uploader = _dedup_uploader(tracker)
+    fake_page = _fake_filepage(exists=True, is_redirect=False, sha1="same-sha1")
+    with patch("tools.uploader.get_page", return_value=fake_page):
+        result = uploader._detect_commons_dedup_skip(
+            page_title="File:Foo (page 2).pdf",
+            our_sha1="same-sha1",
+            dpla_id="abc",
+            ordinal=2,
+        )
+    assert result is None
+
+
+def test_detect_commons_dedup_skip_returns_none_when_sha1_unreadable():
+    """Can't read the target's SHA1 — either the FilePage lookup threw
+    or ``latest_file_info`` raised. Don't classify as byte-drift when
+    we can't verify; fall through to the RuntimeError so the shape
+    stays visible."""
+    tracker = Tracker()
+    uploader = _dedup_uploader(tracker)
+    fake_page = _fake_filepage(exists=True, is_redirect=False, sha1=None)
+    with patch("tools.uploader.get_page", return_value=fake_page):
+        result = uploader._detect_commons_dedup_skip(
+            page_title="File:Foo (page 2).pdf",
+            our_sha1="s3-sha1",
+            dpla_id="abc",
+            ordinal=2,
+        )
+    assert result is None
+
+
+def test_detect_commons_dedup_skip_returns_none_when_get_page_raises():
+    """API failure on the FilePage fetch itself — treat as
+    can't-verify, fall through. Prevents a transient Commons hiccup
+    from turning FAILEDs into false SKIPPEDs."""
+    tracker = Tracker()
+    uploader = _dedup_uploader(tracker)
+    with patch("tools.uploader.get_page", side_effect=RuntimeError("network down")):
+        result = uploader._detect_commons_dedup_skip(
+            page_title="File:Foo (page 2).pdf",
+            our_sha1="s3-sha1",
+            dpla_id="abc",
+            ordinal=2,
+        )
+    assert result is None
+
+
+def test_handle_upload_exception_maps_possible_id_drift_to_distinct_message(caplog):
+    """A ``RuntimeError`` carrying the "possible ID drift" marker gets a
+    distinct log message ("unhandled drift shape") instead of collapsing
+    into the generic "Failed: Unknown". Reached only after
+    ``_detect_commons_dedup_skip`` ruled out the byte-drift class, so
+    the message intentionally reads as an actionable "we still need to
+    handle this shape" flag."""
+    import logging as _logging
+
+    with caplog.at_level(_logging.ERROR):
+        Uploader.handle_upload_exception(
+            RuntimeError("File linked to another page (possible ID drift)")
+        )
+    text = caplog.text
+    assert "Failed: File linked to another page (unhandled drift shape)" in text
+    assert "Failed: Unknown" not in text
 
 
 def _csrf_keyerror() -> KeyError:

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -2146,22 +2146,40 @@ def _dedup_uploader(tracker: Tracker) -> Uploader:
 
 
 def _fake_filepage(
-    *, exists: bool, is_redirect: bool, sha1: str | None, pageid: int = 42
+    *,
+    exists: bool,
+    is_redirect: bool,
+    sha1: str | None,
+    pageid: int = 42,
+    canonical_title: str = "File:Foo (page 2).pdf",
 ):
     """Build a MagicMock that quacks like ``pywikibot.FilePage`` for the
     narrow surface ``_detect_commons_dedup_skip`` reads: ``exists()``,
-    ``isRedirectPage()``, ``latest_file_info.sha1``, ``pageid``."""
-    page = MagicMock()
+    ``isRedirectPage()``, ``latest_file_info.sha1``, ``pageid``, and
+    ``title(with_ns=False)``.
+
+    The ``sha1=None`` branch simulates a fetch failure via a
+    per-instance subclass whose ``latest_file_info`` property raises.
+    Instance-scoped rather than mutating ``type(MagicMock)`` directly
+    — a class-level assignment would persist on the shared MagicMock
+    class and leak into unrelated tests, causing order-dependent
+    failures wherever another test later reads ``latest_file_info``
+    on any MagicMock."""
+    if sha1 is None:
+
+        class _RaisingLatestFileInfo(MagicMock):
+            @property
+            def latest_file_info(self):
+                raise RuntimeError("no info")
+
+        page = _RaisingLatestFileInfo()
+    else:
+        page = MagicMock()
+        page.latest_file_info.sha1 = sha1
     page.exists.return_value = exists
     page.isRedirectPage.return_value = is_redirect
-    if sha1 is None:
-        # Simulate a fetch failure to read the SHA1.
-        type(page).latest_file_info = property(
-            lambda _self: (_ for _ in ()).throw(RuntimeError("no info"))
-        )
-    else:
-        page.latest_file_info.sha1 = sha1
     page.pageid = pageid
+    page.title.return_value = canonical_title
     return page
 
 
@@ -2186,6 +2204,37 @@ def test_detect_commons_dedup_skip_fires_when_target_has_different_sha1():
     assert result["pageid"] == 42
     assert tracker.count(Result.UPLOAD_SKIPPED_COMMONS_DEDUP) == 1
     assert tracker.count(Result.SKIPPED) == 1
+
+
+def test_detect_commons_dedup_skip_returns_canonical_title_not_raw():
+    """Regression: the skip-result ``title`` must be the pywikibot-
+    normalized ``existing.title(with_ns=False)`` rather than the raw
+    constructed ``page_title``. Downstream sidecars + SDC sync key on
+    the Commons-stored title, so returning the raw form breaks
+    equality checks — same rationale as
+    ``_resolve_hash_drift``'s ALREADY_CORRECT branch. Fixture builds
+    a canonical title that differs from the raw ``page_title`` argument
+    so the assertion can distinguish the two."""
+    tracker = Tracker()
+    uploader = _dedup_uploader(tracker)
+    fake_page = _fake_filepage(
+        exists=True,
+        is_redirect=False,
+        sha1="commons-sha1",
+        canonical_title="File:Foo  (page 2).pdf",  # double-space normalised
+    )
+    with patch("tools.uploader.get_page", return_value=fake_page):
+        result = uploader._detect_commons_dedup_skip(
+            page_title="File:Foo (page 2).pdf",  # single-space raw
+            our_sha1="s3-sha1",
+            dpla_id="abc",
+            ordinal=2,
+        )
+    assert result is not None
+    assert result["title"] == "File:Foo  (page 2).pdf", (
+        f"expected canonical title from ``existing.title(with_ns=False)``; "
+        f"got {result['title']!r}"
+    )
 
 
 def test_detect_commons_dedup_skip_returns_none_when_target_is_redirect():

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -339,6 +339,81 @@ class Uploader:
         # the gate (standalone / unit-test construction); main() injects one.
         self.dup_throttle = dup_throttle
 
+    def _detect_commons_dedup_skip(
+        self,
+        *,
+        page_title: str,
+        our_sha1: str,
+        dpla_id: str,
+        ordinal: int,
+    ) -> dict | None:
+        """Return an ``ORDINAL_SKIPPED`` result dict when the state at
+        ``page_title`` matches the "Commons-dedup byte-drift" pattern;
+        return ``None`` when it doesn't and the caller should keep its
+        RuntimeError path.
+
+        The pattern (from investigation of 109k historical events):
+        Commons has a real file at our expected title whose SHA1
+        differs from our S3 SHA1, typically by a single trailing byte.
+        Commons then treats every subsequent re-upload as a
+        "duplicate of current version" via a warning
+        ``IGNORE_WIKIMEDIA_WARNINGS`` doesn't cover — pywikibot returns
+        ``None`` from ``Site.upload()`` and the caller reaches here.
+        Nothing on Commons needs repair; the file is at the right
+        title with valid bytes, we just can't (and don't need to)
+        replace them. Reporting these as ``FAILED`` inflates the
+        counter and hides real drift-repair gaps in the same bucket.
+
+        The detection is intentionally narrow: only a real
+        (non-redirect) file at the exact expected title with a
+        readable, different SHA1 qualifies. Any other state — target
+        is a redirect, target doesn't exist, SHA1 unreadable — falls
+        through to the caller's RuntimeError so genuine
+        drift-repair gaps still surface as FAILED (which is
+        actionable: rerun after fix, investigate manually, or add
+        a new drift-resolution case).
+
+        Increments :attr:`Result.SKIPPED` + the dedicated
+        :attr:`Result.UPLOAD_SKIPPED_COMMONS_DEDUP` breakdown so the
+        SDC phase still targets the ordinal (its ``UPLOADED`` /
+        ``SKIPPED`` gate covers the correct file at the expected
+        title regardless of which counter fired) while the
+        summary keeps the byte-drift class audit-able.
+        """
+        try:
+            existing = get_page(self.site, page_title)
+            existing.exists()  # populate cache
+        except Exception as ex:
+            logging.warning(
+                f"Commons-dedup detection failed for {dpla_id} {ordinal}: "
+                f"could not fetch [[File:{page_title}]] ({ex!r}); "
+                f"falling through to RuntimeError."
+            )
+            return None
+        if not existing.exists() or existing.isRedirectPage():
+            return None
+        try:
+            existing_sha1 = existing.latest_file_info.sha1
+        except Exception:
+            return None
+        if not existing_sha1 or existing_sha1 == our_sha1:
+            return None
+        logging.info(
+            f"Skipping {dpla_id} {ordinal}: Commons-dedup byte-drift — "
+            f"target [[File:{page_title}]] already holds a real file "
+            f"(SHA1 {existing_sha1}) that Commons treats as a "
+            f"duplicate of our re-upload (our S3 SHA1 {our_sha1}). "
+            f"File on Commons is correct; nothing to repair. See "
+            f"``Result.UPLOAD_SKIPPED_COMMONS_DEDUP`` for the counter."
+        )
+        self.tracker.increment(Result.SKIPPED)
+        self.tracker.increment(Result.UPLOAD_SKIPPED_COMMONS_DEDUP)
+        return {
+            "status": ORDINAL_SKIPPED,
+            "title": page_title,
+            "pageid": existing.pageid,
+        }
+
     def _safe_upload(self, *, filepage, **kwargs):
         """Sole sanctioned wrapper around ``site.upload`` — every upload in
         this module MUST go through here so the no-create fence cannot be
@@ -1036,11 +1111,46 @@ class Uploader:
                     gc.collect()
 
                 if not result:
-                    # upload() returned None — file exists under a different page
-                    # title, likely due to DPLA ID drift between runs. The
-                    # ``raise`` below propagates to the generic
-                    # ``except Exception`` at the end of process_file, which
-                    # increments FAILED — no counter bump needed here.
+                    # ``site.upload()`` returned ``None`` — pywikibot's
+                    # signal that the upload response carried a warning
+                    # class our ``ignore_warnings`` list didn't cover.
+                    # Two very different situations reach here, and
+                    # they need to be reported very differently:
+                    #
+                    # 1. **Commons-dedup byte-drift** (the observed
+                    #    dominant class — 91k+ of the 109k historical
+                    #    events, mostly Ohio PDFs). The target title
+                    #    already holds a real file whose SHA1 does not
+                    #    match ours (a subtle byte difference; the
+                    #    file on Commons is one byte shorter than the
+                    #    S3 asset, likely from server-side ingest
+                    #    normalisation on the original upload).
+                    #    Commons rejects our re-upload as "duplicate
+                    #    of current version" via a warning that
+                    #    IGNORE_WIKIMEDIA_WARNINGS doesn't include.
+                    #    The file is CORRECT on Commons; nothing to
+                    #    repair. Reporting as FAILED inflates the
+                    #    counter and buries any real drift-repair
+                    #    gaps in the same log stream. Skip cleanly
+                    #    with a dedicated counter so operators can
+                    #    audit the drift class independently.
+                    # 2. **True unhandled drift** — target is still a
+                    #    redirect, or doesn't exist, or has an
+                    #    unexpected shape ``_resolve_hash_drift`` /
+                    #    the redirect-handler didn't cover. This IS
+                    #    a failure we need to see; keep the
+                    #    RuntimeError path so it lands in FAILED
+                    #    with a distinct log line (see
+                    #    ``handle_upload_exception``'s message
+                    #    mapping for the "possible ID drift" case).
+                    dedup_skipped = self._detect_commons_dedup_skip(
+                        page_title=page_title,
+                        our_sha1=sha1,
+                        dpla_id=dpla_id,
+                        ordinal=ordinal,
+                    )
+                    if dedup_skipped is not None:
+                        return dedup_skipped
                     raise RuntimeError(
                         "File linked to another page (possible ID drift)"
                     )
@@ -2031,6 +2141,18 @@ class Uploader:
             message = f"File exists, no change, {error_string}"
         elif ERROR_BACKEND_FAIL in error_string:
             message = "Wikimedia storage backend error (retries exhausted)"
+            error = True
+        elif "possible ID drift" in error_string:
+            # RuntimeError raised at the ``upload() returned None`` site
+            # in process_file. Reached only after
+            # ``_detect_commons_dedup_skip`` ruled out the byte-drift
+            # class, so what remains is a genuine drift-repair gap: the
+            # target is a redirect / missing / has no readable SHA1 /
+            # some shape ``_resolve_hash_drift`` and the redirect-
+            # handler didn't cover. Log distinctly so this doesn't
+            # disappear into "Failed: Unknown" and stays audit-able
+            # for future drift-resolution work.
+            message = "File linked to another page (unhandled drift shape)"
             error = True
 
         if error:

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -220,7 +220,18 @@ def select_upload_chunk_size(
 # ordinal in this run, so writing structured data would be pointing at the
 # wrong page or none at all.
 ORDINAL_UPLOADED = "UPLOADED"  # file just uploaded (or drift-moved into place)
-ORDINAL_SKIPPED = "SKIPPED"  # existing Commons file matches our SHA1
+# Existing Commons file present at the expected title. Usually its SHA1
+# matches the source S3 SHA1 (the ordinary hash-match skip). One
+# narrow exception: ``_detect_commons_dedup_skip`` also emits SKIPPED
+# when Commons has a real (non-redirect) file whose SHA1 differs from
+# ours — the byte-drift class the class docstring calls out. In both
+# subcases the Commons file at the expected title is CORRECT (the
+# byte-drift file was accepted by Commons on its original upload with
+# server-side normalisation), so ``UPLOADED``/``SKIPPED`` remains the
+# right signal to the SDC phase: a canonical Commons file exists at
+# this ordinal's title, safe to target for wbsetclaims. Audit the
+# byte-drift subcase via ``Result.UPLOAD_SKIPPED_COMMONS_DEDUP``.
+ORDINAL_SKIPPED = "SKIPPED"
 ORDINAL_NOT_PRESENT = "NOT_PRESENT"  # no S3 asset to upload (downloader gap)
 ORDINAL_INELIGIBLE = "INELIGIBLE"  # S3 asset present but uploader chose not
 # to upload (bad MIME, download-only, unguessable extension, etc.)
@@ -398,9 +409,17 @@ class Uploader:
             return None
         if not existing_sha1 or existing_sha1 == our_sha1:
             return None
+        # Persist the pywikibot-normalized title, not the raw
+        # constructed ``page_title`` — downstream sidecars / SDC-sync
+        # key on the Commons-stored form, so returning the raw form
+        # here would break the very equality checks elsewhere in the
+        # pipeline that skip results feed into. Same normalization
+        # ``_resolve_hash_drift``'s ALREADY_CORRECT branch does at
+        # line 693 for the same reason.
+        canonical_title = existing.title(with_ns=False)
         logging.info(
             f"Skipping {dpla_id} {ordinal}: Commons-dedup byte-drift — "
-            f"target [[File:{page_title}]] already holds a real file "
+            f"target [[File:{canonical_title}]] already holds a real file "
             f"(SHA1 {existing_sha1}) that Commons treats as a "
             f"duplicate of our re-upload (our S3 SHA1 {our_sha1}). "
             f"File on Commons is correct; nothing to repair. See "
@@ -410,7 +429,7 @@ class Uploader:
         self.tracker.increment(Result.UPLOAD_SKIPPED_COMMONS_DEDUP)
         return {
             "status": ORDINAL_SKIPPED,
-            "title": page_title,
+            "title": canonical_title,
             "pageid": existing.pageid,
         }
 


### PR DESCRIPTION
## Summary

Investigation of a 2-FAIL run against `nara+center-for-legislative-archives` turned up two failures with wildly different reporting quality despite the same underlying cause:

- **b2bc51b286d1dac59a15f282a880b898** (direct upload) → `APIError(fileexists-no-change)` → `handle_upload_exception` matched `ERROR_NOCHANGE` → logged as **`Failed: File exists, no change, …`**
- **8ac21ee786271baf85bd14040702b012 page 2** (chunked upload) → `Site.upload()` returned `None` → `process_file` raised `RuntimeError("File linked to another page (possible ID drift)")` → generic catch → logged as **`Failed: Unknown`**

Both failures were the same class: S3 asset and Commons file differ by exactly 1 byte for a PDF, Commons treats our re-upload as `duplicate-of-current`, nothing on Commons needs repair. The file is at the correct title with valid bytes; we just can't (and don't need to) replace them.

A log survey found **109,262 "possible ID drift" events** across all historical upload logs — 91,760 in Ohio alone, dominated by this byte-drift class rather than genuine ID drift. Reporting them as `FAILED` inflates the counter and buries any real drift-repair gaps in the same bucket.

## Fix

**1. New `_detect_commons_dedup_skip` helper**, called before raising `RuntimeError` at the `upload()`-returns-None site. When the target title holds a real (non-redirect) file with a readable SHA1 that differs from ours → return `ORDINAL_SKIPPED`. Increments `Result.SKIPPED` **plus a new `Result.UPLOAD_SKIPPED_COMMONS_DEDUP`** breakdown counter so the byte-drift class is audit-able independently.

Detection is intentionally narrow — only these fall through to the byte-drift skip path:

- target exists at the intended title,
- target is not a redirect,
- target has a readable `latest_file_info.sha1`,
- and that SHA1 differs from our S3 SHA1.

Any other state (target is a redirect, target doesn't exist, SHA1 unreadable, API fetch failure) falls through to the `RuntimeError` so genuine drift-repair gaps still surface as `FAILED` — which is actionable: rerun after fix, investigate manually, or add a new drift-resolution case.

**2. `handle_upload_exception`** now maps `"possible ID drift"` in the exception string to `"Failed: File linked to another page (unhandled drift shape)"` — logged as ERROR, not silently coalesced into `"Failed: Unknown"`. Reached only after `_detect_commons_dedup_skip` ruled out the byte-drift class, so this specifically flags residual drift-repair gaps we don't yet cover.

## Test plan

- [x] `python -m pytest -q` — 1201 pass. Seven new tests cover:
  - dedup fires with different SHA1 (returns SKIPPED + bumps both counters);
  - falls through on redirect / missing / matching-SHA1 / unreadable-SHA1 / API-fetch-failure (each preserves the RuntimeError path);
  - `handle_upload_exception` maps "possible ID drift" to "unhandled drift shape" instead of "Failed: Unknown".
- [ ] Post-merge: watch the next batch run's `COUNTS:` line — expect `UPLOAD_SKIPPED_COMMONS_DEDUP` to non-trivially populate (Ohio especially) and `FAILED` to drop by roughly the same amount. Any residual "unhandled drift shape" lines are the real drift-repair-gap sample worth investigating.
- [ ] Separate follow-up: investigate the 1-byte PDF drift itself (pywikibot chunked upload vs MediaWiki ingest normalization). Not addressed here — this PR is about reporting quality, not eliminating the underlying drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a Commons-specific deduplication skip for uploads that previously failed as an ID-drift error.

- Introduces `Result.UPLOAD_SKIPPED_COMMONS_DEDUP` and counts this as a skipped upload when Commons already has the same content bytes under the target title.
- Adds `_detect_commons_dedup_skip()` in the uploader so `site.upload()` returning `None` is treated as a skip only when the target Commons file exists, is not a redirect, and has a readable SHA1 different from the uploaded file.
- Preserves the existing failure path for redirects, missing files, unreadable SHA1s, and Commons API lookup failures.
- Updates upload exception handling so `possible ID drift` errors are logged as `File linked to another page (unhandled drift shape)` instead of `Unknown`.
- Adds tests covering the new skip behavior and the retained failure cases.

No manual pipeline trigger, ECS redeployment, env var/secret changes, database migration, shared infra changes, API changes, or security-related changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->