### PR TITLE
Trust Commons's fileexists-no-change as invariant-satisfied SKIP

### DIFF
--- a/docs/upload-invariant.md
+++ b/docs/upload-invariant.md
@@ -17,13 +17,28 @@ your change must satisfy.
 
 **For every DPLA item we upload, the SHA1 of the S3-staged source
 bytes for that item must live at the Commons title
-`get_page_title(dpla_id, …)` produces.**
+`get_page_title(dpla_id, …)` produces — modulo Commons's own
+server-side ingest normalization for that file type.**
 
 That is the entire correctness criterion. Everything else — Commons
 redirects, `{{Duplicate}}` templates, "duplicate of" notices, human or
 bot dedup judgments, intuitions about whether a state "looks like a
 duplicate" — is downstream of this criterion and does not override
 it.
+
+**Commons-normalization equivalence.** MediaWiki normalizes some file
+formats on ingest — e.g., PDFs with a trailing `\r` after `%%EOF`
+have that byte stripped before storage. When we attempt to re-upload
+such a file, Commons responds with `fileexists-no-change` naming our
+intended target title. That response is authoritative: Commons is
+telling us our upload equals what it already stores at the correct
+title. The invariant is satisfied at the correct title even though
+our S3 SHA1 and Commons's stored SHA1 differ pre-normalization.
+Verified empirically byte-for-byte for the two files that motivated
+this amendment (b2bc51b… and 8ac21ee786… ord 2). Trust Commons's
+`fileexists-no-change`-with-target-title response as the invariant
+check; skip cleanly with `Result.UPLOAD_SKIPPED_COMMONS_DEDUP`
+rather than treating as FAILED.
 
 ## Corollaries (do not re-litigate these)
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -2324,6 +2324,120 @@ def test_detect_commons_dedup_skip_returns_none_when_get_page_raises():
     assert result is None
 
 
