### PR TITLE
Drain: non-blocking opportunistic lock; status: fix phase detection

### DIFF
--- a/ingest_wikimedia/session_state.py
+++ b/ingest_wikimedia/session_state.py
@@ -71,6 +71,13 @@ done""",
     return result
 
 
+# Ordered phase suffixes in log filenames (``…-<label>-<phase>.log``). Shared by
+# the two patterns below so a new phase is a one-line change; only the trailing
+# optional ``-opportunistic`` differs by regex dialect (Python ``re`` uses a
+# non-capturing ``(?:…)`` group; ``find``'s POSIX ERE can't, so it uses ``(…)``).
+_PHASE_ALT = "id-generation|download|upload|sdc|drain-deferred"
+
+
 def log_filename_pattern_for_label(label: str) -> str:
     """Anchored regex matching log filenames for exactly this label.
 
@@ -92,7 +99,7 @@ def log_filename_pattern_for_label(label: str) -> str:
     """
     return (
         rf"-{re.escape(label)}-"
-        r"(id-generation|download|upload|sdc|drain-deferred(?:-opportunistic)?)"
+        rf"({_PHASE_ALT}(?:-opportunistic)?)"
         r"\.log$"
     )
 
@@ -163,7 +170,7 @@ def find_active_label(
     cmd_parts = [
         f"find {paths} -maxdepth 1 -type f -name '*.log'",
         "-regextype posix-extended",
-        f"-regex '.*-({label_alt})-(id-generation|download|upload|sdc|drain-deferred(-opportunistic)?)\\.log'",
+        f"-regex '.*-({label_alt})-({_PHASE_ALT}(-opportunistic)?)\\.log'",
     ]
     if session_created > 0:
         # Time-bound the lookup to files created after this session's

--- a/ingest_wikimedia/session_state.py
+++ b/ingest_wikimedia/session_state.py
@@ -75,8 +75,8 @@ def log_filename_pattern_for_label(label: str) -> str:
     """Anchored regex matching log filenames for exactly this label.
 
     Log filenames follow ``{YYYYMMDD}-{HHMMSS}-{label}-<phase>.log`` where
-    ``<phase>`` is one of ``download``, ``upload``, ``sdc``,
-    ``drain-deferred``, or ``drain-deferred-opportunistic``.
+    ``<phase>`` is one of ``id-generation``, ``download``, ``upload``,
+    ``sdc``, ``drain-deferred``, or ``drain-deferred-opportunistic``.
     The pattern must match ``…-bpl+phillips-academy-download.log`` and NOT
     ``…-bpl+phillips-academy-andover-download.log`` — otherwise sibling
     labels whose names extend this one steal the log selection and the
