### PR TITLE
maintain: build sdc.json on demand for non-NARA lite --cat (drop the pre-stage)

### DIFF
--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -396,13 +396,16 @@ def _build_maintain_lite_pipeline_steps(
     sitelink — authoritative, never derived from the display name) and walked
     with ``sdc-sync --cat … --maintain``.
 
-    The sync reads each (re-linked) item's claims from its precomputed
-    ``sdc.json`` sidecar (``--from-s3``) rather than calling ``api.dp.la`` per
-    file, so a real run first stages those sidecars with ONE ``get-ids-es
-    --maintain`` ES scan over the scope (drops only the upload gate, keeps the
-    QID requirement). ``count_only`` is a pre-flight that just resolves how each
-    file would re-link and writes nothing — it needs neither the staging step
-    nor ``--from-s3``.
+    The sync reads each (re-linked) item's claims from its ``sdc.json`` sidecar
+    (``--from-s3``) rather than calling ``api.dp.la`` per file. For **non-NARA**
+    targets it runs without a pre-stage: ``--build-sdc-on-miss`` makes the sync
+    build each sidecar on demand from the internal ES index, scoped to exactly
+    the category's already-uploaded files (avoiding the over-staging of a
+    whole-hub scan). **NARA** keeps the up-front ``get-ids-es --maintain`` scan
+    (drops only the upload gate, keeps the QID requirement) because its
+    ``sdc.json`` carries batch-reconciled P921 subjects an on-demand build would
+    omit. ``count_only`` is a pre-flight that just resolves how each file would
+    re-link and writes nothing — it needs neither staging nor ``--from-s3``.
 
     A single-DPLA-id or collection-scoped target has no whole-category to walk,
     so it's rejected loudly rather than silently widening the write scope.
@@ -429,7 +432,19 @@ def _build_maintain_lite_pipeline_steps(
     )
     steps = []
     if not count_only:
-        steps.append(_maintain_stage_cmd(canonical, institutions, csv_file))
+        if canonical == "nara":
+            # NARA keeps the whole-scope pre-stage: its sdc.json carries
+            # batch-reconciled P921 subject QIDs that an on-demand build
+            # (subjects_lookup=None) omits, and maintain's claim reconciliation
+            # would then strip those existing P921 statements.
+            steps.append(_maintain_stage_cmd(canonical, institutions, csv_file))
+        else:
+            # Non-NARA: skip the whole-hub pre-stage — the over-staging. It
+            # staged dpla-map.json + sdc.json for every ES-eligible item, but
+            # the ``--cat`` sync only reads the sidecars for files already on
+            # Commons. ``--build-sdc-on-miss`` makes the sync build each file's
+            # sidecar on demand from ES, scoped to exactly the category's files.
+            sync_tail += " --build-sdc-on-miss"
     steps += _maintain_sdc_cat_steps(canonical, institutions, sync_tail)
     return [f"cd {base}", *steps]
 

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -6494,3 +6494,203 @@ def test_inferred_dupe_cleanup_multi_value_subset_ignores_non_inferred_claims():
         sdc_sync._reconcile_inferred_from_wikitext_dupes("M102")
     assert sdc_sync.removals == []
     sdc_sync._reset_per_file_accumulators()