+# ---------------------------------------------------------------------------
+# ``_detect_commons_dedup_from_nochange_error`` — direct-upload path.
+# Extends the byte-drift skip logic to the ``APIError(fileexists-no-change)``
+# response shape (direct upload), symmetric to PR #383's None-return handling
+# (chunked upload). Trust Commons's authoritative "your upload equals the
+# current version of [[:File:X]]" statement: if X is our intended title, the
+# upload invariant is satisfied at the correct title after server-side
+# normalisation, and we skip cleanly with the dedup counter.
+# ---------------------------------------------------------------------------
+
+
+def _nochange_error(title: str) -> Exception:
+    """Build an exception with the same message shape pywikibot raises
+    from Commons's ``fileexists-no-change`` API response."""
+    return RuntimeError(
+        f"fileexists-no-change: The upload is an exact duplicate of the "
+        f"current version of [[:{title}]]."
+    )
+
+
+def test_nochange_matches_intended_title_skips_with_dedup_counter():
+    """b2bc51b… motivating case: direct upload → Commons responds
+    fileexists-no-change naming our target title → invariant is
+    satisfied at the correct title (Commons has our bytes post-
+    normalisation). Skip cleanly."""
+    tracker = Tracker()
+    uploader = _dedup_uploader(tracker)
+    fake_page = _fake_filepage(
+        exists=True,
+        is_redirect=False,
+        sha1="commons-sha1",
+        canonical_title="Final Report - DPLA - b2bc.pdf",
+    )
+    ex = _nochange_error("File:Final Report - DPLA - b2bc.pdf")
+    with patch("tools.uploader.get_page", return_value=fake_page):
+        result = uploader._detect_commons_dedup_from_nochange_error(
+            ex,
+            page_title="Final Report - DPLA - b2bc.pdf",
+            our_sha1="s3-sha1",
+            dpla_id="abc",
+            ordinal=1,
+        )
+    assert result is not None
+    assert result["status"] == "SKIPPED"
+    assert tracker.count(Result.UPLOAD_SKIPPED_COMMONS_DEDUP) == 1
+    assert tracker.count(Result.SKIPPED) == 1
+
+
+def test_nochange_naming_different_title_falls_through_to_failed():
+    """Defense-in-depth: if Commons's message names a title that
+    isn't ours, DON'T classify as skip — it's a real cross-title
+    situation that should stay as FAILED for investigation. The
+    check is cheap and prevents mis-classifying real drift."""
+    tracker = Tracker()
+    uploader = _dedup_uploader(tracker)
+    ex = _nochange_error("File:Some Other Unrelated File.pdf")
+    with patch("tools.uploader.get_page") as get_page:
+        result = uploader._detect_commons_dedup_from_nochange_error(
+            ex,
+            page_title="Our Intended - DPLA - xyz.pdf",
+            our_sha1="s3-sha1",
+            dpla_id="abc",
+            ordinal=1,
+        )
+    assert result is None
+    # get_page must not have been called — we fell through BEFORE the
+    # target-state fetch. Otherwise, a mis-titled response could still
+    # short-circuit into a skip if the target happened to exist.
+    get_page.assert_not_called()
+    assert tracker.count(Result.UPLOAD_SKIPPED_COMMONS_DEDUP) == 0
+
+
+def test_nochange_without_nochange_marker_returns_none():
+    """The helper must only fire on the specific ``no-change`` marker
+    Commons emits. Any other exception falls through to the current
+    FAILED handling."""
+    tracker = Tracker()
+    uploader = _dedup_uploader(tracker)
+    ex = RuntimeError("some unrelated CSRF token failure")
+    with patch("tools.uploader.get_page") as get_page:
+        result = uploader._detect_commons_dedup_from_nochange_error(
+            ex,
+            page_title="Our Intended - DPLA - xyz.pdf",
+            our_sha1="s3-sha1",
+            dpla_id="abc",
+            ordinal=1,
+        )
+    assert result is None
+    get_page.assert_not_called()
+
+
+def test_nochange_with_marker_but_unparseable_title_falls_through():
+    """If the message somehow contains the ``no-change`` marker but
+    doesn't parse into a title (unexpected message format), don't
+    guess — return None so the caller keeps FAILED. Preserves the
+    invariant that any classification-to-SKIP is backed by an
+    explicit target-title match."""
+    tracker = Tracker()
+    uploader = _dedup_uploader(tracker)
+    # Contains ``no-change`` but not the full ``exact duplicate of
+    # the current version of [[:File:X]]`` pattern.
+    ex = RuntimeError("fileexists-no-change: garbled response body")
+    with patch("tools.uploader.get_page") as get_page:
+        result = uploader._detect_commons_dedup_from_nochange_error(
+            ex,
+            page_title="Our Intended - DPLA - xyz.pdf",
+            our_sha1="s3-sha1",
+            dpla_id="abc",
+            ordinal=1,
+        )
+    assert result is None
+    get_page.assert_not_called()
+
+
 def test_handle_upload_exception_maps_possible_id_drift_to_distinct_message(caplog):
     """A ``RuntimeError`` carrying the "possible ID drift" marker gets a
     distinct log message ("unhandled drift shape") instead of collapsing

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -433,6 +433,85 @@ class Uploader:
             "pageid": existing.pageid,
         }
 
+    # Match Commons's ``fileexists-no-change`` message and extract the
+    # namespaced title Commons named. The message pattern is stable:
+    # ``The upload is an exact duplicate of the current version of
+    # [[:File:<title>]]``. Captures the title without the leading
+    # colon so it matches our ``page_title`` shape (``File:<title>``).
+    _NOCHANGE_TITLE_RE = re.compile(
+        r"exact duplicate of the current version of \[\[:(File:[^\]]+)\]\]"
+    )
+
+    def _detect_commons_dedup_from_nochange_error(
+        self,
+        ex: Exception,
+        *,
+        page_title: str,
+        our_sha1: str,
+        dpla_id: str,
+        ordinal: int,
+    ) -> dict | None:
+        """When ``ex`` is Commons's ``fileexists-no-change`` response
+        naming our intended target, treat it as a Commons-dedup
+        byte-drift SKIP and return an ``ORDINAL_SKIPPED`` result;
+        return ``None`` otherwise so the caller keeps the FAILED
+        path.
+
+        Semantic contract: Commons's ``fileexists-no-change`` message
+        is the authoritative statement that our upload equals what
+        Commons already stores at the named title, after any
+        server-side normalisation (e.g., trailing ``\\r`` stripped
+        from PDFs — verified byte-for-byte for the two files that
+        originally motivated this treatment). When the named title
+        matches our intended ``page_title``, the upload invariant is
+        satisfied at the correct title. Trust Commons.
+
+        Defensive title match: if Commons's message names a DIFFERENT
+        title from our intended one (I can't construct that scenario
+        from Commons's current message format, but the check is
+        cheap), fall through to the FAILED path so we don't
+        misclassify a real cross-title drift as a benign skip. Same
+        defense-in-depth stance as ``_detect_commons_dedup_skip``'s
+        redirect / missing / SHA1-mismatch guards.
+
+        Reuses ``_detect_commons_dedup_skip`` for the actual result
+        construction — same counter, same log shape, same pageid
+        refresh — so the two upload paths (direct raise vs
+        chunked-None-return) produce identical outcomes for the same
+        underlying phenomenon.
+        """
+        if ERROR_NOCHANGE not in str(ex):
+            return None
+        m = self._NOCHANGE_TITLE_RE.search(str(ex))
+        if m is None:
+            return None
+        commons_named_title = m.group(1)
+        # ``page_title`` in this file is passed WITHOUT the ``File:`` prefix
+        # elsewhere in ``process_file`` (see the ``get_page_title`` return
+        # contract at line 581), so compare against the prefixed form.
+        if (
+            commons_named_title != f"File:{page_title}"
+            and commons_named_title != page_title
+        ):
+            logging.warning(
+                f"Commons ``fileexists-no-change`` for {dpla_id} {ordinal} "
+                f"names title {commons_named_title!r} which does not match "
+                f"our intended {page_title!r}; treating as FAILED (real "
+                f"drift, not the byte-drift class)."
+            )
+            return None
+        # Fetch the target to confirm state + populate the pageid for the
+        # sidecar. Even though Commons's message is authoritative for the
+        # invariant, downstream sdc-sync keys on the sidecar's pageid, so
+        # we still need a live lookup. This is what
+        # ``_detect_commons_dedup_skip`` already does — reuse it.
+        return self._detect_commons_dedup_skip(
+            page_title=page_title,
+            our_sha1=our_sha1,
+            dpla_id=dpla_id,
+            ordinal=ordinal,
+        )
+
     def _safe_upload(self, *, filepage, **kwargs):
         """Sole sanctioned wrapper around ``site.upload`` — every upload in
         this module MUST go through here so the no-create fence cannot be