@@ -92,7 +92,7 @@ def log_filename_pattern_for_label(label: str) -> str:
     """
     return (
         rf"-{re.escape(label)}-"
-        r"(download|upload|sdc|drain-deferred(?:-opportunistic)?)"
+        r"(id-generation|download|upload|sdc|drain-deferred(?:-opportunistic)?)"
         r"\.log$"
     )
 
@@ -163,7 +163,7 @@ def find_active_label(
     cmd_parts = [
         f"find {paths} -maxdepth 1 -type f -name '*.log'",
         "-regextype posix-extended",
-        f"-regex '.*-({label_alt})-(download|upload|sdc|drain-deferred(-opportunistic)?)\\.log'",
+        f"-regex '.*-({label_alt})-(id-generation|download|upload|sdc|drain-deferred(-opportunistic)?)\\.log'",
     ]
     if session_created > 0:
         # Time-bound the lookup to files created after this session's

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -182,6 +182,11 @@ def _drain_deferred_phase(
     if session_created > 0 and log_mtime > 0 and log_mtime < session_created:
         return None, 0
 
+    if "nothing to do." in tail:
+        # Empty/missing sidecar: the drain logged this and exited immediately,
+        # never acquiring the lock. It's done, not waiting for the host lock —
+        # without this it fell through to the "⏸ waiting for host lock" default.
+        return "Drain complete (nothing queued)", log_mtime
     if "Drain-deferred: complete." in tail:
         return f"Drain complete ({queued:,} still queued)", log_mtime
     if "at capacity; " in tail and is_opportunistic:
@@ -278,11 +283,19 @@ def get_phase_and_progress(
     # use hub-slug-only filenames (e.g. nara-download.log). If no label-prefixed log
     # is found, fall back to the most recent hub-slug log, excluding new-format files
     # (which contain '+' in the name and belong to a different institution).
-    if not log_file:
+    if not log_file and "+" not in label:
+        # Backward-compat ONLY for bare-hub labels: pre-session-label sessions
+        # used hub-slug-only filenames (e.g. nara-download.log). An institution
+        # label ("hub+institution") with no matching log is in id-generation,
+        # not a legacy hub-slug run — falling back here would attach an
+        # unrelated hub log (in particular a partner-level drain-<hub> log) to
+        # it and misreport an id-gen session as "Draining". Exclude drain-<hub>
+        # logs too (they belong to the terminal-drain path, not a target row).
         hub_prefix = shlex.quote(hub + "-")
         log_file = ssm_run(
             client,
-            f"ls -t {log_dir}/ 2>/dev/null | grep -F {hub_prefix} | grep -vF '+' | head -1 || true",
+            f"ls -t {log_dir}/ 2>/dev/null | grep -F {hub_prefix} | grep -vF '+' "
+            "| grep -vF 'drain-' | head -1 || true",
         ).strip()
 
     if not log_file:
@@ -308,6 +321,24 @@ def get_phase_and_progress(
             log_path=log_path,
             log_file=log_file,
             session_created=session_created,
+        )
+
+    if log_file.endswith("-id-generation.log"):
+        # get-ids-es logs a scope line + periodic "N items enumerated so far".
+        # Surface the latest count so a long enumeration reads as progress, not
+        # a hang — and so an id-gen session isn't misclassified (previously it
+        # had no recognized log and fell through to a mislabel).
+        out = ssm_run(
+            client,
+            f"stat -c %Y {log_path} 2>/dev/null || echo 0; "
+            f"grep -oE '[0-9,]+ items enumerated' {log_path} 2>/dev/null | tail -1",
+        )
+        id_lines = out.splitlines()
+        id_mtime = _safe_int(id_lines[0]) if id_lines else 0
+        enumerated = id_lines[1].strip() if len(id_lines) > 1 else ""
+        return (
+            f"Generating IDs ({enumerated})" if enumerated else "Generating IDs",
+            id_mtime,
         )
     # Resolve the CSV(s) backing this label so `wc -l` returns a meaningful
     # "items in scope" denominator.

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -359,6 +359,13 @@ def get_phase_and_progress(
         id_lines = out.splitlines()
         id_now = _safe_int(id_lines[0]) if id_lines else 0
         id_mtime = _safe_int(id_lines[1]) if len(id_lines) > 1 else 0
+        # Log predates this session — a stale id-generation log from a prior
+        # run of this label, picked before the new session has written its
+        # own. Same "predates this session" sentinel as the drain and
+        # download/upload/sdc branches (return None → caller renders a bare
+        # "Generating IDs" rather than a stale enumerated count).
+        if session_created > 0 and id_mtime < session_created:
+            return None, 0
         enumerated = id_lines[2].strip() if len(id_lines) > 2 else ""
         label_txt = f"Generating IDs ({enumerated})" if enumerated else "Generating IDs"
         # Same idle/staleness signal as the download/upload/sdc phases: a hung

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -112,6 +112,28 @@ _DOWNLOAD_COMPLETE_PREFIX = "Download complete"
 # Uploads normally complete items in seconds; downloads in seconds to low minutes.
 _STALE_SECONDS = 1800  # 30 minutes
 
+
+def _idle_suffix(now: int, log_mtime: int) -> str:
+    """Return a `` ⚠ idle {duration}`` suffix when a log hasn't been written
+    in over ``_STALE_SECONDS``, else ``""``.
+
+    Shared by every active (non-complete) phase so a hung run reads distinctly
+    instead of looking active. Callers gate the call on phase-specific
+    conditions (not yet complete, not blocked on slots); this helper only owns
+    the threshold check and the ``h``/``m`` duration formatting.
+    """
+    if now <= 0 or log_mtime <= 0:
+        return ""
+    idle = now - log_mtime
+    if idle <= _STALE_SECONDS:
+        return ""
+    idle_min = idle // 60
+    idle_str = (
+        f"{idle_min // 60}h{idle_min % 60:02d}m" if idle_min >= 60 else f"{idle_min}m"
+    )
+    return f" ⚠ idle {idle_str}"
+
+
 # Labels constructed by ``parse_session_labels`` and ``PARTNER_HUBS`` are
 # slug-form: hub-name-or-institution-name lowercase plus ``+`` and ``-``.
 # The download-log glob below interpolates ``label`` directly into a
@@ -330,16 +352,19 @@ def get_phase_and_progress(
         # had no recognized log and fell through to a mislabel).
         out = ssm_run(
             client,
+            f"date +%s; "
             f"stat -c %Y {log_path} 2>/dev/null || echo 0; "
             f"grep -oE '[0-9,]+ items enumerated' {log_path} 2>/dev/null | tail -1",
         )
         id_lines = out.splitlines()
-        id_mtime = _safe_int(id_lines[0]) if id_lines else 0
-        enumerated = id_lines[1].strip() if len(id_lines) > 1 else ""
-        return (
-            f"Generating IDs ({enumerated})" if enumerated else "Generating IDs",
-            id_mtime,
-        )
+        id_now = _safe_int(id_lines[0]) if id_lines else 0
+        id_mtime = _safe_int(id_lines[1]) if len(id_lines) > 1 else 0
+        enumerated = id_lines[2].strip() if len(id_lines) > 2 else ""
+        label_txt = f"Generating IDs ({enumerated})" if enumerated else "Generating IDs"
+        # Same idle/staleness signal as the download/upload/sdc phases: a hung
+        # enumeration (no log write in _STALE_SECONDS) reads distinctly instead
+        # of looking active.
+        return label_txt + _idle_suffix(id_now, id_mtime), id_mtime
     # Resolve the CSV(s) backing this label so `wc -l` returns a meaningful
     # "items in scope" denominator.
     #
@@ -475,20 +500,14 @@ def get_phase_and_progress(
     waiting_on_slots = SLOTS_BUSY_LOG_MARKER in last_log_line
     slot_suffix = " ⏸ waiting on slots" if waiting_on_slots else ""
 
-    stale_suffix = ""
     # A blocked session legitimately stops writing to its log while polling,
     # so don't also flag it as idle/hung — the slot suffix already explains
     # the silence.
-    if counts_marker == 0 and now > 0 and log_mtime > 0 and not waiting_on_slots:
-        idle = now - log_mtime
-        if idle > _STALE_SECONDS:
-            idle_min = idle // 60
-            idle_str = (
-                f"{idle_min // 60}h{idle_min % 60:02d}m"
-                if idle_min >= 60
-                else f"{idle_min}m"
-            )
-            stale_suffix = f" ⚠ idle {idle_str}"
+    stale_suffix = (
+        _idle_suffix(now, log_mtime)
+        if counts_marker == 0 and not waiting_on_slots
+        else ""
+    )
 
     if log_file.endswith("-download.log"):
         # Use the COUNTS: terminal marker as the definitive completion signal —

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -366,3 +366,48 @@ def test_no_wait_empty_sidecar_early_exits(lock_fd):
     lock_mock.assert_not_called()
     sp.assert_not_called()
     throttle_ctor.assert_not_called()
+
+
+def test_acquire_host_lock_nonblocking_skips_when_held():
+    """The opportunistic pass acquires the host lock NON-BLOCKING: if another
+    drain already holds it, ``_acquire_host_lock(blocking=False)`` returns None
+    (so the pass skips) instead of blocking behind a patient drain that can
+    hold the lock for hours. Regression for the drain-lock-blocking bug."""
+    import fcntl
+
+    # Hold the lock via an independent fd (separate open file description, so
+    # flock genuinely conflicts even within this process).
+    held = os.open(drain_deferred._DRAIN_LOCK_PATH, os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(held, fcntl.LOCK_EX)
+    try:
+        assert drain_deferred._acquire_host_lock(blocking=False) is None
+    finally:
+        fcntl.flock(held, fcntl.LOCK_UN)
+        os.close(held)
+    # Lock now free → non-blocking acquire succeeds and returns an fd.
+    fd = drain_deferred._acquire_host_lock(blocking=False)
+    assert fd is not None
+    os.close(fd)
+
+
+def test_no_wait_skips_when_host_lock_held():
+    """When another drain holds the host lock, the opportunistic pass must skip
+    immediately — no throttle, no subprocesses — leaving the sidecar for the
+    terminal drain. Regression: the blocking acquire kept finished sessions
+    open for hours behind a patient drain."""
+    drain_sidecar.write_sidecar("nara", ["id-1"])
+    with (
+        patch(
+            "tools.drain_deferred._acquire_host_lock", return_value=None
+        ) as lock_mock,
+        patch("tools.drain_deferred._drain_opportunistic_once") as opp,
+        patch("tools.drain_deferred.DuplicateCategoryThrottle") as throttle_ctor,
+        patch("tools.drain_deferred.subprocess.run") as sp,
+    ):
+        result = CliRunner().invoke(drain_deferred.main, ["--no-wait", "nara"])
+    assert result.exit_code == 0, result.output
+    lock_mock.assert_called_once_with(blocking=False)
+    opp.assert_not_called()
+    throttle_ctor.assert_not_called()
+    sp.assert_not_called()
+    assert drain_sidecar.read_sidecar("nara") == ["id-1"]

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -2377,6 +2377,39 @@ def test_get_phase_and_progress_flags_stale_id_generation():
     assert phase == "Generating IDs (42,345 items enumerated) ⚠ idle 2h05m", phase
 
 
+def test_get_phase_and_progress_ignores_stale_id_generation_log():
+    """A stale ``-id-generation.log`` from a prior run of this label (mtime
+    before the session was created) must not be reported as live progress.
+    get_phase_and_progress returns None — same "predates this session"
+    sentinel as the other phase branches — so the caller renders a bare
+    ``Generating IDs`` instead of an old enumerated count."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    calls = []
+
+    def fake_ssm_run(_client, _command, **_kwargs):
+        calls.append(_command)
+        if len(calls) == 1:  # precheck: session_created + newest matching log
+            # Session created AFTER the stale log's mtime returned below.
+            return (
+                "1700009999\n"
+                "20260701-120000-bpl+boston-public-library-id-generation.log\n"
+            )
+        # id-generation branch: now, then a mtime that PREDATES session_created.
+        return "1700010000\n1700000000\n42,345 items enumerated\n"
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-bpl+boston-public-library",
+            hub="bpl",
+            label="bpl+boston-public-library",
+        )
+    assert phase is None, phase
+
+
 def test_institution_label_no_log_does_not_grab_partner_drain_log():
     """An institution session in id-generation (no matching log yet) must NOT
     fall back to the hub-slug glob and pick up an unrelated partner-level

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -2333,8 +2333,9 @@ def test_get_phase_and_progress_reports_generating_ids():
                 "1700000000\n"
                 "20260709-120000-bpl+boston-public-library-id-generation.log\n"
             )
-        # id-generation branch: stat mtime + latest "N items enumerated" line
-        return "1700000000\n42,345 items enumerated\n"
+        # id-generation branch: date +%s (now) + stat mtime + latest
+        # "N items enumerated" line. now == mtime here → not stale.
+        return "1700000000\n1700000000\n42,345 items enumerated\n"
 
     with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
         phase, _ = get_phase_and_progress(
@@ -2344,6 +2345,36 @@ def test_get_phase_and_progress_reports_generating_ids():
             label="bpl+boston-public-library",
         )
     assert phase == "Generating IDs (42,345 items enumerated)", phase
+
+
+def test_get_phase_and_progress_flags_stale_id_generation():
+    """A hung enumeration (no log write in over ``_STALE_SECONDS``) gets the
+    same ``⚠ idle`` suffix as the download/upload/sdc phases, so it reads
+    distinctly instead of looking active."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    calls = []
+
+    def fake_ssm_run(_client, _command, **_kwargs):
+        calls.append(_command)
+        if len(calls) == 1:  # precheck: session_created + newest matching log
+            return (
+                "1700000000\n"
+                "20260709-120000-bpl+boston-public-library-id-generation.log\n"
+            )
+        # id-generation branch: now is 7500s (2h05m) after the log mtime → stale.
+        return "1700007500\n1700000000\n42,345 items enumerated\n"
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-bpl+boston-public-library",
+            hub="bpl",
+            label="bpl+boston-public-library",
+        )
+    assert phase == "Generating IDs (42,345 items enumerated) ⚠ idle 2h05m", phase
 
 
 def test_institution_label_no_log_does_not_grab_partner_drain_log():

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -2384,7 +2384,7 @@ def test_drain_deferred_phase_recognizes_empty_sidecar_completion():
 
     from scripts.wikimedia_upload_status import get_phase_and_progress
 
