### PR TITLE
uploader: preserve community metadata on title-drift (defer to sdc-sync cleanup)

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -46,23 +46,44 @@ from ingest_wikimedia.sdc import (
     unescape_wikitext_magic_words,
 )
 
-# DPLA's Commons-bot account names. Revisions authored by these accounts
-# are treated as DPLA-originated for the purpose of provenance
-# classification — any param value they last touched is safe to
-# overwrite with canonical data. Other accounts are treated as
-# community contributors whose edits must be preserved (by importing
-# to SDC) before the wikitext is rewritten.
+# Bot accounts whose edits are treated as DPLA-/import-originated for provenance
+# classification — any param value they last touched is safe to overwrite with
+# canonical data (never preserved as a "community" contribution). Any OTHER
+# account is treated as a community contributor whose edits must be preserved
+# (imported to SDC) before the wikitext is rewritten.
 #
-# Extend this set in a follow-up if older DPLA bot accounts are
-# discovered in the upload-history of long-tenure files. The set is
-# matched case-insensitively against the revision's ``user`` field;
-# add the canonical form a Commons revision history would display.
+# Coverage:
+#   - "DPLA bot"                 — DPLA's current Commons uploader.
+#   - "US National Archives bot" — NARA's own bot. Every pre-2020 NARA upload
+#                                  was made by it (not DPLA's bot), so this folds
+#                                  the oldest NARA files — the highest-risk,
+#                                  most community-curated set — in correctly.
+#   - "Flickr upload bot"        — Flickr2Commons-style imports. Any partner
+#                                  (NARA especially) that also puts collections
+#                                  on Flickr can have a file uploaded by this bot
+#                                  that we later rename; its metadata is
+#                                  automated import data, not community curation.
+#
+# Matched case- AND underscore/space-insensitively against the revision ``user``
+# field (see :func:`_normalize_account`): Commons displays usernames with spaces
+# (e.g. "DPLA bot"), which is the form the API returns, so the space form is
+# canonical here and the underscore variant folds to it.
 DPLA_BOT_ACCOUNTS: frozenset[str] = frozenset(
     {
-        "DPLA_bot",
+        "DPLA bot",
         "US National Archives bot",
+        "Flickr upload bot",
     }
 )
+
+
+def _normalize_account(name: str) -> str:
+    """Casefold and collapse underscores to spaces so ``DPLA_bot`` and
+    ``DPLA bot`` compare equal — MediaWiki treats the two as one username and
+    the API returns the space form, so provenance matching must not depend on
+    which the code happens to write."""
+    return name.casefold().replace("_", " ")
+
 
 # Wikidata items / properties used in the legacy-import reference shape.
 # Hardcoded here (not behind a config knob) because they are part of the
@@ -318,11 +339,6 @@ def parse_artwork_params(wikitext: str) -> dict[str, str]:
     return parsed
 
 
-def _is_dpla_bot(user: str) -> bool:
-    """Case-insensitive match against :data:`DPLA_BOT_ACCOUNTS`."""
-    return user.casefold() in {a.casefold() for a in DPLA_BOT_ACCOUNTS}
-
-
 def trace_param_provenance(
     revisions: Iterable[RevisionSnapshot],
 ) -> dict[str, str]:
