### PR TITLE
SDC doc-fetch via ES + id-generation observability + status file-count fix

### DIFF
--- a/ingest_wikimedia/logs.py
+++ b/ingest_wikimedia/logs.py
@@ -67,26 +67,33 @@ class TqdmLoggingHandler(logging.Handler):
             self.handleError(record)
 
 
-def setup_logging(partner: str, event_type: str, level: int = logging.INFO) -> None:
+def setup_logging(
+    partner: str, event_type: str, level: int = logging.INFO, console: bool = True
+) -> None:
     """
     Creates a logfile for this process with a unique timestamp and with the partner's
     name. Passes local logging through tqdm so the progress bars don't get mangled.
     Suppresses pywikibot logging below ERROR. Installs a
     logging-aware ``sys.excepthook`` so uncaught tracebacks reach the
     log file — see :func:`_install_logging_excepthook`.
+
+    ``console=False`` omits the tqdm/stdout console handler and logs only to the
+    file. Required for tools whose STDOUT is a data channel — e.g. ``get-ids-es``
+    redirects stdout to the ID CSV, and ``TqdmLoggingHandler`` writes to stdout,
+    so a console handler there would interleave log lines into the CSV.
     """
     os.makedirs(LOGS_DIR_BASE, exist_ok=True)
     time_str = datetime.now().strftime("%Y%m%d-%H%M%S")
     session_label = os.environ.get("WIKIMEDIA_SESSION_LABEL") or partner
     log_file_name = f"{time_str}-{session_label}-{event_type}.log"
     filename = f"{LOGS_DIR_BASE}/{log_file_name}"