-    sep = "__WM_SEP__"
+    sep = "__WM_DRAIN_SEP__"  # _drain_deferred_phase's own separator
     calls = []
 
     def fake_ssm_run(_client, _command, **_kwargs):

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -2313,3 +2313,96 @@ def test_fetch_no_position_annotation_for_single_label_session():
     # No position bracket on a single-label session.
     assert "[1/1]" not in section_text
     assert "[/" not in section_text
+
+
+def test_get_phase_and_progress_reports_generating_ids():
+    """A session whose newest recognized log is an ``-id-generation.log``
+    surfaces as ``Generating IDs (N items enumerated)`` — get-ids-es writes
+    that log with per-page progress. Previously id-generation produced no
+    recognized log and the session was misclassified."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    calls = []
+
+    def fake_ssm_run(_client, _command, **_kwargs):
+        calls.append(_command)
+        if len(calls) == 1:  # precheck: session_created + newest matching log
+            return (
+                "1700000000\n"
+                "20260709-120000-bpl+boston-public-library-id-generation.log\n"
+            )
+        # id-generation branch: stat mtime + latest "N items enumerated" line
+        return "1700000000\n42,345 items enumerated\n"
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-bpl+boston-public-library",
+            hub="bpl",
+            label="bpl+boston-public-library",
+        )
+    assert phase == "Generating IDs (42,345 items enumerated)", phase
+
+
+def test_institution_label_no_log_does_not_grab_partner_drain_log():
+    """An institution session in id-generation (no matching log yet) must NOT
+    fall back to the hub-slug glob and pick up an unrelated partner-level
+    ``drain-<hub>`` log — that misreported id-gen sessions as ``Draining``. It
+    returns None so the caller renders ``Generating IDs``."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    calls = []
+
+    def fake_ssm_run(_client, _command, **_kwargs):
+        calls.append(_command)
+        if len(calls) == 1:  # precheck: session_created + NO matching log
+            return "1700000000\n"
+        # A buggy hub-slug fallback WOULD return this partner-drain log.
+        return "20260709-143326-drain-bpl-drain-deferred.log\n"
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-bpl+boston-public-library",
+            hub="bpl",
+            label="bpl+boston-public-library",
+        )
+    assert phase is None, phase  # caller (main) renders this as "Generating IDs"
+    assert len(calls) == 1, "must not run the hub-slug fallback query for a '+' label"
+
+
+def test_drain_deferred_phase_recognizes_empty_sidecar_completion():
+    """A drain that found an empty/missing sidecar logs ``nothing to do.`` and
+    exits without acquiring the lock — it must read as complete, not
+    ``⏸ waiting for host lock`` (the pre-fix default when no lock-acquired
+    marker was present)."""
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    sep = "__WM_SEP__"
+    calls = []
+
+    def fake_ssm_run(_client, _command, **_kwargs):
+        calls.append(_command)
+        if len(calls) == 1:  # precheck
+            return "1700000000\n20260709-143326-drain-bpl-drain-deferred.log\n"
+        # _drain_deferred_phase sections: mtime, tail, queued, lock_acquired
+        tail = (
+            "Drain-deferred: sidecar for partner bpl is empty (or missing); "
+            "nothing to do."
+        )
+        return f"1700000000\n{sep}\n{tail}\n{sep}\n0\n{sep}\n0"
+
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
+        phase, _ = get_phase_and_progress(
+            client=None,
+            session="wikimedia-drain-bpl",
+            hub="bpl",
+            label="drain-bpl",
+        )
+    assert phase == "Drain complete (nothing queued)", phase

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -63,21 +63,36 @@ from ingest_wikimedia.wikimedia import get_site
 _DRAIN_LOCK_PATH = "/home/ec2-user/ingest-wikimedia/.drain-lock"
 
 