+
+
+# ---------------------------------------------------------------------------
+# Maintain --cat sidecar sourcing: staged sdc.json, SKIP-on-miss (default),
+# and the --build-sdc-on-miss ES fallback (non-NARA over-staging fix).
+# ---------------------------------------------------------------------------
+
+
+def _stub_maintain_globals(monkeypatch, *, build_on_miss, s3_client):
+    """Bind the module globals _maintain_sidecar_payload / _maintain_canonical_title
+    read at call time, without going through _initialize()."""
+    from tools import sdc_sync
+
+    monkeypatch.setattr(sdc_sync, "_s3_partner", "ohio", raising=False)
+    monkeypatch.setattr(sdc_sync, "_s3_client", s3_client, raising=False)
+    monkeypatch.setattr(sdc_sync, "_build_sdc_on_miss", build_on_miss, raising=False)
+    monkeypatch.setattr(sdc_sync, "_maintain_es_doc_cache", None, raising=False)
+    monkeypatch.setattr(sdc_sync, "hubs", {"stub": True}, raising=False)
+    monkeypatch.setattr(sdc_sync, "rights", {"stub": True}, raising=False)
+    monkeypatch.setattr(sdc_sync, "subject_ids", {"stub": True}, raising=False)
+
+
+def test_maintain_sidecar_payload_returns_staged_sidecar_when_present(monkeypatch):
+    from tools import sdc_sync
+
+    s3 = MagicMock()
+    s3.get_sdc_json.return_value = '{"claims": [{"P": 1}], "ingest_date": "2026-01-01"}'
+    _stub_maintain_globals(monkeypatch, build_on_miss=True, s3_client=s3)
+    # ES fallback must NOT be consulted when a sidecar is staged.
+    es_calls = []
+    monkeypatch.setattr(
+        sdc_sync, "_fetch_dpla_doc_from_es", lambda i: es_calls.append(i)
+    )
+
+    payload = sdc_sync._maintain_sidecar_payload("abc123")
+
+    assert payload == {"claims": [{"P": 1}], "ingest_date": "2026-01-01"}
+    assert es_calls == []
+
+
+def test_maintain_sidecar_payload_skips_on_miss_without_build_flag(monkeypatch):
+    from tools import sdc_sync
+
+    s3 = MagicMock()
+    s3.get_sdc_json.return_value = None
+    _stub_maintain_globals(monkeypatch, build_on_miss=False, s3_client=s3)
+    es_calls = []
+    monkeypatch.setattr(
+        sdc_sync, "_fetch_dpla_doc_from_es", lambda i: es_calls.append(i)
+    )
+
+    # Sidecar-or-SKIP by default: a miss returns None (no ES/api fallback) —
+    # this is the contract NARA relies on.
+    assert sdc_sync._maintain_sidecar_payload("abc123") is None
+    assert es_calls == []
+
+
+def test_maintain_sidecar_payload_builds_from_es_on_miss(monkeypatch):
+    from tools import sdc_sync
+
+    s3 = MagicMock()
+    s3.get_sdc_json.return_value = None
+    _stub_maintain_globals(monkeypatch, build_on_miss=True, s3_client=s3)
+
+    doc = {"_id": "abc123", "sourceResource": {"title": ["T"]}}
+    monkeypatch.setattr(sdc_sync, "_fetch_dpla_doc_from_es", lambda i: doc)
+    seen = {}
+
+    def fake_build(d, dpla_id, hubs, rights, subject_ids, subjects_lookup):
+        seen.update(
+            doc=d,
+            dpla_id=dpla_id,
+            subjects_lookup=subjects_lookup,
+        )
+        return {"claims": [{"built": True}], "ingest_date": "2026-07-09"}
+
+    monkeypatch.setattr(sdc_sync, "build_claims_for_doc", fake_build)
+
+    payload = sdc_sync._maintain_sidecar_payload("abc123")
+
+    assert payload == {"claims": [{"built": True}], "ingest_date": "2026-07-09"}
+    assert seen["doc"] is doc and seen["dpla_id"] == "abc123"
+    # Off-NARA there is no reconciled subjects table — must pass None.
+    assert seen["subjects_lookup"] is None
+
+
+def test_maintain_sidecar_payload_build_on_miss_skips_when_doc_gone(monkeypatch):
+    from tools import sdc_sync
+
+    s3 = MagicMock()
+    s3.get_sdc_json.return_value = None
+    _stub_maintain_globals(monkeypatch, build_on_miss=True, s3_client=s3)
+    monkeypatch.setattr(sdc_sync, "_fetch_dpla_doc_from_es", lambda i: None)
+    # build_claims_for_doc must not be reached when the ES doc is gone.
+    monkeypatch.setattr(
+        sdc_sync,
+        "build_claims_for_doc",
+        lambda *a, **k: pytest.fail("should not build when doc is None"),
+    )
+
+    assert sdc_sync._maintain_sidecar_payload("abc123") is None
+
+
+def test_maintain_canonical_title_falls_back_to_es_on_miss(monkeypatch):
+    from tools import sdc_sync
+
+    s3 = MagicMock()
+    s3.get_item_metadata.return_value = None  # no staged dpla-map.json
+    _stub_maintain_globals(monkeypatch, build_on_miss=True, s3_client=s3)
+    doc = {"sourceResource": {"title": ["My Title"]}}
+    es_calls = []
+
+    def fake_es(dpla_id):
+        es_calls.append(dpla_id)
+        return doc
+
+    monkeypatch.setattr(sdc_sync, "_fetch_dpla_doc_from_es", fake_es)
+    monkeypatch.setattr(
+        sdc_sync.wikimedia, "extract_page_ordinal_from_commons_title", lambda _t: None
+    )
+    monkeypatch.setattr(
+        sdc_sync.wikimedia,
+        "get_page_title",
+        lambda title, dpla_id, ext, page=None: f"NEW::{title}::{dpla_id}",
+    )
+    file_page = MagicMock()
+    file_page.title.return_value = "Old_abc123.jpg"
+
+    result = sdc_sync._maintain_canonical_title(file_page, "abc123")
+
+    assert result == "NEW::My Title::abc123"
+    assert es_calls == ["abc123"]
+
+
+def test_maintain_canonical_title_returns_none_on_miss_without_flag(monkeypatch):
+    from tools import sdc_sync
+
+    s3 = MagicMock()
+    s3.get_item_metadata.return_value = None
+    _stub_maintain_globals(monkeypatch, build_on_miss=False, s3_client=s3)
+    es_calls = []
+    monkeypatch.setattr(
+        sdc_sync, "_fetch_dpla_doc_from_es", lambda i: es_calls.append(i)
+    )
+    file_page = MagicMock()
+
+    assert sdc_sync._maintain_canonical_title(file_page, "abc123") is None
+    assert es_calls == []
+
+
+def test_maintain_es_doc_shared_between_title_and_claims_paths(monkeypatch):
+    """With no pre-stage, the title path and the claims path both need the same
+    ES doc for one file — ``_maintain_es_doc`` memoizes it so only ONE
+    ``_fetch_dpla_doc_from_es`` round-trip happens, not two."""
+    from tools import sdc_sync
+
+    s3 = MagicMock()
+    s3.get_item_metadata.return_value = None
+    s3.get_sdc_json.return_value = None
+    _stub_maintain_globals(monkeypatch, build_on_miss=True, s3_client=s3)
+    doc = {"sourceResource": {"title": ["T"]}}
+    calls = []
+
+    def fake_es(dpla_id):
+        calls.append(dpla_id)
+        return doc
+
+    monkeypatch.setattr(sdc_sync, "_fetch_dpla_doc_from_es", fake_es)
+    monkeypatch.setattr(
+        sdc_sync.wikimedia, "extract_page_ordinal_from_commons_title", lambda _t: None
+    )
+    monkeypatch.setattr(sdc_sync.wikimedia, "get_page_title", lambda *a, **k: "NEW.jpg")
+    monkeypatch.setattr(
+        sdc_sync, "build_claims_for_doc", lambda *a, **k: {"claims": []}
+    )
+    file_page = MagicMock()
+    file_page.title.return_value = "Old_abc123.jpg"
+
+    # Title path (rename) then claims path, same id, within one file.
+    sdc_sync._maintain_canonical_title(file_page, "abc123")
+    sdc_sync._maintain_sidecar_payload("abc123")
+
+    assert calls == ["abc123"]  # one fetch, shared across both paths
+
+
+def test_maintain_es_doc_refetches_for_a_different_id(monkeypatch):
+    """The memo holds exactly one entry keyed by id — a different id overwrites
+    it and triggers a fresh fetch (so it can't serve a stale doc)."""
+    from tools import sdc_sync
+
+    _stub_maintain_globals(monkeypatch, build_on_miss=True, s3_client=MagicMock())
+    calls = []
+    monkeypatch.setattr(
+        sdc_sync, "_fetch_dpla_doc_from_es", lambda i: calls.append(i) or {"id": i}
+    )
+
+    assert sdc_sync._maintain_es_doc("id-a") == {"id": "id-a"}
+    assert sdc_sync._maintain_es_doc("id-a") == {"id": "id-a"}  # memo hit
+    assert sdc_sync._maintain_es_doc("id-b") == {"id": "id-b"}  # new id → refetch
+    assert calls == ["id-a", "id-b"]

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -6510,7 +6510,7 @@ def _stub_maintain_globals(monkeypatch, *, build_on_miss, s3_client):
     monkeypatch.setattr(sdc_sync, "_s3_partner", "ohio", raising=False)
     monkeypatch.setattr(sdc_sync, "_s3_client", s3_client, raising=False)
     monkeypatch.setattr(sdc_sync, "_build_sdc_on_miss", build_on_miss, raising=False)
