### PR TITLE
resolve-dpla-ids: add --maintain flag; split conflated INELIGIBLE reason

### DIFF
--- a/ingest_wikimedia/partners.py
+++ b/ingest_wikimedia/partners.py
@@ -243,26 +243,72 @@ def is_institution_upload_eligible(
     return inst_data.get("upload", False)
 
 
+def check_item_eligibility(
+    canonical_slug: str,
+    institution_name: str,
+    *,
+    maintain: bool = False,
+    timeout: int = 5,
+) -> tuple[bool, str]:
+    """Check whether an item from this institution is eligible for processing.
+
+    Returns ``(True, "")`` when eligible. Returns ``(False, reason)`` with a
+    specific reason string when not — one of "unknown hub …", "hub … missing
+    Wikidata ID …", "institution … missing Wikidata ID …", or "institution …
+    has upload=False …". Splitting the reasons lets the caller surface which
+    gate blocked the item; the historical conflated "missing Wikidata ID or
+    upload flag" message hid the difference.
+
+    Two eligibility profiles:
+
+      * ``maintain=False`` (upload): requires hub Wikidata ID (for hub-level
+        Commons category), institution Wikidata ID (for institution-level
+        Commons category), AND ``upload=True`` on either the hub or the
+        institution. Mirrors get-ids-es's default eligibility.
+      * ``maintain=True``: requires the two Wikidata IDs but skips the
+        ``upload=True`` check. The whole point of maintain mode is to
+        re-link + SDC-sync files already on Commons for institutions that
+        are no longer opted in for new uploads (matches
+        ``get-ids-es --maintain`` semantics). New-upload prevention is
+        enforced by the uploader's ``--no-create`` fence, not by this gate.
+    """
+    hub_name = PARTNER_HUBS.get(canonical_slug)
+    if not hub_name:
+        return False, f"unknown hub slug {canonical_slug!r}"
+    hub = load_institutions(timeout).get(hub_name, {})
+    if not hub.get("Wikidata", ""):
+        return False, (
+            f"hub {hub_name!r} missing Wikidata ID in institutions_v2.json"
+            " (can't resolve Commons category)"
+        )
+    inst_data = hub.get("institutions", {}).get(institution_name, {})
+    if not inst_data.get("Wikidata", ""):
+        return False, (
+            f"institution {institution_name!r} missing Wikidata ID in"
+            " institutions_v2.json (can't resolve Commons category)"
+        )
+    if maintain:
+        return True, ""
+    if hub.get("upload", False) or inst_data.get("upload", False):
+        return True, ""
+    return False, (
+        f"institution {institution_name!r} has upload=False in"
+        " institutions_v2.json (retry with maintain mode to reconcile"
+        " already-uploaded files)"
+    )
+
+
 def is_item_upload_eligible(
     canonical_slug: str, institution_name: str, timeout: int = 5
 ) -> bool:
     """Return True if an item from this institution is fully eligible for upload.
 
-    Mirrors the per-institution check performed by get-ids-es: requires that
-    the hub has a Wikidata ID (needed for the hub-level Commons category), the
-    institution has a Wikidata ID (needed for the institution-level Commons
-    category), and either the hub or the institution has upload=True.
+    Thin boolean wrapper over :func:`check_item_eligibility`.
     """
-    hub_name = PARTNER_HUBS.get(canonical_slug)
-    if not hub_name:
-        return False
-    hub = load_institutions(timeout).get(hub_name, {})
-    if not hub.get("Wikidata", ""):
-        return False
-    inst_data = hub.get("institutions", {}).get(institution_name, {})
-    if not inst_data.get("Wikidata", ""):
-        return False
-    return hub.get("upload", False) or inst_data.get("upload", False)
+    eligible, _ = check_item_eligibility(
+        canonical_slug, institution_name, maintain=False, timeout=timeout
+    )
+    return eligible
 
 
 def slugify_session_label_component(name: str) -> str:

--- a/scripts/wikimedia_launch.py
+++ b/scripts/wikimedia_launch.py
@@ -954,8 +954,13 @@ def main() -> None:
     # (same as get-ids-es) so the downloader and uploader can proceed without changes.
     if dpla_id_tokens:
         print(f"Resolving {len(dpla_id_tokens)} DPLA ID(s)...")
+        # Under maintain mode, resolve-dpla-ids must bypass the upload-flag
+        # check — the whole point of maintain is to reconcile files whose
+        # institution is no longer opted in for new uploads. Wikidata-ID
+        # requirements still apply (Commons category resolution needs them).
         resolve_cmd = (
             "/home/ec2-user/ingest-wikimedia/.venv/bin/resolve-dpla-ids "
+            + ("--maintain " if maintain else "")
             + " ".join(shlex.quote(i) for i in dpla_id_tokens)
         )
         resolve_out = None

--- a/tests/test_partners.py
+++ b/tests/test_partners.py
@@ -20,7 +20,9 @@ import pytest
 
 from ingest_wikimedia import partners
 from ingest_wikimedia.partners import (
+    check_item_eligibility,
     commons_has_files_for_qid,
+    is_item_upload_eligible,
     resolve_commons_category,
     resolve_wikidata_id,
     wikidata_qid_for_target,
@@ -505,3 +507,138 @@ def test_commons_has_files_for_qid_rejects_non_qid_without_network():
     with patch.object(partners.urllib.request, "urlopen") as urlopen:
         assert commons_has_files_for_qid("not-a-qid") is False
         urlopen.assert_not_called()
+
+
+# --- check_item_eligibility --------------------------------------------------
+#
+# Splits the historical conflated "missing Wikidata ID or upload flag"
+# response into four distinct reasons. Pins each branch, both eligibility
+# profiles (upload / maintain), and the legacy is_item_upload_eligible
+# boolean wrapper.
+
+_ELIG_HUB_DATA_UPLOAD_ON = {
+    "Digital Library of Georgia": {
+        "Wikidata": "Qhub",
+        "upload": True,
+        "institutions": {
+            "Some University": {"Wikidata": "Qinst", "upload": False},
+        },
+    },
+}
+
+_ELIG_HUB_DATA_UPLOAD_OFF = {
+    "Internet Archive": {
+        "Wikidata": "Q461",
+        "upload": False,
+        "institutions": {
+            "Internet Archive": {"Wikidata": "Q461", "upload": False},
+        },
+    },
+}
+
+
+def test_check_item_eligibility_unknown_hub_reason():
+    """A canonical slug missing from PARTNER_HUBS gets a distinct 'unknown
+    hub' reason, not the same conflated message as the flag/ID branches."""
+    with _mock_institutions({}):
+        ok, reason = check_item_eligibility("not-a-hub", "Anywhere")
+    assert ok is False
+    assert "unknown hub" in reason
+    assert "'not-a-hub'" in reason
+
+
+def test_check_item_eligibility_hub_missing_wikidata_reason():
+    """Hub-level Wikidata ID missing → specific reason mentioning the hub
+    display name and the Commons-category-resolution consequence."""
+    data = {
+        "Digital Library of Georgia": {
+            "Wikidata": "",
+            "upload": True,
+            "institutions": {
+                "Some University": {"Wikidata": "Qinst", "upload": True},
+            },
+        },
+    }
+    with _mock_institutions(data):
+        ok, reason = check_item_eligibility("georgia", "Some University")
+    assert ok is False
+    assert "hub" in reason and "Wikidata" in reason
+    assert "Digital Library of Georgia" in reason
+
+
+def test_check_item_eligibility_institution_missing_wikidata_reason():
+    """Institution-level Wikidata ID missing → distinct reason from the
+    upload-flag case, so an operator can tell why maintain wouldn't
+    unblock this item (Commons category can't be resolved either way)."""
+    data = {
+        "Digital Library of Georgia": {
+            "Wikidata": "Qhub",
+            "upload": True,
+            "institutions": {
+                "Some University": {"Wikidata": "", "upload": True},
+            },
+        },
+    }
+    with _mock_institutions(data):
+        ok, reason = check_item_eligibility("georgia", "Some University")
+    assert ok is False
+    assert "institution" in reason and "Wikidata" in reason
+    assert "'Some University'" in reason
+
+
+def test_check_item_eligibility_upload_off_reason_suggests_maintain():
+    """Both QIDs present but upload=False on hub AND institution → the
+    reported Internet Archive case. Reason must name the upload-flag
+    failure specifically and steer the operator toward maintain mode
+    (the exact scenario maintain is designed for)."""
+    with _mock_institutions(_ELIG_HUB_DATA_UPLOAD_OFF):
+        ok, reason = check_item_eligibility("ia", "Internet Archive")
+    assert ok is False
+    assert "upload=False" in reason
+    assert "maintain" in reason.lower()
+
+
+def test_check_item_eligibility_upload_true_passes():
+    """The happy path — hub.upload=True → eligible."""
+    with _mock_institutions(_ELIG_HUB_DATA_UPLOAD_ON):
+        ok, reason = check_item_eligibility("georgia", "Some University")
+    assert ok is True
+    assert reason == ""
+
+
+def test_check_item_eligibility_maintain_bypasses_upload_flag():
+    """The core bug fix: an institution with QIDs present but upload=False
+    is eligible under maintain=True. Same Internet Archive case as the
+    upload branch above; only the flag flips the result."""
+    with _mock_institutions(_ELIG_HUB_DATA_UPLOAD_OFF):
+        ok, reason = check_item_eligibility("ia", "Internet Archive", maintain=True)
+    assert ok is True
+    assert reason == ""
+
+
+def test_check_item_eligibility_maintain_still_requires_wikidata_ids():
+    """Maintain mode relaxes the upload-flag gate only; missing Wikidata
+    IDs still block (Commons categories can't be resolved without them)."""
+    data = {
+        "Digital Library of Georgia": {
+            "Wikidata": "",
+            "upload": False,
+            "institutions": {
+                "Some University": {"Wikidata": "Qinst", "upload": False},
+            },
+        },
+    }
+    with _mock_institutions(data):
+        ok, reason = check_item_eligibility("georgia", "Some University", maintain=True)
+    assert ok is False
+    assert "Wikidata" in reason
+
+
+def test_is_item_upload_eligible_wraps_check_item_eligibility():
+    """The legacy boolean wrapper stays False under upload=False even
+    though the maintain-mode call in the previous test returned True —
+    proving the wrapper defaults maintain=False."""
+    with _mock_institutions(_ELIG_HUB_DATA_UPLOAD_OFF):
+        assert is_item_upload_eligible("ia", "Internet Archive") is False
+    with _mock_institutions(_ELIG_HUB_DATA_UPLOAD_ON):
+        assert is_item_upload_eligible("georgia", "Some University") is True

--- a/tests/test_resolve_dpla_ids.py
+++ b/tests/test_resolve_dpla_ids.py
@@ -1,0 +1,127 @@
+"""Tests for tools/resolve_dpla_ids.py — the single-item resolver called by
+the launch script's ``/wikimedia-upload <dpla-id>`` and
+``/wikimedia-upload maintain <dpla-id>`` paths.
+
+The bug being pinned: pre-fix, ``resolve_dpla_ids`` unconditionally routed
+through ``is_item_upload_eligible`` — which requires ``upload=True`` on the
+institution — so a single-ID maintain launch against a de-opted institution
+(e.g. Internet Archive) died with the misleading "missing Wikidata ID or
+upload flag" INELIGIBLE message even when both Wikidata IDs were present.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from tools import resolve_dpla_ids
+
+
+def _es_response(source: dict) -> MagicMock:
+    """Fake requests.Response yielding a one-hit ES result for `source`."""
+    resp = MagicMock()
+    resp.json.return_value = {"hits": {"hits": [{"_source": source}]}}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _make_source(dpla_id: str = "abc") -> dict:
+    """Minimal ES `_source` covering the checks in `_process_one` before the
+    eligibility gate: banlist, rights, media, hub resolution."""
+    return {
+        "id": dpla_id,
+        "rightsCategory": "Unlimited Re-Use",
+        "mediaMaster": ["https://example.org/foo.jpg"],
+        "isShownAt": "https://example.org/item/abc",
+        "provider": {"name": "Internet Archive"},
+        "dataProvider": {"name": "Internet Archive"},
+    }
+
+
+def _invoke(*args: str) -> object:
+    """Run resolve_dpla_ids.main with the given CLI args + mocked I/O."""
+    with (
+        patch.object(
+            resolve_dpla_ids, "post_es", return_value=_es_response(_make_source())
+        ),
+        patch.object(resolve_dpla_ids, "check_es_response", lambda _: None),
+        patch.object(resolve_dpla_ids, "Banlist") as banlist_cls,
+        patch.object(resolve_dpla_ids, "S3Client") as s3_cls,
+        patch.object(resolve_dpla_ids, "resolve_slug", return_value="ia"),
+        patch.object(resolve_dpla_ids, "check_item_eligibility") as check_eligibility,
+    ):
+        banlist_cls.return_value.is_banned.return_value = False
+        s3_cls.return_value.write_item_metadata.return_value = None
+        # Set a default return that surfaces the `maintain` arg for
+        # inspection — tests below assert on it directly.
+        check_eligibility.return_value = (True, "")
+        result = CliRunner().invoke(resolve_dpla_ids.main, list(args))
+        return result, check_eligibility, s3_cls.return_value
+
+
+def test_default_call_passes_maintain_false_to_eligibility():
+    """The single-DPLA-ID launch path (no --maintain) must gate on the
+    upload-eligibility profile — matches the pre-fix behaviour for the
+    upload subcommand."""
+    result, check_eligibility, _ = _invoke("abc")
+    assert result.exit_code == 0, result.output
+    check_eligibility.assert_called_once()
+    _, kwargs = check_eligibility.call_args
+    assert kwargs.get("maintain") is False
+
+
+def test_maintain_flag_passes_maintain_true_to_eligibility():
+    """The core fix: ``--maintain`` on the resolver plumbs through to
+    ``check_item_eligibility``. Without this, the launch script's
+    maintain-mode dispatch (below) can't reach maintain-eligible items on
+    de-opted institutions."""
+    result, check_eligibility, _ = _invoke("--maintain", "abc")
+    assert result.exit_code == 0, result.output
+    check_eligibility.assert_called_once()
+    _, kwargs = check_eligibility.call_args
+    assert kwargs.get("maintain") is True
+
+
+def test_ineligible_reason_surfaced_verbatim():
+    """Emit the specific reason from ``check_item_eligibility`` — no
+    conflation into a single "missing Wikidata ID or upload flag" bucket."""
+    # Override the mock inside the with block via a fresh invocation.
+    with (
+        patch.object(
+            resolve_dpla_ids, "post_es", return_value=_es_response(_make_source())
+        ),
+        patch.object(resolve_dpla_ids, "check_es_response", lambda _: None),
+        patch.object(resolve_dpla_ids, "Banlist") as banlist_cls,
+        patch.object(resolve_dpla_ids, "S3Client") as s3_cls,
+        patch.object(resolve_dpla_ids, "resolve_slug", return_value="ia"),
+        patch.object(
+            resolve_dpla_ids,
+            "check_item_eligibility",
+            return_value=(
+                False,
+                "institution 'Internet Archive' has upload=False in"
+                " institutions_v2.json (retry with maintain mode …)",
+            ),
+        ),
+    ):
+        banlist_cls.return_value.is_banned.return_value = False
+        s3_cls.return_value.write_item_metadata.return_value = None
+        result = CliRunner().invoke(resolve_dpla_ids.main, ["abc"])
+    assert result.exit_code == 0, result.output
+    # INELIGIBLE payload carries the specific reason string.
+    assert "abc INELIGIBLE:" in result.output
+    assert "upload=False" in result.output
+    assert "retry with maintain mode" in result.output
+    # Nothing staged when ineligible.
+    s3_cls.return_value.write_item_metadata.assert_not_called()
+
+
+def test_maintain_lets_upload_off_institution_through():
+    """End-to-end: under ``--maintain``, an item whose institution has
+    ``upload=False`` (but both Wikidata IDs present) resolves as
+    ``HUB=<slug>`` instead of INELIGIBLE, and its metadata is staged to S3
+    exactly like an eligible upload target. This is the scenario the launch
+    script's maintain dispatch relies on."""
+    result, _, s3_client = _invoke("--maintain", "abc")
+    assert result.exit_code == 0, result.output
+    assert "abc HUB=ia" in result.output
+    s3_client.write_item_metadata.assert_called_once()

--- a/tools/resolve_dpla_ids.py
+++ b/tools/resolve_dpla_ids.py
@@ -21,7 +21,7 @@ import click
 from ingest_wikimedia.banlist import Banlist
 from ingest_wikimedia.es import check_es_response, post_es
 from ingest_wikimedia.iiif import IIIF
-from ingest_wikimedia.partners import is_item_upload_eligible, resolve_slug
+from ingest_wikimedia.partners import check_item_eligibility, resolve_slug
 from ingest_wikimedia.s3 import S3Client
 
 _IIIF_MANIFEST_FIELD = "iiifManifest"
@@ -31,8 +31,20 @@ _IS_SHOWN_AT_FIELD = "isShownAt"
 
 @click.command()
 @click.argument("dpla_ids", nargs=-1, required=True)
-def main(dpla_ids: tuple[str, ...]) -> None:
-    """Resolve DPLA_IDS, check upload eligibility, and stage metadata to S3."""
+@click.option(
+    "--maintain",
+    is_flag=True,
+    help=(
+        "Maintain mode: include institutions regardless of their upload flag"
+        " (Wikidata ID still required), so IDs + sdc.json are staged for"
+        " already-uploaded files of institutions no longer authorized for"
+        " new uploads. New-upload prevention is enforced by the uploader's"
+        " ``--no-create`` fence, not by this eligibility check. Mirrors the"
+        " same flag on get-ids-es."
+    ),
+)
+def main(dpla_ids: tuple[str, ...], maintain: bool) -> None:
+    """Resolve DPLA_IDS, check eligibility, and stage metadata to S3."""
     banlist = Banlist()
     s3_client = S3Client()
 
@@ -55,13 +67,18 @@ def main(dpla_ids: tuple[str, ...]) -> None:
             if source is None:
                 print(f"{dpla_id} NOT_FOUND", flush=True)
                 continue
-            _process_one(dpla_id, source, banlist, s3_client)
+            _process_one(dpla_id, source, banlist, s3_client, maintain=maintain)
         except Exception as e:
             print(f"{dpla_id} ERROR:{e}", flush=True)
 
 
 def _process_one(
-    dpla_id: str, source: dict, banlist: Banlist, s3_client: S3Client
+    dpla_id: str,
+    source: dict,
+    banlist: Banlist,
+    s3_client: S3Client,
+    *,
+    maintain: bool = False,
 ) -> None:
     if banlist.is_banned(dpla_id):
         print(f"{dpla_id} INELIGIBLE:on banlist", flush=True)
@@ -87,17 +104,17 @@ def _process_one(
         print(f"{dpla_id} INELIGIBLE:unknown hub {provider_name!r}", flush=True)
         return
 
-    # Check institution-level eligibility per institutions_v2.json:
-    # hub must have a Wikidata ID (required for hub Commons category), institution
-    # must have a Wikidata ID (required for institution Commons category), and
-    # either hub.upload=True or institution.upload=True.  Mirrors get-ids-es.
+    # Check institution-level eligibility per institutions_v2.json. Both
+    # profiles (upload / maintain) require the two Wikidata IDs; maintain
+    # relaxes the upload-flag requirement. ``check_item_eligibility``
+    # returns a specific reason so callers (and the operator) can tell
+    # which gate blocked the item — the historical conflated "missing
+    # Wikidata ID or upload flag" message hid that distinction and
+    # steered operators wrong on maintain-eligible items.
     dp_name = (source.get("dataProvider") or {}).get("name", "")
-    if not is_item_upload_eligible(canonical, dp_name):
-        print(
-            f"{dpla_id} INELIGIBLE:institution {dp_name!r} not eligible per"
-            " institutions_v2.json (missing Wikidata ID or upload flag)",
-            flush=True,
-        )
+    eligible, reason = check_item_eligibility(canonical, dp_name, maintain=maintain)
+    if not eligible:
+        print(f"{dpla_id} INELIGIBLE:{reason}", flush=True)
         return
 
     # Derive CONTENTdm IIIF manifest URL if needed (mirrors get-ids-es behaviour).


### PR DESCRIPTION
## Summary

- `/wikimedia-upload maintain lite <dpla-id>` was dying on any single-ID maintain launch against an institution with `upload=False` — even when both hub + institution Wikidata IDs were present. Root cause: `resolve_dpla_ids.py` was gating on `is_item_upload_eligible`, which enforces the upload flag; the maintain-mode counterpart of `get-ids-es --maintain` didn't exist on the single-ID codepath.
- New `partners.check_item_eligibility(canonical, institution, *, maintain=False)` returns `(eligible, reason)` with four distinct failure reasons — "unknown hub", "hub … missing Wikidata ID", "institution … missing Wikidata ID", "institution … has upload=False (retry with maintain mode …)" — so operators can tell which gate blocked an item. `is_item_upload_eligible` stays as a thin boolean wrapper.
- `resolve_dpla_ids.py` gains a `--maintain` click flag; the launch script (`scripts/wikimedia_launch.py`) prepends it to the resolver command when the launch is in maintain mode. `get-ids-es --maintain` semantics preserved exactly — Wikidata IDs still required (Commons categories need them), only the upload-flag check is bypassed.

## Concrete case

DPLA ID `1199e66ccf10646879e72c4fb7e1bc55` (Internet Archive hub, IA institution, both `Wikidata=Q461`, both `upload=False`). Before this PR: `INELIGIBLE:institution 'Internet Archive' not eligible per institutions_v2.json (missing Wikidata ID or upload flag)`. After: under `/wikimedia-upload maintain lite <id>`, resolves as `HUB=ia` and stages to S3.

## Test plan

- [x] `pytest tests/test_partners.py tests/test_resolve_dpla_ids.py` — 36 pass; covers all four reason branches, both eligibility profiles, the boolean-wrapper preservation, and the CLI plumbing (default vs `--maintain` reaches `check_item_eligibility` with the right flag; INELIGIBLE payload surfaces the specific reason verbatim; maintain lets an `upload=False` institution stage).
- [x] Full suite — 1282 pass.
- [x] `ruff check --fix` + `ruff format` — clean.

## Follow-up (not in this PR)

Once merged + deployed, retry `/wikimedia-upload maintain lite 1199e66ccf10646879e72c4fb7e1bc55` (the file the reporter tripped on) to confirm the fix end-to-end on the live Lambda + EC2 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds `--maintain` support to `resolve-dpla-ids` and propagates maintain mode from Wikimedia launches.
- Adds structured eligibility checks with specific failure reasons while preserving the existing boolean wrapper.
- Maintain mode bypasses `upload=False` gates but still requires hub and institution Wikidata IDs.
- Ineligible resolver output now reports the precise reason; staging behavior is covered by tests.
- Adds comprehensive tests for eligibility, CLI propagation, reason reporting, and maintain-mode staging. Full suite passes 1,282 tests.

## Operational impact

- No manual pipeline trigger or ECS redeployment is specifically required; deployment follows the normal application release process.
- No environment variables or AWS Secrets Manager keys are added, removed, or renamed.
- No database migration is included.
- No shared infrastructure configuration changes are included.
- No public-facing API response shapes or endpoints are changed.
- No security, authentication, credential-handling, or new external-input changes are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->