-def _acquire_host_lock():
+def _acquire_host_lock(blocking: bool = True):
     """Return a file descriptor holding an exclusive ``flock`` on
-    ``_DRAIN_LOCK_PATH``. Blocks until acquired.
+    ``_DRAIN_LOCK_PATH``, or ``None`` when ``blocking=False`` and another
+    drain already holds it.
 
     Advisory ``flock`` is released automatically on process exit, so a
     crashed drain doesn't leave a stuck lock. The lock file itself is
     created (empty) if missing; it never grows.
+
+    ``blocking=True`` (patient/terminal drain) waits until the lock frees —
+    it legitimately holds the lock for hours while a human clears
+    ``Category:Duplicate``. ``blocking=False`` (opportunistic ``--no-wait``
+    pass) tries once (``LOCK_NB``) and returns ``None`` if the lock is held:
+    the opportunistic pass is a fire-and-forget interstitial round and must
+    NOT block its target's chain behind a long-running patient drain (that
+    was keeping finished sessions open for hours — see the drain-lock bug).
     """
     Path(_DRAIN_LOCK_PATH).parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(_DRAIN_LOCK_PATH, os.O_RDWR | os.O_CREAT, 0o644)
+    flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
     logging.info(
-        "Acquiring drain-phase host lock at %s (blocking until available)…",
+        "Acquiring drain-phase host lock at %s (%s)…",
         _DRAIN_LOCK_PATH,
+        "blocking until available" if blocking else "non-blocking, skip if held",
     )