-    monkeypatch.setattr(sdc_sync, "_maintain_es_doc_cache", None, raising=False)
+    sdc_sync._maintain_es_doc.cache_clear()  # per-file memo; reset between tests
     monkeypatch.setattr(sdc_sync, "hubs", {"stub": True}, raising=False)
     monkeypatch.setattr(sdc_sync, "rights", {"stub": True}, raising=False)
     monkeypatch.setattr(sdc_sync, "subject_ids", {"stub": True}, raising=False)
@@ -6694,3 +6694,22 @@ def test_maintain_es_doc_refetches_for_a_different_id(monkeypatch):
     assert sdc_sync._maintain_es_doc("id-a") == {"id": "id-a"}  # memo hit
     assert sdc_sync._maintain_es_doc("id-b") == {"id": "id-b"}  # new id → refetch
     assert calls == ["id-a", "id-b"]
+
+
+def test_assert_build_sdc_on_miss_allowed_rejects_nara_combo():
+    """--build-sdc-on-miss + NARA is the one destructive combo (would strip
+    P921 during reconciliation) — the guard must raise before any write."""
+    from tools import sdc_sync
+
+    with pytest.raises(ValueError, match="P921"):
+        sdc_sync._assert_build_sdc_on_miss_allowed(True, "nara")
+
+
+def test_assert_build_sdc_on_miss_allowed_permits_safe_combos():
+    """Non-NARA with the flag, and NARA without it, are both fine (no raise)."""
+    from tools import sdc_sync
+
+    sdc_sync._assert_build_sdc_on_miss_allowed(True, "ohio")
+    sdc_sync._assert_build_sdc_on_miss_allowed(True, "georgia")
+    sdc_sync._assert_build_sdc_on_miss_allowed(False, "nara")
+    sdc_sync._assert_build_sdc_on_miss_allowed(False, None)

--- a/tests/test_wikimedia_launch.py
+++ b/tests/test_wikimedia_launch.py
@@ -537,31 +537,59 @@ def test_per_target_preamble_unsets_wikimedia_step():
     )
 
 
-def test_maintain_real_run_stages_sidecars_then_syncs_from_s3():
+def test_maintain_lite_non_nara_skips_prestage_and_builds_sdc_on_miss():
     steps = _maintain_steps("digitalnc", (), count_only=False)