@@ -1250,6 +1329,43 @@ class Uploader:
             # for every subsequent write, not just this ordinal).
             raise
         except Exception as ex:
+            # Commons-dedup byte-drift, direct-upload path. Commons's
+            # response ``fileexists-no-change: The upload is an exact
+            # duplicate of the current version of [[:File:X]]`` is an
+            # authoritative statement that our upload equals what
+            # Commons already stores at title X, *after* Commons's
+            # server-side normalization. When X matches our intended
+            # title, the upload invariant is satisfied at the correct
+            # title even though our S3 bytes and Commons's bytes may
+            # differ pre-normalization (e.g., partner PDFs with a
+            # trailing ``\r`` after ``%%EOF`` that Commons strips on
+            # ingest — verified for both b2bc51b… and 8ac21ee786…
+            # ord 2, byte-for-byte identical in the overlap). Skip
+            # cleanly with the dedicated dedup counter so the
+            # byte-drift class is audit-able independently of the
+            # FAILED bucket, mirroring the None-return branch's
+            # ``_detect_commons_dedup_skip`` treatment in the chunked-
+            # upload path. See ``docs/upload-invariant.md`` for the
+            # invariant amendment that admits Commons-normalization
+            # equivalence.
+            # ``page_title`` and ``sha1`` are populated after the pre-upload
+            # setup but before the upload attempt; an exception raised BEFORE
+            # they're computed (S3 read failure, provider lookup, etc.)
+            # reaches this except block without them bound. Only run the
+            # dedup check when both are in scope — matches the semantic
+            # intent (we only care about the specific
+            # ``fileexists-no-change`` shape emitted from the upload leg).
+            _frame_locals = locals()
+            if "page_title" in _frame_locals and "sha1" in _frame_locals:
+                dedup_skipped = self._detect_commons_dedup_from_nochange_error(
+                    ex,
+                    page_title=_frame_locals["page_title"],
+                    our_sha1=_frame_locals["sha1"],
+                    dpla_id=dpla_id,
+                    ordinal=ordinal,
+                )
+                if dedup_skipped is not None:
+                    return dedup_skipped
             # Single source of truth for the per-ordinal FAILED counter on
             # every non-timeout, non-session-fatal exception path — includes
             # pywikibot API errors like a *recoverable* CSRF ``KeyError``