-    fcntl.flock(fd, fcntl.LOCK_EX)
+    try:
+        fcntl.flock(fd, flags)
+    except BlockingIOError:
+        os.close(fd)
+        return None
     logging.info("Drain-phase host lock acquired.")
     return fd
 
@@ -286,11 +301,21 @@ def main(no_wait: bool, partner: str) -> None:
         mode_label,
     )
 
-    # Advisory host-level lock. Held for the entire drain (potentially
-    # days in patient mode; usually milliseconds in opportunistic
-    # mode). The ``finally`` below closes the fd (releasing the flock)
-    # on normal exit or exception; a kill releases it on process exit.
-    lock_fd = _acquire_host_lock()
+    # Advisory host-level lock. The patient (terminal) drain BLOCKS until
+    # it's free (it can hold the lock for hours/days while a human clears
+    # Category:Duplicate). The opportunistic (--no-wait) pass acquires
+    # NON-BLOCKING and skips if another drain holds it — it must never block
+    # its target's chain behind a patient drain. The ``finally`` below closes
+    # the fd (releasing the flock) on normal exit or exception; a kill
+    # releases it on process exit.
+    lock_fd = _acquire_host_lock(blocking=not no_wait)
+    if lock_fd is None:
+        logging.info(
+            "Drain-deferred (opportunistic): host lock held by another drain; "
+            "skipping this pass — %d item(s) remain queued for the terminal drain.",
+            len(initial_ids),
+        )
+        return
     try:
         started_at = time.monotonic()
         # ``get_site()`` — same helper the uploader/retirer/fix-categories