-    # One ES scan stages sdc.json sidecars, then the category walk reads them.
+    # Non-NARA lite maintain no longer pre-stages the whole hub (the
+    # over-staging fix): the --cat sync builds each sidecar on demand from ES
+    # via --build-sdc-on-miss, scoped to the category's already-uploaded files.
     assert steps[0] == "cd /srv/base"
-    assert steps[1] == "get-ids-es digitalnc --maintain --skip-media-filter > out.csv"
-    assert steps[2] == (
-        "sdc-sync --cat 'Category:Media contributed by X' --maintain"
-        " --from-s3 digitalnc"
-    )
-    assert "--count-only" not in steps[2]
-
-
-def test_maintain_per_institution_get_ids_repeats_institution_flags():
-    steps = _maintain_steps(
-        "georgia", ("Athens-Clarke County Library", "Atlanta History Center"), False
-    )
+    assert not any("get-ids-es" in s for s in steps)
     assert steps[1] == (
+        "sdc-sync --cat 'Category:Media contributed by X' --maintain"
+        " --from-s3 digitalnc --build-sdc-on-miss"
+    )
+    assert "--count-only" not in steps[1]
+
+
+def test_maintain_lite_nara_keeps_prestage_no_build_on_miss():
+    # NARA keeps the up-front get-ids stage: its sdc.json carries
+    # batch-reconciled P921 subjects an on-demand build (subjects_lookup=None)
+    # would omit — and maintain reconciliation would then strip them. So its
+    # --cat sync must NOT get --build-sdc-on-miss.
+    steps = _maintain_steps("nara", (), count_only=False)
+    assert steps[1] == "get-ids-nara > out.csv"
+    sync = next(s for s in steps if s.startswith("sdc-sync"))
+    assert "--from-s3 nara" in sync
+    assert "--build-sdc-on-miss" not in sync
+
+
+def test_maintain_stage_cmd_repeats_institution_flags():
+    # _maintain_stage_cmd is still used by NARA lite and both hash routes; it
+    # repeats --institution per institution and keeps --skip-media-filter.
+    from scripts.wikimedia_launch import _maintain_stage_cmd
+
+    cmd = _maintain_stage_cmd(
+        "georgia",
+        ("Athens-Clarke County Library", "Atlanta History Center"),
+        "out.csv",
+    )
+    assert cmd == (
         "get-ids-es georgia --institution 'Athens-Clarke County Library'"
         " --institution 'Atlanta History Center' --maintain --skip-media-filter"
         " > out.csv"
     )
-    # One --cat sync per institution category, all reading from S3.
+
+
+def test_maintain_per_institution_non_nara_cat_sync_per_category():
+    # Non-NARA per-institution lite maintain: no pre-stage; one --cat sync per
+    # institution category, each building sidecars on demand from ES.
+    steps = _maintain_steps(
+        "georgia", ("Athens-Clarke County Library", "Atlanta History Center"), False
+    )
+    assert not any("get-ids-es" in s for s in steps)
     syncs = [s for s in steps if s.startswith("sdc-sync")]
     assert len(syncs) == 2
-    assert all("--from-s3 georgia" in s for s in syncs)
+    assert all("--from-s3 georgia --build-sdc-on-miss" in s for s in syncs)
 
 
 def test_maintain_count_only_skips_staging_and_from_s3():
@@ -581,8 +609,9 @@ def test_maintain_write_run_passes_worker_opts_to_cat_sync():
     )
     sync = next(s for s in steps if s.startswith("sdc-sync"))
     # Parallel maintain runs the pool under the box-wide slot budget, same flags