### PR DESCRIPTION
## Summary

Extends PR #383's byte-drift skip logic to the direct-upload path (`APIError(fileexists-no-change)`), symmetric to the chunked-upload None-return path #383 already handles.

**Semantic contract:** Commons's `fileexists-no-change` response literally names the target title in its message — "The upload is an exact duplicate of the current version of `[[:File:X]]`". When X matches our intended `page_title`, Commons is authoritatively telling us: our upload equals what Commons already stores at the correct title, after Commons's server-side normalization. The upload invariant is satisfied at the correct title. Trust Commons; skip cleanly with the `UPLOAD_SKIPPED_COMMONS_DEDUP` counter.

## Verified byte-level equivalence (motivating cases)

For both files that originally showed as FAILEDs in the `nara+center-for-legislative-archives` run:

- **b2bc51b286d1dac59a15f282a880b898** — single-file PDF. S3: 6,778,098 bytes, SHA1 `ab59eb42…`. Commons: 6,778,097 bytes, SHA1 `e0b57b8b…`. `cmp` shows the two files are byte-identical in the overlap; S3 has one extra trailing `\r` (0x0d) after `%%EOF`. NARA source (fetched directly) matches S3 exactly — our downloader is not the source of the divergence; MediaWiki strips the trailing `\r` on ingest.
- **8ac21ee786271baf85bd14040702b012 ord 2** — chunked path with a different exception surface (None-return). Same evidence: S3 579,451 bytes / SHA1 `93bb8313…`, Commons 579,450 bytes / SHA1 `3267433f…`, `cmp` reports 0 differing bytes in the overlap, S3 has trailing `\r`.

Independently confirmable: `sha1sum(first (S3_size − 1) bytes of S3 file)` equals the Commons SHA1 for both files.

## Changes

- `_detect_commons_dedup_from_nochange_error` helper on `Uploader`:
  - Matches Commons's message pattern via a stable regex, captures the target title.
  - Verifies the captured title equals our intended `page_title` (with or without the `File:` prefix). Non-match → returns None (defense-in-depth: keeps FAILED path).
  - On match → delegates to `_detect_commons_dedup_skip` for the actual result construction — same counter, same log shape, same pageid refresh as the chunked-upload path.
- Called from `process_file`'s catch-all before the FAILED counter increment. Guarded on `page_title` and `sha1` being bound so early exceptions (S3 read failures, provider lookup errors, etc.) still route cleanly to FAILED.
- **Invariant doc amendment** in `docs/upload-invariant.md`: adds a "Commons-normalization equivalence" clause documenting that `fileexists-no-change` naming our target title is authoritative confirmation of invariant satisfaction post-normalization.

## Test plan

- [x] `python -m pytest -q` — 1206 pass. Four new tests: title matches → SKIP with dedup counter; title mismatch → falls through to FAILED without invoking `get_page`; missing `no-change` marker → falls through; message contains marker but unparseable-title edge case → falls through.
- [ ] **Follow-up sampling during CR** (in progress): pick ~15 Ohio DPLA IDs from the 91k historical events and confirm each is the same byte-drift class. Any residual class that doesn't fit becomes a follow-up drift-repair task.
- [ ] Watch next batch runs post-merge for the `UPLOAD_SKIPPED_COMMONS_DEDUP` counter — expected to populate heavily (especially Ohio) as byte-drift cases exit the FAILED bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Extended direct uploads to treat Commons `APIError(fileexists-no-change)` as a dedup skip when the response names the intended target title, matching the existing chunked-upload skip behavior. If the title does not match, is missing, or cannot be parsed, the upload still fails normally.

Also updated `docs/upload-invariant.md` to document Commons-normalization equivalence, and added tests covering matching, mismatching, missing-marker, and unparseable responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->