### PR DESCRIPTION
Fixes the two compounding drain/status defects from the upload-status investigation (task_9a52b2c7 + task_b6ae99ac), on one PR.

## 1. Opportunistic drain no longer blocks on the host lock
`drain-deferred --no-wait` (the per-target opportunistic pass) acquired the host lock with a **blocking** `flock`, so it stalled for hours behind the terminal **patient** drain — which legitimately holds the lock while a human clears `Category:Duplicate`. That kept finished upload sessions open indefinitely (observed: `pa+temple-university` open ~2 days, showing a stale "SDC complete").

`_acquire_host_lock` now takes `blocking=`; the opportunistic pass acquires `LOCK_EX | LOCK_NB` and, if another drain holds the lock, logs and **skips** (items stay queued for the terminal drain). The patient/terminal drain still blocks as before.

## 2. Status phase detection
- **Recognize id-generation.** Added `id-generation` to the log-filename phase alternation (`session_state.py`, both patterns kept in sync) and a `get_phase_and_progress` branch that renders **`Generating IDs (N items enumerated)`** from get-ids-es's per-page progress log (added in #392). Previously get-ids produced no recognized log.
- **Stop the hub-slug fallback misattributing logs.** The backward-compat fallback now runs **only for bare-hub labels** and **excludes `drain-<hub>` logs**. An institution session in id-generation (no matching log yet) was falling back to the hub glob and grabbing an unrelated partner-level drain log — misreporting it as "Draining" (observed: `bpl+boston-public-library`). It now returns `None`, so the caller renders "Generating IDs".
- **Recognize the empty-sidecar drain completion.** A drain that logs `nothing to do.` and exits without acquiring the lock now reads as **`Drain complete (nothing queued)`** instead of the `⏸ waiting for host lock` default.