-    # as partner mode, appended after --from-s3.
-    assert sync.endswith("--from-s3 digitalnc --workers 6 --workers-budget 24")
+    # as partner mode, appended after --from-s3; --build-sdc-on-miss follows.
+    assert "--from-s3 digitalnc --workers 6 --workers-budget 24" in sync
+    assert sync.endswith("--build-sdc-on-miss")
 
 
 def test_maintain_count_only_ignores_worker_opts():

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -18,6 +18,7 @@ from ingest_wikimedia.logs import setup_logging
 from ingest_wikimedia.sdc import (
     CHUNKABLE_PROPS,
     NARA_PROVIDER_NAME,
+    build_claims_for_doc,
     casefold_for_compare,
     fetch_institutions_v2,
     fetch_subjects_json,
@@ -59,6 +60,24 @@ rights: dict
 subject_ids: dict
 _s3_partner: str | None = None
 _s3_client = None
+# Maintain ``--cat`` mode (``--build-sdc-on-miss``): when a re-linked id has no
+# staged ``sdc.json``, build its claims on demand from the internal ES index
+# instead of skipping the file. Lets the lite ``--cat`` maintain route run
+# without the whole-hub ``get-ids-es`` pre-stage, so sidecars are built only for
+# the category's already-uploaded files. ``subjects_lookup`` is None on this
+# path (NARA P921 reconciliation is batched only during a get-ids-es stage), so
+# it MUST NOT be used for NARA — maintain's claim reconciliation would strip
+# existing P921 statements. Bound in ``_initialize`` (serial) and injected into
+# ``_init_maintain_worker`` (parallel).
+_build_sdc_on_miss: bool = False
+# Per-file ES ``_source`` memo for the ``--build-sdc-on-miss`` route. With no
+# pre-stage, both the title path (``_maintain_canonical_title``) and the claims
+# path (``_maintain_sidecar_payload``) need the SAME doc for the same id within
+# one file's processing — this caches the last ``(dpla_id, doc)`` so they share
+# one ES round-trip instead of two. Keyed by id, so a new id overwrites: holds
+# exactly one entry and can't grow. Per-process (spawn workers each get their
+# own); files are processed serially within a worker, so no locking needed.
+_maintain_es_doc_cache: tuple[str, dict | None] | None = None
 # Maintain mode: {institution Wikidata QID -> dataProvider name}, built lazily
 # from ``hubs`` (institutions_v2.json) the first time the anchor-3 wildcard
 # needs to scope a re-link to the file's own institution. None until built.
@@ -146,6 +165,22 @@ def _build_parser() -> argparse.ArgumentParser:
             "S3Client.get_item_metadata) rather than reading each item from ES "
             "at sync time. Falls back to a direct ES read when an item's "
             "dpla-map.json is missing."
+        ),
+    )
+    p.add_argument(
+        "--build-sdc-on-miss",
+        dest="build_sdc_on_miss",
+        action="store_true",
+        default=False,
+        help=(
+            "Maintain --cat mode: when a re-linked id has no staged sdc.json, "
+            "build its claims on demand from the internal ES index (via "
+            "_fetch_dpla_doc_from_es) instead of skipping the file. Lets the "
+            "lite maintain route run without the whole-hub get-ids-es "
+            "pre-stage, so sidecars are built only for the category's "
+            "already-uploaded files. Omits reconciled subject (P921) statements "
+            "(subjects_lookup=None); do NOT use for NARA, where maintain would "
+            "then strip existing P921 claims."
         ),
     )
     p.add_argument(
@@ -545,7 +580,7 @@ def _initialize() -> None:
     """
     global parser, args, method, dpla_api, site, hubs, rights, subject_ids
     global _s3_partner, _s3_client, _normalize_wikitext_enabled, _workers
-    global _workers_budget
+    global _workers_budget, _build_sdc_on_miss
 
     parser = _build_parser()
     args = parser.parse_args()
@@ -599,6 +634,7 @@ def _initialize() -> None:
     _normalize_wikitext_enabled = bool(args.normalize_wikitext)
     _workers = max(1, int(getattr(args, "workers", 1) or 1))
     _workers_budget = max(0, int(getattr(args, "workers_budget", 0) or 0))
+    _build_sdc_on_miss = bool(getattr(args, "build_sdc_on_miss", False))
 
 
 # This is the JSON used for formatting a claim. The P459 -> Q61848113 (determination method) qualifier is hardcoded in for everything DPLA adds. Not all data types have the same format for value, so this is formatted in the function for each property added.
@@ -3971,25 +4007,69 @@ def _maintain_resolve(title, embedded_id, file_page, mediaid):
     )
 
 
+def _maintain_es_doc(dpla_id):
+    """Return the item's ES ``_source`` for the ``--build-sdc-on-miss`` route,
+    fetched at most once per file.
+
+    The title and claims paths both need the same doc for the same id in one
+    file's processing; this memoizes the last ``(dpla_id, doc)`` (via
+    :data:`_maintain_es_doc_cache`) so they share a single
+    :func:`_fetch_dpla_doc_from_es` round-trip. A ``None`` doc (item gone) is
+    cached too, so both paths skip on one fetch.
+    """
+    global _maintain_es_doc_cache
+    if _maintain_es_doc_cache is not None and _maintain_es_doc_cache[0] == dpla_id:
+        return _maintain_es_doc_cache[1]
+    doc = _fetch_dpla_doc_from_es(dpla_id)
+    _maintain_es_doc_cache = (dpla_id, doc)
+    return doc
+
+
 def _maintain_sidecar_payload(dpla_id):
-    """Maintain mode: load the precomputed ``sdc.json`` for ``dpla_id`` from S3
-    (staged by ``get-ids-es --maintain``) so the sync runs through
-    :func:`process_one_from_sdc` — no ``api.dp.la`` call, no runtime claim
-    build. Requires ``--from-s3 <partner>`` (which sets ``_s3_partner`` /
-    ``_s3_client``); returns the parsed payload, or None when no sidecar is
-    staged for this id. A None result means the caller should SKIP the file
-    rather than fall back to a per-file live API call — at hub scale (100Ks of
-    files, possibly parallel) that fallback is exactly the api.dp.la load this
-    path exists to avoid.
+    """Maintain mode: return the ``sdc.json`` claim envelope for ``dpla_id`` so
+    the sync runs through :func:`process_one_from_sdc` — no ``api.dp.la`` call.
+    Requires ``--from-s3 <partner>`` (which sets ``_s3_partner`` /
+    ``_s3_client``).
+
+    Reads the precomputed sidecar staged by ``get-ids-es --maintain`` from S3.
+    On a miss the behavior depends on ``--build-sdc-on-miss``:
+
+    * **off (default):** return None. A None result means the caller SKIPs the
+      file rather than falling back to a per-file live ``api.dp.la`` call — at
+      hub scale (100Ks of files, possibly parallel) that fallback is exactly the
+      load this path exists to avoid. NARA relies on this: its staged sdc.json
+      carries batch-reconciled P921 subject QIDs.
+    * **on (non-NARA lite ``--cat`` route, run without a pre-stage):** build the
+      envelope on demand from the internal ES index — the same
+      :func:`build_claims_for_doc` get-ids-es Phase 3 runs, on the same
+      ``_source`` doc, so the result is identical to a staged sidecar
+      (``subjects_lookup=None`` omits only the NARA-specific reconciled P921
+      statements, which never apply off NARA). No ``api.dp.la`` load:
+      :func:`_fetch_dpla_doc_from_es` hits internal ES. None on an
+      unresolvable/unparseable doc → caller SKIPs, as before.
     """
     if _s3_partner is None:
         return None
     raw = _s3_client.get_sdc_json(_s3_partner, dpla_id)
