### PR TITLE
Fix kill path: resolve QIDs without the upload-eligibility filter

### DIFF
--- a/scripts/wikimedia_kill.py
+++ b/scripts/wikimedia_kill.py
@@ -135,7 +135,15 @@ def resolve_kill_components(target_tokens: list[str]) -> list[frozenset[str]]:
         if not token:
             continue
         if is_wikidata_id(token):
-            resolved = resolve_wikidata_id(token)
+            # maintain=True → resolve by QID presence only, dropping the
+            # upload-eligibility filter. A kill must find the running session
+            # regardless of upload flags: opted-out (upload=false) institutions
+            # still launch (e.g. under maintain), and a hub/institution can be
+            # de-opted after its session starts. The default upload-gated filter
+            # would drop those matches and make a present-but-opted-out QID (e.g.
+            # Q955764) look absent, so the kill would refuse to run. With the
+            # filter dropped, an empty result now genuinely means "not in the JSON".
+            resolved = resolve_wikidata_id(token, maintain=True)
             if not resolved:
                 raise ValueError(
                     f"No hub or institution found for Wikidata ID {token!r} in institutions_v2.json."

--- a/tests/test_wikimedia_kill.py
+++ b/tests/test_wikimedia_kill.py
@@ -101,6 +101,19 @@ def test_wikidata_qid_resolves_to_canonical_only_when_no_institution():
         assert resolve_kill_components(["Q67890"]) == [frozenset({"indiana"})]
 
 
+def test_wikidata_qid_resolved_without_upload_eligibility_filter():
+    """Kill resolves QIDs with maintain=True (QID-presence only) so a present-
+    but-opted-out QID still resolves for killing. Regression: the default
+    upload-gated filter dropped opted-out matches, failing the kill (Q955764)."""
+    with patch(
+        "scripts.wikimedia_kill.resolve_wikidata_id",
+        return_value=[("nara", "Herbert Hoover Library")],
+    ) as resolve:
+        groups = resolve_kill_components(["Q955764"])
+    resolve.assert_called_once_with("Q955764", maintain=True)
+    assert groups == [frozenset({"nara", "herbert-hoover-library"})]
+
+
 def test_wikidata_qid_unknown_raises_value_error():
     with patch("scripts.wikimedia_kill.resolve_wikidata_id", return_value=[]):
         with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
Sending a kill for a Wikidata-ID target failed with:

> `No hub or institution found for Wikidata ID 'Q955764' in institutions_v2.json.`

even though the ID **is** in the file. This is a real bug in the kill path (distinct from the message-wording fix in #386).

## Cause

`resolve_kill_components` in `scripts/wikimedia_kill.py` resolved the QID via `resolve_wikidata_id(token)` — the **default (upload-gated)** mode, which filters out non-upload-eligible matches. `Q955764` (University of Illinois at Chicago) is present under both **Illinois Digital Heritage Hub** and **Internet Archive**, but every match is `upload: false`, so the filter dropped them all and the kill refused to run.

A kill must not depend on upload-eligibility: opted-out (`upload: false`) institutions still get launched (e.g. under a maintain run), and a hub/institution can be de-opted *after* its session has started. Filtering at kill time means those sessions can never be killed by QID.

## Fix

Resolve with `maintain=True` — the existing toggle on `resolve_wikidata_id` that gates on QID-presence only and drops the eligibility filter (the same flag the launcher uses for maintain runs). Over-resolving is safe: the caller matches each resolved component group as a **subset** of live tmux session labels, so extra components for opted-out hubs that never launched simply match no session — no false kills. With the filter gone, an empty result now genuinely means the QID is absent from the JSON, so the existing error message is accurate.

Adds a regression test pinning that the kill path calls `resolve_wikidata_id(..., maintain=True)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed Wikidata-ID kill resolution so `resolve_kill_components()` now calls `resolve_wikidata_id(..., maintain=True)`, allowing kill operations to find sessions for QIDs even when upload-eligible filtering would previously suppress them. This prevents false “No hub or institution found” errors for opted-out or later de-opted institutions/hubs.

Added a regression test to assert the kill path uses `maintain=True` and still resolves to the expected canonical/institution component groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->