### PR TITLE
sdc: rewrite PDM rights shape; Module:DPLA emits {{PD-US}}

### DIFF
--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -93,9 +93,6 @@ Q_PUBLIC_DOMAIN = "Q19652"
 Q_COPYRIGHTED = "Q50423863"
 Q_CC0_PD_SOMEWHERE = "Q88088423"
 Q_PD_MARK_RAW = "Q6938433"
-# PDM P6216 write shape — see ``_build_rights_claims`` for the full rationale.
-Q_PDM_DETERMINATION = "Q47246828"
-Q_US = "Q30"
 # DPLA distinguishes two kinds of hub, which take different SDC partnership
 # shapes (see ``_build_contributed_claims``):
 #   * Content hub — a large institution that IS the data provider (NARA,
@@ -925,38 +922,31 @@ def _build_rights_claims(
     out: list[dict] = []
     rs_key = normalize_rights_uri(rs)
 
-    # PDM (Creative Commons Public Domain Mark) is not a copyright license
-    # — it's an assertion by the source institution that the work is
-    # already in the public domain. Emitting it as a P275 (copyright
-    # license) claim, as rights.json would have us do, produces SDC that
-    # Module:License's branch table can't reconcile: a subsequent
-    # community edit adding a second P6216 value (a common shape on
-    # historical PD material) trips the ``#cs>=2, #cl>=1`` branch that
-    # falls through to an empty bundle, and no license template renders.
-    # Instead, express the PD assertion structurally via P6216 alone,
-    # with P459 (determination method) and P1001 (jurisdiction) qualifiers
-    # that dispatch to {{PD-US-expired}} through Wikidata's P1424 sitelink
-    # chain. Overriding P459 doesn't strip DPLA-attribution — the P123
-    # publisher marker in the reference triple ``formattedclaim`` emits is
-    # what Module:DPLA's ``isDplaDetermined`` predicate keys on.
+    # PDM (Creative Commons Public Domain Mark) is not a copyright license —
+    # it's an assertion by the source institution that the work is already in
+    # the public domain. Emitting it as a P275 (copyright license) claim, as
+    # rights.json would have us do, produces SDC that Module:License's branch
+    # table can't reconcile: a subsequent community edit adding a second P6216
+    # value trips the ``#cs>=2, #cl>=1`` branch that falls through to an empty
+    # bundle, and no license template renders on the file page.
     #
-    # This assumes US jurisdiction and >95-years-old publication — true for
-    # essentially all DPLA content (US-only aggregator, archival material).
-    # The corresponding ``rights.json`` PDM entry has been removed so this
-    # branch is the single source of truth.
+    # Express the PD assertion structurally via a bare P6216=Q19652 (public
+    # domain) statement instead. Module:DPLA reads this shape and emits
+    # ``{{PD-US}}`` directly, matching what the source institution has
+    # declared via PDM without asserting a specific reason (e.g. >95 years
+    # old, government work) that our upstream data doesn't warrant. The
+    # corresponding ``rights.json`` PDM entry has been removed so this branch
+    # is the single source of truth.
     if rs_key == PD_MARK_URI_CANONICAL:
-        claim = formattedclaim(
-            "P6216",
-            _item_value(Q_PUBLIC_DOMAIN),
-            "wikibase-entityid",
-            dpla_id,
-            retrieval_date,
+        out.append(
+            formattedclaim(
+                "P6216",
+                _item_value(Q_PUBLIC_DOMAIN),
+                "wikibase-entityid",
+                dpla_id,
+                retrieval_date,
+            )
         )
-        claim["qualifiers"]["P459"] = [
-            _qualifier_item_snak("P459", Q_PDM_DETERMINATION)
-        ]
-        claim["qualifiers"]["P1001"] = [_qualifier_item_snak("P1001", Q_US)]
-        out.append(claim)
         return out
 
     rights_entry = rights.get(rs_key)

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -93,6 +93,9 @@ Q_PUBLIC_DOMAIN = "Q19652"
 Q_COPYRIGHTED = "Q50423863"
 Q_CC0_PD_SOMEWHERE = "Q88088423"
 Q_PD_MARK_RAW = "Q6938433"
+# PDM P6216 write shape — see ``_build_rights_claims`` for the full rationale.
+Q_PDM_DETERMINATION = "Q47246828"
+Q_US = "Q30"
 # DPLA distinguishes two kinds of hub, which take different SDC partnership
 # shapes (see ``_build_contributed_claims``):
 #   * Content hub — a large institution that IS the data provider (NARA,
@@ -916,10 +919,46 @@ def _build_rights_claims(
     effects. Order of precedence:
       * If the rights URI maps via rights.json, emit the mapped P275 or
         P6426 claim and a parallel P6216 (status) derived from it.
-      * Public Domain Mark gets a P6216=Q19652 status directly.
+      * Public Domain Mark is a rights-statement declaration (not a
+        copyright license), so it does NOT emit a P275 claim — see below.
     """
     out: list[dict] = []
     rs_key = normalize_rights_uri(rs)
+
+    # PDM (Creative Commons Public Domain Mark) is not a copyright license
+    # — it's an assertion by the source institution that the work is
+    # already in the public domain. Emitting it as a P275 (copyright
+    # license) claim, as rights.json would have us do, produces SDC that
+    # Module:License's branch table can't reconcile: a subsequent
+    # community edit adding a second P6216 value (a common shape on
+    # historical PD material) trips the ``#cs>=2, #cl>=1`` branch that
+    # falls through to an empty bundle, and no license template renders.
+    # Instead, express the PD assertion structurally via P6216 alone,
+    # with P459 (determination method) and P1001 (jurisdiction) qualifiers
+    # that dispatch to {{PD-US-expired}} through Wikidata's P1424 sitelink
+    # chain. Overriding P459 doesn't strip DPLA-attribution — the P123
+    # publisher marker in the reference triple ``formattedclaim`` emits is
+    # what Module:DPLA's ``isDplaDetermined`` predicate keys on.
+    #
+    # This assumes US jurisdiction and >95-years-old publication — true for
+    # essentially all DPLA content (US-only aggregator, archival material).
+    # The corresponding ``rights.json`` PDM entry has been removed so this
+    # branch is the single source of truth.
+    if rs_key == PD_MARK_URI_CANONICAL:
+        claim = formattedclaim(
+            "P6216",
+            _item_value(Q_PUBLIC_DOMAIN),
+            "wikibase-entityid",
+            dpla_id,
+            retrieval_date,
+        )
+        claim["qualifiers"]["P459"] = [
+            _qualifier_item_snak("P459", Q_PDM_DETERMINATION)
+        ]
+        claim["qualifiers"]["P1001"] = [_qualifier_item_snak("P1001", Q_US)]
+        out.append(claim)
+        return out
+
     rights_entry = rights.get(rs_key)
     status_prop: str | None = None
     status_qid: str | None = None
@@ -939,9 +978,6 @@ def _build_rights_claims(
             status_prop, status_qid = "P6216", Q_PUBLIC_DOMAIN
         if qid == Q_PD_MARK_RAW:
             status_prop, status_qid = "P6216", Q_CC0_PD_SOMEWHERE
-
-    if rs_key == PD_MARK_URI_CANONICAL:
-        status_prop, status_qid = "P6216", Q_PUBLIC_DOMAIN
 
     if status_prop is not None and status_qid is not None:
         out.append(

--- a/metrics/dpla-dup-window/release_window.py
+++ b/metrics/dpla-dup-window/release_window.py
@@ -126,11 +126,17 @@ def parse_window_value(text: str | None) -> int:
 
 
 def render_window_value(value: int, doc_note: str = "") -> str:
-    """Render the window page wikitext for ``value``.
+    """Render the window page wikitext for ``value`` from scratch.
 
     The value sits in an <includeonly> block (so transclusion yields exactly
     the integer) followed by a <noinclude> note pointing maintainers at the
     template docs. ``doc_note`` lets callers/tests override the note.
+
+    Used only for the bootstrap case (page absent or its wikitext has no
+    parseable <includeonly>N</includeonly>). On existing pages, callers
+    should use :func:`update_window_value` — the page's <noinclude>
+    documentation may have been edited by maintainers, and overwriting
+    the whole body strips their edits.
     """
     note = doc_note or (
         "This page holds a single integer: the DPLA duplicate moving-window "
@@ -140,6 +146,27 @@ def render_window_value(value: int, doc_note: str = "") -> str:
         "[[Template:DPLA duplicate/doc]]."
     )
     return f"<includeonly>{value}</includeonly><noinclude>\n{note}\n</noinclude>"
+
+
+def update_window_value(existing_text: str, value: int) -> str:
+    """Return ``existing_text`` with the <includeonly> integer replaced by
+    ``value``; everything else (noinclude docs, layout, community edits)
+    is preserved verbatim.
+
+    Falls back to :func:`render_window_value` when no
+    ``<includeonly>N</includeonly>`` block is found.
+    """
+    new_text, n = _WINDOW_VALUE_RE.subn(
+        f"<includeonly>{value}</includeonly>", existing_text, count=1
+    )
+    if n == 0:
+        logging.warning(
+            "window page has no parseable <includeonly>N</includeonly>; "
+            "rebuilding from scratch — any maintainer-authored noinclude "
+            "documentation will be lost"
+        )
+        return render_window_value(value)
+    return new_text
 
 
 def compute_release_plan(
@@ -350,7 +377,11 @@ def main() -> int:
         return 0
 
     site.login()  # only reached when actually releasing — never on no-op runs
-    window_page.text = render_window_value(plan.new_window)
+    # In-place integer swap so any human-edited noinclude documentation is
+    # preserved. Prior full-page rewrite via ``render_window_value`` wiped
+    # maintainer edits every advance — see the 2026-07-10 diff on
+    # Template:DPLA duplicate/moving window.
+    window_page.text = update_window_value(window_page.text, plan.new_window)
     window_page.save(
         summary=(
             f"Advance DPLA duplicate moving window {current_window} → "

--- a/metrics/dpla-dup-window/release_window.py
+++ b/metrics/dpla-dup-window/release_window.py
@@ -85,7 +85,10 @@ FILE_NAMESPACE = 6
 # The window value is stored inside an <includeonly> block so the page can
 # also carry human-readable <noinclude> documentation without leaking it into
 # the transcluded expression. Match the first run of digits inside it.
-_WINDOW_VALUE_RE = re.compile(r"<includeonly>\s*(\d+)\s*</includeonly>", re.IGNORECASE)
+_WINDOW_VALUE_RE = re.compile(
+    r"(?P<prefix><includeonly>\s*)(?P<value>\d+)(?P<suffix>\s*</includeonly>)",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -122,7 +125,7 @@ def parse_window_value(text: str | None) -> int:
         # includeonly wrapper), still fail-closed if nothing numeric is found.
         stripped = text.strip()
         return int(stripped) if stripped.isdigit() else 0
-    return int(m.group(1))
+    return int(m.group("value"))
 
 
 def render_window_value(value: int, doc_note: str = "") -> str:
@@ -157,7 +160,13 @@ def update_window_value(existing_text: str, value: int) -> str:
     ``<includeonly>N</includeonly>`` block is found.
     """
     new_text, n = _WINDOW_VALUE_RE.subn(
-        f"<includeonly>{value}</includeonly>", existing_text, count=1
+        # Preserve the maintainer's original tag casing and internal
+        # whitespace (``<INCLUDEONLY>\n  0  \n</INCLUDEONLY>`` stays that
+        # way modulo the integer). Substituting a static string instead
+        # would silently normalise both.
+        lambda match: f"{match.group('prefix')}{value}{match.group('suffix')}",
+        existing_text,
+        count=1,
     )
     if n == 0:
         logging.warning(

--- a/rights.json
+++ b/rights.json
@@ -26,7 +26,6 @@
     "http://creativecommons.org/licenses/by-nc-sa/3.0/it/deed.it": {"P275": "Q108103640"},
     "http://creativecommons.org/licenses/by-nc-sa/3.0/tw/": {"P275": "Q110354772"},
     "http://creativecommons.org/licenses/by/2.5/mk/": {"P275": "Q75761383"},
-    "http://creativecommons.org/publicdomain/mark/1.0/": {"P275": "Q7257361"},
     "http://creativecommons.org/licenses/by/2.5/mt/": {"P275": "Q75761779"},
     "http://creativecommons.org/licenses/by/2.5/mx/": {"P275": "Q75762418"},
     "http://creativecommons.org/licenses/by/2.5/my/": {"P275": "Q75762784"},

--- a/tests/test_release_window.py
+++ b/tests/test_release_window.py
@@ -28,6 +28,7 @@ _spec.loader.exec_module(release_window)
 
 parse_window_value = release_window.parse_window_value
 render_window_value = release_window.render_window_value
+update_window_value = release_window.update_window_value
 compute_release_plan = release_window.compute_release_plan
 is_dpla_duplicate_title = release_window.is_dpla_duplicate_title
 
@@ -105,6 +106,60 @@ def test_render_window_value_transcludes_only_the_integer():
     assert "<noinclude>" in out and "</noinclude>" in out
     # Note text lives only in the noinclude section.
     assert out.index("777") < out.index("<noinclude>")
+
+
+def test_update_window_value_preserves_maintainer_edits():
+    """The 2026-07-10 regression: every window advance overwrote the whole
+    page via ``render_window_value`` and lost the noinclude documentation a
+    maintainer had expanded (``<code>`` blocks, a ``<nowiki>`` example,
+    prose). ``update_window_value`` must swap only the <includeonly>
+    integer and leave everything else byte-identical."""
+    existing = (
+        "<includeonly>0</includeonly><noinclude>\n"
+        "This page holds a single integer: the [[Template:DPLA duplicate]]\n"
+        "moving-window cutoff. A file tagged with "
+        "<code><nowiki>{{DPLA duplicate}}</nowiki></code> is released into "
+        "[[:Category:Duplicate]] when its <code>ts</code> sort key is less "
+        "than this value. It is maintained automatically by the "
+        "<code>dpla-dup-window</code> scheduled job, which advances it just "
+        "enough to keep the target number of DPLA files visible to "
+        "administrators as they clear the queue. The value is monotonic "
+        "and starts at <code>0</code> (nothing released).\n\n"
+        "'''Do not edit this page by hand.''' See "
+        "[[Template:DPLA duplicate/doc]].\n</noinclude>"
+    )
+    out = update_window_value(existing, 178328765700001)
+    assert "<includeonly>178328765700001</includeonly>" in out
+    # The entire noinclude body must be preserved verbatim.
+    _, _, tail_before = existing.partition("</includeonly>")
+    _, _, tail_after = out.partition("</includeonly>")
+    assert tail_before == tail_after
+
+
+def test_update_window_value_bootstrap_when_page_missing_or_bare():
+    """No parseable <includeonly> block → fall back to rendering the full
+    page. Covers both the missing-page (empty text) and never-initialised
+    (arbitrary content) cases so the job self-heals on a corrupted page."""
+    for empty in ("", "no includeonly here"):
+        out = update_window_value(empty, 42)
+        assert "<includeonly>42</includeonly>" in out
+        assert "<noinclude>" in out
+
+
+def test_update_window_value_first_includeonly_only():
+    """Guardrail: only the first <includeonly> block is substituted. A
+    maintainer might document the template body inside another
+    <includeonly> block as an example (nested inside a <noinclude> so it
+    doesn't actually transclude); a global replace would corrupt it."""
+    text = (
+        "<includeonly>0</includeonly><noinclude>\n"
+        "Example transclusion body: <includeonly>0</includeonly>\n"
+        "</noinclude>"
+    )
+    out = update_window_value(text, 99)
+    # First block updated, second (documentation example) untouched.
+    assert out.count("<includeonly>99</includeonly>") == 1
+    assert out.count("<includeonly>0</includeonly>") == 1
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_release_window.py
+++ b/tests/test_release_window.py
@@ -167,9 +167,14 @@ def test_update_window_value_first_includeonly_only():
         "</noinclude>"
     )
     out = update_window_value(text, 99)
-    # First block updated, second (documentation example) untouched.
-    assert out.count("<includeonly>99</includeonly>") == 1
-    assert out.count("<includeonly>0</includeonly>") == 1
+    # Aggregate counts alone would pass even if the WRONG block got updated
+    # (both start with 0). Assert the full expected output so the FIRST
+    # block is provably the one that changed.
+    assert out == (
+        "<includeonly>99</includeonly><noinclude>\n"
+        "Example transclusion body: <includeonly>0</includeonly>\n"
+        "</noinclude>"
+    )
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_release_window.py
+++ b/tests/test_release_window.py
@@ -146,6 +146,16 @@ def test_update_window_value_bootstrap_when_page_missing_or_bare():
         assert "<noinclude>" in out
 
 
+def test_update_window_value_preserves_tag_casing_and_inner_whitespace():
+    """The wrapper tags and any whitespace immediately inside the
+    ``<includeonly>`` block are maintainer choices — casing (uppercase,
+    mixed) or padding (``\\n  0  \\n``) may be deliberate. Substitute only
+    the digits; leave the wrapper byte-identical."""
+    existing = "<INCLUDEONLY>\n  0  \n</INCLUDEONLY><noinclude>docs</noinclude>"
+    out = update_window_value(existing, 99)
+    assert out == "<INCLUDEONLY>\n  99  \n</INCLUDEONLY><noinclude>docs</noinclude>"
+
+
 def test_update_window_value_first_includeonly_only():
     """Guardrail: only the first <includeonly> block is substituted. A
     maintainer might document the template body inside another

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -924,15 +924,17 @@ def test_build_claims_for_doc_tolerates_missing_rights_field():
     )
 
 
-def test_build_rights_claims_pdm_emits_public_domain_with_pd_us_qualifiers():
+def test_build_rights_claims_pdm_emits_bare_public_domain_status():
     """CC's Public Domain Mark is a rights-statement declaration, not a
     copyright license — emitting it as a P275 (copyright license) claim
     (as rights.json would naively have us do) produces SDC that
     Module:License's branch table can't reconcile. Assert the shape we
-    write instead: a single P6216=Q19652 (public domain) statement with
-    P459=Q47246828 (published >95 years ago) and P1001=Q30 (US
-    jurisdiction) qualifiers, which dispatches to {{PD-US-expired}}
-    through Wikidata's P1424 sitelink chain. No P275 emission."""
+    write instead: a single P6216=Q19652 (public domain) statement,
+    DPLA-authored via ``formattedclaim``'s default reference triple + P459
+    qualifier. No P275, no jurisdiction qualifier, no reason-specific
+    determination method — PDM doesn't warrant asserting a particular
+    reason (>95 years old, government work, etc.). Module:DPLA reads this
+    shape and emits ``{{PD-US}}`` directly."""
     import datetime as _dt
 
     from ingest_wikimedia.sdc import (
@@ -955,26 +957,22 @@ def test_build_rights_claims_pdm_emits_public_domain_with_pd_us_qualifiers():
     p6216 = claims[0]
     assert p6216["mainsnak"]["datavalue"]["value"]["numeric-id"] == 19652
 
+    # Only the default P459=Q61848113 (heuristic) qualifier is stamped by
+    # ``formattedclaim`` — no P1001, no reason-specific determination method.
     quals = p6216["qualifiers"]
-    assert quals["P459"][0]["datavalue"]["value"]["numeric-id"] == 47246828, (
-        "P459 must be Q47246828 (published >95 years ago), not the default "
-        "Q61848113 (heuristic) — Module:License needs the specific "
-        "determination-method to dispatch to {{PD-US-expired}}"
+    assert list(quals.keys()) == ["P459"], (
+        f"PDM P6216 must carry only the default P459 qualifier; got {list(quals.keys())}"
     )
-    assert quals["P1001"][0]["datavalue"]["value"]["numeric-id"] == 30, (
-        "P1001=Q30 (United States) satisfies Module:License's "
-        "jurisdiction-match branch against Q47246828's own P1001"
-    )
+    assert quals["P459"][0]["datavalue"]["value"]["numeric-id"] == 61848113
 
-    # DPLA-provenance reference triple still present — the switch to a
-    # non-heuristic P459 value doesn't strip DPLA-attribution.
+    # DPLA-provenance reference triple present.
     assert any(
         any(
             snak.get("datavalue", {}).get("value", {}).get("numeric-id") == 2944483
             for snak in ref.get("snaks", {}).get("P123", [])
         )
         for ref in p6216.get("references", [])
-    ), "PDM shape must still carry the DPLA-publisher reference marker"
+    ), "PDM shape must carry the DPLA-publisher reference marker"
 
 
 def test_build_rights_claims_pdm_uri_variants_all_route_through_pdm_branch():

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -924,6 +924,86 @@ def test_build_claims_for_doc_tolerates_missing_rights_field():
     )
 
 
+def test_build_rights_claims_pdm_emits_public_domain_with_pd_us_qualifiers():
+    """CC's Public Domain Mark is a rights-statement declaration, not a
+    copyright license — emitting it as a P275 (copyright license) claim
+    (as rights.json would naively have us do) produces SDC that
+    Module:License's branch table can't reconcile. Assert the shape we
+    write instead: a single P6216=Q19652 (public domain) statement with
+    P459=Q47246828 (published >95 years ago) and P1001=Q30 (US
+    jurisdiction) qualifiers, which dispatches to {{PD-US-expired}}
+    through Wikidata's P1424 sitelink chain. No P275 emission."""
+    import datetime as _dt
+
+    from ingest_wikimedia.sdc import (
+        PD_MARK_URI_CANONICAL,
+        _build_rights_claims,
+        load_rights_json,
+    )
+
+    claims = _build_rights_claims(
+        PD_MARK_URI_CANONICAL,
+        load_rights_json(),
+        "abc1234567890",
+        _dt.date(2026, 7, 10),
+    )
+
+    props = [c["mainsnak"]["property"] for c in claims]
+    assert props == ["P6216"], (
+        f"PDM shape must be a single P6216 statement, got {props}"
+    )
+    p6216 = claims[0]
+    assert p6216["mainsnak"]["datavalue"]["value"]["numeric-id"] == 19652
+
+    quals = p6216["qualifiers"]
+    assert quals["P459"][0]["datavalue"]["value"]["numeric-id"] == 47246828, (
+        "P459 must be Q47246828 (published >95 years ago), not the default "
+        "Q61848113 (heuristic) — Module:License needs the specific "
+        "determination-method to dispatch to {{PD-US-expired}}"
+    )
+    assert quals["P1001"][0]["datavalue"]["value"]["numeric-id"] == 30, (
+        "P1001=Q30 (United States) satisfies Module:License's "
+        "jurisdiction-match branch against Q47246828's own P1001"
+    )
+
+    # DPLA-provenance reference triple still present — the switch to a
+    # non-heuristic P459 value doesn't strip DPLA-attribution.
+    assert any(
+        any(
+            snak.get("datavalue", {}).get("value", {}).get("numeric-id") == 2944483
+            for snak in ref.get("snaks", {}).get("P123", [])
+        )
+        for ref in p6216.get("references", [])
+    ), "PDM shape must still carry the DPLA-publisher reference marker"
+
+
+def test_build_rights_claims_pdm_uri_variants_all_route_through_pdm_branch():
+    """DPLA emits the PDM URI in http/https and with/without trailing
+    slash variants. ``normalize_rights_uri`` canonicalises all of them
+    to the same key, and the PDM branch must fire regardless of which
+    variant the source record supplies. Failing on any of these would
+    leak the old rights.json-driven P275=Q7257361 shape into a subset
+    of PDM ingests."""
+    import datetime as _dt
+
+    from ingest_wikimedia.sdc import _build_rights_claims, load_rights_json
+
+    rights = load_rights_json()
+    for variant in (
+        "http://creativecommons.org/publicdomain/mark/1.0",
+        "http://creativecommons.org/publicdomain/mark/1.0/",
+        "https://creativecommons.org/publicdomain/mark/1.0",
+        "https://creativecommons.org/publicdomain/mark/1.0/",
+    ):
+        claims = _build_rights_claims(
+            variant, rights, "abc1234567890", _dt.date(2026, 7, 10)
+        )
+        props = [c["mainsnak"]["property"] for c in claims]
+        assert props == ["P6216"], (
+            f"variant {variant!r} produced {props} instead of a single P6216"
+        )
+
+
 def test_build_source_claim_never_stamps_p2699():
     """``P2699`` is per-ordinal — different ordinals of the same DPLA
     item have different download URLs, so the qualifier can't be baked

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -199,16 +199,9 @@ def test_safe_to_amend_dpla_qualifier_no_reference():
 
 def test_unsafe_when_user_authored_qualifier_alongside_dpla():
     """The residual bug case: claim has DPLA's P459 AND a user-added
-    qualifier that isn't in the DPLA envelope for this property
-    (e.g. P585 "point in time" added by a community editor after our
+    qualifier (e.g. P1001=Q30 added by a community editor after our
     write). The looser `_is_dpla_shaped` predecessor returned True here;
-    `_is_safe_to_amend_in_place` correctly returns False.
-
-    (Historically this test used P1001=Q30 as the foreign qualifier —
-    that specific case was the production incident that motivated the
-    gate. P1001 is now DPLA-authored on P6216 via the PDM-shape write,
-    so the regression coverage is expressed through a different foreign
-    qualifier property that will remain outside the envelope.)"""
+    `_is_safe_to_amend_in_place` correctly returns False."""
     from tools.sdc_sync import _is_safe_to_amend_in_place
 
     assert not _is_safe_to_amend_in_place(
@@ -217,7 +210,7 @@ def test_unsafe_when_user_authored_qualifier_alongside_dpla():
             "Q19652",
             qualifiers={
                 "P459": _dpla_p459(),
-                "P585": _qual_entity("P585", "Q42"),
+                "P1001": _qual_entity("P1001", "Q30"),
             },
         ),
         "P6216",
@@ -266,47 +259,23 @@ def test_safe_when_per_property_extra_qualifier_is_recognised():
     assert not _is_safe_to_amend_in_place(stmt_with_p973, "P6216")
 
 
-def test_safe_to_amend_pdm_shape_p6216_with_p1001():
-    """The PDM-shape P6216 claim carries P459 (repurposed from the
-    universal Q61848113 to Q47246828 = "published >95 years ago", so
-    Module:License dispatches to {{PD-US-expired}}) AND P1001=Q30
-    (US jurisdiction, satisfying Module:License's jurisdiction check).
-    P1001 is DPLA-authored for this property — an amend-in-place pass
-    must round-trip both qualifiers instead of stripping P1001 as
-    foreign."""
-    from tools.sdc_sync import _is_safe_to_amend_in_place
-
-    pdm_stmt = _item_statement(
-        "M999$pdm",
-        "Q19652",
-        qualifiers={
-            "P459": _qual_entity("P459", "Q47246828"),
-            "P1001": _qual_entity("P1001", "Q30"),
-        },
-        references=[_dpla_reference()],
-    )
-    assert _is_safe_to_amend_in_place(pdm_stmt, "P6216")
-
-
 # ---------------------------------------------------------------------------
 # check() — end-to-end behaviour through the tightened gate
 # ---------------------------------------------------------------------------
 
 
 def test_check_foreign_qualifier_match_adds_alongside():
-    """A P6216=Q19652 claim carrying a qualifier property outside the
-    DPLA envelope for P6216 (e.g. P585 "point in time" or another
-    community-added annotation) can't be safely amended: the bot must
-    NOT capture this claim's id or wbeditentity-with-id would clobber
-    the foreign qualifier. Instead add the DPLA-authored claim
-    alongside as a separate statement."""
+    """Production bug case: P6216=Q19652 claim with P1001+P459 qualifiers
+    that we didn't author. The bot must NOT capture this claim's id —
+    that would clobber P1001 via wbeditentity-with-id. Instead add the
+    DPLA-authored claim alongside as a separate statement."""
     from tools import sdc_sync
 
     foreign_stmt = _item_statement(
         "M999$abc",
         "Q19652",
         qualifiers={
-            "P585": _qual_entity("P585", "Q42"),
+            "P1001": _qual_entity("P1001", "Q30"),
             "P459": _qual_entity("P459", "Q60671452"),
         },
     )
@@ -318,10 +287,9 @@ def test_check_foreign_qualifier_match_adds_alongside():
 
 def test_check_mixed_dpla_and_foreign_qualifier_treated_as_foreign():
     """A claim with BOTH DPLA's P459=Q61848113 AND a user-added qualifier
-    outside the P6216 envelope (e.g. P585 "as of <date>" added by a
-    community editor later) is no longer safe to amend — the prior
-    `_is_dpla_shaped` gate would have misclassified this as
-    DPLA-shaped. Expected: add new alongside.
+    (e.g. P1001=Q30 added by a community editor later) is no longer
+    safe to amend — the prior `_is_dpla_shaped` gate would have
+    misclassified this as DPLA-shaped. Expected: add new alongside.
 
     This is the residual-bug case the tightened gate now handles."""
     from tools import sdc_sync
@@ -331,7 +299,7 @@ def test_check_mixed_dpla_and_foreign_qualifier_treated_as_foreign():
         "Q19652",
         qualifiers={
             "P459": _dpla_p459(),
-            "P585": _qual_entity("P585", "Q42"),
+            "P1001": _qual_entity("P1001", "Q30"),
         },
     )
     fake_entity = {"pageid": 999, "statements": {"P6216": [mixed_stmt]}}
@@ -4652,34 +4620,6 @@ def test_entity_has_dpla_attributed_claims_finds_dpla_reference():
             "P195": [
                 {
                     "mainsnak": {"snaktype": "value"},
-                    "references": [_dpla_reference()],
-                }
-            ]
-        }
-    }
-    assert sdc_sync._entity_has_dpla_attributed_claims(entity) is True
-
-
-def test_entity_has_dpla_attributed_claims_recognizes_pdm_shape():
-    """The PDM-shape P6216 claim (see
-    ``ingest_wikimedia.sdc._build_rights_claims``) uses a non-default
-    P459 qualifier value (Q47246828 rather than the universal
-    Q61848113) so Module:License dispatches through the correct
-    determination method. DPLA provenance is still detectable via
-    the reference triple — matching how Module:DPLA classifies the
-    statement — so the guard must recognise the entity as
-    DPLA-attributed on this shape."""
-    from tools import sdc_sync
-
-    entity = {
-        "statements": {
-            "P6216": [
-                {
-                    "mainsnak": {"snaktype": "value"},
-                    "qualifiers": {
-                        "P459": _qual_entity("P459", "Q47246828"),
-                        "P1001": _qual_entity("P1001", "Q30"),
-                    },
                     "references": [_dpla_reference()],
                 }
             ]

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -199,9 +199,16 @@ def test_safe_to_amend_dpla_qualifier_no_reference():
 
 def test_unsafe_when_user_authored_qualifier_alongside_dpla():
     """The residual bug case: claim has DPLA's P459 AND a user-added
-    qualifier (e.g. P1001=Q30 added by a community editor after our
+    qualifier that isn't in the DPLA envelope for this property
+    (e.g. P585 "point in time" added by a community editor after our
     write). The looser `_is_dpla_shaped` predecessor returned True here;
-    `_is_safe_to_amend_in_place` correctly returns False."""
+    `_is_safe_to_amend_in_place` correctly returns False.
+
+    (Historically this test used P1001=Q30 as the foreign qualifier —
+    that specific case was the production incident that motivated the
+    gate. P1001 is now DPLA-authored on P6216 via the PDM-shape write,
+    so the regression coverage is expressed through a different foreign
+    qualifier property that will remain outside the envelope.)"""
     from tools.sdc_sync import _is_safe_to_amend_in_place
 
     assert not _is_safe_to_amend_in_place(
@@ -210,7 +217,7 @@ def test_unsafe_when_user_authored_qualifier_alongside_dpla():
             "Q19652",
             qualifiers={
                 "P459": _dpla_p459(),
-                "P1001": _qual_entity("P1001", "Q30"),
+                "P585": _qual_entity("P585", "Q42"),
             },
         ),
         "P6216",
@@ -259,23 +266,47 @@ def test_safe_when_per_property_extra_qualifier_is_recognised():
     assert not _is_safe_to_amend_in_place(stmt_with_p973, "P6216")
 
 
+def test_safe_to_amend_pdm_shape_p6216_with_p1001():
+    """The PDM-shape P6216 claim carries P459 (repurposed from the
+    universal Q61848113 to Q47246828 = "published >95 years ago", so
+    Module:License dispatches to {{PD-US-expired}}) AND P1001=Q30
+    (US jurisdiction, satisfying Module:License's jurisdiction check).
+    P1001 is DPLA-authored for this property — an amend-in-place pass
+    must round-trip both qualifiers instead of stripping P1001 as
+    foreign."""
+    from tools.sdc_sync import _is_safe_to_amend_in_place
+
+    pdm_stmt = _item_statement(
+        "M999$pdm",
+        "Q19652",
+        qualifiers={
+            "P459": _qual_entity("P459", "Q47246828"),
+            "P1001": _qual_entity("P1001", "Q30"),
+        },
+        references=[_dpla_reference()],
+    )
+    assert _is_safe_to_amend_in_place(pdm_stmt, "P6216")
+
+
 # ---------------------------------------------------------------------------
 # check() — end-to-end behaviour through the tightened gate
 # ---------------------------------------------------------------------------
 
 
 def test_check_foreign_qualifier_match_adds_alongside():
-    """Production bug case: P6216=Q19652 claim with P1001+P459 qualifiers
-    that we didn't author. The bot must NOT capture this claim's id —
-    that would clobber P1001 via wbeditentity-with-id. Instead add the
-    DPLA-authored claim alongside as a separate statement."""
+    """A P6216=Q19652 claim carrying a qualifier property outside the
+    DPLA envelope for P6216 (e.g. P585 "point in time" or another
+    community-added annotation) can't be safely amended: the bot must
+    NOT capture this claim's id or wbeditentity-with-id would clobber
+    the foreign qualifier. Instead add the DPLA-authored claim
+    alongside as a separate statement."""
     from tools import sdc_sync
 
     foreign_stmt = _item_statement(
         "M999$abc",
         "Q19652",
         qualifiers={
-            "P1001": _qual_entity("P1001", "Q30"),
+            "P585": _qual_entity("P585", "Q42"),
             "P459": _qual_entity("P459", "Q60671452"),
         },
     )
@@ -287,9 +318,10 @@ def test_check_foreign_qualifier_match_adds_alongside():
 
 def test_check_mixed_dpla_and_foreign_qualifier_treated_as_foreign():
     """A claim with BOTH DPLA's P459=Q61848113 AND a user-added qualifier
-    (e.g. P1001=Q30 added by a community editor later) is no longer
-    safe to amend — the prior `_is_dpla_shaped` gate would have
-    misclassified this as DPLA-shaped. Expected: add new alongside.
+    outside the P6216 envelope (e.g. P585 "as of <date>" added by a
+    community editor later) is no longer safe to amend — the prior
+    `_is_dpla_shaped` gate would have misclassified this as
+    DPLA-shaped. Expected: add new alongside.
 
     This is the residual-bug case the tightened gate now handles."""
     from tools import sdc_sync
@@ -299,7 +331,7 @@ def test_check_mixed_dpla_and_foreign_qualifier_treated_as_foreign():
         "Q19652",
         qualifiers={
             "P459": _dpla_p459(),
-            "P1001": _qual_entity("P1001", "Q30"),
+            "P585": _qual_entity("P585", "Q42"),
         },
     )
     fake_entity = {"pageid": 999, "statements": {"P6216": [mixed_stmt]}}
@@ -2010,17 +2042,7 @@ def test_post_sdc_cleanup_dispatches_to_strip_on_new_template(monkeypatch):
                 "P1476": [
                     {
                         "mainsnak": {"snaktype": "value"},
-                        "qualifiers": {
-                            "P459": [
-                                {
-                                    "snaktype": "value",
-                                    "datavalue": {
-                                        "value": {"id": "Q61848113"},
-                                        "type": "wikibase-entityid",
-                                    },
-                                }
-                            ]
-                        },
+                        "references": [_dpla_reference()],
                     }
                 ]
             }
@@ -4619,10 +4641,10 @@ def test_resolve_pageid_from_title_prepends_file_namespace(monkeypatch):
     )
 
 
-def test_entity_has_dpla_attributed_claims_finds_p459_q61848113():
-    """The cleanup guard's notion of "has DPLA SDC" matches
+def test_entity_has_dpla_attributed_claims_finds_dpla_reference():
+    """The cleanup guard's notion of "has DPLA SDC" mirrors
     Module:DPLA's ``isDplaDetermined`` filter: at least one statement
-    with P459 = Q61848113 qualifier."""
+    with a DPLA-authored reference (P123 = Q2944483)."""
     from tools import sdc_sync
 
     entity = {
@@ -4630,17 +4652,35 @@ def test_entity_has_dpla_attributed_claims_finds_p459_q61848113():
             "P195": [
                 {
                     "mainsnak": {"snaktype": "value"},
+                    "references": [_dpla_reference()],
+                }
+            ]
+        }
+    }
+    assert sdc_sync._entity_has_dpla_attributed_claims(entity) is True
+
+
+def test_entity_has_dpla_attributed_claims_recognizes_pdm_shape():
+    """The PDM-shape P6216 claim (see
+    ``ingest_wikimedia.sdc._build_rights_claims``) uses a non-default
+    P459 qualifier value (Q47246828 rather than the universal
+    Q61848113) so Module:License dispatches through the correct
+    determination method. DPLA provenance is still detectable via
+    the reference triple — matching how Module:DPLA classifies the
+    statement — so the guard must recognise the entity as
+    DPLA-attributed on this shape."""
+    from tools import sdc_sync
+
+    entity = {
+        "statements": {
+            "P6216": [
+                {
+                    "mainsnak": {"snaktype": "value"},
                     "qualifiers": {
-                        "P459": [
-                            {
-                                "snaktype": "value",
-                                "datavalue": {
-                                    "value": {"id": "Q61848113"},
-                                    "type": "wikibase-entityid",
-                                },
-                            }
-                        ]
+                        "P459": _qual_entity("P459", "Q47246828"),
+                        "P1001": _qual_entity("P1001", "Q30"),
                     },
+                    "references": [_dpla_reference()],
                 }
             ]
         }
@@ -4658,10 +4698,9 @@ def test_entity_has_dpla_attributed_claims_false_on_empty_entity():
     assert sdc_sync._entity_has_dpla_attributed_claims({"statements": {}}) is False
 
 
-def test_entity_has_dpla_attributed_claims_false_on_unrelated_p459_value():
-    """Other heuristic determination Q-IDs (e.g. P459 = Q131783016
-    for inferred-from-Wikitext community-import claims) don't count
-    as DPLA-attributed."""
+def test_entity_has_dpla_attributed_claims_false_on_foreign_reference():
+    """Community-added statements carry non-DPLA references (or none).
+    The guard must not classify them as DPLA-attributed."""
     from tools import sdc_sync
 
     entity = {
@@ -4669,17 +4708,7 @@ def test_entity_has_dpla_attributed_claims_false_on_unrelated_p459_value():
             "P1476": [
                 {
                     "mainsnak": {"snaktype": "value"},
-                    "qualifiers": {
-                        "P459": [
-                            {
-                                "snaktype": "value",
-                                "datavalue": {
-                                    "value": {"id": "Q131783016"},
-                                    "type": "wikibase-entityid",
-                                },
-                            }
-                        ]
-                    },
+                    "references": [_foreign_reference()],
                 }
             ]
         }
@@ -4770,17 +4799,7 @@ def test_post_sdc_cleanup_for_page_strips_when_entity_has_dpla_sdc(monkeypatch):
                 "P1476": [
                     {
                         "mainsnak": {"snaktype": "value"},
-                        "qualifiers": {
-                            "P459": [
-                                {
-                                    "snaktype": "value",
-                                    "datavalue": {
-                                        "value": {"id": "Q61848113"},
-                                        "type": "wikibase-entityid",
-                                    },
-                                }
-                            ]
-                        },
+                        "references": [_dpla_reference()],
                     }
                 ]
             }

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -373,11 +373,21 @@ def _fetch_entity_for_cleanup_guard(mediaid: str) -> dict:
 
 
 def _entity_has_dpla_attributed_claims(entity: dict) -> bool:
-    """True iff ``entity`` carries at least one statement with the
-    DPLA-attribution qualifier (``P459 = Q61848113``, "heuristic" →
-    "DPLA"). Mirrors :func:`Module:DPLA`'s ``isDplaDetermined`` filter
-    on Commons so the guard's notion of "has DPLA SDC" matches the
-    template renderer's notion exactly.
+    """True iff ``entity`` carries at least one DPLA-attributed statement.
+
+    Mirrors :func:`Module:DPLA`'s ``isDplaDetermined`` filter on Commons:
+    the canonical DPLA-provenance marker is the ``P123 = Q2944483``
+    (publisher = DPLA) snak in any statement reference — stamped by
+    ``formattedclaim`` on every claim DPLA writes. The
+    ``P459 = Q61848113`` qualifier is co-stamped as a display-side
+    "determination method = heuristic" marker but is not
+    reference-independent: the PDM-shape P6216 claim (see
+    ``ingest_wikimedia.sdc._build_rights_claims``) overrides it to
+    ``P459 = Q47246828`` so Module:License dispatches through the correct
+    determination method, yet the statement is still DPLA-authored via
+    its reference triple. Detecting provenance via the reference matches
+    Module:DPLA's own predicate and keeps this guard aligned with the
+    template renderer's notion of "has DPLA SDC".
     """
     if not entity:
         return False
@@ -390,13 +400,8 @@ def _entity_has_dpla_attributed_claims(entity: dict) -> bool:
         for stmt in stmt_list:
             if not isinstance(stmt, dict):
                 continue
-            quals = stmt.get("qualifiers") or {}
-            for q in quals.get("P459", []):
-                dv = q.get("datavalue") if isinstance(q, dict) else None
-                if not isinstance(dv, dict):
-                    continue
-                val = dv.get("value")
-                if isinstance(val, dict) and val.get("id") == "Q61848113":
+            for reference in stmt.get("references") or []:
+                if _is_dpla_reference(reference):
                     return True
     return False
 
@@ -994,6 +999,12 @@ _DPLA_EXTRA_QUALIFIER_PROPS = {
     # write time from upload-result.json by sdc-sync (multipage items only,
     # grouped per file extension).
     "P760": {"P304"},
+    # P1001 (jurisdiction) is DPLA-authored on P6216 (copyright status)
+    # statements built from a PDM source URI — see the ``is_pdm`` branch of
+    # ``ingest_wikimedia.sdc._build_rights_claims``. Marking it as
+    # DPLA-owned here lets amend-in-place round-trip the qualifier without
+    # treating it as user-added.
+    "P6216": {"P1001"},
 }
 for _chunkable_prop in CHUNKABLE_PROPS:
     _DPLA_EXTRA_QUALIFIER_PROPS.setdefault(_chunkable_prop, set()).add("P1545")

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -377,17 +377,13 @@ def _entity_has_dpla_attributed_claims(entity: dict) -> bool:
 
     Mirrors :func:`Module:DPLA`'s ``isDplaDetermined`` filter on Commons:
     the canonical DPLA-provenance marker is the ``P123 = Q2944483``
-    (publisher = DPLA) snak in any statement reference — stamped by
-    ``formattedclaim`` on every claim DPLA writes. The
-    ``P459 = Q61848113`` qualifier is co-stamped as a display-side
-    "determination method = heuristic" marker but is not
-    reference-independent: the PDM-shape P6216 claim (see
-    ``ingest_wikimedia.sdc._build_rights_claims``) overrides it to
-    ``P459 = Q47246828`` so Module:License dispatches through the correct
-    determination method, yet the statement is still DPLA-authored via
-    its reference triple. Detecting provenance via the reference matches
-    Module:DPLA's own predicate and keeps this guard aligned with the
-    template renderer's notion of "has DPLA SDC".
+    (publisher = DPLA) snak in any statement reference, stamped by
+    ``formattedclaim`` on every claim DPLA writes. The prior implementation
+    checked the ``P459 = Q61848113`` qualifier instead — a display-side
+    co-stamp that isn't a reference-independent marker — despite the
+    docstring already claiming alignment with Module:DPLA. Detecting
+    provenance via the reference closes that drift and keeps this guard
+    aligned with the template renderer's notion of "has DPLA SDC".
     """
     if not entity:
         return False
@@ -999,12 +995,6 @@ _DPLA_EXTRA_QUALIFIER_PROPS = {
     # write time from upload-result.json by sdc-sync (multipage items only,
     # grouped per file extension).
     "P760": {"P304"},
-    # P1001 (jurisdiction) is DPLA-authored on P6216 (copyright status)
-    # statements built from a PDM source URI — see the ``is_pdm`` branch of
-    # ``ingest_wikimedia.sdc._build_rights_claims``. Marking it as
-    # DPLA-owned here lets amend-in-place round-trip the qualifier without
-    # treating it as user-added.
-    "P6216": {"P1001"},
 }
 for _chunkable_prop in CHUNKABLE_PROPS:
     _DPLA_EXTRA_QUALIFIER_PROPS.setdefault(_chunkable_prop, set()).add("P1545")


### PR DESCRIPTION
## Summary

- PDM (Creative Commons Public Domain Mark) is a rights-statement declaration, not a copyright license. Emitting it as `P275=Q7257361` (as `rights.json` had us do) produces SDC that Module:License's branch table can't reconcile — a community edit adding a second P6216 trips the `#cs>=2, #cl>=1` branch and no license template renders. Rewrite the PDM branch of `_build_rights_claims` to emit **only a bare `P6216=Q19652`** (public domain) statement, DPLA-authored via `formattedclaim`'s default reference triple + `P459=Q61848113` (heuristic) qualifier. No P275, no jurisdiction qualifier, no reason-specific determination method — PDM doesn't warrant asserting a particular reason (>95 years old, government work, etc.) that our upstream data doesn't provide. `rights.json`'s stale PDM entry is deleted so the config file isn't a misleading second source of truth.
- **Module:DPLA on Commons** (live edit, [rev 1246162242](https://commons.wikimedia.org/w/index.php?title=Module:DPLA&oldid=1246162242)) reads this shape and dispatches to `{{PD-US}}` directly. Module:License can't route it — no Wikidata item sitelinks to `Template:PD-US`, so its P1424-based dispatch has nothing to follow. Same pattern as the existing `RIGHTS_TEMPLATE_BY_P6426` map for `{{NoC-US}}`/`{{NKC}}`.
- `sdc_sync.py::_entity_has_dpla_attributed_claims` now keys on references (`P123=Q2944483`) instead of the `P459=Q61848113` qualifier, closing a drift with Module:DPLA's `isDplaDetermined` predicate that the docstring already claimed. Independent correctness fix — makes the writer's and reader's notion of "DPLA-authored" agree.
- **Unrelated small fix folded in**: `metrics/dpla-dup-window/release_window.py` used to overwrite the entire window template page every advance, wiping any maintainer-edited noinclude documentation. New `update_window_value` swaps just the `<includeonly>` integer via named-group regex substitution — preserving maintainer tag casing and inner whitespace byte-identical modulo the digit. `render_window_value` stays as the bootstrap fallback with a warning log so the corrupted-page branch is observable. Regression traced to [this diff](https://commons.wikimedia.org/w/index.php?title=Template:DPLA_duplicate/moving_window&diff=prev&oldid=1246121435).

## Scope of the write-shape change

- **21 currently-broken files** (Oregon Historical Society) — first PDM files to migrate to `{{DPLA metadata}}`, currently in `Category:Media without a license: needs history check`. Confirmed live on M192658658: Module:DPLA emits the neutral `{{PD-US}}` ("This media file is in the public domain in the United States") with `licensetpl` + `SDC-PD-US` machine-readable marker.
- **~57,540 legacy Artwork files** (Science History Institute + Philadelphia MoA) — same wrong SDC shape but rendering `{{PD-US}}` from hardcoded wikitext, so invisible today. Will surface when the Artwork → DPLA-metadata migration reaches them; the new write shape means no re-break.
- **Follow-up (not in this PR)**: one-time re-sync tool over the ~57.6k affected files so on-Commons SDC catches up.
- **Follow-up (not in this PR)**: move `_entity_has_dpla_attributed_claims` + `_is_dpla_reference` from `tools/sdc_sync.py` into `ingest_wikimedia/sdc.py` next to `formattedclaim`, so writer + provenance predicate share one source of truth.

## Test plan

- [x] `pytest tests/test_sdc.py tests/test_sdc_sync.py tests/test_release_window.py` — all pass; tests cover the PDM shape (bare P6216, default P459, DPLA reference triple, no P275 / P1001 / custom P459), URI variants (http/https, with/without trailing slash), reference-based DPLA-provenance detection, and `update_window_value` behaviour (preserve maintainer docs including uppercase tag casing + inner whitespace; bootstrap fallback with warning log; first-match-only).
- [x] Full suite — 1276 pass.
- [x] `ruff check --fix` + `ruff format` — clean.
- [x] `/simplify` — 4-agent parallel cleanup pass; findings applied.
- [x] Live-validated on M192658658: renders `{{PD-US}}` with `SDC-PD-US` marker and the neutral "public domain in the United States" text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary
- Updated Wikimedia SDC rights-claim construction so the Creative Commons Public Domain Mark URI is handled as an early special case and emits a single bare `P6216=Q19652` (“public domain”) mainsnak with the expected DPLA reference qualifier, removing reliance on the old `rights.json` PDM mapping and enabling `Module:DPLA` to emit `{{PD-US}}`.
- Changed DPLA attribution detection/cleanup logic from a qualifier-based heuristic (`P459=Q61848113`) to a reference-based provenance check (`P123=Q2944483`) to align with `Module:DPLA`.
- Improved `metrics/dpla-dup-window/release_window.py` updates to modify the first parseable `<includeonly>N</includeonly>` value in-place (preserving any maintainer-edited `<noinclude>` content) rather than fully regenerating the page for normal window advances.

### Notable code/test changes
- `ingest_wikimedia/sdc.py`: canonical PDM URI now normalizes and immediately emits the single `P6216` shape (skipping the prior companion-derivation flow).
- `rights.json`: removed the stale CC Public Domain Mark (`P275: Q7257361`) mapping.
- `metrics/dpla-dup-window/release_window.py`: added `update_window_value(existing_text, value)` and switched the main write path to use it.
- Tests updated/added:
  - `tests/test_sdc.py`: verifies the `P6216` claim shape (including qualifier and DPLA reference) and URI normalization variants.
  - `tests/test_sdc_sync.py`: rewired fixtures and assertions to detect DPLA attribution via references.
  - `tests/test_release_window.py`: added direct unit coverage for `update_window_value` (whitespace/casing/noinclude preservation and first-occurrence behavior).

### Validation
- Reported passing targeted + full test suites, linting/formatting, and live validation on Commons file `M192658658`.

### Operational / risk notes
- No changes to environment variables/AWS secrets, database migrations, external service endpoints, shared infrastructure (pipelines/build/ECS/IAM), or public API response shapes.
- No auth/credential handling changes; only data-shaping and template/provenance detection logic were updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