-    if raw is None:
+    if raw is not None:
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+    if not _build_sdc_on_miss:
+        return None
+    doc = _maintain_es_doc(dpla_id)
+    if doc is None:
         return None
     try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
+        return build_claims_for_doc(doc, dpla_id, hubs, rights, subject_ids, None)
+    except ValueError:
+        # doc lacks a valid ingestDate — same per-item log-and-skip convention
+        # as get-ids-es / get-ids-nara; treat as no sidecar (caller SKIPs).
+        logging.warning(
+            "maintain: could not build sdc.json for %s (invalid ingestDate); skipping.",
+            dpla_id,
+        )
         return None
 
 
@@ -4010,11 +4090,21 @@ def _maintain_canonical_title(file_page, dpla_id):
     if _s3_partner is None:
         return None
     raw = _s3_client.get_item_metadata(_s3_partner, dpla_id)
-    if not raw:
-        return None
-    try:
-        metadata = json.loads(raw)
-    except json.JSONDecodeError:
+    if raw:
+        try:
+            metadata = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+    elif _build_sdc_on_miss:
+        # No staged dpla-map.json — the lite ``--cat`` maintain route runs
+        # without the whole-hub pre-stage. Fetch the same ``_source`` doc on
+        # demand from the internal ES index (the dpla-map.json IS that doc) so
+        # title-drift renames still work; ``_maintain_sidecar_payload`` builds
+        # its sdc.json from the same doc (shared via ``_maintain_es_doc``).
+        metadata = _maintain_es_doc(dpla_id)
+        if metadata is None:
+            return None
+    else:
         return None
     titles = get_list(
         get_dict(metadata, SOURCE_RESOURCE_FIELD_NAME), DC_TITLE_FIELD_NAME
@@ -5596,19 +5686,26 @@ def _enumerate_maintain_groups(generator, limit):
 def _init_maintain_worker(
     log_queue,
     hubs_data,
+    rights_data,
+    subject_ids_data,
     s3_partner,
     normalize_wikitext_enabled,
     workers_budget,
+    build_sdc_on_miss,
 ):
     """Per-worker setup for parallel maintain — mirrors
     :func:`_init_partner_worker`: a fresh pywikibot session, the parent's
-    ``hubs`` snapshot (anchor-3 QID scope map + post-SDC cleanup provider
-    lookup), the ``--from-s3`` partner key and an S3 client for sidecar reads,
-    the normalize flag, the box-wide slot budget, and log routing to the parent.
+    ``hubs`` / ``rights`` / ``subject_ids`` snapshots, the ``--from-s3`` partner
+    key and an S3 client for sidecar reads, the normalize flag, the
+    ``--build-sdc-on-miss`` flag, the box-wide slot budget, and log routing to
+    the parent.
 
     No ``dpla_api`` is injected: embedded ids are precomputed by the parent and
     carried in each group tuple, and the sync reads claims from the staged
-    sidecar — neither path calls ``api.dp.la``.
+    sidecar or (``--build-sdc-on-miss``) builds them from the internal ES index
+    via :func:`build_claims_for_doc` — neither path calls ``api.dp.la``.
+    ``rights`` / ``subject_ids`` are injected (as in partner mode) because that
+    on-demand build needs them.
     """
     import logging.handlers
 
@@ -5619,14 +5716,17 @@ def _init_maintain_worker(
     pywikibot.config.retry_max = _PYWIKIBOT_RETRY_MAX
     pywikibot.config.socket_timeout = _PYWIKIBOT_SOCKET_TIMEOUT
 
-    global site, hubs, _s3_partner, _s3_client
-    global _normalize_wikitext_enabled, _worker_slot_budget
+    global site, hubs, rights, subject_ids, _s3_partner, _s3_client
+    global _normalize_wikitext_enabled, _worker_slot_budget, _build_sdc_on_miss
     site = pywikibot.Site("commons", "commons")
     site.login()
     hubs = hubs_data
+    rights = rights_data
+    subject_ids = subject_ids_data
     _s3_partner = s3_partner
     _normalize_wikitext_enabled = bool(normalize_wikitext_enabled)
     _worker_slot_budget = WorkerSlotBudget(workers_budget)
+    _build_sdc_on_miss = bool(build_sdc_on_miss)
     if s3_partner is not None:
         from ingest_wikimedia.s3 import S3Client
 
@@ -5707,9 +5807,12 @@ def _run_maintain_parallel(groups, workers):
         initializer=_init_maintain_worker,
         initargs=(
             hubs,
+            rights,
+            subject_ids,
             _s3_partner,
             _normalize_wikitext_enabled,
             _workers_budget,
+            _build_sdc_on_miss,
         ),
         task_fn=_worker_maintain_group_task,
     )

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -1,6 +1,7 @@
 # TODO caption, date, page, iiif manifest, url
 
 import copy
+import functools
 import logging
 import pywikibot
 import requests
@@ -70,14 +71,28 @@ _s3_client = None
 # existing P921 statements. Bound in ``_initialize`` (serial) and injected into
 # ``_init_maintain_worker`` (parallel).
 _build_sdc_on_miss: bool = False
-# Per-file ES ``_source`` memo for the ``--build-sdc-on-miss`` route. With no
-# pre-stage, both the title path (``_maintain_canonical_title``) and the claims
-# path (``_maintain_sidecar_payload``) need the SAME doc for the same id within
-# one file's processing — this caches the last ``(dpla_id, doc)`` so they share
-# one ES round-trip instead of two. Keyed by id, so a new id overwrites: holds
-# exactly one entry and can't grow. Per-process (spawn workers each get their
-# own); files are processed serially within a worker, so no locking needed.
-_maintain_es_doc_cache: tuple[str, dict | None] | None = None
+
+
+def _assert_build_sdc_on_miss_allowed(build_sdc_on_miss: bool, s3_partner) -> None:
+    """Guard the one combination that would silently destroy data: NARA +
+    ``--build-sdc-on-miss``. On that combo the on-demand build passes
+    ``subjects_lookup=None`` (NARA's P921 subjects are only batch-reconciled by a
+    ``get-ids-es`` stage), and maintain's claim reconciliation would then strip
+    the existing P921 statements off NARA items on Commons — irreversible. The
+    launcher never emits this pairing (it keeps NARA's pre-stage and omits the
+    flag), but a hand-run ``sdc-sync --cat --from-s3 nara --build-sdc-on-miss``
+    would. Raises ``ValueError`` so both entry points fail fast before any write:
+    ``_initialize`` converts it to a ``parser.error``; ``_init_maintain_worker``
+    lets it abort the worker.
+    """
+    if build_sdc_on_miss and s3_partner == "nara":
+        raise ValueError(
+            "--build-sdc-on-miss must not be used with --from-s3 nara: it omits "
+            "batch-reconciled P921 subjects, so maintain would strip existing "
+            "P921 statements from NARA items."
+        )
+
+
 # Maintain mode: {institution Wikidata QID -> dataProvider name}, built lazily
 # from ``hubs`` (institutions_v2.json) the first time the anchor-3 wildcard
 # needs to scope a re-link to the file's own institution. None until built.
@@ -635,6 +650,10 @@ def _initialize() -> None:
     _workers = max(1, int(getattr(args, "workers", 1) or 1))
     _workers_budget = max(0, int(getattr(args, "workers_budget", 0) or 0))
     _build_sdc_on_miss = bool(getattr(args, "build_sdc_on_miss", False))
+    try:
+        _assert_build_sdc_on_miss_allowed(_build_sdc_on_miss, _s3_partner)
+    except ValueError as e:
+        parser.error(str(e))
 
 
 # This is the JSON used for formatting a claim. The P459 -> Q61848113 (determination method) qualifier is hardcoded in for everything DPLA adds. Not all data types have the same format for value, so this is formatted in the function for each property added.
@@ -4007,22 +4026,21 @@ def _maintain_resolve(title, embedded_id, file_page, mediaid):
     )
 
 