@@ -394,9 +410,9 @@ def classify_param_provenance(
     default; new bot accounts get added to :data:`DPLA_BOT_ACCOUNTS`
     rather than the per-call argument.
     """
-    bot_set_cf = {a.casefold() for a in bot_accounts}
+    bot_set = {_normalize_account(a) for a in bot_accounts}
     return {
-        key: ("dpla" if editor.casefold() in bot_set_cf else "community")
+        key: ("dpla" if _normalize_account(editor) in bot_set else "community")
         for key, editor in provenance.items()
     }
 

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -129,15 +129,6 @@ LEGACY_IMPORT_PROPERTY: dict[str, tuple[str, str]] = {
     "creator": ("P2093", "string"),
 }
 
-# Every property a legacy migration can write — the LEGACY_IMPORT_PROPERTY
-# scalars plus P6802 (related image, handled outside that per-key map). The
-# idempotency probe (:func:`entity_was_already_migrated`) checks all of these
-# for the inferred-from-Wikitext reference.
-_LEGACY_IMPORT_PIDS: tuple[str, ...] = (
-    *dict.fromkeys(prop for prop, _ in LEGACY_IMPORT_PROPERTY.values()),
-    PID_RELATED_IMAGE,
-)
-
 # Canonical mapping from legacy template param names (case-folded) to
 # the canonical-params keys both the writer and comparator use. Covers
 # the param sets the legacy DPLA-bot ``{{Artwork}}`` form emitted plus
@@ -1883,15 +1874,20 @@ def entity_was_already_migrated(entity: dict) -> bool:
     today-practice is a manual re-edit).
 
     Looks for a P887 reference snak whose target is exactly
-    :data:`QID_INFERRED_FROM_WIKITEXT` on any statement of any property a
-    migration writes (:data:`_LEGACY_IMPORT_PIDS` — the scalar fields plus
-    P6802 related image). Subtle: a non-DPLA editor could in principle stamp
-    the same ref shape on a hand-authored claim, but that's the same semantic
-    ("inferred from Wikitext") and the skip-on-detect behaviour is still
-    correct — we just don't add duplicates.
+    :data:`QID_INFERRED_FROM_WIKITEXT` on any statement of a *scalar* import
+    property (:data:`LEGACY_IMPORT_PROPERTY`). Subtle: a non-DPLA editor could
+    in principle stamp the same ref shape on a hand-authored claim, but that's
+    the same semantic ("inferred from Wikitext") and the skip-on-detect
+    behaviour is still correct — we just don't add duplicates.
+
+    P6802 (related image) is deliberately EXCLUDED from this global trip-wire.
+    It's an always-preserve secondary output with its own value-level dedup in
+    :func:`materialize_pending_related_image_claim`; letting a P6802-only prior
+    import mark the whole file "migrated" would wrongly block a later rescue
+    from picking up a newly-added scalar community value on the source page.
     """
     statements = entity.get("statements") or entity.get("claims") or {}
-    for prop in _LEGACY_IMPORT_PIDS:
+    for prop, _ in LEGACY_IMPORT_PROPERTY.values():
         for stmt in statements.get(prop, []):
             for ref in stmt.get("references", []):
                 for snak in ref.get("snaks", {}).get(PID_BASED_ON_HEURISTIC, []):
@@ -2269,7 +2265,7 @@ def migrate_legacy_file(
 def import_cross_page_community_sdc(
     *,
     source_page,
-    dest_page,
+    dest_mediaid: str,
     item_metadata: dict,
     provider: dict,
     data_provider: dict,
@@ -2291,8 +2287,10 @@ def import_cross_page_community_sdc(
     (:func:`plan_migration`), and writes them to the destination as
     inferred-from-Wikitext SDC.
 
-    Reads the SOURCE page's history but writes the DESTINATION's MediaInfo
-    entity. Idempotent on the destination entity
+    Reads the SOURCE page's history but writes ``dest_mediaid`` (the
+    DESTINATION's ``M<pageid>`` MediaInfo id — the caller resolves the pageid,
+    riding out post-upload indexing lag, so this never targets a bogus "M0").
+    Idempotent on the destination entity
     (:func:`entity_was_already_migrated`). Returns the number of
     community-import claims posted — 0 when the source has no legacy template,
     nothing community-authored to rescue, or the destination was already
@@ -2321,7 +2319,7 @@ def import_cross_page_community_sdc(
     if find_legacy_template(source_page.text) is None:
         return 0
 
-    mediaid = f"M{dest_page.pageid}"
+    mediaid = dest_mediaid
     entity = _fetch_entity_or_empty(site, mediaid)
     if entity_was_already_migrated(entity):
         return 0

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -145,6 +145,27 @@ ARTWORK_PARAM_TO_CANONICAL_KEY: dict[str, str] = {
 # match is migrated; the others are left alone for a manual sweep.
 LEGACY_TEMPLATE_NAMES: tuple[str, ...] = ("artwork", "information", "photograph")
 
+# Metadata wrappers the cross-page drift rescue can node-swap for a fresh
+# {{DPLA metadata}} block. A superset of LEGACY_TEMPLATE_NAMES: also the
+# already-migrated {{DPLA metadata}} form (a source page can already be on the
+# new template) and NARA's {{NARA-image-full}}. The rescue only needs to
+# *locate* the metadata wrapper so it can swap that one node and keep everything
+# else on the page verbatim — it does not parse the wrapper's params, so
+# {{NARA-image-full}} is fine here even though its param mapping isn't wired for
+# the regular migration yet. The regular migration keeps using the narrower
+# LEGACY_TEMPLATE_NAMES (it only ever runs on a not-yet-migrated legacy page and
+# must not treat an existing {{DPLA metadata}} as swappable).
+#
+# This set governs OUTSIDE-template preservation only (which node to swap so
+# everything around it survives). It is deliberately broader than the set whose
+# INSIDE-template params get lifted to SDC — see the asymmetry note in
+# ``import_cross_page_community_sdc`` before widening it.
+RESCUE_WRAPPER_NAMES: tuple[str, ...] = (
+    *LEGACY_TEMPLATE_NAMES,
+    "dpla metadata",
+    "nara-image-full",
+)
+
 
 @dataclass(frozen=True)
 class RevisionSnapshot:
@@ -1711,17 +1732,60 @@ def render_migrated_wikitext(
     page-level structure survive in their original positions. Only
     the legacy-template node itself is replaced.
     """
+    text, _swapped = _swap_wrapper_node(
+        original_text, new_template_block, LEGACY_TEMPLATE_NAMES
+    )
+    return text
+
+
+def _swap_wrapper_node(
+    original_text: str,
+    new_template_block: str,
+    wrapper_names: tuple[str, ...],
+) -> tuple[str, bool]:
+    """Replace the first template in ``original_text`` whose name is in
+    ``wrapper_names`` with the ``{{DPLA metadata}}`` template extracted
+    from ``new_template_block``, leaving everything else verbatim.
+
+    Returns ``(text, swapped)``. ``swapped`` is False — and ``text`` is
+    ``original_text`` byte-for-byte — when no matching wrapper is present,
+    so callers can distinguish "swapped the wrapper" from "nothing to do"
+    (the shared preserve-by-default primitive behind both the regular
+    migration and the cross-page drift rescue).
+    """
     wikicode = mwparserfromhell.parse(original_text)
-    template = None
     for tpl in wikicode.filter_templates():
-        if _template_name(tpl) in LEGACY_TEMPLATE_NAMES:
-            template = tpl
-            break
-    if template is None:
-        return original_text
-    replacement = _extract_dpla_metadata_template(new_template_block)
-    wikicode.replace(template, replacement)
-    return str(wikicode)
+        if _template_name(tpl) in wrapper_names:
+            wikicode.replace(tpl, _extract_dpla_metadata_template(new_template_block))
+            return str(wikicode), True
+    return original_text, False
+
+
+def rescue_wikitext(source_text: str, new_template_block: str) -> str:
+    """Destination wikitext for a cross-page drift rescue — preserve by default.
+
+    If the source page carries a recognised metadata wrapper
+    (:data:`RESCUE_WRAPPER_NAMES`), node-swap just that wrapper for the fresh
+    ``{{DPLA metadata}}`` block and keep everything else on the source verbatim:
+    categories, ``{{ImageNote}}`` annotations, and every other community
+    template survive with no allowlist to maintain. This is the same mechanism
+    the regular migration (:func:`render_migrated_wikitext`) uses — the drift
+    paths just never adopted it (the node-swap postdates them).
+
+    Only when the source has *no* recognised wrapper — nothing to swap, so
+    preserve-by-default is impossible — fall back to
+    :func:`ingest_wikimedia.wikimedia.merge_preserved_wikitext`, the narrow
+    license/category/assessment allowlist. That no-wrapper case is the sole
+    reason ``merge_preserved_wikitext`` still exists.
+    """
+    text, swapped = _swap_wrapper_node(
+        source_text, new_template_block, RESCUE_WRAPPER_NAMES
+    )
+    if swapped:
+        return text
+    from .wikimedia import merge_preserved_wikitext
+
+    return merge_preserved_wikitext(source_text, new_template_block)
 
 
 def _inject_preserved_extras(text: str, extras: dict[str, str]) -> str:
@@ -1982,6 +2046,89 @@ def migrate_legacy_file(
         wikitext_changed=wikitext_changed,
         plan=plan,
     )
+
+
+def import_cross_page_community_sdc(
+    *,
+    source_page,
+    dest_page,
+    item_metadata: dict,
+    provider: dict,
+    data_provider: dict,
+    dpla_id: str,
+    site,
+    bot_accounts: frozenset[str] = DPLA_BOT_ACCOUNTS,
+    summary: str | None = None,
+) -> int:
+    """Rescue community-authored, *in-template* metadata from a source page's
+    revision history into the destination file's SDC.
+
+    The cross-page analogue of the SDC half of :func:`migrate_legacy_file`,
+    for the case where the source page is about to be destroyed (tagged as a
+    duplicate) so its history — the only record of who authored each param —
+    won't survive. Node-swapping the wikitext (:func:`rescue_wikitext`)
+    preserves everything *outside* the metadata template, but the template's
+    own params are dropped in the swap; this recovers the ones a non-bot
+    editor set, via the same provenance attribution the regular migration uses
+    (:func:`plan_migration`), and writes them to the destination as
+    inferred-from-Wikitext SDC.
+
+    Reads the SOURCE page's history but writes the DESTINATION's MediaInfo
+    entity. Idempotent on the destination entity
+    (:func:`entity_was_already_migrated`). Returns the number of
+    community-import claims posted — 0 when the source has no legacy template,
+    nothing community-authored to rescue, or the destination was already
+    migrated.
+    """
+    from .wikimedia import dpla_metadata_params
+
+    # Cheap pre-check before any network I/O. ``plan_migration`` returns None
+    # unless the source's *current* wikitext carries a LEGACY_TEMPLATE_NAMES
+    # wrapper, and that decision rests on the latest revision alone — so gate
+    # on ``source_page.text`` (a single-revision read, usually already cached)
+    # and skip the ``wbgetentities`` round-trip and the full
+    # revision-history-with-content walk ``fetch_revision_snapshots`` does.
+    #
+    # This gate is also where the swap-set/rescue-set asymmetry lives, on
+    # purpose: ``rescue_wikitext`` node-swaps any RESCUE_WRAPPER_NAMES wrapper
+    # (so *outside*-template content is preserved for every wrapper, including
+    # {{DPLA metadata}} and {{NARA-image-full}}), but only the machine-parseable
+    # LEGACY_TEMPLATE_NAMES wrappers have their *inside*-template params lifted
+    # to SDC here. A source already on {{DPLA metadata}}/{{NARA-image-full}}
+    # short-circuits with 0 — no worse than the pre-refactor allowlist, which
+    # rescued no inside-template params at all. Extending SDC rescue to a new
+    # wrapper means teaching plan_migration/find_legacy_template to parse it,
+    # not merely widening RESCUE_WRAPPER_NAMES.
+    if find_legacy_template(source_page.text) is None:
+        return 0
+
+    mediaid = f"M{dest_page.pageid}"
+    entity = _fetch_entity_or_empty(site, mediaid)
+    if entity_was_already_migrated(entity):
+        return 0
+    canonical_params = dpla_metadata_params(
+        dpla_id, item_metadata, provider, data_provider
+    )
+    plan = plan_migration(
+        source_page.title(),
+        fetch_revision_snapshots(source_page),
+        canonical_params,
+        bot_accounts,
+    )
+    if plan is None or not plan.community_imports:
+        return 0
+    claims = materialize_import_claims(
+        build_legacy_import_claims(plan), site=site, existing_entity=entity
+    )
+    if not claims:
+        return 0
+    post_legacy_import_claims(
+        mediaid,
+        claims,
+        site,
+        summary=summary or build_migration_summary(len(claims)),
+    )
+    return len(claims)
 
 
 def _fetch_entity_or_empty(site, mediaid: str) -> dict:

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -92,6 +92,15 @@ def _normalize_account(name: str) -> str:
 QID_INFERRED_FROM_WIKITEXT = "Q131783016"  # the source-of-truth item
 PID_BASED_ON_HEURISTIC = "P887"
 PID_WIKIMEDIA_IMPORT_URL = "P4656"
+# Related image (P6802) — a commonsMedia-datatype property pointing at another
+# Commons file. Populated from a legacy template's "other versions" param
+# ({{other version|<file>}}); Module:DPLA already renders it into the yellow
+# box. This is the pipeline's FIRST commonsMedia-typed SDC property: its
+# datavalue serialises as {"type": "string", "value": "<bare filename>"} while
+# the snak's datatype is "commons-media", and Wikibase validates the value
+# against a live Commons file — see _build_related_image_claim and
+# materialize_pending_related_image_claim.
+PID_RELATED_IMAGE = "P6802"
 
 # Per-param Wikidata-property mapping for the SDC import. Each key is a
 # canonical-params key (matching what `dpla_metadata_params` returns);
@@ -119,6 +128,15 @@ LEGACY_IMPORT_PROPERTY: dict[str, tuple[str, str]] = {
     # editors can promote individual statements to P170 manually later.
     "creator": ("P2093", "string"),
 }
+
+# Every property a legacy migration can write — the LEGACY_IMPORT_PROPERTY
+# scalars plus P6802 (related image, handled outside that per-key map). The
+# idempotency probe (:func:`entity_was_already_migrated`) checks all of these
+# for the inferred-from-Wikitext reference.
+_LEGACY_IMPORT_PIDS: tuple[str, ...] = (
+    *dict.fromkeys(prop for prop, _ in LEGACY_IMPORT_PROPERTY.values()),
+    PID_RELATED_IMAGE,
+)
 
 # Canonical mapping from legacy template param names (case-folded) to
 # the canonical-params keys both the writer and comparator use. Covers
@@ -222,6 +240,12 @@ class MigrationPlan:
     dpla_originated_params: dict[str, str] = field(default_factory=dict)
     wikitext_preserved_extras: dict[str, str] = field(default_factory=dict)
     artwork_template_name: str = ""
+    # Filenames from the template's "other versions" param ({{other version|X}})
+    # to import as P6802 (related image). Unconditional preserve, NOT
+    # provenance-gated: DPLA has no canonical related-image value, so it is
+    # never "drifted DPLA metadata" — it's an additive Commons relationship kept
+    # for every author. Each becomes one commonsMedia SDC statement.
+    related_image_imports: list[str] = field(default_factory=list)
 
 
 def _template_name(template) -> str:
@@ -368,6 +392,42 @@ def parse_artwork_params(wikitext: str) -> dict[str, str]:
         # overrides the earlier.
         parsed[canonical] = value
     return parsed
+
+
+# {{other version|<file>}} inside an "other versions" param. Commons filenames
+# can't contain |, {, or }, so [^{}|]+ safely grabs the (first, positional)
+# filename; an optional |extra tail (rare) is consumed but ignored.
+_OTHER_VERSION_RE = re.compile(
+    r"\{\{\s*other[\s_]*version\s*\|([^{}|]+)(?:\|[^{}]*)?\}\}",
+    re.IGNORECASE,
+)
+
+
+def _extract_related_image_files(wikitext: str) -> list[str]:
+    """Bare Commons filenames referenced by ``{{other version|<file>}}`` inside
+    the legacy template's *other versions* param — the value form P6802
+    (commonsMedia) stores (no ``File:`` prefix).
+
+    Deduped, order-preserving. ``[]`` when there is no legacy template, no
+    *other versions* param, or no ``{{other version}}`` invocations. Only the
+    ``{{other version|…}}`` shape is parsed; galleries and bare ``[[File:…]]``
+    links in the param are left alone — out of scope, and they have no single
+    unambiguous P6802 target.
+    """
+    template = find_legacy_template(wikitext)
+    if template is None:
+        return []
+    files: list[str] = []
+    for param in template.params:
+        if _normalize_param_name(param) not in ("other versions", "other_versions"):
+            continue
+        for match in _OTHER_VERSION_RE.finditer(str(param.value)):
+            name = match.group(1).strip()
+            if name.lower().startswith("file:"):
+                name = name[len("File:") :].strip()
+            if name and name not in files:
+                files.append(name)
+    return files
 
 
 def trace_param_provenance(
@@ -527,6 +587,11 @@ def plan_migration(
         dpla_originated_params=dpla_originated,
         wikitext_preserved_extras=wikitext_preserved_extras,
         artwork_template_name=_template_name(legacy_template),
+        # Unconditional (not provenance-gated): DPLA has no canonical
+        # related-image value, so an "other versions" reference is never
+        # drifted DPLA metadata — preserve it for every author. See the
+        # MigrationPlan field docstring.
+        related_image_imports=_extract_related_image_files(latest.text),
     )
 
 
@@ -985,6 +1050,31 @@ def _string_datavalue(text: str) -> dict:
     return {"type": "string", "value": text}
 
 
+def _commons_media_datavalue(filename: str) -> dict:
+    # commonsMedia serialises as a plain string datavalue — the SAME shape as a
+    # string value (hence delegating to _string_datavalue). What marks it a file
+    # reference is the snak's ``datatype`` ("commons-media"), not the datavalue
+    # ``type``. The value is the BARE filename (no "File:" prefix); Wikibase
+    # validates it against a live Commons file at write time.
+    return _string_datavalue(filename)
+
+
+def _build_related_image_claim(filename: str, permalink: str) -> dict:
+    """Build a P6802 (related image) commonsMedia statement for ``filename``,
+    with the inferred-from-Wikitext reference shape (P887 + P4656)."""
+    return {
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "value",
+            "property": PID_RELATED_IMAGE,
+            "datatype": "commons-media",
+            "datavalue": _commons_media_datavalue(filename),
+        },
+        "references": [_reference_snaks(permalink)],
+    }
+
+
 def format_legacy_import_claim(
     canonical_key: str,
     value: str,
@@ -1076,12 +1166,27 @@ def build_legacy_import_claims(plan: MigrationPlan) -> list[dict]:
     Skips canonical keys with no mapping in
     :data:`LEGACY_IMPORT_PROPERTY` — those values stay in wikitext
     until a later phase widens the supported set.
+
+    Also emits one P6802 (related image) placeholder per
+    ``plan.related_image_imports`` entry. These are placeholders (not final
+    claims) because commonsMedia values are validated against a live Commons
+    file, so :func:`materialize_import_claims` confirms existence in the
+    executor context before emitting the real claim.
     """
     claims: list[dict] = []
     for key, value in plan.community_imports.items():
         claim = format_legacy_import_claim(key, value, plan.source_permalink)
         if claim is not None:
             claims.append(claim)
+    for filename in plan.related_image_imports:
+        claims.append(
+            {
+                "type": "statement",
+                "rank": "normal",
+                "_phase3a_pending_related_image": filename,
+                "_permalink": plan.source_permalink,
+            }
+        )
     return claims
 
 
@@ -1613,6 +1718,79 @@ def materialize_pending_creator_claim(
     return None
 
 
+def _entity_p6802_files(existing_entity: dict | None) -> set[str]:
+    """Filenames already stated in ``existing_entity``'s P6802 (related image)
+    commonsMedia mainsnaks. Used to drop a related-image import the entity
+    already carries, so re-runs don't add duplicate statements."""
+    if not existing_entity:
+        return set()
+    statements = (
+        existing_entity.get("statements") or existing_entity.get("claims") or {}
+    )
+    files: set[str] = set()
+    for stmt in statements.get(PID_RELATED_IMAGE, []):
+        ms = stmt.get("mainsnak") or {}
+        if ms.get("snaktype") != "value":
+            continue
+        value = (ms.get("datavalue") or {}).get("value")
+        if isinstance(value, str) and value:
+            files.add(value)
+    return files
+
+
+def _commons_file_exists(site, filename: str) -> bool:
+    """True when ``File:<filename>`` exists on Commons.
+
+    ``site is None`` (test / pure contexts) short-circuits to True — the
+    existence gate is a live-Wikibase concern. Any API failure returns False so
+    an unconfirmable file is *dropped* rather than risking the commonsMedia
+    validation error that would fail the whole atomic ``wbeditentity`` bundle.
+    """
+    if site is None:
+        return True
+    try:
+        response = site.simple_request(
+            action="query",
+            titles=f"File:{filename}",
+            format="json",
+        ).submit()
+    except Exception:  # noqa: BLE001 — any lookup failure → treat as absent
+        return False
+    pages = (response.get("query") or {}).get("pages") or {}
+    page = next(iter(pages.values()), None)
+    return page is not None and "missing" not in page and "invalid" not in page
+
+
+def materialize_pending_related_image_claim(
+    placeholder: dict,
+    *,
+    site=None,
+    existing_entity: dict | None = None,
+) -> dict | None:
+    """Convert a Phase-3a related-image placeholder into a real P6802 (related
+    image) commonsMedia statement — or drop it (return ``None``) when:
+
+    * a required sentinel key is missing (defensive), or
+    * the file is already a P6802 value on the entity (re-run dedup), or
+    * the referenced Commons file does not exist / can't be confirmed.
+
+    The last case is the important one: commonsMedia is validated by Wikibase
+    against a live file, so emitting a claim for a missing target would fail the
+    entire atomic ``wbeditentity`` bundle and block the file's other imports.
+    Dropping the one claim keeps the rest; the reference still lives in the
+    page's revision history for manual recovery.
+    """
+    filename = placeholder.get("_phase3a_pending_related_image")
+    permalink = placeholder.get("_permalink")
+    if not filename or not permalink:
+        return None
+    if filename in _entity_p6802_files(existing_entity):
+        return None
+    if not _commons_file_exists(site, filename):
+        return None
+    return _build_related_image_claim(filename, permalink)
+
+
 def materialize_import_claims(
     claims: list[dict],
     *,
@@ -1622,13 +1800,16 @@ def materialize_import_claims(
     """Walk an import-claim list and substitute every Phase-3a
     placeholder for a real Wikibase statement.
 
-    Handles two placeholder shapes: date placeholders (P571 time
-    statements via :func:`materialize_pending_date_claim`) and
-    creator placeholders (P170 statements via
-    :func:`materialize_pending_creator_claim`). Claims without a
+    Handles three placeholder shapes: date placeholders (P571 time
+    statements via :func:`materialize_pending_date_claim`), creator
+    placeholders (P170 statements via
+    :func:`materialize_pending_creator_claim`), and related-image
+    placeholders (P6802 commonsMedia statements via
+    :func:`materialize_pending_related_image_claim`). Claims without a
     placeholder marker pass through unchanged. Placeholders whose
-    materialiser returns ``None`` — duplicate of existing SDC, or
-    an unparseable value — are dropped from the returned list.
+    materialiser returns ``None`` — duplicate of existing SDC, a
+    missing Commons file, or an unparseable value — are dropped from
+    the returned list.
 
     ``site`` and ``existing_entity`` are forwarded to the
     materialisers so they can (a) expand wikitext templates
@@ -1656,6 +1837,12 @@ def materialize_import_claims(
             )
             if real is not None:
                 materialised.append(real)
+        elif "_phase3a_pending_related_image" in claim:
+            real = materialize_pending_related_image_claim(
+                claim, site=site, existing_entity=existing_entity
+            )
+            if real is not None:
+                materialised.append(real)
         else:
             materialised.append(claim)
     return materialised
@@ -1675,15 +1862,15 @@ def entity_was_already_migrated(entity: dict) -> bool:
     today-practice is a manual re-edit).
 
     Looks for a P887 reference snak whose target is exactly
-    :data:`QID_INFERRED_FROM_WIKITEXT` on any statement of any
-    Phase-3a-mapped property. Subtle: a non-DPLA editor could in
-    principle stamp the same ref shape on a hand-authored claim, but
-    that's the same semantic ("inferred from Wikitext") and the
-    skip-on-detect behaviour is still correct — we just don't add
-    duplicates.
+    :data:`QID_INFERRED_FROM_WIKITEXT` on any statement of any property a
+    migration writes (:data:`_LEGACY_IMPORT_PIDS` — the scalar fields plus
+    P6802 related image). Subtle: a non-DPLA editor could in principle stamp
+    the same ref shape on a hand-authored claim, but that's the same semantic
+    ("inferred from Wikitext") and the skip-on-detect behaviour is still
+    correct — we just don't add duplicates.
     """
     statements = entity.get("statements") or entity.get("claims") or {}
-    for prop, _ in LEGACY_IMPORT_PROPERTY.values():
+    for prop in _LEGACY_IMPORT_PIDS:
         for stmt in statements.get(prop, []):
             for ref in stmt.get("references", []):
                 for snak in ref.get("snaks", {}).get(PID_BASED_ON_HEURISTIC, []):
@@ -2126,7 +2313,7 @@ def import_cross_page_community_sdc(
         canonical_params,
         bot_accounts,
     )
-    if plan is None or not plan.community_imports:
+    if plan is None or (not plan.community_imports and not plan.related_image_imports):
         return 0
     claims = materialize_import_claims(
         build_legacy_import_claims(plan), site=site, existing_entity=entity

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -143,27 +143,37 @@ ARTWORK_PARAM_TO_CANONICAL_KEY: dict[str, str] = {
 # Template names (case-folded) whose params get walked during migration.
 # Order doesn't matter — if a page carries multiple, only the first
 # match is migrated; the others are left alone for a manual sweep.
-LEGACY_TEMPLATE_NAMES: tuple[str, ...] = ("artwork", "information", "photograph")
+#
+# {{NARA-image-full}} is included: its Title/Description/Date/Author/Creator
+# params share names with the {{Artwork}} form, so they map through
+# ARTWORK_PARAM_TO_CANONICAL_KEY with no NARA-specific parsing. Its many
+# NARA-only archival params (ARC, NAID, record group, series, scope & content,
+# …) have no canonical/SDC target and are dropped on migration — the same
+# treatment any unrecognised param gets on any template — so converting a
+# {{NARA-image-full}} page lifts its four core fields to SDC and does not carry
+# those archival fields onto the new {{DPLA metadata}} form.
+LEGACY_TEMPLATE_NAMES: tuple[str, ...] = (
+    "artwork",
+    "information",
+    "photograph",
+    "nara-image-full",
+)
 
 # Metadata wrappers the cross-page drift rescue can node-swap for a fresh
 # {{DPLA metadata}} block. A superset of LEGACY_TEMPLATE_NAMES: also the
-# already-migrated {{DPLA metadata}} form (a source page can already be on the
-# new template) and NARA's {{NARA-image-full}}. The rescue only needs to
-# *locate* the metadata wrapper so it can swap that one node and keep everything
-# else on the page verbatim — it does not parse the wrapper's params, so
-# {{NARA-image-full}} is fine here even though its param mapping isn't wired for
-# the regular migration yet. The regular migration keeps using the narrower
-# LEGACY_TEMPLATE_NAMES (it only ever runs on a not-yet-migrated legacy page and
-# must not treat an existing {{DPLA metadata}} as swappable).
+# already-migrated {{DPLA metadata}} form, since a source page can already be on
+# the new template. The rescue only needs to *locate* the metadata wrapper so it
+# can swap that one node and keep everything else on the page verbatim.
 #
-# This set governs OUTSIDE-template preservation only (which node to swap so
-# everything around it survives). It is deliberately broader than the set whose
-# INSIDE-template params get lifted to SDC — see the asymmetry note in
-# ``import_cross_page_community_sdc`` before widening it.
+# This set governs OUTSIDE-template preservation (which node to swap so
+# everything around it survives). It is broader than the set whose
+# INSIDE-template params get lifted to SDC by exactly the {{DPLA metadata}}
+# entry: a source already on {{DPLA metadata}} carries no legacy params for
+# plan_migration to walk, so it is swapped for outside content only. See the
+# asymmetry note in ``import_cross_page_community_sdc``.
 RESCUE_WRAPPER_NAMES: tuple[str, ...] = (
     *LEGACY_TEMPLATE_NAMES,
     "dpla metadata",
-    "nara-image-full",
 )
 
 
@@ -2091,14 +2101,15 @@ def import_cross_page_community_sdc(
     #
     # This gate is also where the swap-set/rescue-set asymmetry lives, on
     # purpose: ``rescue_wikitext`` node-swaps any RESCUE_WRAPPER_NAMES wrapper
-    # (so *outside*-template content is preserved for every wrapper, including
-    # {{DPLA metadata}} and {{NARA-image-full}}), but only the machine-parseable
-    # LEGACY_TEMPLATE_NAMES wrappers have their *inside*-template params lifted
-    # to SDC here. A source already on {{DPLA metadata}}/{{NARA-image-full}}
-    # short-circuits with 0 — no worse than the pre-refactor allowlist, which
-    # rescued no inside-template params at all. Extending SDC rescue to a new
-    # wrapper means teaching plan_migration/find_legacy_template to parse it,
-    # not merely widening RESCUE_WRAPPER_NAMES.
+    # (so *outside*-template content is preserved for every wrapper), but only
+    # the LEGACY_TEMPLATE_NAMES wrappers have their *inside*-template params
+    # lifted to SDC here. The one swap-but-not-rescued wrapper is the
+    # already-migrated {{DPLA metadata}} form: it carries no legacy params for
+    # plan_migration to walk, so a source already on it short-circuits with 0 —
+    # no worse than the pre-refactor allowlist, which rescued no inside-template
+    # params at all. Extending SDC rescue to a new wrapper means adding it to
+    # LEGACY_TEMPLATE_NAMES (so find_legacy_template/parse_artwork_params walk
+    # it), not merely widening RESCUE_WRAPPER_NAMES.
     if find_legacy_template(source_page.text) is None:
         return 0
 

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -403,6 +403,26 @@ _OTHER_VERSION_RE = re.compile(
 )
 
 
+def _normalize_commons_filename(name: str) -> str:
+    """Canonicalise a Commons filename to MediaWiki's title form: strip a
+    ``File:`` prefix, underscores → spaces, collapse whitespace runs, and
+    uppercase the first character.
+
+    MediaWiki treats File: titles as first-letter-insensitive and
+    space/underscore-equivalent, so ``rel_image.jpg`` and ``Rel image.jpg`` name
+    the *same* file. Normalising both the extracted value and the stored P6802
+    values makes the dedup and existence checks compare like MediaWiki does (and
+    the value we write already matches the canonical form Wikibase stores, so
+    re-runs dedup cleanly)."""
+    name = name.strip()
+    if name.lower().startswith("file:"):
+        name = name[len("File:") :]
+    name = re.sub(r"[\s_]+", " ", name).strip()
+    if name:
+        name = name[0].upper() + name[1:]
+    return name
+
+
 def _extract_related_image_files(wikitext: str) -> list[str]:
     """Bare Commons filenames referenced by ``{{other version|<file>}}`` inside
     the legacy template's *other versions* param — the value form P6802
@@ -422,9 +442,7 @@ def _extract_related_image_files(wikitext: str) -> list[str]:
         if _normalize_param_name(param) not in ("other versions", "other_versions"):
             continue
         for match in _OTHER_VERSION_RE.finditer(str(param.value)):
-            name = match.group(1).strip()
-            if name.lower().startswith("file:"):
-                name = name[len("File:") :].strip()
+            name = _normalize_commons_filename(match.group(1))
             if name and name not in files:
                 files.append(name)
     return files
@@ -1719,9 +1737,12 @@ def materialize_pending_creator_claim(
 
 
 def _entity_p6802_files(existing_entity: dict | None) -> set[str]:
-    """Filenames already stated in ``existing_entity``'s P6802 (related image)
-    commonsMedia mainsnaks. Used to drop a related-image import the entity
-    already carries, so re-runs don't add duplicate statements."""
+    """MediaWiki-normalized filenames already stated in ``existing_entity``'s
+    P6802 (related image) commonsMedia mainsnaks. Used to drop a related-image
+    import the entity already carries, so re-runs don't add duplicate
+    statements. Values are normalized (:func:`_normalize_commons_filename`) so a
+    stored ``Rel_image.jpg`` dedups against an extracted ``rel image.jpg`` —
+    MediaWiki treats them as the same file."""
     if not existing_entity:
         return set()
     statements = (
@@ -1734,7 +1755,7 @@ def _entity_p6802_files(existing_entity: dict | None) -> set[str]:
             continue
         value = (ms.get("datavalue") or {}).get("value")
         if isinstance(value, str) and value:
-            files.add(value)
+            files.add(_normalize_commons_filename(value))
     return files
 
 

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -998,14 +998,19 @@ def merge_preserved_wikitext(existing_text: str, new_wikitext: str) -> str:
     blank-line separator, since they conventionally sit in their
     own section between the description and the categories.)
 
-    TODO (Goal 2 follow-up): the title-drift rescue currently
-    overwrites the metadata template wholesale, discarding any
-    community-contributed template params an editor added between
-    the original upload and the rescue. The same provenance-aware
-    migration logic from :mod:`ingest_wikimedia.legacy_artwork`
-    would let us preserve community values as SDC imports first,
-    then overwrite. Out of scope for the flat-shape uploader PR;
-    flagged here so the integration point doesn't get lost.
+    Scope note: the primary title-drift path
+    (``Uploader._move_to_correct_title``) no longer calls this — after a move it
+    leaves the page's wikitext intact and the post-SDC ``sdc-sync`` cleanup runs
+    the provenance-aware :mod:`ingest_wikimedia.legacy_artwork` migration
+    (community values imported to SDC; only bot-authored, drifted fields
+    replaced with canonical). The two remaining callers —
+    ``_resolve_redirect_overwrite`` (overwrites a redirect) and
+    ``_tag_drift_duplicate`` (rescues into a survivor before the old file is
+    tagged as a duplicate) — are *cross-page* rescues: the metadata to preserve
+    lives on a different page whose history the cleanup never walks, so
+    capturing it inline here (the narrow license/category/assessment set) is the
+    only available point. That narrowness is inherent to cross-page rescue, not
+    pending work.
     """
     new_stripped = new_wikitext.rstrip()
     parts: list[str] = [new_stripped]

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -957,14 +957,13 @@ _ASSESSMENT_TEMPLATE_RE = re.compile(
 def merge_preserved_wikitext(existing_text: str, new_wikitext: str) -> str:
     """Append preserved metadata from existing_text to new_wikitext.
 
-    Used when the uploader rewrites a file description during a
-    redirect-overwrite or a cross-page metadata rescue (see the Scope note
-    below for the exact call sites — the title-drift *move* path no longer
-    calls this). The new {{DPLA metadata}} wikitext is
-    authoritative for the file's description, but page-level metadata that
-    pre-existed — PD-USGov license tags, Image-extracted parent links,
-    category membership, and assessment-class templates — must survive the
-    rewrite.
+    Narrow-allowlist fallback for the cross-page drift rescue, invoked by
+    :func:`ingest_wikimedia.legacy_artwork.rescue_wikitext` **only** when the
+    source page carries no recognised metadata wrapper to node-swap (see the
+    Scope note below). The new {{DPLA metadata}} wikitext is authoritative for
+    the file's description, but page-level metadata that pre-existed — PD-USGov
+    license tags, Image-extracted parent links, category membership, and
+    assessment-class templates — must survive the rewrite.
 
     Result order (matches Commons page-structure convention):
         1. new_wikitext (the freshly generated {{DPLA metadata}} block)
@@ -1000,19 +999,18 @@ def merge_preserved_wikitext(existing_text: str, new_wikitext: str) -> str:
     blank-line separator, since they conventionally sit in their
     own section between the description and the categories.)
 
-    Scope note: the primary title-drift path
-    (``Uploader._move_to_correct_title``) no longer calls this — after a move it
-    leaves the page's wikitext intact and the post-SDC ``sdc-sync`` cleanup runs
-    the provenance-aware :mod:`ingest_wikimedia.legacy_artwork` migration
-    (community values imported to SDC; only bot-authored, drifted fields
-    replaced with canonical). The two remaining callers —
-    ``_resolve_redirect_overwrite`` (overwrites a redirect) and
-    ``_tag_drift_duplicate`` (rescues into a survivor before the old file is
-    tagged as a duplicate) — are *cross-page* rescues: the metadata to preserve
-    lives on a different page whose history the cleanup never walks, so
-    capturing it inline here (the narrow license/category/assessment set) is the
-    only available point. That narrowness is inherent to cross-page rescue, not
-    pending work.
+    Scope note: this is no longer the primary rescue mechanism. Both the
+    regular migration and the cross-page drift rescue now *preserve by
+    default* — :func:`ingest_wikimedia.legacy_artwork.rescue_wikitext` and
+    :func:`~ingest_wikimedia.legacy_artwork.render_migrated_wikitext` node-swap
+    only the metadata-template node and keep everything else (categories,
+    {{ImageNote}} annotations, every community template) verbatim, so there is
+    no allowlist to keep chasing new community-template shapes. This function
+    survives solely as ``rescue_wikitext``'s fallback for the rare source page
+    that has *no* recognised wrapper to swap — nothing to preserve-by-default
+    around, so the narrow license/category/assessment allowlist is the best
+    available. That narrowness is inherent to the no-wrapper case, not pending
+    work.
     """
     new_stripped = new_wikitext.rstrip()
     parts: list[str] = [new_stripped]

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -957,8 +957,10 @@ _ASSESSMENT_TEMPLATE_RE = re.compile(
 def merge_preserved_wikitext(existing_text: str, new_wikitext: str) -> str:
     """Append preserved metadata from existing_text to new_wikitext.
 
-    Used when the uploader rewrites a file description after a title-drift
-    move or redirect-overwrite. The new {{DPLA metadata}} wikitext is
+    Used when the uploader rewrites a file description during a
+    redirect-overwrite or a cross-page metadata rescue (see the Scope note
+    below for the exact call sites — the title-drift *move* path no longer
+    calls this). The new {{DPLA metadata}} wikitext is
     authoritative for the file's description, but page-level metadata that
     pre-existed — PD-USGov license tags, Image-extracted parent links,
     category membership, and assessment-class templates — must survive the

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -787,6 +787,7 @@ from ingest_wikimedia.legacy_artwork import (  # noqa: E402
     MigrationResult,
     _build_related_image_claim,
     _extract_related_image_files,
+    _normalize_commons_filename,
     build_migration_summary,
     entity_was_already_migrated,
     fetch_revision_snapshots,
@@ -1901,6 +1902,23 @@ def test_extract_related_image_files_empty_when_absent():
     assert _extract_related_image_files("no template here") == []
 
 
+def test_normalize_commons_filename_canonicalises_title_form():
+    # underscore→space, first-letter upper, whitespace collapse, File: strip.
+    assert _normalize_commons_filename("rel_image.jpg") == "Rel image.jpg"
+    assert _normalize_commons_filename("File:rel image.jpg") == "Rel image.jpg"
+    assert _normalize_commons_filename("  a   b.jpg ") == "A b.jpg"
+
+
+def test_extract_related_image_files_normalizes_and_dedups_surface_forms():
+    # rel image.jpg and Rel_image.jpg name the SAME Commons file → one entry,
+    # in MediaWiki's canonical form.
+    wt = (
+        "{{Artwork|Other versions="
+        "{{other version|rel image.jpg}}{{other version|Rel_image.jpg}}}}"
+    )
+    assert _extract_related_image_files(wt) == ["Rel image.jpg"]
+
+
 def test_build_related_image_claim_serialises_commons_media_correctly():
     """The first commonsMedia-typed property in the pipeline — verify the
     exact Wikibase shape: string datavalue, 'commons-media' snak datatype,
@@ -1975,6 +1993,29 @@ def test_materialize_related_image_dedups_existing_p6802():
     }
     claim = materialize_pending_related_image_claim(
         {"_phase3a_pending_related_image": "Rel.jpg", "_permalink": "P"},
+        site=None,
+        existing_entity=entity,
+    )
+    assert claim is None
+
+
+def test_materialize_related_image_dedups_across_title_surface_forms():
+    """CR nitpick: a stored P6802 written as 'Rel_image.jpg' must dedup against
+    an extracted 'Rel image.jpg' — MediaWiki treats them as the same file."""
+    entity = {
+        "statements": {
+            "P6802": [
+                {
+                    "mainsnak": {
+                        "snaktype": "value",
+                        "datavalue": {"value": "Rel_image.jpg"},
+                    }
+                }
+            ]
+        }
+    }
+    claim = materialize_pending_related_image_claim(
+        {"_phase3a_pending_related_image": "Rel image.jpg", "_permalink": "P"},
         site=None,
         existing_entity=entity,
     )

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1787,15 +1787,13 @@ def test_import_cross_page_community_sdc_imports_from_source_history():
         revid, user, text = 2, "EditorOne", "{{Artwork|title=A Better Title}}"
 
     source = _mock_file_page("File:Old.jpg", _Rev2.text, [_Rev1(), _Rev2()])
-    dest = _mock_file_page("File:New.jpg", "{{DPLA metadata}}", [])
-    dest.pageid = 99
     item, provider, dp = _item_md()
     site = _site_with_empty_entity()
     site.simple_request.return_value.submit.return_value = {"entities": {"M99": {}}}
 
     n = import_cross_page_community_sdc(
         source_page=source,
-        dest_page=dest,
+        dest_mediaid="M99",
         item_metadata=item,
         provider=provider,
         data_provider=dp,
@@ -1829,7 +1827,6 @@ def test_import_cross_page_community_sdc_idempotent_on_dest_entity():
         revid, user, text = 2, "EditorOne", "{{Artwork|title=A Better Title}}"
 
     source = _mock_file_page("File:Old.jpg", _Rev2.text, [_Rev2()])
-    dest = _mock_file_page("File:New.jpg", "{{DPLA metadata}}", [])
     item, provider, dp = _item_md()
     site = MagicMock()
     site.tokens = {"csrf": "CSRFTOKEN"}
@@ -1839,7 +1836,7 @@ def test_import_cross_page_community_sdc_idempotent_on_dest_entity():
 
     n = import_cross_page_community_sdc(
         source_page=source,
-        dest_page=dest,
+        dest_mediaid="M42",
         item_metadata=item,
         provider=provider,
         data_provider=dp,
@@ -1861,13 +1858,12 @@ def test_import_cross_page_community_sdc_nothing_to_rescue_on_bot_only_history()
         revid, user, text = 1, "DPLA_bot", "{{Artwork|title=A Title}}"
 
     source = _mock_file_page("File:Old.jpg", _Rev.text, [_Rev()])
-    dest = _mock_file_page("File:New.jpg", "{{DPLA metadata}}", [])
     item, provider, dp = _item_md()
     site = _site_with_empty_entity()
 
     n = import_cross_page_community_sdc(
         source_page=source,
-        dest_page=dest,
+        dest_mediaid="M42",
         item_metadata=item,
         provider=provider,
         data_provider=dp,
@@ -2022,8 +2018,14 @@ def test_materialize_related_image_dedups_across_title_surface_forms():
     assert claim is None
 
 
-def test_entity_was_already_migrated_detects_p6802_ref():
-    assert entity_was_already_migrated(_entity_with_legacy_import("P6802")) is True
+def test_entity_was_already_migrated_ignores_p6802_only():
+    """P6802 (related image) is deliberately NOT part of the global migrated
+    trip-wire: a file whose only prior import was a related image must stay
+    eligible so a later rescue can pick up a newly-added scalar community
+    value. (P6802 duplicate-prevention lives in the materializer instead.)"""
+    assert entity_was_already_migrated(_entity_with_legacy_import("P6802")) is False
+    # A scalar import property still trips it.
+    assert entity_was_already_migrated(_entity_with_legacy_import("P1476")) is True
 
 
 def test_migrate_legacy_file_imports_related_image_as_commons_media():
@@ -2085,7 +2087,6 @@ def test_import_cross_page_rescues_related_image_with_no_scalar_community():
         text = "{{Artwork|title=A Title|Other versions={{other version|Rel.jpg}}}}"
 
     source = _mock_file_page("File:Old.jpg", _Rev.text, [_Rev()])
-    dest = _mock_file_page("File:New.jpg", "{{DPLA metadata}}", [])
     item, provider, dp = _item_md()
     site = MagicMock()
     site.tokens = {"csrf": "CSRFTOKEN"}
@@ -2095,7 +2096,7 @@ def test_import_cross_page_rescues_related_image_with_no_scalar_community():
     }
     n = import_cross_page_community_sdc(
         source_page=source,
-        dest_page=dest,
+        dest_mediaid="M42",
         item_metadata=item,
         provider=provider,
         data_provider=dp,

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -511,6 +511,36 @@ def test_plan_migration_classifies_bot_value_as_dpla_originated():
     }
 
 
+def test_plan_migration_recognizes_nara_image_full():
+    """{{NARA-image-full}} is a recognised migration wrapper: its core params
+    map by NAME through ARTWORK_PARAM_TO_CANONICAL_KEY (no NARA-specific
+    parsing), so a community-edited Title is imported, while its NARA-only
+    archival params (ARC / Record group / …) have no canonical target and are
+    simply dropped — not imported, not errored."""
+    revs = _make_revs(
+        (
+            1,
+            "US National Archives bot",
+            "{{NARA-image-full|Title=A Title|Date=1900|ARC=12345|Record group=RG 26}}",
+        ),
+        (
+            2,
+            "CommunityEditor",
+            "{{NARA-image-full|Title=A Better Title|Date=1900"
+            "|ARC=12345|Record group=RG 26}}",
+        ),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    # Community-edited core field rescued via the name-based mapping.
+    assert plan.community_imports == {"title": "A Better Title"}
+    # NARA-only archival params never became canonical keys.
+    assert "ARC" not in plan.dpla_originated_params
+    assert "record group" not in plan.dpla_originated_params
+    # Date matched canonical and was bot-set → dpla-originated (not imported).
+    assert plan.dpla_originated_params.get("date") == "1900"
+
+
 def test_plan_migration_does_not_resurrect_drifted_bot_value():
     """Core drift-safety property: a value the *bot* last set that now DIFFERS
     from canonical is drifted DPLA metadata (DPLA-caused) — NOT a community
@@ -1699,6 +1729,43 @@ def test_migrate_legacy_file_imports_community_value_and_rewrites_wikitext():
         posted["claims"][0]["mainsnak"]["datavalue"]["value"]["text"]
         == "A Better Title"
     )
+
+
+def test_migrate_legacy_file_converts_nara_image_full_and_drops_archival_params():
+    """A {{NARA-image-full}} page migrates like any legacy template: its
+    community-edited core field imports to SDC and the wrapper is node-swapped
+    for {{DPLA metadata}}. Its NARA-only archival params are not carried onto
+    the new form — accepted loss, they have no canonical/SDC home."""
+
+    class _Rev1:
+        revid = 1
+        user = "US National Archives bot"
+        text = "{{NARA-image-full|Title=A Title|ARC=12345|Record group=RG 26}}"
+
+    class _Rev2:
+        revid = 2
+        user = "CommunityEditor"
+        text = "{{NARA-image-full|Title=A Better Title|ARC=12345|Record group=RG 26}}"
+
+    page = _mock_file_page("File:Foo.jpg", _Rev2.text, [_Rev1(), _Rev2()])
+    item, provider, dp = _item_md()
+    site = _site_with_empty_entity()
+    result = migrate_legacy_file(
+        file_page=page,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    assert result.imports_posted == 1
+    assert result.wikitext_changed is True
+    saved = page.text
+    assert "{{NARA-image-full" not in saved
+    assert "{{DPLA metadata" in saved
+    # Archival params dropped on the swap (no canonical/SDC home).
+    assert "ARC" not in saved
+    assert "RG 26" not in saved
 
 
 # --- import_cross_page_community_sdc (cross-page inside-template rescue) ---

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -785,12 +785,15 @@ from ingest_wikimedia.legacy_artwork import (  # noqa: E402
     LEGACY_MIGRATION_BASE_SUMMARY,
     LEGACY_MIGRATION_EDIT_SUMMARY,
     MigrationResult,
+    _build_related_image_claim,
+    _extract_related_image_files,
     build_migration_summary,
     entity_was_already_migrated,
     fetch_revision_snapshots,
     import_cross_page_community_sdc,
     materialize_import_claims,
     materialize_pending_date_claim,
+    materialize_pending_related_image_claim,
     migrate_legacy_file,
     post_legacy_import_claims,
     render_migrated_wikitext,
@@ -1875,6 +1878,190 @@ def test_import_cross_page_community_sdc_nothing_to_rescue_on_bot_only_history()
         c.kwargs.get("action") != "wbeditentity"
         for c in site.simple_request.call_args_list
     )
+
+
+# --- related image (P6802, commonsMedia datatype) -------------------------
+
+
+def test_extract_related_image_files_parses_other_version_templates():
+    wt = (
+        "{{Artwork|title=T|Other versions="
+        "{{other version|File:First related.jpg}}"
+        "{{Other Version|Second related.jpg}}}}"
+    )
+    # File: prefix stripped; case-insensitive template name; order preserved.
+    assert _extract_related_image_files(wt) == [
+        "First related.jpg",
+        "Second related.jpg",
+    ]
+
+
+def test_extract_related_image_files_empty_when_absent():
+    assert _extract_related_image_files("{{Artwork|title=T}}") == []
+    assert _extract_related_image_files("no template here") == []
+
+
+def test_build_related_image_claim_serialises_commons_media_correctly():
+    """The first commonsMedia-typed property in the pipeline — verify the
+    exact Wikibase shape: string datavalue, 'commons-media' snak datatype,
+    bare filename, standard inferred-from-Wikitext reference."""
+    claim = _build_related_image_claim(
+        "A file.jpg", "https://commons.wikimedia.org/w/index.php?title=X&oldid=1"
+    )
+    ms = claim["mainsnak"]
+    assert ms["property"] == "P6802"
+    assert ms["datatype"] == "commons-media"
+    assert ms["datavalue"] == {"type": "string", "value": "A file.jpg"}
+    assert ms["snaktype"] == "value"
+    ref = claim["references"][0]["snaks"]
+    assert ref["P887"][0]["datavalue"]["value"]["id"] == "Q131783016"
+
+
+def test_plan_migration_extracts_related_images_unconditionally():
+    """Related images are preserved regardless of provenance — a bot-only
+    history (no community edits) still yields the P6802 import, because DPLA
+    has no canonical related-image value to drift from."""
+    revs = _make_revs(
+        (
+            1,
+            "DPLA_bot",
+            "{{Artwork|title=A Title|Other versions={{other version|Rel.jpg}}}}",
+        ),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert plan.community_imports == {}  # bot-only → nothing provenance-gated
+    assert plan.related_image_imports == ["Rel.jpg"]  # ...but kept anyway
+
+
+def test_build_legacy_import_claims_emits_related_image_placeholder():
+    plan = MigrationPlan(source_permalink="P", related_image_imports=["Rel.jpg"])
+    claims = build_legacy_import_claims(plan)
+    assert len(claims) == 1
+    assert claims[0]["_phase3a_pending_related_image"] == "Rel.jpg"
+    assert claims[0]["_permalink"] == "P"
+
+
+def test_materialize_related_image_builds_when_site_none():
+    claim = materialize_pending_related_image_claim(
+        {"_phase3a_pending_related_image": "Rel.jpg", "_permalink": "P"}
+    )
+    assert claim is not None
+    assert claim["mainsnak"]["datatype"] == "commons-media"
+    assert claim["mainsnak"]["datavalue"]["value"] == "Rel.jpg"
+
+
+def test_materialize_related_image_drops_missing_file():
+    """A {{other version}} pointing at a non-existent file is dropped, so it
+    can't fail Wikibase's commonsMedia validation and poison the whole atomic
+    claim bundle."""
+    site = MagicMock()
+    site.simple_request.return_value.submit.return_value = {
+        "query": {"pages": {"-1": {"missing": ""}}}
+    }
+    claim = materialize_pending_related_image_claim(
+        {"_phase3a_pending_related_image": "Gone.jpg", "_permalink": "P"}, site=site
+    )
+    assert claim is None
+
+
+def test_materialize_related_image_dedups_existing_p6802():
+    entity = {
+        "statements": {
+            "P6802": [
+                {"mainsnak": {"snaktype": "value", "datavalue": {"value": "Rel.jpg"}}}
+            ]
+        }
+    }
+    claim = materialize_pending_related_image_claim(
+        {"_phase3a_pending_related_image": "Rel.jpg", "_permalink": "P"},
+        site=None,
+        existing_entity=entity,
+    )
+    assert claim is None
+
+
+def test_entity_was_already_migrated_detects_p6802_ref():
+    assert entity_was_already_migrated(_entity_with_legacy_import("P6802")) is True
+
+
+def test_migrate_legacy_file_imports_related_image_as_commons_media():
+    """End-to-end: an {{Artwork}} with Other versions={{other version|X}}
+    posts a P6802 commonsMedia claim carrying the bare filename."""
+
+    class _Rev:
+        revid = 1
+        user = "DPLA_bot"
+        text = "{{Artwork|title=A Title|Other versions={{other version|Rel file.jpg}}}}"
+
+    page = _mock_file_page("File:Foo.jpg", _Rev.text, [_Rev()])
+    item, provider, dp = _item_md()
+    site = MagicMock()
+    site.tokens = {"csrf": "CSRFTOKEN"}
+    # One response satisfies both the wbgetentities fetch (entities key) and
+    # the commonsMedia existence query (query.pages, no "missing").
+    site.simple_request.return_value.submit.return_value = {
+        "entities": {"M42": {}},
+        "query": {"pages": {"1": {"pageid": 1, "title": "File:Rel file.jpg"}}},
+    }
+    result = migrate_legacy_file(
+        file_page=page,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    assert (
+        result.imports_posted == 1
+    )  # only the related image (title matches canonical)
+
+    import json as _json
+
+    wbedit = [
+        c
+        for c in site.simple_request.call_args_list
+        if c.kwargs.get("action") == "wbeditentity"
+    ]
+    assert len(wbedit) == 1
+    posted = _json.loads(wbedit[0].kwargs["data"])["claims"]
+    p6802 = [c for c in posted if c["mainsnak"]["property"] == "P6802"]
+    assert len(p6802) == 1
+    assert p6802[0]["mainsnak"]["datatype"] == "commons-media"
+    assert p6802[0]["mainsnak"]["datavalue"] == {
+        "type": "string",
+        "value": "Rel file.jpg",
+    }
+
+
+def test_import_cross_page_rescues_related_image_with_no_scalar_community():
+    """The cross-page guard must not skip a source whose only rescuable
+    content is a related image (no scalar community_imports)."""
+
+    class _Rev:
+        revid = 1
+        user = "DPLA_bot"
+        text = "{{Artwork|title=A Title|Other versions={{other version|Rel.jpg}}}}"
+
+    source = _mock_file_page("File:Old.jpg", _Rev.text, [_Rev()])
+    dest = _mock_file_page("File:New.jpg", "{{DPLA metadata}}", [])
+    item, provider, dp = _item_md()
+    site = MagicMock()
+    site.tokens = {"csrf": "CSRFTOKEN"}
+    site.simple_request.return_value.submit.return_value = {
+        "entities": {"M42": {}},
+        "query": {"pages": {"1": {"pageid": 1}}},
+    }
+    n = import_cross_page_community_sdc(
+        source_page=source,
+        dest_page=dest,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    assert n == 1  # the related image, despite no scalar community imports
 
 
 def test_legacy_migration_edit_summary_mentions_q131783016():

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -758,11 +758,13 @@ from ingest_wikimedia.legacy_artwork import (  # noqa: E402
     build_migration_summary,
     entity_was_already_migrated,
     fetch_revision_snapshots,
+    import_cross_page_community_sdc,
     materialize_import_claims,
     materialize_pending_date_claim,
     migrate_legacy_file,
     post_legacy_import_claims,
     render_migrated_wikitext,
+    rescue_wikitext,
 )
 
 
@@ -1358,6 +1360,28 @@ def test_render_migrated_wikitext_does_not_duplicate_section_heading():
     assert "[[Category:Foo]]" in result
 
 
+def test_render_migrated_wikitext_preserves_image_notes():
+    """The regular migration is a node-swap, so {{ImageNote}} annotation
+    blocks outside the legacy template survive verbatim. The #397 title-drift
+    fix defers to this path, so it must not drop community image notes."""
+    note = (
+        "{{ImageNote|id=1|x=10|y=20|w=30|h=40|dimx=100|dimy=200|style=2}}\n"
+        "a detail worth noting\n"
+        "{{ImageNoteEnd|id=1}}"
+    )
+    original = (
+        "== {{int:filedesc}} ==\n"
+        "{{Artwork|title=Old}}\n"
+        f"{note}\n"
+        "[[Category:Foo]]"
+    )
+    result = render_migrated_wikitext(original, "{{DPLA metadata|title=New}}")
+    assert "{{Artwork" not in result
+    assert "{{DPLA metadata|title=New}}" in result
+    assert note in result
+    assert "[[Category:Foo]]" in result
+
+
 def test_render_migrated_wikitext_accepts_template_only_block_for_back_compat():
     """The previous test asserts the new caller contract — but the
     extraction step must also be a no-op on the old caller contract
@@ -1439,6 +1463,84 @@ def test_fetch_revision_snapshots_tolerates_missing_user_and_text():
     snapshots = fetch_revision_snapshots(file_page)
     assert len(snapshots) == 1
     assert snapshots[0].user == "" and snapshots[0].text == ""
+
+
+# --- rescue_wikitext (cross-page, preserve-by-default) --------------------
+
+
+def test_rescue_wikitext_node_swaps_and_preserves_everything_outside():
+    """Preserve-by-default: node-swap the source's wrapper for the fresh
+    {{DPLA metadata}} block and keep ALL other content verbatim — including
+    image-note annotations and arbitrary community templates that no
+    allowlist ever enumerated."""
+    note = (
+        "{{ImageNote|id=1|x=10|y=20|w=30|h=40|dimx=100|dimy=200|style=2}}\n"
+        "a community annotation\n"
+        "{{ImageNoteEnd|id=1}}"
+    )
+    source = (
+        "== {{int:filedesc}} ==\n"
+        "{{Artwork|title=Old|creator={{Creator:Jane Doe}}}}\n"
+        f"{note}\n"
+        "{{SomeCommunityTemplate|x=1}}\n"
+        "[[Category:Community curated]]"
+    )
+    result = rescue_wikitext(source, "{{DPLA metadata|title=New}}")
+    assert "{{Artwork" not in result
+    assert "{{DPLA metadata|title=New}}" in result
+    assert note in result  # image notes preserved for free
+    assert "{{SomeCommunityTemplate|x=1}}" in result  # arbitrary template preserved
+    assert "[[Category:Community curated]]" in result
+
+
+@pytest.mark.parametrize(
+    "wrapper",
+    [
+        "{{Artwork|title=Old}}",
+        "{{Information|title=Old}}",
+        "{{Photograph|title=Old}}",
+        "{{DPLA metadata|title=Old}}",
+        "{{NARA-image-full|title=Old}}",
+    ],
+)
+def test_rescue_wikitext_recognizes_all_wrappers(wrapper):
+    """Every wrapper the cross-page rescue can meet — the legacy forms, the
+    already-migrated {{DPLA metadata}}, and NARA's {{NARA-image-full}} — is
+    node-swapped for the fresh block, carrying a trailing category through."""
+    source = f"{wrapper}\n[[Category:Keep me]]"
+    result = rescue_wikitext(source, "{{DPLA metadata|title=New}}")
+    assert "{{DPLA metadata|title=New}}" in result
+    assert "[[Category:Keep me]]" in result
+    assert "title=Old" not in result  # old wrapper replaced, not appended
+
+
+def test_rescue_wikitext_falls_back_to_allowlist_when_no_wrapper():
+    """A source with no recognised metadata wrapper can't be node-swapped, so
+    rescue_wikitext falls back to the narrow merge_preserved_wikitext allowlist
+    — license/category kept, an unrecognised community template dropped (the
+    inherent limit of the no-wrapper case, not a regression)."""
+    source = (
+        "{{PD-USGov}}\n{{UnknownCommunityThing|x=1}}\n[[Category:Kept by allowlist]]"
+    )
+    result = rescue_wikitext(source, "{{DPLA metadata|title=New}}")
+    assert "{{DPLA metadata|title=New}}" in result
+    assert "{{PD-USGov}}" in result
+    assert "[[Category:Kept by allowlist]]" in result
+    assert "{{UnknownCommunityThing" not in result
+
+
+def test_rescue_wikitext_no_duplicate_heading_with_full_form_block():
+    """Regression (lesson from #299): the live callers pass get_wiki_text's
+    FULL upload form (heading + blank line + template), not a bare template.
+    rescue_wikitext must substitute template-only, so a source that already
+    carries a heading doesn't end up with two."""
+    source = "== {{int:filedesc}} ==\n{{Artwork|title=Old}}\n[[Category:Keep]]"
+    full_form_block = "== {{int:filedesc}} ==\n\n{{DPLA metadata\n| title = New\n}}"
+    result = rescue_wikitext(source, full_form_block)
+    assert result.count("== {{int:filedesc}} ==") == 1
+    assert "{{DPLA metadata" in result
+    assert "{{Artwork" not in result
+    assert "[[Category:Keep]]" in result
 
 
 # --- migrate_legacy_file end-to-end ---------------------------------------
@@ -1596,6 +1698,115 @@ def test_migrate_legacy_file_imports_community_value_and_rewrites_wikitext():
     assert (
         posted["claims"][0]["mainsnak"]["datavalue"]["value"]["text"]
         == "A Better Title"
+    )
+
+
+# --- import_cross_page_community_sdc (cross-page inside-template rescue) ---
+
+
+def test_import_cross_page_community_sdc_imports_from_source_history():
+    """Plans over the SOURCE page's history and posts the community-authored
+    value to the DESTINATION entity — the cross-page analogue of the SDC half
+    of migrate_legacy_file."""
+
+    class _Rev1:
+        revid, user, text = 1, "DPLA_bot", "{{Artwork|title=A Title}}"
+
+    class _Rev2:
+        revid, user, text = 2, "EditorOne", "{{Artwork|title=A Better Title}}"
+
+    source = _mock_file_page("File:Old.jpg", _Rev2.text, [_Rev1(), _Rev2()])
+    dest = _mock_file_page("File:New.jpg", "{{DPLA metadata}}", [])
+    dest.pageid = 99
+    item, provider, dp = _item_md()
+    site = _site_with_empty_entity()
+    site.simple_request.return_value.submit.return_value = {"entities": {"M99": {}}}
+
+    n = import_cross_page_community_sdc(
+        source_page=source,
+        dest_page=dest,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    assert n == 1
+
+    import json as _json
+
+    wbeditentity = [
+        c
+        for c in site.simple_request.call_args_list
+        if c.kwargs.get("action") == "wbeditentity"
+    ]
+    assert len(wbeditentity) == 1
+    # Written to the DESTINATION entity (M99), not the source page.
+    assert wbeditentity[0].kwargs["id"] == "M99"
+    posted = _json.loads(wbeditentity[0].kwargs["data"])
+    assert (
+        posted["claims"][0]["mainsnak"]["datavalue"]["value"]["text"]
+        == "A Better Title"
+    )
+
+
+def test_import_cross_page_community_sdc_idempotent_on_dest_entity():
+    """If the destination entity already carries a legacy-import ref, bail
+    out with 0 and post nothing — a re-run must not duplicate claims."""
+
+    class _Rev2:
+        revid, user, text = 2, "EditorOne", "{{Artwork|title=A Better Title}}"
+
+    source = _mock_file_page("File:Old.jpg", _Rev2.text, [_Rev2()])
+    dest = _mock_file_page("File:New.jpg", "{{DPLA metadata}}", [])
+    item, provider, dp = _item_md()
+    site = MagicMock()
+    site.tokens = {"csrf": "CSRFTOKEN"}
+    site.simple_request.return_value.submit.return_value = {
+        "entities": {"M42": _entity_with_legacy_import("P1476")}
+    }
+
+    n = import_cross_page_community_sdc(
+        source_page=source,
+        dest_page=dest,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    assert n == 0
+    assert all(
+        c.kwargs.get("action") != "wbeditentity"
+        for c in site.simple_request.call_args_list
+    )
+
+
+def test_import_cross_page_community_sdc_nothing_to_rescue_on_bot_only_history():
+    """A DPLA-bot-only source history has no community-authored value to
+    import, so nothing is posted and the count is 0."""
+
+    class _Rev:
+        revid, user, text = 1, "DPLA_bot", "{{Artwork|title=A Title}}"
+
+    source = _mock_file_page("File:Old.jpg", _Rev.text, [_Rev()])
+    dest = _mock_file_page("File:New.jpg", "{{DPLA metadata}}", [])
+    item, provider, dp = _item_md()
+    site = _site_with_empty_entity()
+
+    n = import_cross_page_community_sdc(
+        source_page=source,
+        dest_page=dest,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    assert n == 0
+    assert all(
+        c.kwargs.get("action") != "wbeditentity"
+        for c in site.simple_request.call_args_list
     )
 
 

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -431,10 +431,31 @@ def test_classify_respects_explicit_bot_accounts_argument():
 
 def test_dpla_bot_allowlist_contains_known_accounts():
     """Pin the known accounts so a typo'd rename can't silently lose
-    classification coverage for the long-tenure files those bots
-    uploaded."""
-    assert "DPLA_bot" in DPLA_BOT_ACCOUNTS
+    classification coverage for the long-tenure files those bots uploaded.
+    Space form is canonical — it's what the Commons API returns in ``user``."""
+    assert "DPLA bot" in DPLA_BOT_ACCOUNTS
     assert "US National Archives bot" in DPLA_BOT_ACCOUNTS
+    assert "Flickr upload bot" in DPLA_BOT_ACCOUNTS
+
+
+def test_classify_matches_underscore_and_space_username_forms():
+    """Commons returns usernames with spaces ("DPLA bot"); the allowlist stores
+    the space form. Matching must be underscore/space-insensitive so DPLA-bot
+    edits are never misclassified as community — which, for a *drifted* value,
+    would resurrect stale DPLA metadata as a fake community contribution."""
+    classified = classify_param_provenance(
+        {"a": "DPLA bot", "b": "DPLA_bot", "c": "dpla_BOT"}
+    )
+    assert classified == {"a": "dpla", "b": "dpla", "c": "dpla"}
+
+
+def test_classify_flickr_upload_bot_is_dpla():
+    """Flickr2Commons imports are automated import data, not community
+    curation — a file the Flickr bot uploaded and we later renamed must not
+    have its (drifted) fields resurrected as community contributions."""
+    assert classify_param_provenance({"title": "Flickr upload bot"}) == {
+        "title": "dpla"
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -488,6 +509,26 @@ def test_plan_migration_classifies_bot_value_as_dpla_originated():
         "description": "A description",
         "date": "1900",
     }
+
+
+def test_plan_migration_does_not_resurrect_drifted_bot_value():
+    """Core drift-safety property: a value the *bot* last set that now DIFFERS
+    from canonical is drifted DPLA metadata (DPLA-caused) — NOT a community
+    edit — so it must stay dpla-originated (replaced by canonical), never
+    imported as a community contribution. Uses NARA's own bot (its pre-2020
+    uploads) with the space-form username the Commons API returns."""
+    revs = _make_revs(
+        (
+            1,
+            "US National Archives bot",
+            "{{Artwork|title=Old Drifted Title|date=1900}}",
+        ),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params(title="A Title"))
+    assert plan is not None
+    # Title differs from canonical ("A Title") but was bot-authored → NOT rescued.
+    assert plan.community_imports == {}
+    assert plan.dpla_originated_params["title"] == "Old Drifted Title"
 
 
 def test_plan_migration_imports_community_value_that_differs_from_canonical():

--- a/tests/test_upload_invariant.py
+++ b/tests/test_upload_invariant.py
@@ -90,7 +90,6 @@ def test_invariant_corollary_1_cross_item_collision_uploads_to_our_intended_titl
             page_title=our_intended,
             dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ordinal=1,
-            wiki_markup="",
         )
 
     assert action is DriftResolution.LEAVE_OTHERS_ALONE, (
@@ -157,7 +156,6 @@ def test_invariant_corollary_2_redirect_at_intended_title_defers_to_overwrite_ha
             page_title=our_intended,
             dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ordinal=1,
-            wiki_markup="",
         )
     assert action is DriftResolution.LEAVE_OTHERS_ALONE, (
         f"expected LEAVE_OTHERS_ALONE (cross-item collision detected "
@@ -202,7 +200,6 @@ def test_invariant_already_satisfied_via_normalized_identity_returns_already_cor
             page_title=raw_page_title,
             dpla_id="cccccccccccccccccccccccccccccccc",
             ordinal=1,
-            wiki_markup="",
         )
 
     assert action is DriftResolution.ALREADY_CORRECT, (
@@ -239,7 +236,6 @@ def test_drift_resolution_sentinel_contract_pin():
             page_title="Ours - DPLA - eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee (page 1).jpg",
             dpla_id="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
             ordinal=1,
-            wiki_markup="",
         )
     assert action is DriftResolution.LEAVE_OTHERS_ALONE
     assert action.value == "leave_others_alone"

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1678,6 +1678,9 @@ def _drift_uploader_with_pages(
 
     uploader = Uploader.__new__(Uploader)
     uploader.site = MagicMock(name="site")
+    # The tag-duplicate rescue resolves the destination pageid via this helper
+    # before the SDC import; give it a real id so the import path is exercised.
+    uploader._refresh_pageid_with_retries = MagicMock(return_value=42)
 
     old_page = MagicMock(name="old_page")
     old_page.text = old_text
@@ -1799,8 +1802,29 @@ def test_rescue_imports_inside_template_sdc_from_old_page():
     sdc_mock.assert_called_once()
     kwargs = sdc_mock.call_args.kwargs
     assert kwargs["source_page"] is old_page
-    assert kwargs["dest_page"] is new_page
+    # Destination targeted by resolved mediaid (pageid refreshed to 42), not a
+    # raw page object — guards against a lagged pageid becoming "M0".
+    assert kwargs["dest_mediaid"] == "M42"
     assert kwargs["dpla_id"] == _DPLA_ID
+
+
+def test_rescue_skips_sdc_when_pageid_unresolved():
+    """If the destination pageid can't be resolved post-upload (indexing lag),
+    the SDC import is skipped (no bogus M0) while the wikitext rescue and the
+    tag still proceed."""
+    old_text = "{{Artwork|title=Old}}\n[[Category:Curated]]\n"
+    uploader, old_page, new_page = _drift_uploader_with_pages(old_text)
+    uploader._refresh_pageid_with_retries = MagicMock(return_value=None)
+    sdc_mock = MagicMock(return_value=0)
+
+    with patch("tools.uploader.tag_as_duplicate") as tag_mock:
+        _call_tag_drift(
+            uploader, old_page, new_page, import_cross_page_community_sdc=sdc_mock
+        )
+
+    sdc_mock.assert_not_called()  # pageid unresolved → no M0 import
+    assert new_page.save.called  # outside-template wikitext rescue still runs
+    tag_mock.assert_called_once()  # tag still runs
 
 
 def test_rescue_no_save_when_nothing_to_preserve():

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -760,7 +760,6 @@ def test_resolve_hash_drift_case2_skips_tag_when_existing_in_expected_titles():
             page_title=intended_title,
             dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ordinal=4,
-            wiki_markup="",
             expected_item_titles=expected_titles,
         )
     assert action == "leave_others_alone"
@@ -788,7 +787,6 @@ def test_resolve_hash_drift_case2_still_tags_when_existing_is_true_orphan():
             page_title=intended_title,
             dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ordinal=4,
-            wiki_markup="",
             expected_item_titles=expected_titles,
         )
     assert action == "upload_and_tag"
@@ -810,7 +808,6 @@ def test_resolve_hash_drift_case2_tags_when_expected_titles_is_none():
             page_title=intended_title,
             dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ordinal=4,
-            wiki_markup="",
         )
     assert action == "upload_and_tag"
 
@@ -875,7 +872,6 @@ def test_resolve_hash_drift_404_on_colliding_id_falls_through_to_migration():
             page_title=intended_title,
             dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ordinal=2,
-            wiki_markup="",
         )
     assert action == "moved", (
         "404 on the colliding DPLA ID is the rename signal — the orphan "
@@ -903,7 +899,6 @@ def test_resolve_hash_drift_non_404_exception_stays_on_leave_others_alone():
         page_title=intended_title,
         dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         ordinal=2,
-        wiki_markup="",
     )
     assert action == "leave_others_alone"
 
@@ -924,7 +919,6 @@ def test_resolve_hash_drift_5xx_response_stays_on_leave_others_alone():
         page_title=intended_title,
         dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         ordinal=2,
-        wiki_markup="",
     )
     assert action == "leave_others_alone"
 
@@ -942,7 +936,6 @@ def test_resolve_hash_drift_valid_cross_item_collision_leaves_others_alone():
         page_title=intended_title,
         dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         ordinal=2,
-        wiki_markup="",
     )
     assert action == "leave_others_alone"
 
@@ -1178,7 +1171,6 @@ def test_case3_move_suppresses_commonsdelinker_when_actual_is_sibling():
             page_title=_ITEM_PAGE_8,
             dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ordinal=11,
-            wiki_markup="",
             expected_item_titles=expected_titles,
         )
     assert action == "moved"
@@ -1207,7 +1199,6 @@ def test_case3_move_posts_commonsdelinker_when_actual_is_not_sibling():
             page_title=_ITEM_PAGE_8,
             dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ordinal=11,
-            wiki_markup="",
             expected_item_titles=expected_titles,
         )
     assert action == "moved"
@@ -1237,7 +1228,6 @@ def test_case1_move_suppresses_commonsdelinker_when_actual_is_sibling():
             page_title=_ITEM_PAGE_8,
             dpla_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             ordinal=11,
-            wiki_markup="",
             expected_item_titles=expected_titles,
         )
     assert action == "moved"
@@ -1294,6 +1284,26 @@ def test_move_to_correct_title_posts_with_check_usage_false_when_used():
     assert order == ["usage_check", "move"]
     mock_post.assert_called_once()
     assert mock_post.call_args.kwargs.get("check_usage") is False
+
+
+def test_move_to_correct_title_does_not_rewrite_description_defers_to_cleanup():
+    """Deferral fix: after the title-drift move, the method must NOT rewrite the
+    moved page's description. It previously blind-overwrote it (dropping
+    community metadata like {{Creator:...}}); the community-preserving migration
+    is now left to the post-SDC sdc-sync cleanup. Assert the move still happens
+    but there is no post-move page fetch/save (the only get_page use in this
+    method was the removed description-rewrite block)."""
+    uploader = _build_uploader_with_dpla()
+    existing = _drift_existing_file("Old Title - DPLA - a (page 1).jpg")
+    intended = _make_intended_page("New Title - DPLA - b (page 1).jpg")
+    with (
+        patch("tools.uploader.file_has_inbound_usage", return_value=False),
+        patch("tools.uploader.post_commonsdelinker_request"),
+        patch("tools.uploader.get_page") as mock_get_page,
+    ):
+        uploader._move_to_correct_title(existing, intended, "b", "Case 3")
+    existing.move.assert_called_once()
+    mock_get_page.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -2753,7 +2763,6 @@ def test_resolve_hash_drift_returns_already_correct_on_whitespace_normalized_mat
             page_title=raw_page_title,
             dpla_id="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             ordinal=1,
-            wiki_markup="",
         )
     assert action == "already_correct"
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1648,12 +1648,13 @@ def test_main_dispatches_to_pool_when_workers_gt_one():
 # _tag_drift_duplicate — rescue + tag combined operation
 #
 # Case 2 hash-drift (``upload_and_tag``) is the only title-correction path
-# where the bot must explicitly preserve community-contributed metadata
-# from the file it's about to queue for deletion (the move and redirect
-# paths do this via merge_preserved_wikitext inline). _tag_drift_duplicate
-# now does both: rescue community categories/licenses/assessments into the
-# new (correct-title) file, then tag the old one. The two steps are
-# independently best-effort so a rescue failure does not block the tag.
+# where the source page is destroyed, so the bot must explicitly preserve
+# community-contributed metadata before queuing it for deletion.
+# _tag_drift_duplicate does both: rescue the old page's content into the new
+# (correct-title) file — outside-template content via rescue_wikitext's
+# node-swap, inside-template community params via import_cross_page_community_sdc
+# — then tag the old one. The steps are independently best-effort so a rescue
+# failure does not block the tag.
 
 
 _NEW_WIKI_MARKUP = "{{DPLA metadata}}\n"
@@ -1704,25 +1705,37 @@ def _patch_get_page(old_page, new_page):
 
 def _call_tag_drift(uploader, old_page, new_page, **patches):
     """Invoke ``_tag_drift_duplicate`` with the standard arg shape so
-    each test asserts on outcomes instead of plumbing the call."""
-    extras = {f"tools.uploader.{name}": value for name, value in patches.items()}
-    with patch(
-        "tools.uploader.get_page",
-        side_effect=_patch_get_page(old_page, new_page),
-    ):
-        if extras:
-            from contextlib import ExitStack
+    each test asserts on outcomes instead of plumbing the call.
 
-            with ExitStack() as stack:
-                for target, value in extras.items():
-                    stack.enter_context(patch(target, value))
-                uploader._tag_drift_duplicate(
-                    "old.jpg", "new.jpg", _NEW_WIKI_MARKUP, _DPLA_ID
-                )
-        else:
-            uploader._tag_drift_duplicate(
-                "old.jpg", "new.jpg", _NEW_WIKI_MARKUP, _DPLA_ID
-            )
+    The inside-template SDC import is patched to a no-op (returns 0) by
+    default, so these tests exercise only the outside-template node-swap
+    rescue; pass ``import_cross_page_community_sdc=<mock>`` to override.
+    """
+    from contextlib import ExitStack
+
+    extras = {f"tools.uploader.{name}": value for name, value in patches.items()}
+    extras.setdefault(
+        "tools.uploader.import_cross_page_community_sdc",
+        MagicMock(return_value=0),
+    )
+    with (
+        patch(
+            "tools.uploader.get_page",
+            side_effect=_patch_get_page(old_page, new_page),
+        ),
+        ExitStack() as stack,
+    ):
+        for target, value in extras.items():
+            stack.enter_context(patch(target, value))
+        uploader._tag_drift_duplicate(
+            "old.jpg",
+            "new.jpg",
+            _NEW_WIKI_MARKUP,
+            _DPLA_ID,
+            item_metadata={},
+            provider={},
+            data_provider={},
+        )
 
 
 def test_rescue_preserves_community_categories_into_new_file():
@@ -1766,11 +1779,37 @@ def test_rescue_preserves_assessment_and_license_templates():
     assert "[[Category:Notable images]]" in saved_text
 
 
+def test_rescue_imports_inside_template_sdc_from_old_page():
+    """The tag-duplicate path invokes the inside-template SDC rescue,
+    passing the OLD page as source and the NEW (survivor) page as dest —
+    since the old page is about to be deleted, its in-template community
+    provenance has to be captured before it's gone."""
+    old_text = "{{Artwork|title=Old}}\n[[Category:Curated]]\n"
+    uploader, old_page, new_page = _drift_uploader_with_pages(old_text)
+    sdc_mock = MagicMock(return_value=2)
+
+    with patch("tools.uploader.tag_as_duplicate"):
+        _call_tag_drift(
+            uploader,
+            old_page,
+            new_page,
+            import_cross_page_community_sdc=sdc_mock,
+        )
+
+    sdc_mock.assert_called_once()
+    kwargs = sdc_mock.call_args.kwargs
+    assert kwargs["source_page"] is old_page
+    assert kwargs["dest_page"] is new_page
+    assert kwargs["dpla_id"] == _DPLA_ID
+
+
 def test_rescue_no_save_when_nothing_to_preserve():
-    """If the old page has nothing in merge_preserved_wikitext's
-    pattern set, the new page must NOT be saved — calling save() on
-    identical content would emit a no-op revision on Commons."""
-    # Information template alone is NOT in the preserve set.
+    """If the old page has no content outside its metadata template, the
+    node-swap produces just the fresh block we already uploaded, so the new
+    page must NOT be saved — calling save() on identical content would emit a
+    no-op revision on Commons."""
+    # A bare {{Information}} with nothing around it: node-swapping it for
+    # {{DPLA metadata}} yields exactly wiki_markup, so there's nothing to save.
     old_text = "{{Information|description=Plain text}}\n"
     uploader, old_page, new_page = _drift_uploader_with_pages(old_text)
 
@@ -2783,6 +2822,9 @@ def test_tag_drift_duplicate_refuses_self_tag_byte_equal():
             new_filename=same,
             wiki_markup="wt",
             dpla_id="cccccccccccccccccccccccccccccccc",
+            item_metadata={},
+            provider={},
+            data_provider={},
         )
     tag_mock.assert_not_called()
     get_page_mock.assert_not_called()
@@ -2805,6 +2847,9 @@ def test_tag_drift_duplicate_refuses_self_tag_whitespace_run_equal():
             new_filename=double_space,
             wiki_markup="wt",
             dpla_id="dddddddddddddddddddddddddddddddd",
+            item_metadata={},
+            provider={},
+            data_provider={},
         )
     tag_mock.assert_not_called()
     get_page_mock.assert_not_called()
@@ -2820,12 +2865,16 @@ def test_tag_drift_duplicate_still_tags_when_names_genuinely_differ():
     with (
         patch("tools.uploader.tag_as_duplicate") as tag_mock,
         patch("tools.uploader.get_page", return_value=old_page),
-        patch("tools.uploader.merge_preserved_wikitext", return_value="wt"),
+        patch("tools.uploader.rescue_wikitext", return_value="wt"),
+        patch("tools.uploader.import_cross_page_community_sdc", return_value=0),
     ):
         uploader._tag_drift_duplicate(
             old_filename="Old title - DPLA - eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.jpg",
             new_filename="New title - DPLA - eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.jpg",
             wiki_markup="wt",
             dpla_id="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            item_metadata={},
+            provider={},
+            data_provider={},
         )
     tag_mock.assert_called_once()

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1955,16 +1955,30 @@ class Uploader:
                 # new page exists and isn't a redirect because we just
                 # uploaded it. Skip the exists/redirect round-trips.
                 new_page = get_page(self.site, f"File:{new_filename}")
-                imported = import_cross_page_community_sdc(
-                    source_page=old_page,
-                    dest_page=new_page,
-                    item_metadata=item_metadata,
-                    provider=provider,
-                    data_provider=data_provider,
-                    dpla_id=dpla_id,
-                    site=self.site,
-                    summary=rescue_summary,
-                )
+                # Resolve the destination pageid explicitly, riding out the
+                # post-upload indexing-lag race, so the SDC import targets a
+                # real MediaInfo entity — a lagged 0/None must never become
+                # the bogus "M0". The wikitext rescue below is independent and
+                # runs regardless.
+                dest_pageid = self._refresh_pageid_with_retries(f"File:{new_filename}")
+                imported = 0
+                if dest_pageid:
+                    imported = import_cross_page_community_sdc(
+                        source_page=old_page,
+                        dest_mediaid=f"M{dest_pageid}",
+                        item_metadata=item_metadata,
+                        provider=provider,
+                        data_provider=data_provider,
+                        dpla_id=dpla_id,
+                        site=self.site,
+                        summary=rescue_summary,
+                    )
+                else:
+                    logging.warning(
+                        f"Skipping community-SDC rescue into "
+                        f"[[File:{new_filename}]]: pageid unresolved post-upload "
+                        f"(sdc-sync's title→pageid fallback recovers next run)."
+                    )
                 rescued = rescue_wikitext(old_page.text or "", wiki_markup)
                 # Equality means the node-swap carried nothing beyond the
                 # fresh block we already uploaded (the old page had no

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -107,7 +107,6 @@ from ingest_wikimedia.wikimedia import (
     find_file_by_hash,
     extract_dpla_id_from_commons_title,
     is_same_item_redirect_relic,
-    merge_preserved_wikitext,
     tag_as_duplicate,
     check_content_type,
     is_download_only,
@@ -121,6 +120,10 @@ from ingest_wikimedia.wikimedia import (
     get_site,
     file_has_inbound_usage,
     post_commonsdelinker_request,
+)
+from ingest_wikimedia.legacy_artwork import (
+    import_cross_page_community_sdc,
+    rescue_wikitext,
 )
 
 MAX_UPLOAD_RETRIES = 3
@@ -1255,7 +1258,13 @@ class Uploader:
                 logging.info(f"Uploaded to {wikimedia_url(page_title)}")
                 if drift_old_filename:
                     self._tag_drift_duplicate(
-                        drift_old_filename, page_title, wiki_markup, dpla_id
+                        drift_old_filename,
+                        page_title,
+                        wiki_markup,
+                        dpla_id,
+                        item_metadata=item_metadata,
+                        provider=provider,
+                        data_provider=data_provider,
                     )
                 self.tracker.increment(Result.UPLOADED)
                 self.tracker.increment(Result.BYTES, file_size)
@@ -1469,11 +1478,20 @@ class Uploader:
         edit), or a no-DPLA-ID legacy title. The S3 sha1 must land at the
         intended title regardless of where the redirect points.
 
-        When `preserve_from_target` is True (default), license/Image-extracted/
-        category metadata from the redirect target is carried into the new
-        page. Callers should pass False when the target is a foreign DPLA
-        item, since its categories and Image-extracted parent link don't
-        apply to our page.
+        When `preserve_from_target` is True (default), the redirect target's
+        content is carried into the new page by :func:`rescue_wikitext`:
+        node-swap the target's metadata wrapper for our fresh
+        ``{{DPLA metadata}}`` and keep everything else verbatim (categories,
+        image-note annotations, every community template). Callers should pass
+        False when the target is a foreign DPLA item, since its categories and
+        Image-extracted parent link don't apply to our page.
+
+        Unlike the tag-duplicate path, this does *not* import the target's
+        in-template community params to SDC: the redirect target is not
+        deleted here (we overwrite our own title in place, pre-upload — there
+        is no destination MediaInfo entity yet), so any in-template community
+        value keeps living on the still-existing target page. Only the
+        outside-template presentation is copied forward.
 
         Returns (updated_file_page, old_filename).
         """
@@ -1486,7 +1504,7 @@ class Uploader:
             f"preserve_metadata={preserve_from_target})"
         )
         if preserve_from_target:
-            new_text = merge_preserved_wikitext(redirect_target.text or "", wiki_markup)
+            new_text = rescue_wikitext(redirect_target.text or "", wiki_markup)
         else:
             new_text = wiki_markup
         wiki_file_page.text = new_text
@@ -1870,17 +1888,26 @@ class Uploader:
         new_filename: str,
         wiki_markup: str,
         dpla_id: str,
+        item_metadata: dict,
+        provider: dict,
+        data_provider: dict,
     ) -> None:
         """Tag a stranded file as duplicate of the new (correct-title)
         file, AND carry any community-contributed metadata from the
         old page across to the new one before the admin-side delete.
 
-        Mirrors what ``_move_to_correct_title`` and
-        ``_resolve_redirect_overwrite`` already do in the move and
-        redirect-overwrite paths: license tags, assessment templates,
-        ``{{Image extracted}}`` parents, and category links community
-        editors have added are preserved via
-        :func:`merge_preserved_wikitext`.
+        This is the one drift path where the source page is *destroyed*, so
+        it does the full community rescue the regular migration does:
+
+        * **Outside the metadata template** — categories, ``{{ImageNote}}``
+          annotations, and every other community template — is carried into
+          the new page's wikitext by :func:`rescue_wikitext`'s node-swap
+          (preserve-by-default: no allowlist to keep in sync with whatever
+          template a community editor reaches for next).
+        * **Inside the old template's params** — values a non-bot editor set
+          — are imported to the new file's SDC by
+          :func:`import_cross_page_community_sdc`, via the same provenance
+          attribution (:func:`plan_migration`) the regular migration uses.
 
         Rescue and tag are independent best-effort steps — a failure
         on either is logged and does NOT block the other. The old
@@ -1915,40 +1942,48 @@ class Uploader:
 
         old_page = get_page(self.site, f"File:{old_filename}")
 
-        # Rescue community contributions, if any.
+        rescue_summary = (
+            f"Rescue community-contributed metadata from "
+            f"[[File:{old_filename}]] (DPLA ID [[dpla:{dpla_id}|{dpla_id}]])"
+        )
+        # Rescue community contributions, if any. SDC first — so a later
+        # wikitext-save failure can't strand the in-template provenance we
+        # imported — then the outside-template node-swap.
         try:
             if old_page.exists():
-                merged = merge_preserved_wikitext(old_page.text or "", wiki_markup)
-                # Equality means nothing matched merge_preserved_wikitext's
-                # patterns. Skip the save so we don't emit a no-op revision
-                # on the new file (the other two preserve sites — move,
-                # redirect-overwrite — don't need this guard because their
-                # destination text always differs from wiki_markup before
-                # the merge, but here new_page already carries wiki_markup
-                # from the upload we just completed).
-                if merged.rstrip() != wiki_markup.rstrip():
-                    # `get_page` is a constructor — no API hit — and we
-                    # know the page exists and isn't a redirect because
-                    # we just uploaded it. Skip the exists/redirect
-                    # round-trips and write directly.
-                    new_page = get_page(self.site, f"File:{new_filename}")
-                    new_page.text = merged
+                # `get_page` is a constructor — no API hit — and we know the
+                # new page exists and isn't a redirect because we just
+                # uploaded it. Skip the exists/redirect round-trips.
+                new_page = get_page(self.site, f"File:{new_filename}")
+                imported = import_cross_page_community_sdc(
+                    source_page=old_page,
+                    dest_page=new_page,
+                    item_metadata=item_metadata,
+                    provider=provider,
+                    data_provider=data_provider,
+                    dpla_id=dpla_id,
+                    site=self.site,
+                    summary=rescue_summary,
+                )
+                rescued = rescue_wikitext(old_page.text or "", wiki_markup)
+                # Equality means the node-swap carried nothing beyond the
+                # fresh block we already uploaded (the old page had no
+                # outside-template content). Skip the save so we don't emit a
+                # no-op revision on the new file.
+                wikitext_changed = rescued.rstrip() != wiki_markup.rstrip()
+                if wikitext_changed:
+                    new_page.text = rescued
                     with_csrf_recovery(
                         self.site,
                         f"save {new_page.title()} (rescue community metadata)",
-                        lambda: new_page.save(
-                            summary=(
-                                f"Rescue community-contributed metadata from "
-                                f"[[File:{old_filename}]] (DPLA ID "
-                                f"[[dpla:{dpla_id}|{dpla_id}]])"
-                            ),
-                            minor=False,
-                        ),
+                        lambda: new_page.save(summary=rescue_summary, minor=False),
                     )
+                if imported or wikitext_changed:
                     logging.info(
                         f"Rescued community-contributed metadata from "
-                        f"[[File:{old_filename}]] into "
-                        f"[[File:{new_filename}]] (DPLA ID {dpla_id})"
+                        f"[[File:{old_filename}]] into [[File:{new_filename}]] "
+                        f"(DPLA ID {dpla_id}; {imported} SDC import(s), "
+                        f"wikitext {'updated' if wikitext_changed else 'unchanged'})"
                     )
         except CsrfRecoveryFailed:
             # Session-level fatal — the community-metadata rescue is a

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -835,7 +835,6 @@ class Uploader:
                             page_title=page_title,
                             dpla_id=dpla_id,
                             ordinal=ordinal,
-                            wiki_markup=wiki_markup,
                             expected_item_titles=expected_item_titles,
                         )
                         if drift_action == DriftResolution.MOVED:
@@ -1511,13 +1510,15 @@ class Uploader:
         intended_page: pywikibot.FilePage,
         dpla_id: str,
         case_label: str,
-        wiki_markup: str | None = None,
         post_commonsdelinker: bool = True,
     ) -> None:
         """Move existing_file to intended_page and post a CommonsDelinker request.
 
-        If wiki_markup is provided, the moved page's description is updated to
-        reflect current DPLA metadata after the move.
+        The moved page's *description* is intentionally left untouched — the
+        community-preserving template migration is done later by the post-SDC
+        ``sdc-sync`` cleanup (see the NOTE in the body). This method only
+        restores the title invariant (the S3 SHA1 now lives at the canonical
+        title) and relinks inbound usage.
 
         post_commonsdelinker controls whether we ask CommonsDelinker to
         rewrite external references to actual_filename. Default True (the
@@ -1571,26 +1572,17 @@ class Uploader:
                 actual_filename,
             )
 
-        if wiki_markup:
-            moved_page = get_page(self.site, intended_page.title())
-            if moved_page.exists() and not moved_page.isRedirectPage():
-                # After the move, moved_page carries the original page's
-                # wikitext. Preserve license, Image-extracted, and category
-                # metadata from it before replacing with the {{DPLA metadata}} block.
-                moved_page.text = merge_preserved_wikitext(
-                    moved_page.text or "", wiki_markup
-                )
-                with_csrf_recovery(
-                    self.site,
-                    f"save {moved_page.title()} (post-drift description)",
-                    lambda: moved_page.save(
-                        summary=(
-                            f"Update description after title drift correction "
-                            f"(DPLA ID [[dpla:{dpla_id}|{dpla_id}]])"
-                        ),
-                        minor=False,
-                    ),
-                )
+        # NOTE: we deliberately do NOT rewrite the moved page's description
+        # here. Title/ID drift is DPLA-caused, so the old wikitext's
+        # DPLA-authored fields (id/url/title) legitimately differ from current —
+        # but the page may ALSO carry genuine community contributions. Safely
+        # distinguishing the two needs the revision-history *provenance* walk in
+        # ``ingest_wikimedia.legacy_artwork.migrate_legacy_file``, which the
+        # post-SDC ``sdc-sync`` cleanup (``_post_sdc_cleanup_for_page``) runs on
+        # this file later in the same pipeline: community edits are imported to
+        # SDC and only bot-authored (drifted) fields are replaced with canonical
+        # data. A blunt overwrite here previously discarded community metadata
+        # (e.g. ``{{Creator:...}}``); the move alone restores the title invariant.
 
     def _resolve_hash_drift(
         self,
@@ -1598,7 +1590,6 @@ class Uploader:
         page_title: str,
         dpla_id: str,
         ordinal: int,
-        wiki_markup: str | None = None,
         expected_item_titles: set[str] | None = None,
     ) -> DriftResolution:
         """Resolve the case where our S3 source's SHA1 already lives on
@@ -1801,7 +1792,6 @@ class Uploader:
                 intended_page,
                 dpla_id,
                 "title_text_drift_empty_intended (Case 3)",
-                wiki_markup,
                 post_commonsdelinker=not sibling_slot,
             )
             return DriftResolution.MOVED
@@ -1819,7 +1809,6 @@ class Uploader:
                     intended_page,
                     dpla_id,
                     "title_text_drift_redirect_at_intended (Case 1)",
-                    wiki_markup,
                     post_commonsdelinker=not sibling_slot,
                 )
                 return DriftResolution.MOVED


### PR DESCRIPTION
## Problem
The uploader's title-drift correction destructively overwrote a moved file's description with a fresh `{{DPLA metadata}}` block, keeping only a narrow **allowlist** (categories, PD-USGov, `{{Image extracted}}`, assessments) via `merge_preserved_wikitext`. That **dropped genuine community contributions** — `{{Creator:Webster & Stevens}}` on the [Seattle Central Library file](https://commons.wikimedia.org/w/index.php?title=File:Seattle_Central_Library_Circulation_Department,_1910_-_DPLA_-_fcce94e6f3834da238792875413113ec.jpg&diff=prev&oldid=1245831947), and `{{ImageNote}}` annotation blocks on the [Seattle waterfront file](https://commons.wikimedia.org/w/index.php?title=File:Seattle_waterfront_at_Pier_4,_ca._1910_-_DPLA_-_885aa5020b31023925ce94b55e801b8d.jpg&diff=prev&oldid=1245848691). An allowlist is a treadmill — it drops whatever community-template shape it doesn't yet enumerate.

## Why it was hard (and the key realization)
Title/ID drift is detected purely by the S3 SHA1 landing at a different title — which *means* the old wikitext's DPLA-authored fields (id/url/title) are *expected* to differ from current, because **DPLA's metadata drifted upstream**. So a naive "anything differing from current DPLA = community, preserve it" rule would resurrect the stale id/url/title we just corrected.

The resolution: `legacy_artwork.plan_migration` classifies each param by **authorship provenance** (who *last set* it, from revision history), not value-vs-canonical. Drifted DPLA fields are **bot-authored** → replaced with canonical; community edits are **human-authored** → imported to SDC (`P887→Q131783016` inferred-from-Wikitext). That machinery lives in the post-SDC `sdc-sync` cleanup, which runs after the uploader in **every** pipeline (`get-ids → downloader → uploader → sdc-sync`).

## Changes

### 1. Title-drift *move* defers to the cleanup
`_move_to_correct_title` no longer rewrites the moved page's description — the move alone restores the title invariant, and the post-SDC cleanup migrates the wikitext community-safely afterward. Removed the now-dead `wiki_markup` param from it and `_resolve_hash_drift` (+ call sites/tests).

### 2. Provenance allowlist hardened
`DPLA_BOT_ACCOUNTS` → `{DPLA bot, US National Archives bot, Flickr upload bot}`, matched case- **and** underscore/space-insensitively (`_normalize_account`). Fixes a latent bug where `"DPLA_bot"` never matched the space form Commons returns, which would have resurrected drifted DPLA-bot values as community. NARA's own bot folds in pre-2020 NARA; Flickr upload bot covers Flickr2Commons imports we later rename.

### 3. Cross-page rescues: preserve-by-default node-swap, not allowlist
The two remaining `merge_preserved_wikitext` sites (`_resolve_redirect_overwrite`, `_tag_drift_duplicate`) now use the **same node-swap the regular migration has used since #295** (`rescue_wikitext` / `_swap_wrapper_node`): swap only the source's metadata wrapper for the fresh `{{DPLA metadata}}`, keep **everything else verbatim** — categories, `{{ImageNote}}` blocks, every community template. `merge_preserved_wikitext` is **demoted to the fallback** for the rare source with no recognized wrapper (its sole remaining purpose). The allowlist predated the node-swap (#202) and was never retrofitted — this closes that gap.
- **`import_cross_page_community_sdc`**: the tag-duplicate path *destroys* the source, so it also lifts inside-template community params (via `plan_migration` over the old page's history) into the new file's SDC — full parity with the regular migration. A cheap `find_legacy_template` pre-check skips the history walk + `wbgetentities` for the common already-on-`{{DPLA metadata}}` source.
- **redirect-overwrite** runs pre-upload and leaves the target page intact, so it does node-swap only (no destination entity yet; inside-template content isn't at risk since the source survives).

### 4. `{{NARA-image-full}}` recognized as a migration wrapper
Its `Title`/`Description`/`Date`/`Author`/`Creator` params share names with `{{Artwork}}`, so they map through the existing `ARTWORK_PARAM_TO_CANONICAL_KEY` with no NARA-specific parsing — added to `LEGACY_TEMPLATE_NAMES` so both the regular migration and the rescue lift its four core fields to SDC. Its ~60 NARA-only archival params (ARC/NAID/record group/series/scope & content/…) have no canonical/SDC target and are dropped on the swap — the same treatment any unrecognized param gets (accepted loss; no home on the `{{DPLA metadata}}` form).

### 5. `{{other version}}` → P6802 related image (first commonsMedia-datatype property)
A legacy template's `Other versions = {{other version|<file>}}` was dropped on migration. Module:DPLA renders **P6802** (related image), so this parses the filename and imports it to SDC (inferred-from-Wikitext), showing in the yellow box.
- **Preserved unconditionally** (not provenance-gated): DPLA has no canonical related-image value, so it's never drifted DPLA metadata — kept for every author. Multiple `{{other version}}` each become a statement.
- **commonsMedia serialization** (a pipeline first): string datavalue `{"type":"string","value":"<bare filename>"}` with snak `datatype:"commons-media"`. Wikibase validates the value against a **live Commons file**, so a `{{other version}}` pointing at a deleted/renamed file would fail the *whole atomic `wbeditentity` bundle*. To prevent that, related-image claims are placeholders resolved in the executor-side materializer (like date/creator), which **drops any file it can't confirm exists** and dedups against P6802 already on the entity. `entity_was_already_migrated` and the cross-page guard both account for P6802.

## Follow-ups (out of scope)
- **`{{NARA-image-full}}` archival fields**: preserving NARA catalog provenance (record group/series/NAID) would need a place to put it; deferred.
- **`{{DPLA metadata}}`-form in-place drift**: preserved (not destroyed); template params aren't yet updated in place (SDC is authoritative). Too new to have cases; a clear extension point.
- **Mass remediation** of files already drift-corrected by the old code (recover dropped content from history) — a separate maintenance task.

## Tests
Full suite green under `.venv` (Python 3.14): **1266 passed**. New coverage: provenance drift-safety; underscore/space + Flickr allowlist matching; `rescue_wikitext` (every wrapper, ImageNote/arbitrary-template preservation, no-wrapper fallback, full-form-block no-duplicate-heading regression); `import_cross_page_community_sdc` (source-history→dest-entity import, idempotency, bot-only no-op); `{{NARA-image-full}}` recognition end-to-end; P6802 related image (extraction single/multiple/`File:`-prefix, exact commonsMedia serialization, unconditional plan extraction, materializer build/drop-missing/dedup, idempotency, end-to-end, cross-page related-image-only rescue); uploader wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Defers title-drift description and metadata rewriting during `Uploader._move_to_correct_title`; moved-page cleanup/migration is deferred to the post-SDC `sdc-sync` cleanup pass so community metadata is preserved if cleanup is delayed or fails.
- Improves provenance classification for DPLA/NARA/Flickr uploader bots by expanding bot/origin handling via username normalization (case- and underscore/space-insensitive matching).
- Updates cross-page “drift rescue” to preserve-by-default wikitext node swapping (including wrapper recognition such as legacy `{{NARA-image-full}}`) with a safe fallback when no recognized wrapper is present.
- Extends legacy template migration to support related-image imports (`P6802`) by parsing legacy `other versions` (`{{other version|...}}`), normalizing/deduplicating Commons filenames, validating Commons file existence before materializing claims, and dropping placeholders when deduped/unconfirmable; also ensures `P6802` is excluded from the cross-page import idempotency trip-wire so related-image-only histories don’t block later scalar rescues.
- Adds a new cross-page entry point for importing community SDC (`import_cross_page_community_sdc`), and updates rescue/tagging flow to run the SDC import before applying wikitext rescue.
- Adds extensive regression coverage for bot vs community provenance, `{{NARA-image-full}}` conversion to `{{DPLA metadata}}`, wikitext rescue/wrapper swapping behavior, cross-page community SDC importing (including idempotency and destination page-id resolution safety), and `P6802` related-image claim/materialization behavior; full test suite passes (1,270 tests).

## Operational impact

- No manual pipeline trigger or ECS redeployment is required to take effect.
- No environment variables or AWS Secrets Manager keys were added/removed/renamed.
- No database migration is included.
- No shared infrastructure configuration (CodePipeline, CodeBuild, ECS task definitions, IAM policies) changes are included.
- No public-facing API response shape changes are included; changes are confined to internal library behavior and processing.
- No authentication/credential-handling changes are included; the PR continues to treat Commons filename references as external inputs and validates referenced files before writing `P6802` related-image claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->