## How the two connect
The pa+temple "SDC complete" ghost was the drain-lock bug — the session was parked in a stuck opportunistic drain. With fix #1 that session completes and closes instead of lingering, so the misreport disappears at the source; fix #2 hardens the status tool so genuinely in-progress phases (id-gen, empty drains) are reported correctly rather than misattributed.

## Tests
- drain: `_acquire_host_lock(blocking=False)` returns `None` when the lock is held (real flock) and an fd when free; `main --no-wait` skips (no throttle/subprocess, sidecar intact) when the lock is held.
- status: id-generation log → "Generating IDs (N…)"; an institution label with no matching log does **not** run the hub-slug fallback (no drain-log misattribution); an empty-sidecar drain log → "Drain complete (nothing queued)".

## Verification
Static + unit-test only — I can't run the 3.13 suite locally (this box is 3.9) and didn't exercise the live drain/status pipeline on EC2. The non-blocking flock and the awk/log-selection changes are unit-tested (mocked `ssm_run` / real temp flock); relying on CI + CodeRabbit. Both paths only run when a launch/status/drain job invokes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Updated `drain-deferred --no-wait` to acquire the host lock in non-blocking mode for opportunistic passes: if the lock is already held, it logs and skips (the terminal/patient drain continues to block as before).
- Improved Wikimedia pipeline status parsing by:
  - Recognizing the `id-generation` phase.
  - Narrowing hub-slug fallback lookups to avoid misattributing institution logs to other drain logs.
  - Detecting an empty/missing drain sidecar that ends with “nothing to do.” and reporting `Drain complete (nothing queued)`.
- Added regression tests covering the new non-blocking host-lock behavior and the updated phase/status detection logic.

No environment variable, AWS secret key, ECS/CodePipeline/CodeBuild/IAM, database migration, or public API response-shape changes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->