+@functools.lru_cache(maxsize=1)
 def _maintain_es_doc(dpla_id):
     """Return the item's ES ``_source`` for the ``--build-sdc-on-miss`` route,
     fetched at most once per file.
 
-    The title and claims paths both need the same doc for the same id in one
-    file's processing; this memoizes the last ``(dpla_id, doc)`` (via
-    :data:`_maintain_es_doc_cache`) so they share a single
-    :func:`_fetch_dpla_doc_from_es` round-trip. A ``None`` doc (item gone) is
-    cached too, so both paths skip on one fetch.
+    The title path (:func:`_maintain_canonical_title`) and claims path
+    (:func:`_maintain_sidecar_payload`) both need the same doc for the same id
+    within one file's processing. ``lru_cache(maxsize=1)`` holds the most recent
+    ``dpla_id``'s result, so the two share one :func:`_fetch_dpla_doc_from_es`
+    round-trip; the next id evicts it, so the cache never holds more than one
+    entry. A ``None`` doc (item gone) is cached too, so both paths skip on one
+    fetch. Per-process (spawn workers each build their own); tests call
+    ``_maintain_es_doc.cache_clear()``.
     """
-    global _maintain_es_doc_cache
-    if _maintain_es_doc_cache is not None and _maintain_es_doc_cache[0] == dpla_id:
-        return _maintain_es_doc_cache[1]
-    doc = _fetch_dpla_doc_from_es(dpla_id)
-    _maintain_es_doc_cache = (dpla_id, doc)
-    return doc
+    return _fetch_dpla_doc_from_es(dpla_id)
 
 
 def _maintain_sidecar_payload(dpla_id):
