### PR TITLE
Stage institutions_v2.json locally so the eligibility precheck stops 429-ing

### DIFF
--- a/ingest_wikimedia/dpla.py
+++ b/ingest_wikimedia/dpla.py
@@ -8,7 +8,7 @@ from requests import Session
 from .banlist import Banlist
 from .common import null_safe, get_str, get_list, get_dict
 from .iiif import IIIF
-from .partners import PARTNER_HUBS, is_upload_eligible
+from .partners import PARTNER_HUBS, is_upload_eligible, load_institutions
 from .s3 import S3Client
 from .tracker import Tracker, Result
 
@@ -336,8 +336,13 @@ class DPLA:
         return provider, data_provider
 
     def get_providers_data(self) -> dict:
-        """Loads the institutions file from ingestion3 in GitHub."""
-        return self.http_session.get(INSTITUTIONS_URL).json()
+        """Loads institutions_v2.json (hub → config) from ingestion3.
+
+        Delegates to ``partners.load_institutions`` so it reads the launch-staged
+        local copy when present instead of re-fetching from
+        raw.githubusercontent.com (per-IP HTTP 429 under a multi-target batch).
+        """
+        return load_institutions()
 
     def extract_urls(
         self,
@@ -383,10 +388,6 @@ class DPLA:
 
 DPLA_API_URL_BASE = "https://api.dp.la/v2/items/"
 DPLA_API_DOCS = "docs"
-INSTITUTIONS_URL = (
-    "https://raw.githubusercontent.com/dpla/ingestion3"
-    "/refs/heads/main/src/main/resources/wiki/institutions_v2.json"
-)
 UPLOAD_FIELD_NAME = "upload"
 INSTITUTIONS_FIELD_NAME = "institutions"
 SOURCE_RESOURCE_FIELD_NAME = "sourceResource"

--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -5,7 +5,9 @@ GitHub Actions without installing the full ingest_wikimedia package dependencies
 """
 
 import json
+import os
 import re
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -17,6 +19,15 @@ INSTITUTIONS_URL = (
     "https://raw.githubusercontent.com/dpla/ingestion3"
     "/refs/heads/main/src/main/resources/wiki/institutions_v2.json"
 )
+
+# A session may stage institutions_v2.json to a local path and point this env
+# var at it, so the many short-lived pipeline processes read it from disk
+# instead of each re-fetching INSTITUTIONS_URL. That anonymous
+# raw.githubusercontent.com fetch is rate-limited per IP: a batch of dozens of
+# targets (each a fresh uploader/sdc-sync process) otherwise hits HTTP 429 and
+# every target's eligibility precheck crashes. Unset / unusable file (Lambda,
+# GitHub Actions — no local checkout) → live fetch with retry/backoff instead.
+INSTITUTIONS_FILE_ENV = "WIKIMEDIA_INSTITUTIONS_FILE"
 
 # Wikidata QID pattern (e.g. Q12345).
 _QID_RE = re.compile(r"^Q\d+$")
@@ -122,12 +133,62 @@ def resolve_slug(slug: str) -> str | None:
     return _SLUG_BY_HUB_NAME.get(s)
 
 
+def _load_local_institutions() -> dict | None:
+    """Return institutions data from the locally-staged file, or None.
+
+    None (→ caller falls back to the live fetch) when the env var is unset, the
+    file is missing/unreadable, or its contents aren't a non-empty object — so a
+    truncated or empty stage never silently makes every hub ineligible.
+    """
+    path = os.environ.get(INSTITUTIONS_FILE_ENV)
+    if not path:
+        return None
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) and data else None
+
+
+def _fetch_remote_institutions(timeout: int, attempts: int = 4) -> dict:
+    """Fetch INSTITUTIONS_URL, retrying with exponential backoff (honoring
+    ``Retry-After``) on HTTP 429 so a transient rate-limit doesn't crash the
+    caller. Re-raises immediately on any non-429 error and after the final
+    attempt.
+    """
+    delay = 2.0
+    for attempt in range(1, attempts + 1):
+        try:
+            with urllib.request.urlopen(INSTITUTIONS_URL, timeout=timeout) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as ex:
+            if ex.code != 429 or attempt == attempts:
+                raise
+            retry_after = ex.headers.get("Retry-After") if ex.headers else None
+            try:
+                wait = float(retry_after) if retry_after else delay
+            except (TypeError, ValueError):
+                wait = delay
+            time.sleep(min(wait, 60.0))
+            delay *= 2
+    raise RuntimeError("unreachable: institutions fetch retry loop exited")
+
+
 def _get_institutions(timeout: int = 5) -> dict:
-    """Fetch institutions_v2.json from GitHub, caching after the first call."""
+    """Return institutions_v2.json (hub → config), cached after the first call.
+
+    Prefers a locally-staged copy (``WIKIMEDIA_INSTITUTIONS_FILE``) so pipeline
+    processes don't each re-fetch and trip raw.githubusercontent.com's per-IP
+    rate limit; falls back to a retrying live fetch when no local copy exists
+    (the Lambda / GitHub Actions path).
+    """
     global _institutions_cache
     if _institutions_cache is None:
-        with urllib.request.urlopen(INSTITUTIONS_URL, timeout=timeout) as resp:
-            _institutions_cache = json.loads(resp.read())
+        local = _load_local_institutions()
+        _institutions_cache = (
+            local if local is not None else _fetch_remote_institutions(timeout)
+        )
     return _institutions_cache
 
 

--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -12,22 +12,29 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-# Module-level cache so warm Lambda invocations skip repeated network fetches.
-_institutions_cache: dict | None = None
+# Per-URL cache so a warm/long-lived process fetches each config at most once.
+_staged_config_cache: dict[str, dict] = {}
 
+# Config files sourced from dpla/ingestion3 (main is the source of authority).
 INSTITUTIONS_URL = (
     "https://raw.githubusercontent.com/dpla/ingestion3"
     "/refs/heads/main/src/main/resources/wiki/institutions_v2.json"
 )
+SUBJECTS_URL = (
+    "https://raw.githubusercontent.com/dpla/ingestion3"
+    "/refs/heads/main/src/main/resources/subjects.json"
+)
 
-# A session may stage institutions_v2.json to a local path and point this env
-# var at it, so the many short-lived pipeline processes read it from disk
-# instead of each re-fetching INSTITUTIONS_URL. That anonymous
-# raw.githubusercontent.com fetch is rate-limited per IP: a batch of dozens of
-# targets (each a fresh uploader/sdc-sync process) otherwise hits HTTP 429 and
-# every target's eligibility precheck crashes. Unset / unusable file (Lambda,
-# GitHub Actions — no local checkout) → live fetch with retry/backoff instead.
+# A session may stage these JSON configs to local paths and point these env vars
+# at them, so the many short-lived pipeline processes read them from disk
+# instead of each re-fetching from raw.githubusercontent.com. That anonymous
+# fetch is rate-limited per IP: a batch of dozens of targets (each a fresh
+# get-ids/uploader/sdc-sync process) otherwise hits HTTP 429 and crashes. Unset
+# / unusable file (Lambda, GitHub Actions — no local checkout) → live fetch with
+# retry/backoff instead. See scripts/wikimedia_launch.py, which stages the files
+# and sets these vars.
 INSTITUTIONS_FILE_ENV = "WIKIMEDIA_INSTITUTIONS_FILE"
+SUBJECTS_FILE_ENV = "WIKIMEDIA_SUBJECTS_FILE"
 
 # Wikidata QID pattern (e.g. Q12345).
 _QID_RE = re.compile(r"^Q\d+$")
@@ -133,14 +140,15 @@ def resolve_slug(slug: str) -> str | None:
     return _SLUG_BY_HUB_NAME.get(s)
 
 
-def _load_local_institutions() -> dict | None:
-    """Return institutions data from the locally-staged file, or None.
+def _load_local_json(env_var: str) -> dict | None:
+    """Return a staged JSON config from the path named by ``env_var``, or None.
 
-    None (→ caller falls back to the live fetch) when the env var is unset, the
-    file is missing/unreadable, or its contents aren't a non-empty object — so a
-    truncated or empty stage never silently makes every hub ineligible.
+    None (→ caller falls back to the live fetch) when the var is unset, the file
+    is missing/unreadable, or its contents aren't a non-empty object — so a
+    truncated or empty stage never silently yields empty config (which for
+    institutions would make every hub ineligible).
     """
-    path = os.environ.get(INSTITUTIONS_FILE_ENV)
+    path = os.environ.get(env_var)
     if not path:
         return None
     try:
@@ -151,16 +159,15 @@ def _load_local_institutions() -> dict | None:
     return data if isinstance(data, dict) and data else None
 
 
-def _fetch_remote_institutions(timeout: int, attempts: int = 4) -> dict:
-    """Fetch INSTITUTIONS_URL, retrying with exponential backoff (honoring
-    ``Retry-After``) on HTTP 429 so a transient rate-limit doesn't crash the
-    caller. Re-raises immediately on any non-429 error and after the final
-    attempt.
+def _fetch_remote_json(url: str, timeout: int, attempts: int = 4) -> dict:
+    """Fetch ``url``, retrying with exponential backoff (honoring ``Retry-After``)
+    on HTTP 429 so a transient rate-limit doesn't crash the caller. Re-raises
+    immediately on any non-429 error and after the final attempt.
     """
     delay = 2.0
     for attempt in range(1, attempts + 1):
         try:
-            with urllib.request.urlopen(INSTITUTIONS_URL, timeout=timeout) as resp:
+            with urllib.request.urlopen(url, timeout=timeout) as resp:
                 return json.loads(resp.read())
         except urllib.error.HTTPError as ex:
             if ex.code != 429 or attempt == attempts:
@@ -172,24 +179,38 @@ def _fetch_remote_institutions(timeout: int, attempts: int = 4) -> dict:
                 wait = delay
             time.sleep(min(wait, 60.0))
             delay *= 2
-    raise RuntimeError("unreachable: institutions fetch retry loop exited")
+    raise RuntimeError("unreachable: staged-config fetch retry loop exited")
 
 
-def _get_institutions(timeout: int = 5) -> dict:
-    """Return institutions_v2.json (hub → config), cached after the first call.
+def _load_staged_config(url: str, env_var: str, timeout: int = 5) -> dict:
+    """Local-first loader for a staged ingestion3 JSON config, cached per URL.
 
-    Prefers a locally-staged copy (``WIKIMEDIA_INSTITUTIONS_FILE``) so pipeline
-    processes don't each re-fetch and trip raw.githubusercontent.com's per-IP
-    rate limit; falls back to a retrying live fetch when no local copy exists
-    (the Lambda / GitHub Actions path).
+    Prefers the launch-staged copy named by ``env_var`` (no network); falls back
+    to a retrying live fetch of ``url`` (the Lambda / GitHub Actions path, where
+    no local file exists).
     """
-    global _institutions_cache
-    if _institutions_cache is None:
-        local = _load_local_institutions()
-        _institutions_cache = (
-            local if local is not None else _fetch_remote_institutions(timeout)
+    if url not in _staged_config_cache:
+        local = _load_local_json(env_var)
+        _staged_config_cache[url] = (
+            local if local is not None else _fetch_remote_json(url, timeout)
         )
-    return _institutions_cache
+    return _staged_config_cache[url]
+
+
+def load_institutions(timeout: int = 5) -> dict:
+    """institutions_v2.json (hub name → hub/institution config), local-first."""
+    return _load_staged_config(INSTITUTIONS_URL, INSTITUTIONS_FILE_ENV, timeout)
+
+
+def load_subjects(timeout: int = 30) -> dict:
+    """subjects.json (DPLA subject name → Wikidata-QID map for P921), local-first.
+
+    Larger fallback timeout than load_institutions: subjects.json is ~2.7 MB and
+    the live-fetch fallback is only retried on HTTP 429, not on a socket timeout,
+    so keep subjects' historical 30s ceiling rather than risk an un-retried
+    timeout on the rare no-local-file path.
+    """
+    return _load_staged_config(SUBJECTS_URL, SUBJECTS_FILE_ENV, timeout)
 
 
 def is_upload_eligible(canonical_slug: str, timeout: int = 5) -> bool:
@@ -197,7 +218,7 @@ def is_upload_eligible(canonical_slug: str, timeout: int = 5) -> bool:
     hub_name = PARTNER_HUBS.get(canonical_slug)
     if not hub_name:
         return False
-    hub = _get_institutions(timeout).get(hub_name, {})
+    hub = load_institutions(timeout).get(hub_name, {})
     return hub.get("upload", False) or any(
         inst.get("upload", False) for inst in hub.get("institutions", {}).values()
     )
@@ -215,7 +236,7 @@ def is_institution_upload_eligible(
     hub_name = PARTNER_HUBS.get(canonical_slug)
     if not hub_name:
         return False
-    hub = _get_institutions(timeout).get(hub_name, {})
+    hub = load_institutions(timeout).get(hub_name, {})
     if hub.get("upload", False):
         return True
     inst_data = hub.get("institutions", {}).get(institution_name, {})
@@ -235,7 +256,7 @@ def is_item_upload_eligible(
     hub_name = PARTNER_HUBS.get(canonical_slug)
     if not hub_name:
         return False
-    hub = _get_institutions(timeout).get(hub_name, {})
+    hub = load_institutions(timeout).get(hub_name, {})
     if not hub.get("Wikidata", ""):
         return False
     inst_data = hub.get("institutions", {}).get(institution_name, {})
@@ -289,7 +310,7 @@ def wikidata_qid_for_target(
     hub_name = PARTNER_HUBS.get(canonical_slug)
     if not hub_name:
         return None
-    hub = _get_institutions(timeout).get(hub_name, {})
+    hub = load_institutions(timeout).get(hub_name, {})
     if institution_name is None:
         return hub.get("Wikidata") or None
     inst = hub.get("institutions", {}).get(institution_name, {})
@@ -452,7 +473,7 @@ def canonical_matches_session_component(
     hub_name = PARTNER_HUBS.get(canonical)
     if not hub_name:
         return False
-    hub_data = _get_institutions(timeout).get(hub_name, {})
+    hub_data = load_institutions(timeout).get(hub_name, {})
     return any(
         inst.lower().replace(" ", "-") == component
         for inst in hub_data.get("institutions", {})
@@ -495,7 +516,7 @@ def resolve_wikidata_id(
     one session each (as it does for any cross-hub QID); the same
     QID-derived Commons category is therefore walked once per hub.
     """
-    institutions = _get_institutions(timeout)
+    institutions = load_institutions(timeout)
     results: list[tuple[str, str | None]] = []
     for hub_name, hub_data in institutions.items():
         canonical = _SLUG_BY_HUB_NAME.get(hub_name.lower())

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -82,7 +82,7 @@ from typing import Any
 
 import requests
 
-from ingest_wikimedia.dpla import INSTITUTIONS_URL
+from ingest_wikimedia.partners import load_institutions, load_subjects
 
 # Hardcoded Wikibase entities used across the SDC mapping. Centralized here
 # so any change has a single edit site.
@@ -228,14 +228,6 @@ CHUNKABLE_PROPS = frozenset(
 # what Wikibase will actually store after the wbeditentity round-trip.
 _CONTROL_CHAR_RUN = re.compile(r"[\x00-\x1F\x7F-\x9F]+")
 
-# DPLA subject → Wikidata Q-ID lookup table; sourced from dpla/ingestion3
-# alongside institutions_v2.json. Fetched fresh per run so upstream changes
-# land in the next sync without a redeploy.
-SUBJECTS_URL = (
-    "https://raw.githubusercontent.com/dpla/ingestion3/develop/"
-    "src/main/resources/subjects.json"
-)
-
 # Locate rights.json by walking up from this module's directory. sdc.py
 # lives at <repo>/ingest_wikimedia/sdc.py, so two dirname's above gives the
 # repo root.
@@ -245,23 +237,22 @@ logger = logging.getLogger(__name__)
 
 
 def fetch_institutions_v2() -> dict:
-    """Fetch the full institutions_v2.json document used for hub/institution
-    eligibility and (in the SDC pre-compute pass) Wikidata-ID resolution."""
-    resp = requests.get(INSTITUTIONS_URL, timeout=15)
-    resp.raise_for_status()
-    return resp.json()
+    """Full institutions_v2.json (hub/institution eligibility + Wikidata IDs).
+
+    Delegates to ``partners.load_institutions`` so it reads the launch-staged
+    local copy when present instead of re-fetching from raw.githubusercontent.com
+    (per-IP HTTP 429 under a multi-target batch).
+    """
+    return load_institutions()
 
 
 def fetch_subjects_json() -> dict:
-    """Fetch the DPLA-subject → Wikidata-ID map used to populate P921.
+    """DPLA-subject → Wikidata-QID map used to populate P921.
 
-    Sourced from dpla/ingestion3 alongside institutions_v2.json; fetched
-    fresh per run so upstream changes land in the next sync without a
-    redeploy.
+    Delegates to ``partners.load_subjects`` (local-first, see there) instead of
+    re-fetching from raw.githubusercontent.com per run.
     """
-    resp = requests.get(SUBJECTS_URL, timeout=30)
-    resp.raise_for_status()
-    return resp.json()
+    return load_subjects()
 
 
 def load_rights_json() -> dict:

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -37,6 +37,7 @@ import boto3
 import requests
 
 from ingest_wikimedia.partners import (
+    INSTITUTIONS_URL,
     PARTNER_DIR,
     commons_has_files_for_qid,
     is_dpla_id,
@@ -55,6 +56,12 @@ from ingest_wikimedia.session_state import (
 )
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run, stage_and_launch_tmux
+
+# Where the launcher stages ingestion3's institutions_v2.json on EC2 (fetched
+# once per launch) so the per-target pipeline processes read it from disk via
+# WIKIMEDIA_INSTITUTIONS_FILE instead of each hitting raw.githubusercontent.com
+# (which rate-limits the box IP to HTTP 429). See ingest_wikimedia.partners.
+INSTITUTIONS_LOCAL_PATH = "/home/ec2-user/ingest-wikimedia/institutions_v2.json"
 
 # Each ingest session peaks at ~300–500 MB; 30% of 7.6 GB leaves headroom for 4–5 concurrent sessions.
 MEMORY_HEADROOM_PCT = 30
@@ -882,7 +889,17 @@ def main() -> None:
         "cp -r ingest-wikimedia-update/tools/* /home/ec2-user/ingest-wikimedia/tools/ && "
         "cp ingest-wikimedia-update/pyproject.toml /home/ec2-user/ingest-wikimedia/pyproject.toml && "
         "cp ingest-wikimedia-update/uv.lock /home/ec2-user/ingest-wikimedia/uv.lock && "
-        "/home/ec2-user/.local/bin/uv sync --project /home/ec2-user/ingest-wikimedia && echo UPDATE_DONE"
+        # Stage ingestion3's institutions_v2.json once per launch so the many
+        # short-lived pipeline processes read it from disk (via
+        # WIKIMEDIA_INSTITUTIONS_FILE) instead of each hitting anonymous
+        # raw.githubusercontent.com, which rate-limits the box IP to HTTP 429.
+        # Best-effort: one fetch won't rate-limit, and if it fails the runtime
+        # falls back to a retrying live fetch (partners._get_institutions), so a
+        # GitHub hiccup must not block the launch (`|| echo`, not `&&`).
+        + f"( curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors {shlex.quote(INSTITUTIONS_URL)} "
+        + f"-o {shlex.quote(INSTITUTIONS_LOCAL_PATH)} "
+        + "|| echo 'WARN: institutions_v2.json stage failed; runtime falls back to live fetch' ) && "
+        + "/home/ec2-user/.local/bin/uv sync --project /home/ec2-user/ingest-wikimedia && echo UPDATE_DONE"
     )
     out = ""
     try:
@@ -1280,6 +1297,10 @@ def main() -> None:
         [
             "source ~/.bashrc",
             "source /home/ec2-user/ingest-wikimedia/.venv/bin/activate",
+            # Point partners._get_institutions at the launch-staged copy so
+            # every target reads it from disk instead of re-fetching from
+            # raw.githubusercontent.com (per-IP 429 under a multi-target batch).
+            f"export WIKIMEDIA_INSTITUTIONS_FILE={shlex.quote(INSTITUTIONS_LOCAL_PATH)}",
         ]
     )
     target_blocks = []

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -39,6 +39,7 @@ import requests
 from ingest_wikimedia.partners import (
     INSTITUTIONS_URL,
     PARTNER_DIR,
+    SUBJECTS_URL,
     commons_has_files_for_qid,
     is_dpla_id,
     is_upload_eligible,
@@ -57,11 +58,33 @@ from ingest_wikimedia.session_state import (
 from ingest_wikimedia.slack import post_message
 from ingest_wikimedia.ssm import REGION, ssm_run, stage_and_launch_tmux
 
-# Where the launcher stages ingestion3's institutions_v2.json on EC2 (fetched
-# once per launch) so the per-target pipeline processes read it from disk via
-# WIKIMEDIA_INSTITUTIONS_FILE instead of each hitting raw.githubusercontent.com
+# Where the launcher stages ingestion3's config JSON on EC2 (fetched once per
+# launch) so the per-target pipeline processes read it from disk via the
+# WIKIMEDIA_*_FILE env vars instead of each hitting raw.githubusercontent.com
 # (which rate-limits the box IP to HTTP 429). See ingest_wikimedia.partners.
 INSTITUTIONS_LOCAL_PATH = "/home/ec2-user/ingest-wikimedia/institutions_v2.json"
+SUBJECTS_LOCAL_PATH = "/home/ec2-user/ingest-wikimedia/subjects.json"
+
+
+def _stage_config_cmd(url: str, local_path: str) -> str:
+    """Shell snippet staging one ingestion3 config JSON to a local path.
+
+    Best-effort: one fetch per launch won't rate-limit, and if it fails the
+    runtime falls back to a retrying live fetch, so a GitHub hiccup must not
+    block the launch (`|| echo`, not `&&`). Atomic: curl to a temp file, mv
+    into place only on success, so a failed/interrupted fetch can't truncate a
+    good copy staged by an earlier launch (which would silently drop this
+    launch back to live fetch).
+    """
+    name = local_path.rsplit("/", 1)[-1]
+    tmp = local_path + ".tmp"
+    return (
+        f"( curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors {shlex.quote(url)} "
+        f"-o {shlex.quote(tmp)} "
+        f"&& mv {shlex.quote(tmp)} {shlex.quote(local_path)} "
+        f"|| echo 'WARN: {name} stage failed; runtime falls back to live fetch' ) && "
+    )
+
 
 # Each ingest session peaks at ~300–500 MB; 30% of 7.6 GB leaves headroom for 4–5 concurrent sessions.
 MEMORY_HEADROOM_PCT = 30
@@ -889,20 +912,13 @@ def main() -> None:
         "cp -r ingest-wikimedia-update/tools/* /home/ec2-user/ingest-wikimedia/tools/ && "
         "cp ingest-wikimedia-update/pyproject.toml /home/ec2-user/ingest-wikimedia/pyproject.toml && "
         "cp ingest-wikimedia-update/uv.lock /home/ec2-user/ingest-wikimedia/uv.lock && "
-        # Stage ingestion3's institutions_v2.json once per launch so the many
-        # short-lived pipeline processes read it from disk (via
-        # WIKIMEDIA_INSTITUTIONS_FILE) instead of each hitting anonymous
-        # raw.githubusercontent.com, which rate-limits the box IP to HTTP 429.
-        # Best-effort: one fetch won't rate-limit, and if it fails the runtime
-        # falls back to a retrying live fetch (partners._get_institutions), so a
-        # GitHub hiccup must not block the launch (`|| echo`, not `&&`).
-        # Atomic: curl to a temp file, mv into place only on success, so a
-        # failed/interrupted fetch can't truncate a good copy staged by an
-        # earlier launch (which would silently drop this launch back to live fetch).
-        + f"( curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors {shlex.quote(INSTITUTIONS_URL)} "
-        + f"-o {shlex.quote(INSTITUTIONS_LOCAL_PATH + '.tmp')} "
-        + f"&& mv {shlex.quote(INSTITUTIONS_LOCAL_PATH + '.tmp')} {shlex.quote(INSTITUTIONS_LOCAL_PATH)} "
-        + "|| echo 'WARN: institutions_v2.json stage failed; runtime falls back to live fetch' ) && "
+        # Stage ingestion3's config JSON (institutions_v2.json + subjects.json)
+        # once per launch so the many short-lived pipeline processes read them
+        # from disk (via WIKIMEDIA_INSTITUTIONS_FILE / WIKIMEDIA_SUBJECTS_FILE)
+        # instead of each hitting anonymous raw.githubusercontent.com, which
+        # rate-limits the box IP to HTTP 429 under a multi-target batch.
+        + _stage_config_cmd(INSTITUTIONS_URL, INSTITUTIONS_LOCAL_PATH)
+        + _stage_config_cmd(SUBJECTS_URL, SUBJECTS_LOCAL_PATH)
         + "/home/ec2-user/.local/bin/uv sync --project /home/ec2-user/ingest-wikimedia && echo UPDATE_DONE"
     )
     out = ""
@@ -1301,10 +1317,12 @@ def main() -> None:
         [
             "source ~/.bashrc",
             "source /home/ec2-user/ingest-wikimedia/.venv/bin/activate",
-            # Point partners._get_institutions at the launch-staged copy so
-            # every target reads it from disk instead of re-fetching from
-            # raw.githubusercontent.com (per-IP 429 under a multi-target batch).
+            # Point partners.load_institutions / load_subjects at the
+            # launch-staged copies so every target reads them from disk instead
+            # of re-fetching from raw.githubusercontent.com (per-IP 429 under a
+            # multi-target batch).
             f"export WIKIMEDIA_INSTITUTIONS_FILE={shlex.quote(INSTITUTIONS_LOCAL_PATH)}",
+            f"export WIKIMEDIA_SUBJECTS_FILE={shlex.quote(SUBJECTS_LOCAL_PATH)}",
         ]
     )
     target_blocks = []

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -896,8 +896,12 @@ def main() -> None:
         # Best-effort: one fetch won't rate-limit, and if it fails the runtime
         # falls back to a retrying live fetch (partners._get_institutions), so a
         # GitHub hiccup must not block the launch (`|| echo`, not `&&`).
+        # Atomic: curl to a temp file, mv into place only on success, so a
+        # failed/interrupted fetch can't truncate a good copy staged by an
+        # earlier launch (which would silently drop this launch back to live fetch).
         + f"( curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors {shlex.quote(INSTITUTIONS_URL)} "
-        + f"-o {shlex.quote(INSTITUTIONS_LOCAL_PATH)} "
+        + f"-o {shlex.quote(INSTITUTIONS_LOCAL_PATH + '.tmp')} "
+        + f"&& mv {shlex.quote(INSTITUTIONS_LOCAL_PATH + '.tmp')} {shlex.quote(INSTITUTIONS_LOCAL_PATH)} "
         + "|| echo 'WARN: institutions_v2.json stage failed; runtime falls back to live fetch' ) && "
         + "/home/ec2-user/.local/bin/uv sync --project /home/ec2-user/ingest-wikimedia && echo UPDATE_DONE"
     )

--- a/tests/test_dpla.py
+++ b/tests/test_dpla.py
@@ -239,15 +239,13 @@ def test_get_provider_and_data_provider(dpla):
 
 
 def test_get_providers_data(dpla):
-    mock_response = MagicMock()
-    mock_response.json.return_value = {"provider": "data"}
-
-    mock_http_session = MagicMock()
-    mock_http_session.get.return_value = mock_response
-
-    dpla.http_session = mock_http_session
-
-    result = dpla.get_providers_data()
+    # get_providers_data delegates to partners.load_institutions (local-first,
+    # urllib) — no longer the requests http_session — so patch that.
+    with patch(
+        "ingest_wikimedia.dpla.load_institutions",
+        return_value={"provider": "data"},
+    ):
+        result = dpla.get_providers_data()
     assert result == {"provider": "data"}
 
 

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -13,7 +13,10 @@ non-eligible matches never leak to the launcher.
 """
 
 import json
+import urllib.error
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from ingest_wikimedia import partners
 from ingest_wikimedia.partners import (
@@ -29,6 +32,88 @@ def _mock_institutions(data: dict):
     institutions_v2.json over the network. Returns the patch context
     manager for use in ``with`` blocks."""
     return patch("ingest_wikimedia.partners._get_institutions", return_value=data)
+
+
+def _json_urlopen(data: dict):
+    """urlopen replacement: a context manager whose read() yields ``data`` as JSON bytes."""
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(data).encode()
+    cm = MagicMock()
+    cm.__enter__.return_value = resp
+    cm.__exit__.return_value = False
+    return cm
+
+
+def _http_429(retry_after=None):
+    hdrs = {"Retry-After": retry_after} if retry_after is not None else None
+    return urllib.error.HTTPError("https://x", 429, "Too Many Requests", hdrs, None)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_institutions(monkeypatch):
+    """Reset the module cache and clear WIKIMEDIA_INSTITUTIONS_FILE around every
+    test so cached data or a stray env var can't leak between tests."""
+    monkeypatch.delenv(partners.INSTITUTIONS_FILE_ENV, raising=False)
+    partners._institutions_cache = None
+    yield
+    partners._institutions_cache = None
+
+
+def test_get_institutions_prefers_local_file(tmp_path, monkeypatch):
+    data = {"Hub": {"upload": True}}
+    f = tmp_path / "institutions_v2.json"
+    f.write_text(json.dumps(data))
+    monkeypatch.setenv(partners.INSTITUTIONS_FILE_ENV, str(f))
+    with patch.object(partners.urllib.request, "urlopen") as urlopen:
+        assert partners._get_institutions() == data
+        urlopen.assert_not_called()  # local copy → no network fetch
+
+
+def test_get_institutions_fetches_when_no_local_file():
+    data = {"Hub": {"upload": True}}
+    with patch.object(
+        partners.urllib.request, "urlopen", return_value=_json_urlopen(data)
+    ):
+        assert partners._get_institutions() == data
+
+
+def test_get_institutions_empty_local_file_falls_back_to_fetch(tmp_path, monkeypatch):
+    fetched = {"Hub": {"upload": True}}
+    f = tmp_path / "institutions_v2.json"
+    f.write_text("{}")  # valid JSON but empty → treated as unusable, fetch instead
+    monkeypatch.setenv(partners.INSTITUTIONS_FILE_ENV, str(f))
+    with patch.object(
+        partners.urllib.request, "urlopen", return_value=_json_urlopen(fetched)
+    ) as urlopen:
+        assert partners._get_institutions() == fetched
+        urlopen.assert_called_once()
+
+
+def test_get_institutions_retries_on_429_then_succeeds():
+    data = {"Hub": {"upload": True}}
+    queue = [_http_429(), _http_429(), _json_urlopen(data)]
+
+    def _urlopen(*args, **kwargs):
+        item = queue.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    with (
+        patch.object(partners.time, "sleep") as sleep,
+        patch.object(partners.urllib.request, "urlopen", side_effect=_urlopen),
+    ):
+        assert partners._get_institutions() == data
+        assert sleep.call_count == 2  # two 429s → two backoff sleeps
+
+
+def test_get_institutions_raises_after_exhausting_429_retries():
+    with (
+        patch.object(partners.time, "sleep"),
+        patch.object(partners.urllib.request, "urlopen", side_effect=_http_429()),
+        pytest.raises(urllib.error.HTTPError),
+    ):
+        partners._get_institutions()
 
 
 def test_resolve_wikidata_id_drops_hub_level_match_when_hub_upload_false():

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -107,6 +107,24 @@ def test_get_institutions_retries_on_429_then_succeeds():
         assert sleep.call_count == 2  # two 429s → two backoff sleeps
 
 
+def test_get_institutions_honors_retry_after_header():
+    data = {"Hub": {"upload": True}}
+    queue = [_http_429(retry_after="1"), _json_urlopen(data)]
+
+    def _urlopen(*args, **kwargs):
+        item = queue.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    with (
+        patch.object(partners.time, "sleep") as sleep,
+        patch.object(partners.urllib.request, "urlopen", side_effect=_urlopen),
+    ):
+        assert partners._get_institutions() == data
+        sleep.assert_called_once_with(1.0)  # honors Retry-After, not default backoff
+
+
 def test_get_institutions_raises_after_exhausting_429_retries():
     with (
         patch.object(partners.time, "sleep"),

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -49,6 +49,19 @@ def _http_429(retry_after=None):
     return urllib.error.HTTPError("https://x", 429, "Too Many Requests", hdrs, None)
 
 
+def _queue_urlopen(queue):
+    """urlopen side-effect that pops ``queue`` in order, raising Exception items
+    (to simulate 429s) and returning the rest — for multi-attempt retry tests."""
+
+    def _urlopen(*args, **kwargs):
+        item = queue.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    return _urlopen
+
+
 @pytest.fixture(autouse=True)
 def _isolate_staged_config(monkeypatch):
     """Reset the staged-config cache and clear the WIKIMEDIA_*_FILE env vars
@@ -94,16 +107,11 @@ def test_load_institutions_empty_local_file_falls_back_to_fetch(tmp_path, monkey
 def test_load_institutions_retries_on_429_then_succeeds():
     data = {"Hub": {"upload": True}}
     queue = [_http_429(), _http_429(), _json_urlopen(data)]
-
-    def _urlopen(*args, **kwargs):
-        item = queue.pop(0)
-        if isinstance(item, Exception):
-            raise item
-        return item
-
     with (
         patch.object(partners.time, "sleep") as sleep,
-        patch.object(partners.urllib.request, "urlopen", side_effect=_urlopen),
+        patch.object(
+            partners.urllib.request, "urlopen", side_effect=_queue_urlopen(queue)
+        ),
     ):
         assert partners.load_institutions() == data
         assert sleep.call_count == 2  # two 429s → two backoff sleeps
@@ -112,16 +120,11 @@ def test_load_institutions_retries_on_429_then_succeeds():
 def test_load_institutions_honors_retry_after_header():
     data = {"Hub": {"upload": True}}
     queue = [_http_429(retry_after="1"), _json_urlopen(data)]
-
-    def _urlopen(*args, **kwargs):
-        item = queue.pop(0)
-        if isinstance(item, Exception):
-            raise item
-        return item
-
     with (
         patch.object(partners.time, "sleep") as sleep,
-        patch.object(partners.urllib.request, "urlopen", side_effect=_urlopen),
+        patch.object(
+            partners.urllib.request, "urlopen", side_effect=_queue_urlopen(queue)
+        ),
     ):
         assert partners.load_institutions() == data
         sleep.assert_called_once_with(1.0)  # honors Retry-After, not default backoff

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -28,10 +28,10 @@ from ingest_wikimedia.partners import (
 
 
 def _mock_institutions(data: dict):
-    """Patch ``_get_institutions`` to return ``data`` instead of fetching
+    """Patch ``load_institutions`` to return ``data`` instead of fetching
     institutions_v2.json over the network. Returns the patch context
     manager for use in ``with`` blocks."""
-    return patch("ingest_wikimedia.partners._get_institutions", return_value=data)
+    return patch("ingest_wikimedia.partners.load_institutions", return_value=data)
 
 
 def _json_urlopen(data: dict):
@@ -50,34 +50,36 @@ def _http_429(retry_after=None):
 
 
 @pytest.fixture(autouse=True)
-def _isolate_institutions(monkeypatch):
-    """Reset the module cache and clear WIKIMEDIA_INSTITUTIONS_FILE around every
-    test so cached data or a stray env var can't leak between tests."""
+def _isolate_staged_config(monkeypatch):
+    """Reset the staged-config cache and clear the WIKIMEDIA_*_FILE env vars
+    around every test so cached data or a stray env var can't leak between
+    tests."""
     monkeypatch.delenv(partners.INSTITUTIONS_FILE_ENV, raising=False)
-    partners._institutions_cache = None
+    monkeypatch.delenv(partners.SUBJECTS_FILE_ENV, raising=False)
+    partners._staged_config_cache.clear()
     yield
-    partners._institutions_cache = None
+    partners._staged_config_cache.clear()
 
 
-def test_get_institutions_prefers_local_file(tmp_path, monkeypatch):
+def test_load_institutions_prefers_local_file(tmp_path, monkeypatch):
     data = {"Hub": {"upload": True}}
     f = tmp_path / "institutions_v2.json"
     f.write_text(json.dumps(data))
     monkeypatch.setenv(partners.INSTITUTIONS_FILE_ENV, str(f))
     with patch.object(partners.urllib.request, "urlopen") as urlopen:
-        assert partners._get_institutions() == data
+        assert partners.load_institutions() == data
         urlopen.assert_not_called()  # local copy → no network fetch
 
 
-def test_get_institutions_fetches_when_no_local_file():
+def test_load_institutions_fetches_when_no_local_file():
     data = {"Hub": {"upload": True}}
     with patch.object(
         partners.urllib.request, "urlopen", return_value=_json_urlopen(data)
     ):
-        assert partners._get_institutions() == data
+        assert partners.load_institutions() == data
 
 
-def test_get_institutions_empty_local_file_falls_back_to_fetch(tmp_path, monkeypatch):
+def test_load_institutions_empty_local_file_falls_back_to_fetch(tmp_path, monkeypatch):
     fetched = {"Hub": {"upload": True}}
     f = tmp_path / "institutions_v2.json"
     f.write_text("{}")  # valid JSON but empty → treated as unusable, fetch instead
@@ -85,11 +87,11 @@ def test_get_institutions_empty_local_file_falls_back_to_fetch(tmp_path, monkeyp
     with patch.object(
         partners.urllib.request, "urlopen", return_value=_json_urlopen(fetched)
     ) as urlopen:
-        assert partners._get_institutions() == fetched
+        assert partners.load_institutions() == fetched
         urlopen.assert_called_once()
 
 
-def test_get_institutions_retries_on_429_then_succeeds():
+def test_load_institutions_retries_on_429_then_succeeds():
     data = {"Hub": {"upload": True}}
     queue = [_http_429(), _http_429(), _json_urlopen(data)]
 
@@ -103,11 +105,11 @@ def test_get_institutions_retries_on_429_then_succeeds():
         patch.object(partners.time, "sleep") as sleep,
         patch.object(partners.urllib.request, "urlopen", side_effect=_urlopen),
     ):
-        assert partners._get_institutions() == data
+        assert partners.load_institutions() == data
         assert sleep.call_count == 2  # two 429s → two backoff sleeps
 
 
-def test_get_institutions_honors_retry_after_header():
+def test_load_institutions_honors_retry_after_header():
     data = {"Hub": {"upload": True}}
     queue = [_http_429(retry_after="1"), _json_urlopen(data)]
 
@@ -121,17 +123,54 @@ def test_get_institutions_honors_retry_after_header():
         patch.object(partners.time, "sleep") as sleep,
         patch.object(partners.urllib.request, "urlopen", side_effect=_urlopen),
     ):
-        assert partners._get_institutions() == data
+        assert partners.load_institutions() == data
         sleep.assert_called_once_with(1.0)  # honors Retry-After, not default backoff
 
 
-def test_get_institutions_raises_after_exhausting_429_retries():
+def test_load_institutions_raises_after_exhausting_429_retries():
     with (
         patch.object(partners.time, "sleep"),
         patch.object(partners.urllib.request, "urlopen", side_effect=_http_429()),
         pytest.raises(urllib.error.HTTPError),
     ):
-        partners._get_institutions()
+        partners.load_institutions()
+
+
+def test_load_subjects_prefers_local_file(tmp_path, monkeypatch):
+    """subjects.json rides the same local-first loader: a staged file is read
+    from disk with no network fetch (the whole point of WIKIMEDIA_SUBJECTS_FILE)."""
+    data = {"Photographs": "Q125191"}
+    f = tmp_path / "subjects.json"
+    f.write_text(json.dumps(data))
+    monkeypatch.setenv(partners.SUBJECTS_FILE_ENV, str(f))
+    with patch.object(partners.urllib.request, "urlopen") as urlopen:
+        assert partners.load_subjects() == data
+        urlopen.assert_not_called()
+
+
+def test_load_subjects_fetches_when_no_local_file():
+    data = {"Photographs": "Q125191"}
+    with patch.object(
+        partners.urllib.request, "urlopen", return_value=_json_urlopen(data)
+    ):
+        assert partners.load_subjects() == data
+
+
+def test_load_institutions_and_subjects_cached_independently(tmp_path, monkeypatch):
+    """The shared staged-config cache is keyed by URL, so institutions and
+    subjects staged to different files must not collide."""
+    insts = {"Hub": {"upload": True}}
+    subs = {"Photographs": "Q125191"}
+    fi = tmp_path / "institutions_v2.json"
+    fi.write_text(json.dumps(insts))
+    fs = tmp_path / "subjects.json"
+    fs.write_text(json.dumps(subs))
+    monkeypatch.setenv(partners.INSTITUTIONS_FILE_ENV, str(fi))
+    monkeypatch.setenv(partners.SUBJECTS_FILE_ENV, str(fs))
+    with patch.object(partners.urllib.request, "urlopen") as urlopen:
+        assert partners.load_institutions() == insts
+        assert partners.load_subjects() == subs
+        urlopen.assert_not_called()
 
 
 def test_resolve_wikidata_id_drops_hub_level_match_when_hub_upload_false():

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -2181,9 +2181,11 @@ def test_initialize_pins_pywikibot_retry_budget(monkeypatch, tmp_path):
         ),
     )
     monkeypatch.setattr(pywikibot, "Site", MagicMock)
-    monkeypatch.setattr(
-        sdc_sync.requests, "get", lambda *a, **k: MagicMock(json=lambda: {})
-    )
+    # _initialize() pulls the two ingestion3 configs via fetch_institutions_v2 /
+    # fetch_subjects_json (partners' local-first loader, urllib) — not
+    # requests.get — so stub those to keep this test offline.
+    monkeypatch.setattr(sdc_sync, "fetch_institutions_v2", lambda *a, **k: {})
+    monkeypatch.setattr(sdc_sync, "fetch_subjects_json", lambda *a, **k: {})
 
     sdc_sync._initialize()
 

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -19,6 +19,8 @@ from ingest_wikimedia.sdc import (
     CHUNKABLE_PROPS,
     NARA_PROVIDER_NAME,
     casefold_for_compare,
+    fetch_institutions_v2,
+    fetch_subjects_json,
     ingest_date_from_doc,
     is_wikitext_junk_value,
     parse_date_range,
@@ -577,16 +579,10 @@ def _initialize() -> None:
     # that data, and a vendored snapshot would defeat the point. rights.json
     # is the exception — it lives here because it's a small, slow-moving
     # SDC-specific mapping not maintained in ingestion3.
-    hubs = requests.get(
-        "https://raw.githubusercontent.com/dpla/ingestion3/develop/src/main/resources/wiki/institutions_v2.json",
-        timeout=30,
-    ).json()
+    hubs = fetch_institutions_v2()
     with open(os.path.join(_REPO_ROOT, "rights.json")) as f:
         rights = {_normalize_rights_uri(k): v for k, v in json.load(f).items()}
-    subject_ids = requests.get(
-        "https://raw.githubusercontent.com/dpla/ingestion3/develop/src/main/resources/subjects.json",
-        timeout=30,
-    ).json()
+    subject_ids = fetch_subjects_json()
 
     # When --from-s3 <partner> is set, parsed() reads each item's dpla-map.json
     # from S3 instead of calling api.dp.la. Imported lazily so this module


### PR DESCRIPTION
## Problem

The upload-eligibility precheck (`partners._get_institutions` → `is_upload_eligible` → `check_partner`) fetches `institutions_v2.json` from **`raw.githubusercontent.com`** with a bare `urllib.urlopen` on **every short-lived pipeline process**. Under a multi-target batch, the box's anonymous per-IP requests cross GitHub's raw-content rate limit and it returns **HTTP 429** — and with no retry, that crashes every target's precheck as `pipeline step failed (exit 1)`. This is the failure observed on the running texas batch (wharton / atlanta / schulenburg, several in a row).

## Change

- **`ingest_wikimedia/partners.py`** — `_get_institutions()` now prefers a locally-staged copy named by `WIKIMEDIA_INSTITUTIONS_FILE` (no per-process network), and falls back to a live fetch **with retry/backoff honoring `Retry-After`** on 429 for the Lambda / GitHub-Actions path where there is no local file. A truncated/empty staged file is ignored so a bad stage never silently makes every hub ineligible. Kept **stdlib-only** per the module's portability contract (docstring), so the retry is hand-rolled rather than importing the `requests`-based `Web` session — please don't "consolidate" it onto `web.py`, that would pull `requests`/`urllib3` into the Lambda-safe module.
- **`scripts/wikimedia_launch.py`** — fetches `institutions_v2.json` once per launch (best-effort `curl --retry`) alongside the existing `git clone` code refresh, and exports `WIKIMEDIA_INSTITUTIONS_FILE` into the pipeline env so every target reads the local copy. Best-effort by design: one fetch won't rate-limit, and if it fails the runtime falls back to the retrying live fetch, so a GitHub hiccup can't block the launch.
- **`tests/test_partners.py`** — covers local-first, empty-file fallback, no-env fetch, 429 retry-then-succeed, and retry-exhaustion; an autouse fixture isolates the module cache + env var per test.

## Scope — this is foundational, not the whole fix

This covers the **eligibility-precheck** path — the one that actually crashed, because it was the only fetcher **without** retry. `institutions_v2.json` is fetched by **three other per-target paths** that still hit GitHub raw and do **not** yet read the staged file:

| fetcher | callers | retry? |
|---|---|---|
| `dpla.get_providers_data` (`dpla.py:340`, requests session) | uploader, retirer | session-level |
| `sdc.fetch_institutions_v2` (`sdc.py:250`, bare `requests.get`) | get-ids-es, get-ids-nara | **none** |
| inline `requests.get` (`sdc_sync.py:581`) | sdc-sync | **none** + reads **`develop`**, not `main` |

So this PR reduces load and removes the observed crash, but a **follow-up** should route those three through the same local-first + retry loader (and resolve the `develop`-vs-`main` branch split, a latent correctness issue independent of the 429) to remove the rate-limit exposure entirely.

Note: this does not affect the *currently running* batch — its orchestration script and code were frozen at an earlier launch; it takes effect on the next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated Wikimedia ingest eligibility prechecks to avoid upload failures caused by repeated per-target fetching of `institutions_v2.json` from `raw.githubusercontent.com` (hitting GitHub’s anonymous rate limits and returning HTTP 429).

- `ingest_wikimedia/partners.py` now supports **local-first** loading of both `institutions_v2.json` and `subjects.json` via new environment variables:
  - `WIKIMEDIA_INSTITUTIONS_FILE`
  - `WIKIMEDIA_SUBJECTS_FILE`
- If the corresponding env var is unset, the file is missing/unreadable, or the staged JSON is empty/invalid (not a non-empty object), it falls back to a live fetch.
- Live fetches now use retry/backoff for HTTP 429 and **honor `Retry-After`** (with bounded sleep); non-429 errors are re-raised immediately. Successful loads are cached for the process lifetime.
- `scripts/wikimedia_launch.py` now stages `institutions_v2.json` and `subjects.json` **once per EC2 launch** (download to a temp file, then atomic `mv`) and exports `WIKIMEDIA_INSTITUTIONS_FILE`/`WIKIMEDIA_SUBJECTS_FILE` so targets read the local copies instead of refetching.
- Call sites (`ingest_wikimedia/dpla.py`, `ingest_wikimedia/sdc.py`, and `tools/sdc_sync.py`) were updated to use the shared loaders to keep eligibility and partner mapping behavior consistent.

Tests were added to verify local precedence, fallback on empty staged files, behavior when env vars are not set, 429 retry success, retry exhaustion, and `Retry-After` handling.

Notes:
- **Environment variables added:** `WIKIMEDIA_INSTITUTIONS_FILE`, `WIKIMEDIA_SUBJECTS_FILE`.
- **No database migration** (reversible or otherwise).
- **No shared infra configuration changes** (no CodePipeline/CodeBuild/ECS/IAM changes) and **no public API shape/endpoint changes**.
- **No special manual action required** beyond running the pipeline/launch with the updated code (no additional ECS redeployment workflow beyond the normal deployment of this change).
- **Security:** still consumes external GitHub raw JSON, but reduces external requests by switching from per-target fetches to a single per-launch staged copy and adds safer retry behavior for rate limiting.
- Follow-up: other per-target fetch paths that still read from GitHub raw remain out of scope for this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->