### PR TITLE
Report ineligible QID targets as "not upload-eligible", not "not found"

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -788,7 +788,7 @@ def main() -> None:
             resolved = resolve_wikidata_id(token, maintain=maintain)
             if not resolved:
                 skipped_warnings.append(
-                    f"Wikidata ID {token!r}: not found in institutions_v2.json."
+                    f"Wikidata ID {token!r}: not upload-eligible per institutions_v2.json."
                 )
                 continue
             # Group resolved pairs by canonical hub so multiple institutions


### PR DESCRIPTION
The launcher skip warning for a Wikidata-ID target that resolves to nothing reads:

> `Wikidata ID 'Q955764': not found in institutions_v2.json.`

That is misleading. `resolve_wikidata_id` returns an empty result in **two** cases:

1. the QID is genuinely absent from `institutions_v2.json`, **and**
2. the QID is present but every matching hub/institution is `upload: false` (opted out).

`Q955764` (University of Illinois at Chicago) is the second case — it is in the file under both **Illinois Digital Heritage Hub** and **Internet Archive**, both with `upload: false` (and both parent hubs `upload: false`), so the default upload-gated filter correctly drops it and the target is skipped. But the message claims it isn't in the file at all.

Since upload-eligibility presupposes presence, the present/absent distinction is irrelevant to the skip: the target is **not upload-eligible** either way, which is the only thing the operator needs to know. This changes the message to say exactly that, matching the wording the launcher already uses for the analogous slug-based skip:

> `'<slug>': not upload-eligible per institutions_v2.json.`

Message-only change; no behavior change to resolution or eligibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the launcher’s Wikidata-ID skip warning in `scripts/wikimedia_launch.py` so empty `resolve_wikidata_id` results are reported as “not upload-eligible per institutions_v2.json” instead of “not found in institutions_v2.json.” This clarifies the message for both missing QIDs and QIDs present but gated off by `upload: false`, without changing resolution or eligibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->