@@ -5727,6 +5745,9 @@ def _init_maintain_worker(
     _normalize_wikitext_enabled = bool(normalize_wikitext_enabled)
     _worker_slot_budget = WorkerSlotBudget(workers_budget)
     _build_sdc_on_miss = bool(build_sdc_on_miss)
+    # Defense in depth: the parent _initialize already rejects this combo, but
+    # re-check here so a worker can never run the P921-stripping path.
+    _assert_build_sdc_on_miss_allowed(_build_sdc_on_miss, _s3_partner)
     if s3_partner is not None:
         from ingest_wikimedia.s3 import S3Client
 

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -4101,9 +4101,12 @@ def _maintain_canonical_title(file_page, dpla_id):
     title-text change) — never a fresh normalization rule. Maintain changes
     neither the bytes nor the page structure, so the extension and page ordinal
     are taken from the file's own existing title; only the descriptive prefix
-    and the embedded id can move. The descriptive title comes from the item's
-    staged ``dpla-map.json`` (``sourceResource.title``), so this requires
-    ``--from-s3``.
+    and the embedded id can move. The descriptive title
+    (``sourceResource.title``) comes from the item's staged ``dpla-map.json``;
+    this requires ``--from-s3``. When that sidecar is missing and
+    ``--build-sdc-on-miss`` is set (the non-NARA lite ``--cat`` route, run
+    without a pre-stage), the same ``_source`` doc is fetched on demand from ES
+    via :func:`_maintain_es_doc` instead.
     """
     if _s3_partner is None:
         return None


### PR DESCRIPTION
Fixes the lite maintain over-staging (task_5c1f77de).

## Problem
The lite `--cat` maintain route pre-staged `dpla-map.json` + `sdc.json` for the **whole ES-eligible hub/institution universe** (`get-ids-es --maintain --skip-media-filter`), but the `--cat` sync only ever reads sidecars for files **already on Commons** (it walks the live category). So sidecars for every not-yet-uploaded item were pure waste — a full internal-ES scan + 2 S3 writes per item, over the entire institution.

## Fix (non-NARA, lite route only)
Non-NARA lite maintain now runs with **no pre-stage**. A new `--build-sdc-on-miss` flag makes `sdc-sync --cat --from-s3 <partner>` build each file's `sdc.json` (and read the rename title) **on demand from the internal ES index** — `_fetch_dpla_doc_from_es` + `build_claims_for_doc`, both added in #392 — scoped to exactly the category's already-uploaded files.

- Output is **identical** to a staged sidecar for non-NARA: same `_source` doc, same `build_claims_for_doc`, and `subjects_lookup=None` omits only the NARA-specific reconciled P921 statements (which never apply off NARA).
- A per-file memo (`_maintain_es_doc`) shares the one ES doc between the title and claims paths, so each file costs **one** ES round-trip, not two.
- Parallel maintain workers now get `rights`/`subject_ids` injected (as partner mode already does) so the on-demand build works under `--workers`.

## Deliberately out of scope
- **NARA keeps its pre-stage.** Its `sdc.json` carries batch-reconciled P921 subject QIDs an on-demand build would omit — and maintain's claim reconciliation (`_reconcile_existing_claims`) would then *strip* those existing statements. The launcher gates on `canonical == "nara"`.
- **The hash maintain route is untouched.** Its pre-stage also produces the CSV consumed by the `downloader` + `uploader --no-create` content-drift pass, so its staging isn't over-staging.

## Verification
Static + unit only — I didn't exercise the live maintain pipeline on EC2. Ran the full suite under `.venv` (Python 3.14): **1234 passed**, including 10 new/updated tests: non-NARA lite drops the pre-stage and adds `--build-sdc-on-miss`; NARA keeps the pre-stage without the flag; ES-built payload on sidecar miss; SKIP-on-miss without the flag; and the shared-doc memo (one fetch across both paths). ruff clean. A live `--count`-only then small-institution maintain run on EC2 is the recommended next validation before relying on it in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated lite `--maintain --cat` so non-NARA runs no longer pre-stage `dpla-map.json`/`sdc.json` for every ES-eligible item. Instead, `sdc-sync --cat --from-s3 <partner> --build-sdc-on-miss` now builds missing `sdc.json` sidecars on demand from Elasticsearch for files already present on Commons, while NARA keeps the existing pre-stage path to preserve batch-reconciled subject QIDs.

Also added memoized ES doc reuse across title/claims generation, passed `rights` and `subject_ids` through parallel maintain workers, and expanded tests to cover staged sidecars, ES fallback, memoization, and the updated lite maintain command wiring.

No manual pipeline trigger, redeployment, env var, secret, migration, API, or IAM changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->