+    handlers: list[logging.Handler] = [logging.FileHandler(filename=filename, mode="w")]
+    if console:
+        handlers.insert(0, TqdmLoggingHandler())
     logging.basicConfig(
         level=level,
         datefmt="%H:%M:%S",
-        handlers=[
-            TqdmLoggingHandler(),
-            logging.FileHandler(filename=filename, mode="w"),
-        ],
+        handlers=handlers,
         format="[%(levelname)s] %(asctime)s: %(message)s",
     )
     logging.info(f"Logging to {filename}.")

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -348,24 +348,26 @@ def get_phase_and_progress(
     # shlex.quote) — single-quoting would disable shell glob expansion
     # so the ``*`` would no longer expand. The slug-shape guard at the
     # top of this function makes the unquoted interpolation safe.
-    # Total-ordinals denominator from the download log. Count the
-    # per-ordinal ``Downloading <partner> <id> <ordinal> from <url>`` line
-    # at `downloader.py:532` — emitted unconditionally for every ordinal
-    # attempted, regardless of whether the bytes ended up downloaded or
-    # skipped (key already in S3) — rather than the per-item summary
-    # ``Item <id>: N ordinals`` line, which PR #272 added but didn't
-    # backfill into older logs.
+    # Total-ordinals denominator from the download log. Prefer the per-item
+    # summary ``Item <id>: N ordinals`` line (downloader.py:563) — emitted for
+    # EVERY item regardless of whether its media was freshly fetched or already
+    # staged/skipped — and sum its N. Fall back to counting the per-ordinal
+    # ``Downloading <partner> <id> <ordinal> from <url>`` line (downloader.py:543)
+    # ONLY when no Item-summary lines exist, i.e. old pre-#272 download logs.
     #
-    # This matters because for large multi-day hubs (NARA in particular)
-    # the download phase runs once and stays in its original form
-    # forever — the bot then iterates upload + SDC many times against the
-    # already-staged data without re-downloading. A status report run
-    # today against an SDC-only relaunch sees a fresh SDC log but an
-    # old download log whose Item-summary lines never existed; counting
-    # ``Downloading`` works on logs from every version of the downloader.
+    # The previous code counted ``Downloading`` alone on the assumption it was
+    # "emitted unconditionally for every ordinal" — but it fires only on an
+    # actual fetch ATTEMPT, not for already-staged skips. So any run whose media
+    # was already downloaded (re-runs, SDC-only relaunches, download-once-then-
+    # iterate hubs like NARA) had 0 ``Downloading`` lines, collapsing the total
+    # to 0 and wrongly dropping the status row from file- to item-granularity —
+    # even though the ``Item`` summaries carried the true counts.
     ordinals_awk = (
-        "BEGIN{n=0} /Downloading [a-z0-9-]+ [a-f0-9]+ [0-9]+ from / {n++} "
-        "END {print n+0}"
+        "BEGIN{item=0; dl=0} "
+        "/Item [a-f0-9]+: [0-9]+ ordinals/ "
+        '{for(i=1;i<=NF;i++) if($i=="ordinals"){item+=$(i-1); break}} '
+        "/Downloading [a-z0-9-]+ [a-f0-9]+ [0-9]+ from / {dl++} "
+        "END {print (item>0 ? item : dl)}"
     )
     # One awk pass counts all four marker lines in a single sequential read
     # of the upload log; the previous code ran four separate `grep -c`

--- a/tests/test_get_ids_es.py
+++ b/tests/test_get_ids_es.py
@@ -73,6 +73,28 @@ def _invoke(*args: str):
         return runner.invoke(get_ids_es.main, list(args))
 
 
+def test_id_generation_uses_file_only_logging():
+    """get-ids-es's stdout IS the ID CSV, so it must set up FILE-ONLY logging
+    (console=False) — the tqdm console handler writes to stdout and would
+    interleave log lines into the CSV. Pin the call args so a regression can't
+    silently re-enable console logging and corrupt the CSV."""
+    from tools import get_ids_es
+
+    with (
+        patch.object(get_ids_es.DPLA, "check_partner", return_value=None),
+        patch.object(get_ids_es, "setup_logging") as setup_logging,
+        patch.object(get_ids_es, "notify_phase_start"),
+        patch.object(get_ids_es, "PARTNER_HUBS", {"bpl": "Digital Commonwealth"}),
+        patch.object(
+            get_ids_es,
+            "fetch_institutions_v2",
+            side_effect=RuntimeError("stop-after-validation"),
+        ),
+    ):
+        CliRunner().invoke(get_ids_es.main, ["bpl"])
+    setup_logging.assert_called_once_with("bpl", "id-generation", console=False)
+
+
 def test_collection_without_institution_is_hub_wide():
     """``--collection`` with no ``--institution`` is valid: the collection
     is matched across every upload-eligible institution in the hub (some

--- a/tests/test_get_ids_es.py
+++ b/tests/test_get_ids_es.py
@@ -22,6 +22,10 @@ def _invoke(*args: str):
 
     with (
         patch.object(get_ids_es.DPLA, "check_partner", return_value=None),
+        # get-ids-es now calls setup_logging (file-only) right after
+        # check_partner; stub it so tests don't write a stray ./logs file or
+        # mutate global logging state.
+        patch.object(get_ids_es, "setup_logging"),
         patch.object(get_ids_es, "notify_phase_start"),
         patch.object(get_ids_es, "PARTNER_HUBS", {"bpl": "Digital Commonwealth"}),
         patch.object(
@@ -192,6 +196,10 @@ def _invoke_single_id(single_id, hits):
 
     with (
         patch.object(get_ids_es.DPLA, "check_partner", return_value=None),
+        # get-ids-es now calls setup_logging (file-only) right after
+        # check_partner; stub it so tests don't write a stray ./logs file or
+        # mutate global logging state.
+        patch.object(get_ids_es, "setup_logging"),
         patch.object(get_ids_es, "notify_phase_start"),
         patch.object(get_ids_es, "PARTNER_HUBS", {"bpl": "Digital Commonwealth"}),
         patch.object(
@@ -287,6 +295,10 @@ def test_single_id_banlist_hit_gets_distinct_error():
     )
     with (
         patch.object(get_ids_es.DPLA, "check_partner", return_value=None),
+        # get-ids-es now calls setup_logging (file-only) right after
+        # check_partner; stub it so tests don't write a stray ./logs file or
+        # mutate global logging state.
+        patch.object(get_ids_es, "setup_logging"),
         patch.object(get_ids_es, "notify_phase_start"),
         patch.object(get_ids_es, "PARTNER_HUBS", {"bpl": "Digital Commonwealth"}),
         patch.object(

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -1816,7 +1816,7 @@ def test_safe_process_one_clears_doc_cache_on_missing_entity(monkeypatch):
 
 def test_post_sdc_cleanup_for_legacy_mode_reuses_cached_doc(monkeypatch):
     """The doc ``parsed()`` cached during ``process_one`` gets popped
-    and reused in the cleanup helper — no second S3 / api.dp.la fetch.
+    and reused in the cleanup helper — no second S3 / ES fetch.
     Locks in the optimisation so a refactor can't silently regress to
     re-fetching the same doc."""
     from ingest_wikimedia.dpla import DPLA
@@ -1827,7 +1827,7 @@ def test_post_sdc_cleanup_for_legacy_mode_reuses_cached_doc(monkeypatch):
     sdc_sync._legacy_mode_doc_cache["dpla-1"] = cached_doc
 
     s3_fetches = []
-    api_fetches = []
+    es_fetches = []
     monkeypatch.setattr(
         sdc_sync,
         "_fetch_dpla_doc_from_s3",
@@ -1835,8 +1835,8 @@ def test_post_sdc_cleanup_for_legacy_mode_reuses_cached_doc(monkeypatch):
     )
     monkeypatch.setattr(
         sdc_sync,
-        "_fetch_dpla_doc_from_api",
-        lambda *a, **kw: api_fetches.append(a) or None,
+        "_fetch_dpla_doc_from_es",
+        lambda *a, **kw: es_fetches.append(a) or None,
     )
 
     dispatch_calls = []
@@ -1855,7 +1855,7 @@ def test_post_sdc_cleanup_for_legacy_mode_reuses_cached_doc(monkeypatch):
     sdc_sync._post_sdc_cleanup_for_legacy_mode(MagicMock(name="FilePage"), "dpla-1")
 
     assert s3_fetches == []
-    assert api_fetches == []
+    assert es_fetches == []
     assert len(dispatch_calls) == 1
     assert dispatch_calls[0][1] is cached_doc
     # Pop-on-read drains the cache so a second cleanup call on the

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -462,13 +462,14 @@ def test_wrap_step_with_marker_tags_each_tool_with_its_phase():
 
 
 def test_wrap_step_with_marker_tees_id_generation_stderr():
-    """The id-generation step is the one tool that doesn't call
-    ``setup_logging``, so it produces no log file. To let the
-    failure handler include its stderr in Slack, the launcher tees
-    stderr to a known path while keeping the live stream visible in
-    the tmux pane (``>&2``). Pin the tee shape so a refactor can't
-    silently drop it — the digitalnc-class case (``click.BadParameter``
-    from ``DPLA.check_partner``) only reaches Slack via this tee."""
+    """get-ids-es now writes a file log (``setup_logging``, console=False), but
+    that only captures logging AFTER ``DPLA.check_partner`` — a
+    ``click.BadParameter`` from check_partner (the digitalnc class) raises
+    before logging is set up and reaches Slack ONLY via this stderr tee (which
+    also captures the tool's ``print(file=sys.stderr)`` output). So the launcher
+    tees stderr to a known path while keeping the live stream visible in the
+    tmux pane (``>&2``). Pin the tee shape so a refactor can't silently drop
+    it."""
     from scripts.wikimedia_launch import _wrap_step_with_marker
 
     wrapped = _wrap_step_with_marker(

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -2143,20 +2143,20 @@ def test_download_log_glob_is_not_single_quoted():
     assert "/*-bpl+phillips-academy-download.log" in main_cmd, main_cmd
 
 
-def test_total_ordinals_awk_counts_universal_downloading_marker():
-    """The total-ordinals denominator must come from a marker that's
-    present in EVERY version of the downloader's log, not just
-    post-PR-272 logs. NARA-style large hubs run their download phase
-    once and iterate upload + SDC many times — the download log stays
-    in its original form forever, so the status script must work
-    against logs from before PR #272 added the per-item ``Item <id>:
-    N ordinals`` summary line.
+def test_total_ordinals_awk_prefers_item_summary_with_downloading_fallback():
+    """The total-ordinals denominator sums the per-item ``Item <id>: N
+    ordinals`` summary (downloader.py:563), which the downloader emits for
+    EVERY item regardless of whether its media was fetched or already-staged/
+    skipped. It falls back to counting the per-ordinal ``Downloading <partner>
+    <id> <ordinal> from <url>`` line ONLY when the Item-summary sum is 0 — i.e.
+    pre-PR-272 logs that lack the summary.
 
-    The ``Downloading <partner> <id> <ordinal> from <url>`` line at
-    ``downloader.py:532`` has been emitted unconditionally since the
-    downloader was first written, so it's the right universal source.
-    Pin the contract: the rendered SSM command must use that pattern,
-    not the post-PR-272-only Item-summary one."""
+    Counting ``Downloading`` alone (the previous contract) collapsed to 0 for
+    any already-staged run — re-runs, SDC-only relaunches, and download-once-
+    then-iterate hubs like NARA — because that line fires only on an actual
+    fetch attempt, which wrongly dropped the row from file- to
+    item-granularity. Pin the rendered SSM command: both patterns present,
+    Item-sum preferred."""
     from unittest.mock import patch
 
     from scripts.wikimedia_upload_status import get_phase_and_progress
@@ -2180,11 +2180,13 @@ def test_total_ordinals_awk_counts_universal_downloading_marker():
             label="bpl+phillips-academy",
         )
     main_cmd = captured[1]
-    # The new pattern that works on legacy AND current downloader logs.
+    # Primary: sum the per-item Item-summary (present for every item, even an
+    # already-staged/skipped run that logged no Downloading lines).
+    assert "Item [a-f0-9]+: [0-9]+ ordinals" in main_cmd, main_cmd
+    # Fallback for pre-#272 logs that lack the summary.
     assert "Downloading [a-z0-9-]+ [a-f0-9]+ [0-9]+ from" in main_cmd, main_cmd
-    # The old post-PR-272-only pattern must NOT be present — it would
-    # silently return 0 against any download log that predates PR #272.
-    assert "Item [a-f0-9]+: [0-9]+ ordinals" not in main_cmd, main_cmd
+    # END prefers the Item-sum, using the Downloading count only when it's 0.
+    assert "item>0 ? item : dl" in main_cmd, main_cmd
 
 
 def test_download_phase_classifies_no_media_skip_marker_as_active():

--- a/tools/get_ids_es.py
+++ b/tools/get_ids_es.py
@@ -64,6 +64,7 @@ from ingest_wikimedia.sdc import (
     load_rights_json,
     reconcile_subjects,
 )
+from ingest_wikimedia.logs import setup_logging
 from ingest_wikimedia.slack import notify_phase_start
 from ingest_wikimedia.staging import (
     make_s3_stage_context,
@@ -358,6 +359,23 @@ def main(
     except ValueError as e:
         raise click.BadParameter(str(e)) from e
 
+    # File-only logging (console=False): this tool's STDOUT is the ID CSV, so a
+    # stdout console handler would corrupt it. Without this, the id-generation
+    # phase produced NO persistent log at all — a long enumeration (e.g. a
+    # skip-media-filter maintain scan over a 60K+ item institution) was
+    # indistinguishable from a hang. The scope line below makes the size of the
+    # scan visible immediately.
+    setup_logging(partner, "id-generation", console=False)
+    logging.info(
+        "id-generation start: partner=%s institutions=%s collection=%s "
+        "single_id=%s maintain=%s skip_media_filter=%s",
+        partner,
+        list(institutions) or "ALL",
+        collection,
+        single_id,
+        maintain,
+        skip_media_filter,
+    )
     notify_phase_start(partner, "id-generation")
     provider_name = PARTNER_HUBS[partner]
 
@@ -519,6 +537,7 @@ def main(
             if single_id is not None:
                 # No pagination — single-id mode is a one-shot lookup.
                 break
+            logging.info(f"id-generation: {len(dpla_ids):,} items enumerated so far")
             search_after = hits[-1]["sort"]
 
     if single_id is not None and not dpla_ids:

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -143,8 +143,9 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Read each DPLA item's metadata from the dpla-map.json staged in S3 "
             "by get-ids-es (under the partner's sharded item prefix; resolved by "
-            "S3Client.get_item_metadata) instead of calling api.dp.la. Falls back "
-            "to ES when an item's dpla-map.json is missing."
+            "S3Client.get_item_metadata) rather than reading each item from ES "
+            "at sync time. Falls back to a direct ES read when an item's "
+            "dpla-map.json is missing."
         ),
     )
     p.add_argument(
@@ -586,8 +587,8 @@ def _initialize() -> None:
     subject_ids = fetch_subjects_json()
 
     # When --from-s3 <partner> is set, parsed() reads each item's dpla-map.json
-    # from S3 instead of calling api.dp.la. Imported lazily so this module
-    # doesn't pay the boto3 import cost when nothing needs S3.
+    # from S3, falling back to a direct ES read on miss. Imported lazily so this
+    # module doesn't pay the boto3 import cost when nothing needs S3.
     _s3_partner = args.from_s3
     _s3_client = None
     if _s3_partner is not None:
@@ -3646,6 +3647,9 @@ def _fetch_dpla_doc_from_es(dpla_id):
             else:
                 print(f" -- ES retry failed for {dpla_id}: {e!r}")
                 return None
+    # Unreachable — the loop returns on every attempt — but makes the
+    # "doc or None" contract explicit (no implicit fall-through to None).
+    return None
 
 
 def _fetch_dpla_doc_from_s3(s3_client, partner, dpla_id):
@@ -3713,7 +3717,7 @@ def parsed(dpla_id, dpla_api):
         return None
     # Stash the raw doc so ``_post_sdc_cleanup_for_legacy_mode`` can
     # reuse it after ``process_one`` returns, skipping a redundant
-    # S3 / api.dp.la fetch on the same dpla_id. Cache is per dpla_id
+    # S3 / ES fetch on the same dpla_id. Cache is per dpla_id
     # and pop-on-read in the cleanup helper so it doesn't grow.
     _legacy_mode_doc_cache[dpla_id] = dpla
     return _parse_dpla_doc(dpla, dpla_id)

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -32,6 +32,7 @@ from ingest_wikimedia import legacy_artwork, wikimedia, wikitext_normalize
 from ingest_wikimedia.common import get_dict, get_list
 from ingest_wikimedia.csrf import CsrfRecoveryFailed, with_csrf_recovery
 from ingest_wikimedia.dpla import DC_TITLE_FIELD_NAME, SOURCE_RESOURCE_FIELD_NAME
+from ingest_wikimedia.es import check_es_response, post_es
 from ingest_wikimedia.maintain import resolve_current_dpla_id
 from ingest_wikimedia.slack import notify_phase_start, notify_sdc_complete
 from ingest_wikimedia.tracker import Result, Tracker
@@ -64,7 +65,7 @@ _s3_client = None
 _maintain_qid_to_name: dict[str, str] | None = None
 # Legacy-mode (``--file`` / ``--cat`` / ``--list``) DPLA-doc cache.
 # ``parsed()`` populates it during ``process_one``; the post-SDC
-# cleanup helper pops on read so the same S3 / api.dp.la doc isn't
+# cleanup helper pops on read so the same S3 / ES doc isn't
 # re-fetched. One entry per in-flight ``dpla_id``; the pop keeps the
 # cache from growing past one entry in practice.
 _legacy_mode_doc_cache: dict[str, dict] = {}
@@ -143,7 +144,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "Read each DPLA item's metadata from the dpla-map.json staged in S3 "
             "by get-ids-es (under the partner's sharded item prefix; resolved by "
             "S3Client.get_item_metadata) instead of calling api.dp.la. Falls back "
-            "to api.dp.la when an item's dpla-map.json is missing."
+            "to ES when an item's dpla-map.json is missing."
         ),
     )
     p.add_argument(
@@ -3617,37 +3618,34 @@ def _reconcile_inferred_from_wikitext_junk(mediaid):
                 removals.append(stmt["id"])
 
 
-def _fetch_dpla_doc_from_api(dpla_id, dpla_api):
-    """Fetch a single DPLA item's inner doc from the public DPLA API.
+def _fetch_dpla_doc_from_es(dpla_id):
+    """Fetch a single DPLA item's inner doc from the internal ES index.
 
-    Returns the inner doc (same shape as an ES `_source` and as the
-    dpla-map.json staged in S3 under the partner's sharded item prefix) on
-    success, or None on API error. Retries once after a 30-second sleep on
-    the first network failure; if the retry also raises, returns None so
-    parsed() can treat the item as Missing rather than aborting the batch.
+    Returns the ES ``_source`` — the same shape as the old api.dp.la inner doc
+    (``docs[0]``) and as the dpla-map.json staged in S3, since api.dp.la is just
+    a read layer over this same MAP index — or None when the id isn't in the
+    index or ES is unreachable. Queried directly against ES (the index
+    ``get-ids-es`` reads and ``maintain.resolve_current_dpla_id`` already uses)
+    rather than the public API, so a large or concurrent maintain run that
+    reconciles from scratch (no staged sidecars) doesn't hammer api.dp.la.
+    Retries once after a 30-second sleep on a transient failure; a None return
+    lets ``parsed()`` treat the item as Missing rather than aborting the batch.
     """
-    try:
-        response = requests.get(
-            f"https://api.dp.la/v2/items/{dpla_id}?api_key={dpla_api}",
-            timeout=15,
-        ).json()
-    except Exception:
-        print(" -- Sleeping 30 seconds and retrying...")
-        time.sleep(30)
+    for attempt in (1, 2):
         try:
-            response = requests.get(
-                f"https://api.dp.la/v2/items/{dpla_id}?api_key={dpla_api}",
-                timeout=15,
-            ).json()
-        except Exception as retry_e:
-            print(f" -- DPLA API retry failed for {dpla_id}: {retry_e!r}")
-            return None
-    try:
-        return response["docs"][0]
-    except Exception:
-        print(response)
-        print("DPLA API returned error.")
-        return None
+            resp = post_es({"size": 1, "query": {"ids": {"values": [dpla_id]}}})
+            resp.raise_for_status()
+            data = resp.json()
+            check_es_response(data)
+            hits = data.get("hits", {}).get("hits", [])
+            return hits[0]["_source"] if hits else None
+        except Exception as e:
+            if attempt == 1:
+                print(f" -- ES fetch failed for {dpla_id} ({e!r}); retrying in 30s...")
+                time.sleep(30)
+            else:
+                print(f" -- ES retry failed for {dpla_id}: {e!r}")
+                return None
 
 
 def _fetch_dpla_doc_from_s3(s3_client, partner, dpla_id):
@@ -3675,8 +3673,7 @@ def _fetch_dpla_doc_from_s3(s3_client, partner, dpla_id):
         raw = s3_client.get_item_metadata(partner, dpla_id)
     except ClientError as e:
         print(
-            f" -- S3 fetch failed for {partner}/{dpla_id} ({e!r}); "
-            "falling back to api.dp.la."
+            f" -- S3 fetch failed for {partner}/{dpla_id} ({e!r}); falling back to ES."
         )
         return None
     if raw is None:
@@ -3693,9 +3690,9 @@ def parsed(dpla_id, dpla_api):
 
     Source-of-truth selection:
       * When --from-s3 <partner> is configured, try S3 first. On miss
-        (object not present, parse error), fall back to api.dp.la so a
+        (object not present, parse error), fall back to ES so a
         not-yet-staged item still syncs.
-      * Otherwise hit api.dp.la directly.
+      * Otherwise read from ES directly.
 
     Returns None when neither source has a usable doc — process_one()
     treats that as a Missing ID.
@@ -3708,7 +3705,7 @@ def parsed(dpla_id, dpla_api):
         if dpla is not None:
             print(f" -- Loaded {dpla_id} from S3 ({_s3_partner})")
     if dpla is None:
-        dpla = _fetch_dpla_doc_from_api(dpla_id, dpla_api)
+        dpla = _fetch_dpla_doc_from_es(dpla_id)
 
     print(f" -- Accessed DPLA ID {dpla_id}")
 
@@ -4725,7 +4722,7 @@ def _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id: str) -> bool:
     :func:`_post_sdc_cleanup_for_page`. On a cache miss (e.g. process_one
     early-returned on a missing-ID before the cache populated, or the
     cache was cleared by an earlier cleanup) the doc is fetched fresh
-    from S3 / api.dp.la so the cleanup still runs.
+    from S3 / ES so the cleanup still runs.
 
     Best-effort: any failure is logged but doesn't raise. Returns
     ``True`` if cleanup actually rewrote the page, else ``False`` —
@@ -4740,9 +4737,9 @@ def _post_sdc_cleanup_for_legacy_mode(file_page, dpla_id: str) -> bool:
             if _s3_partner is not None:
                 doc = _fetch_dpla_doc_from_s3(_s3_client, _s3_partner, dpla_id)
                 if doc is None:
-                    doc = _fetch_dpla_doc_from_api(dpla_id, dpla_api)
+                    doc = _fetch_dpla_doc_from_es(dpla_id)
             else:
-                doc = _fetch_dpla_doc_from_api(dpla_id, dpla_api)
+                doc = _fetch_dpla_doc_from_es(dpla_id)
         except Exception:
             logging.exception(
                 f" -- cleanup: DPLA-doc fetch failed for {dpla_id}; skipping."


### PR DESCRIPTION
Three independent fixes from the UIC maintain-run investigation. **The maintain over-staging fix is intentionally _not_ here** — see "Deferred" below.

## A — SDC doc-fetch fallback: api.dp.la → internal ES
`tools/sdc_sync.py`'s `parsed()` S3-miss fallback (and the legacy `--file`/`--cat`/`--list` path) hit `api.dp.la` per item. It now queries the same MAP ES index that `get-ids-es` and `maintain.resolve_current_dpla_id` already use, via `es.post_es`, returning the identical `_source` doc (`api.dp.la/v2/items/{id}` is just a read layer over this index). Same retry / None-means-Missing contract, plus `raise_for_status()` to match the repo idiom. Avoids public-API load — the policy the ES migration exists for. Stale `api.dp.la` docstrings/CLI-help updated.

## C — id-generation observability
`get-ids-es` never called `setup_logging`, so the id-generation phase produced **no persistent log** — a long enumeration (e.g. a 66K-item `--skip-media-filter` maintain scan) was indistinguishable from a hang, exactly the confusion behind the UIC incident.
- `setup_logging` gains `console=False` (file-only) — required because `get-ids-es`'s stdout **is** the ID CSV, and the tqdm console handler writes to stdout (a console handler there would corrupt the CSV).
- `get-ids-es` now logs a **scope line** (partner / institutions / maintain / skip_media_filter — which would have made the 66K scope obvious immediately) plus **per-page enumeration progress** to `<label>-id-generation.log`.

## D — upload-status file count reported "items" instead of "files"
`total_ordinals` was derived by counting `Downloading … from` lines, which fire only on an actual fetch **attempt** — so any run whose media was already staged (re-runs, SDC-only relaunches, download-once-then-iterate hubs like NARA) had 0 such lines, collapsed the total to 0, and dropped the status row from file- to item-granularity (observed on `ohio+kent-state-university`: 0 `Downloading` lines, 1,506 `Item … ordinals` lines). Now sums the per-item `Item <id>: N ordinals` summary (emitted for every item regardless of fetch/skip), falling back to the `Downloading` count only for pre-#272 logs.

## Deferred — maintain over-staging
The reported 66K-catalog over-staging is **not** fixed here. The obvious "drop the lite pre-stage and rely on a per-file fallback" is **wrong**: the maintain `--cat --from-s3` path is sidecar-or-**skip** by design (`_maintain_sidecar_payload` returns `None` → skip, never a per-file live fetch, specifically to avoid hub-scale api.dp.la load), so the `get-ids-es` pre-stage is load-bearing — dropping it makes lite skip every file. A `/simplify` review caught this before it shipped. The real fix needs either category-scoped staging or an ES-built `sdc.json` fallback in the sidecar path (now viable given A); tracked in a separate task.

## Verification
Static + inspection only — I could not run the 3.13 suite locally (this box is 3.9) and did not exercise the maintain pipeline. Affected tests were updated (`test_sdc_sync` rename, `test_get_ids_es` stub for the new `setup_logging` call, `test_wikimedia_launch` docstring). Relying on CI (pytest/ruff) + CodeRabbit to validate. None of these paths run until a launch/status job invokes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Switched SDC doc fallback from `api.dp.la` to the internal Elasticsearch-backed MAP index for both S3-miss fallback and legacy `--file`/`--cat`/`--list` flows, preserving the existing retry/`None`-as-Missing behavior and updating related help/doc text.
- Improved `get-ids-es` observability by adding file-only logging support (`setup_logging(..., console=False)`), emitting persistent `id-generation` logs with a start line plus per-page progress to `<label>-id-generation.log`, and preventing stdout/CSV corruption during Click runs.
- Fixed upload-status progress calculation so `total_ordinals` sums per-item `Item <id>: N ordinals` summaries when present (falling back to counting `Downloading ... from` lines only for older/legacy log formats), correcting cases where downloads weren’t attempted because files were already staged.

## Notes

- No manual pipeline trigger/ECS redeployment, no environment variable or AWS Secrets Manager key changes, no database migration, no shared infrastructure configuration changes, no public API response shape changes, and no security/auth/credential handling changes.
- The maintain over-staging issue was explicitly deferred and is not included in this PR.
- Updated tests to reflect the ES-based fetch path, the new logging behavior, and the corrected ordinals counting logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->