### PR TITLE
legacy_artwork: migration fixes from remediation live-testing (multi-line community values + Creator-page QID)

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -1625,28 +1625,39 @@ def _entity_p170_qids(existing_entity: dict | None) -> set[str]:
     return qids
 
 
+_CREATOR_WIKIDATA_PARAM_RE = re.compile(r"\|\s*[Ww]ikidata\s*=\s*(Q\d+)")
+
+
 def _resolve_commons_creator_qid(site, page_title: str) -> str | None:
-    """Look up the Wikidata QID linked from a Commons ``Creator:<title>``
-    page via the ``prop=pageprops`` API.
+    """Look up the Wikidata QID for a Commons ``Creator:<title>`` page.
 
-    Returns the QID string (``"Q…"``) when the Creator page exists and
-    has a ``wikibase_item`` sitelink; ``None`` for missing pages,
-    orphaned Creator pages, or any API failure. Falling back to
-    ``None`` is intentional: the caller substitutes a P170 somevalue
-    + P2093 stated-as name claim so the community contribution is
-    preserved as a stated-as string even when the QID resolution
-    can't succeed — same outcome as a plain ``| creator = <name>``
-    parameter would produce.
+    Checks two sources, in order:
+      1. the ``wikibase_item`` pageprop — a Wikidata *sitelink* to the Creator
+         page, and
+      2. the ``{{Creator | Wikidata = Q… }}`` parameter in the page's own
+         wikitext — the far more common way Commons Creator pages carry their
+         Wikidata id (most are NOT sitelinked, so their ``wikibase_item`` is
+         empty; e.g. Creator:Theodore E. Peiser → Q56159174 lives only in the
+         template param).
 
-    Requires ``site`` to be a live pywikibot Site; test callers can
-    pass ``None`` to short-circuit to the name-only fallback path.
+    Returns the QID string (``"Q…"``) when found; ``None`` for missing/orphaned
+    pages or any API failure. Falling back to ``None`` is intentional: the
+    caller then substitutes a P170 somevalue + P2093 stated-as name claim so
+    the community contribution is still preserved as a string. Resolving the
+    QID instead lets the caller build a P170 → wikibase-entityid claim, so
+    Module:DPLA can render the full ``{{Creator:…}}`` template from SDC.
+
+    Requires ``site`` to be a live pywikibot Site; test callers can pass
+    ``None`` to short-circuit to the name-only fallback path.
     """
     if site is None or not page_title:
         return None
     try:
         response = site.simple_request(
             action="query",
-            prop="pageprops",
+            prop="pageprops|revisions",
+            rvprop="content",
+            rvslots="main",
             titles=f"Creator:{page_title}",
             format="json",
         ).submit()
@@ -1658,6 +1669,12 @@ def _resolve_commons_creator_qid(site, page_title: str) -> str | None:
         qid = pp.get("wikibase_item")
         if isinstance(qid, str) and qid.startswith("Q"):
             return qid
+        for rev in page.get("revisions") or []:
+            slots = rev.get("slots") or {}
+            content = (slots.get("main") or {}).get("*") or rev.get("*") or ""
+            match = _CREATOR_WIKIDATA_PARAM_RE.search(content)
+            if match:
+                return match.group(1)
     return None
 
 

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -849,6 +849,19 @@ def _split_embedded_creator_templates(
     return [(kind, cap) for _s, _e, kind, cap in found], remainder
 
 
+def _creator_sdc_clean(value: str) -> bool:
+    """A community creator value is SDC-clean iff, after splitting out recognised
+    embedded creator templates ({{Creator:}}/{{Unknown}}), the leftover stated-as
+    text carries NO residual template ({{...}}) or wikilink ([[...]]) markup —
+    i.e. it can be stored as a clean SDC string (a P170 QID, or a P170 somevalue
+    + P2093 stated-as). Otherwise the value carries rich wikitext that can't be
+    an SDC string and belongs on the wikitext creator param instead (where its
+    markup renders); :func:`_community_value_unfit_for_sdc` routes it there."""
+    parts, remainder = _split_embedded_creator_templates(value)
+    check = remainder if parts is not None else value
+    return "{{" not in check and "[[" not in check
+
+
 def _extract_institution_qid(value: str) -> str | None:
     """Return the inner Q-ID from a wikitext ``institution`` param
     value, or ``None`` if the value isn't a bare Q-ID or an
@@ -940,25 +953,26 @@ def _community_value_unfit_for_sdc(key: str, value: str) -> bool:
     """True when a community value can't be posted as an SDC claim and must be
     preserved on the migrated template's param instead of dropped.
 
-    Two cases:
+    Cases (any one routes the value to wikitext preservation):
 
-    * **No SDC import mapping at all** (``permission``, ``source``,
-      ``institution`` — not in :data:`LEGACY_IMPORT_PROPERTY`). These have no
-      Phase-3a claim builder, so a *community* override of one — e.g. a
-      hand-set ``permission = {{PD-old-auto-1923|deathyear=1922}}`` — would
-      otherwise land in ``community_imports`` and be silently dropped
-      (``format_legacy_import_claim`` returns ``None``). Preserve it on the
-      template param, where Module:DPLA renders it in the yellow box.
-    * **SDC-mappable but vertical-whitespace-bearing** (``title``/
-      ``description`` monolingualtext, ``creator`` string): the Wikibase text
-      validators reject newlines/tabs/CR, so a value with such whitespace that
-      is *not* a DPLA-prefixed extension (:func:`_split_extension_extras`)
-      can't be an SDC claim either. ``date`` (time) is parsed, not
-      text-validated, so a mapped time key is never unfit on whitespace.
-    * **Unrecognised-language wrapper** — a single ``{{<code>|…}}`` whose code
-      has language-code shape but isn't in :data:`_KNOWN_LANG_CODES`: can't be
-      unwrapped or language-labelled, so preserved as wikitext rather than
-      imported as a mislabelled ``en`` monolingual value with literal markup.
+    * **No SDC import mapping at all** (``permission``/``source``/
+      ``institution`` — not in :data:`LEGACY_IMPORT_PROPERTY`): no Phase-3a
+      claim builder, so a community override would otherwise be silently
+      dropped. Preserve it on the template param (Module:DPLA's yellow box).
+    * **Vertical whitespace** (``title``/``description`` monolingualtext,
+      ``creator`` string): the Wikibase text validators reject newlines/tabs/CR.
+      ``date`` (time) is parsed, not text-validated, so never unfit here.
+    * **Rich creator wikitext** (``creator``): after splitting recognised
+      embedded creator templates, residual ``{{...}}`` / ``[[...]]`` markup
+      remains — the value can't be a clean SDC string, so the whole thing rides
+      the wikitext creator param (where its links render). See
+      :func:`_creator_sdc_clean`.
+    * **Residual monolingual markup** (``title``/``description``): template or
+      wikilink markup survives :func:`_unwrap_lang_template` — an unrecognised
+      language code (``{{nan|…}}``), a multi-parameter wrapper
+      (``{{en|First|Second}}``), or a non-language template — so a literal
+      ``{{…}}`` would otherwise be stored as the monolingual value. Preserve as
+      wikitext instead.
     """
     mapping = LEGACY_IMPORT_PROPERTY.get(key)
     if mapping is None:
@@ -968,10 +982,13 @@ def _community_value_unfit_for_sdc(key: str, value: str) -> bool:
         return False
     if _VERTICAL_WHITESPACE_RE.search(value):
         return True
-    # A single {{<code>|…}} wrapper whose code has language shape but isn't
-    # recognised can't be safely unwrapped/labelled — preserve it as wikitext
-    # rather than import a mislabelled 'en' monolingual value with literal markup.
-    return _is_unrecognized_lang_wrapper(value)
+    if key == "creator":
+        return not _creator_sdc_clean(value)
+    # title/description: unfit if template/wikilink markup survives language
+    # unwrap (an unrecognised code, a multi-param wrapper, or a non-language
+    # template) — a literal {{...}} must not be stored as the monolingual value.
+    text, _lang = _unwrap_lang_template(value)
+    return "{{" in text or "[[" in text
 
 
 def _multi_value_subset_of_canonical(value: str, canonical: str) -> bool:
@@ -1021,16 +1038,12 @@ def _multi_value_subset_of_canonical(value: str, canonical: str) -> bool:
     return bool(value_parts) and value_parts.issubset(canonical_parts)
 
 
-# Bare Commons language templates ({{en|text}}, {{de|text}}, …) wrap a single
-# monolingual value in a language code. Only unwrap when the ENTIRE value is
-# one such template with a KNOWN language code — so non-language 2–3 letter
-# templates ({{PD|…}}) and values that merely contain a template are left
-# untouched.
 # Complete ISO 639-1 two-letter language codes (the set MediaWiki's per-language
-# templates use). A single {{<code>|<text>}} wrapper with one of these codes is
-# unwrapped to (text, code); a wrapper whose code has language shape but isn't
-# here is preserved as wikitext (see _is_unrecognized_lang_wrapper), never
-# mislabelled as English.
+# templates use). A single {{<code>|<text>}} wrapper with one of these codes and
+# a sole text parameter is unwrapped to (text, code) by _unwrap_lang_template.
+# Anything else — an unrecognised code, multiple parameters, or a non-language
+# template — leaves residual markup and is preserved on the wikitext param by
+# _community_value_unfit_for_sdc, never stored as a mislabelled 'en' string.
 _KNOWN_LANG_CODES = frozenset(
     "aa ab ae af ak am an ar as av ay az ba be bg bh bi bm bn bo br bs ca ce ch "
     "co cr cs cu cv cy da de dv dz ee el en eo es et eu fa ff fi fj fo fr fy ga "
@@ -1070,28 +1083,6 @@ def _unwrap_lang_template(value: str) -> tuple[str, str]:
             ):
                 return str(params[0].value).strip(), name
     return value, "en"
-
-
-# A {{<code>|…}} whose <code> has language-code shape (2–3 letters + optional
-# -variant) — used to tell a language wrapper apart from a non-language template.
-_LANG_CODE_SHAPE_RE = re.compile(r"^[a-z]{2,3}(?:-[a-z0-9]+)*$", re.IGNORECASE)
-
-
-def _is_unrecognized_lang_wrapper(value: str) -> bool:
-    """True when ``value`` is a single ``{{<code>|…}}`` template whose ``<code>``
-    has language-code shape but is NOT in :data:`_KNOWN_LANG_CODES`. Such a
-    wrapper can't be safely unwrapped or language-labelled, so it is preserved on
-    the wikitext template (via :func:`_community_value_unfit_for_sdc`) instead of
-    being imported as a mislabelled ``en`` monolingual value with literal
-    markup."""
-    if "{{" not in value:
-        return False
-    parsed = mwparserfromhell.parse(value.strip())
-    templates = parsed.filter_templates(recursive=False)
-    if len(templates) == 1 and str(parsed).strip() == str(templates[0]).strip():
-        name = str(templates[0].name).strip().casefold()
-        return bool(_LANG_CODE_SHAPE_RE.match(name)) and name not in _KNOWN_LANG_CODES
-    return False
 
 
 def _value_equivalent_to_canonical(key: str, value: str, canonical: str) -> bool:

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -582,8 +582,22 @@ def plan_migration(
             # parameter, where the yellow-box renderer picks it up.
             extras = _split_extension_extras(value, canonical_value)
             if extras is not None:
+                # DPLA value + community structural addition: the DPLA prefix
+                # keeps its canonical SDC, only the remainder rides the param.
                 wikitext_preserved_extras[key] = extras
                 dpla_originated[key] = value
+                continue
+            if _community_value_unfit_for_sdc(key, value):
+                # Fully community-authored value that can't be an SDC claim of
+                # its type — it carries vertical whitespace, which the
+                # monolingualtext/string validators reject (e.g. a
+                # multi-paragraph description with an HR, italics, a wikilink).
+                # There's no DPLA prefix to peel off, so preserve the WHOLE
+                # value on the migrated template's param — where Module:DPLA
+                # renders it in the yellow box — instead of failing the whole
+                # file's import. Same destination as the extension case above:
+                # community content that can't be SDC lands in wikitext.
+                wikitext_preserved_extras[key] = value
                 continue
             community_imports[key] = value
         else:
@@ -827,6 +841,28 @@ def _split_extension_extras(value: str, canonical: str) -> str | None:
     if not folded_prefix or folded_prefix != folded_canonical:
         return None
     return remainder
+
+
+def _community_value_unfit_for_sdc(key: str, value: str) -> bool:
+    """True when a community value can't be posted as its SDC claim type
+    because it contains vertical whitespace.
+
+    ``title``/``description`` (monolingualtext) and ``creator`` (string) go
+    through :func:`_validate_wikibase_text`, whose validator rejects
+    newlines/tabs/CR. A value with such whitespace that is *not* a
+    DPLA-prefixed extension (:func:`_split_extension_extras`) can't be an SDC
+    claim at all, so the caller preserves it on the migrated template's param
+    rather than erroring the whole import. ``date`` (time) is parsed, not
+    text-validated, so it's excluded; keys with no import mapping never reach
+    the text validator either.
+    """
+    mapping = LEGACY_IMPORT_PROPERTY.get(key)
+    if mapping is None:
+        return False
+    _prop, kind = mapping
+    return kind in ("monolingualtext", "string") and bool(
+        _VERTICAL_WHITESPACE_RE.search(value)
+    )
 
 
 def _multi_value_subset_of_canonical(value: str, canonical: str) -> bool:

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -780,6 +780,14 @@ def _parse_creator_shape(value: str) -> str | None:
         # optional role. Preserve as a P170 somevalue (+ P3831 role) rather
         # than dropping it with the other unrecognised templates below.
         return _CREATOR_UNKNOWN_PREFIX + (m.group(1) or "").strip()
+    # A compound value that EMBEDS a recognised creator template alongside
+    # other text/templates (e.g. "{{Unknown|author}} {{Creator:B}}") is passed
+    # through for format_legacy_import_claim to tokenise + split — do NOT drop
+    # it here even though it is {{…}}-bookended.
+    if _EMBEDDED_UNKNOWN_RE.search(stripped) or _EMBEDDED_CREATOR_PAGE_RE.search(
+        stripped
+    ):
+        return stripped
     # Any remaining ``{{…}}`` template-shaped value we don't recognise
     # is dropped rather than passed through as a raw string. See the
     # returns-``None`` clause of the docstring for the rationale.
@@ -788,55 +796,57 @@ def _parse_creator_shape(value: str) -> str | None:
     return stripped
 
 
-# {{Unknown|role}} embedded in a longer creator credit (e.g.
-# "{{unknown|author}} reprinted by Webster & Stevens") — as opposed to a bare
-# {{Unknown|role}}, which _parse_creator_shape already tags as the
-# unknown-creator sentinel. A compound value otherwise falls through as a plain
-# string and stores the literal template markup in the P2093 stated-as.
+# Recognised creator sub-templates that can appear EMBEDDED in a longer,
+# compound free-text creator credit (as opposed to being the entire value —
+# those bare shapes are tagged by _parse_creator_shape). Each is tokenised out
+# and emitted as its own claim; the leftover text becomes a P2093 stated-as.
+# Unanchored (the bare {{Unknown}} matcher is _UNKNOWN_CREATOR_RE).
 _EMBEDDED_UNKNOWN_RE = re.compile(_UNKNOWN_CREATOR_BODY)
-
-
-def _creator_remainder(value: str, m: re.Match) -> str:
-    """The creator text left after removing the matched sub-template ``m``,
-    with dangling join punctuation/whitespace trimmed. Shared by the compound
-    creator splitters."""
-    return (value[: m.start()] + value[m.end() :]).strip(" ;,·—–-\t\n").strip()
-
-
-def _split_unknown_from_creator(value: str) -> tuple[str, str] | None:
-    """If ``value`` contains a ``{{Unknown|role}}`` template alongside other
-    text, return ``(role, remainder)`` so the caller can emit a P170 somevalue
-    (+ P3831 role) for the unknown creator and a separate P170 somevalue +
-    P2093 stated-as for ``remainder``. Returns ``None`` when there is no
-    embedded ``{{Unknown}}`` or when the template is the *entire* value (a bare
-    ``{{Unknown|role}}`` is handled by :func:`_parse_creator_shape`)."""
-    m = _EMBEDDED_UNKNOWN_RE.search(value)
-    if not m:
-        return None
-    remainder = _creator_remainder(value, m)
-    if not remainder:
-        return None
-    return (m.group(1) or "").strip(), remainder
-
-
-# {{Creator:PageName}} embedded in a longer free-text creator credit (e.g.
-# "Believed to be by Asahel Curtis, working for … {{Creator:Asahel Curtis}}").
-# A bare {{Creator:Foo}} is tagged by _parse_creator_shape as a page sentinel;
-# a compound value falls through as a plain string and would store the literal
-# {{Creator:…}} markup in the P2093 stated-as.
 _EMBEDDED_CREATOR_PAGE_RE = re.compile(r"\{\{\s*[Cc]reator\s*:\s*([^}|]+?)\s*\}\}")
+# A remainder made up only of join punctuation / connector words ("A and B")
+# is not a real stated-as name — drop it rather than emit a junk P2093.
+_CREATOR_CONNECTOR_RE = re.compile(
+    r"^(?:and|und|et|&|,|;|/|·|—|–|-|\s)+$", re.IGNORECASE
+)
 
 
-def _split_creator_page_from_text(value: str) -> tuple[str, str] | None:
-    """If ``value`` embeds a ``{{Creator:PageName}}`` transclusion, return
-    ``(page_title, remainder)`` so the caller can emit a P170 creator-page
-    claim (QID-resolved in the materializer) plus a P170 somevalue + P2093
-    stated-as for the remaining community text. ``remainder`` may be empty."""
-    m = _EMBEDDED_CREATOR_PAGE_RE.search(value)
-    if not m:
-        return None
-    remainder = _creator_remainder(value, m)
-    return m.group(1).strip(), remainder
+def _split_embedded_creator_templates(
+    value: str,
+) -> tuple[list[tuple[str, str]] | None, str]:
+    """Tokenise every recognised embedded creator sub-template out of a compound
+    free-text creator credit. Returns ``(parts, remainder)`` where ``parts`` is
+    an ordered list of ``("unknown", role)`` / ``("page", page_title)`` tuples —
+    one per embedded ``{{Unknown|role}}`` / ``{{Creator:Page}}`` — and
+    ``remainder`` is the leftover text with all recognised templates removed and
+    join punctuation trimmed. Returns ``(None, value)`` when the value embeds no
+    recognised creator template.
+
+    Handles multiple templates and both kinds in one value (e.g.
+    ``{{Creator:A}} and {{Creator:B}}`` → two page claims, no stated-as;
+    ``{{unknown|author}} reprinted by {{Creator:B}}`` → an unknown claim, a page
+    claim, and a stated-as remainder), so no literal ``{{…}}`` markup survives
+    into P2093."""
+    found: list[tuple[int, int, str, str]] = []
+    for m in _EMBEDDED_UNKNOWN_RE.finditer(value):
+        found.append((m.start(), m.end(), "unknown", (m.group(1) or "").strip()))
+    for m in _EMBEDDED_CREATOR_PAGE_RE.finditer(value):
+        found.append((m.start(), m.end(), "page", m.group(1).strip()))
+    if not found:
+        return None, value
+    found.sort()
+    kept: list[str] = []
+    last = 0
+    for start, end, _kind, _cap in found:
+        if start < last:  # defensive: overlapping matches (not expected)
+            last = max(last, end)
+            continue
+        kept.append(value[last:start])
+        last = end
+    kept.append(value[last:])
+    remainder = "".join(kept).strip(" ;,·—–-\t\n").strip()
+    if _CREATOR_CONNECTOR_RE.fullmatch(remainder):
+        remainder = ""
+    return [(kind, cap) for _s, _e, kind, cap in found], remainder
 
 
 def _extract_institution_qid(value: str) -> str | None:
@@ -945,14 +955,23 @@ def _community_value_unfit_for_sdc(key: str, value: str) -> bool:
       is *not* a DPLA-prefixed extension (:func:`_split_extension_extras`)
       can't be an SDC claim either. ``date`` (time) is parsed, not
       text-validated, so a mapped time key is never unfit on whitespace.
+    * **Unrecognised-language wrapper** — a single ``{{<code>|…}}`` whose code
+      has language-code shape but isn't in :data:`_KNOWN_LANG_CODES`: can't be
+      unwrapped or language-labelled, so preserved as wikitext rather than
+      imported as a mislabelled ``en`` monolingual value with literal markup.
     """
     mapping = LEGACY_IMPORT_PROPERTY.get(key)
     if mapping is None:
         return True
     _prop, kind = mapping
-    return kind in ("monolingualtext", "string") and bool(
-        _VERTICAL_WHITESPACE_RE.search(value)
-    )
+    if kind not in ("monolingualtext", "string"):
+        return False
+    if _VERTICAL_WHITESPACE_RE.search(value):
+        return True
+    # A single {{<code>|…}} wrapper whose code has language shape but isn't
+    # recognised can't be safely unwrapped/labelled — preserve it as wikitext
+    # rather than import a mislabelled 'en' monolingual value with literal markup.
+    return _is_unrecognized_lang_wrapper(value)
 
 
 def _multi_value_subset_of_canonical(value: str, canonical: str) -> bool:
@@ -1007,51 +1026,20 @@ def _multi_value_subset_of_canonical(value: str, canonical: str) -> bool:
 # one such template with a KNOWN language code — so non-language 2–3 letter
 # templates ({{PD|…}}) and values that merely contain a template are left
 # untouched.
+# Complete ISO 639-1 two-letter language codes (the set MediaWiki's per-language
+# templates use). A single {{<code>|<text>}} wrapper with one of these codes is
+# unwrapped to (text, code); a wrapper whose code has language shape but isn't
+# here is preserved as wikitext (see _is_unrecognized_lang_wrapper), never
+# mislabelled as English.
 _KNOWN_LANG_CODES = frozenset(
-    {
-        "en",
-        "de",
-        "fr",
-        "es",
-        "it",
-        "nl",
-        "pt",
-        "sv",
-        "da",
-        "no",
-        "nb",
-        "nn",
-        "fi",
-        "is",
-        "pl",
-        "cs",
-        "sk",
-        "ru",
-        "uk",
-        "be",
-        "bg",
-        "sr",
-        "hr",
-        "sl",
-        "ja",
-        "zh",
-        "ko",
-        "ar",
-        "he",
-        "el",
-        "hu",
-        "ro",
-        "tr",
-        "ca",
-        "gl",
-        "eu",
-        "ga",
-        "cy",
-        "la",
-        "hi",
-        "fa",
-        "id",
-    }
+    "aa ab ae af ak am an ar as av ay az ba be bg bh bi bm bn bo br bs ca ce ch "
+    "co cr cs cu cv cy da de dv dz ee el en eo es et eu fa ff fi fj fo fr fy ga "
+    "gd gl gn gu gv ha he hi ho hr ht hu hy hz ia id ie ig ii ik io is it iu ja "
+    "jv ka kg ki kj kk kl km kn ko kr ks ku kv kw ky la lb lg li ln lo lt lu lv "
+    "mg mh mi mk ml mn mr ms mt my na nb nd ne ng nl nn no nr nv ny oc oj om or "
+    "os pa pi pl ps pt qu rm rn ro ru rw sa sc sd se sg sh si sk sl sm sn so sq "
+    "sr ss st su sv sw ta te tg th ti tk tl tn to tr ts tt tw ty ug uk ur uz ve "
+    "vi vo wa wo xh yi yo za zh zu".split()
 )
 
 
@@ -1072,12 +1060,38 @@ def _unwrap_lang_template(value: str) -> tuple[str, str]:
         tpl = templates[0]
         name = str(tpl.name).strip().casefold()
         if name in _KNOWN_LANG_CODES:
-            for p in tpl.params:
-                if not p.showkey:
-                    return str(p.value).strip(), name
-            if tpl.has("1"):
-                return str(tpl.get("1").value).strip(), name
+            # Unwrap only a SOLE text parameter (one positional, or one explicit
+            # 1=). A multi-parameter template like {{en|First|Second}} is not a
+            # simple language wrapper; unwrapping it would silently drop the
+            # extra parameters, so leave it untouched.
+            params = tpl.params
+            if len(params) == 1 and (
+                not params[0].showkey or str(params[0].name).strip() == "1"
+            ):
+                return str(params[0].value).strip(), name
     return value, "en"
+
+
+# A {{<code>|…}} whose <code> has language-code shape (2–3 letters + optional
+# -variant) — used to tell a language wrapper apart from a non-language template.
+_LANG_CODE_SHAPE_RE = re.compile(r"^[a-z]{2,3}(?:-[a-z0-9]+)*$", re.IGNORECASE)
+
+
+def _is_unrecognized_lang_wrapper(value: str) -> bool:
+    """True when ``value`` is a single ``{{<code>|…}}`` template whose ``<code>``
+    has language-code shape but is NOT in :data:`_KNOWN_LANG_CODES`. Such a
+    wrapper can't be safely unwrapped or language-labelled, so it is preserved on
+    the wikitext template (via :func:`_community_value_unfit_for_sdc`) instead of
+    being imported as a mislabelled ``en`` monolingual value with literal
+    markup."""
+    if "{{" not in value:
+        return False
+    parsed = mwparserfromhell.parse(value.strip())
+    templates = parsed.filter_templates(recursive=False)
+    if len(templates) == 1 and str(parsed).strip() == str(templates[0]).strip():
+        name = str(templates[0].name).strip().casefold()
+        return bool(_LANG_CODE_SHAPE_RE.match(name)) and name not in _KNOWN_LANG_CODES
+    return False
 
 
 def _value_equivalent_to_canonical(key: str, value: str, canonical: str) -> bool:
@@ -1355,31 +1369,24 @@ def format_legacy_import_claim(
         # string mapping) is unconventional and Module:DPLA doesn't render
         # it as a creator (so it silently failed to appear as one). This is
         # the same shape the {{Creator:}}-no-QID fallback builds.
-        compound = _split_unknown_from_creator(value)
-        if compound is not None:
-            # Compound credit with an embedded {{Unknown|role}} (e.g.
-            # "{{unknown|author}} reprinted by Webster & Stevens"): split the
-            # unknown-role assertion from the remaining name so neither the raw
-            # template markup nor the role is lost — a P170 somevalue (+ P3831
-            # role) for the unknown creator plus a P170 somevalue + P2093
-            # stated-as for the remainder.
-            role, remainder = compound
-            return [
-                _build_creator_unknown_claim(role, permalink),
-                _stated_as(remainder),
-            ]
-        creator_page = _split_creator_page_from_text(value)
-        if creator_page is not None:
-            # Compound credit with an embedded {{Creator:PageName}}: the page
-            # transclusion becomes a QID-resolved P170 (via the materializer)
-            # and the remaining free text a P170 somevalue + P2093 stated-as,
-            # so neither the structured creator link nor the community's
-            # attribution note is lost to literal markup.
-            page_title, remainder = creator_page
-            result = [_build_pending_creator_page_claim(page_title, permalink)]
+        parts, remainder = _split_embedded_creator_templates(value)
+        if parts is not None:
+            # Compound credit embedding one or more recognised creator templates
+            # ({{Unknown|role}}, {{Creator:Page}}): emit a claim per template
+            # (unknown → P170 somevalue + P3831 role; page → QID-resolved P170),
+            # plus a P2093 stated-as ONLY for the fully-cleaned remainder — so no
+            # literal template markup survives into the stated-as string.
+            claims: list[dict] = []
+            for kind, captured in parts:
+                if kind == "unknown":
+                    claims.append(_build_creator_unknown_claim(captured, permalink))
+                else:  # "page"
+                    claims.append(
+                        _build_pending_creator_page_claim(captured, permalink)
+                    )
             if remainder:
-                result.append(_stated_as(remainder))
-            return result
+                claims.append(_stated_as(remainder))
+            return claims
         return _stated_as(value)
 
     mapping = LEGACY_IMPORT_PROPERTY.get(canonical_key)
@@ -1954,11 +1961,10 @@ def _build_creator_unknown_claim(role: str, permalink: str) -> dict:
     statement has role) qualifier; an absent or unrecognised role yields a
     bare P170 somevalue. Carries the inferred-from-Wikitext reference.
 
-    NOTE: Module:DPLA does not yet render the P3831 role for a somevalue
-    creator (its creator renderer reads only the P2093 name-string
-    qualifier), so this statement is written correctly but renders blank
-    until the module is taught to surface ``{{Unknown|<role>}}`` from a
-    P170 somevalue + P3831. Tracked as the module-update follow-up.
+    Module:DPLA renders this shape as ``{{Unknown|<role>}}`` (e.g. "Unknown
+    photographer") as of the 2026-07-11 module update (revid 1246261799): its
+    creator renderers surface the P3831 role for a somevalue P170 that has no
+    P2093 name-string qualifier. (Before that update the shape rendered blank.)
     """
     claim = {
         "type": "statement",

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -1664,14 +1664,24 @@ def _resolve_commons_creator_qid(site, page_title: str) -> str | None:
     except Exception:
         return None
     pages = (response.get("query") or {}).get("pages") or {}
-    for page in pages.values():
+    # ``pages`` is a dict keyed by pageid under formatversion=1 and a list under
+    # formatversion=2; revision content likewise lives under the ``*`` key
+    # (fv=1) or ``content`` key (fv=2). Accept both so the resolver is immune to
+    # the pywikibot/API formatversion in effect.
+    for page in pages.values() if isinstance(pages, dict) else pages:
         pp = page.get("pageprops") or {}
         qid = pp.get("wikibase_item")
         if isinstance(qid, str) and qid.startswith("Q"):
             return qid
         for rev in page.get("revisions") or []:
-            slots = rev.get("slots") or {}
-            content = (slots.get("main") or {}).get("*") or rev.get("*") or ""
+            main = (rev.get("slots") or {}).get("main") or {}
+            content = (
+                main.get("content")
+                or main.get("*")
+                or rev.get("content")
+                or rev.get("*")
+                or ""
+            )
             match = _CREATOR_WIKIDATA_PARAM_RE.search(content)
             if match:
                 return match.group(1)

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -122,10 +122,16 @@ LEGACY_IMPORT_PROPERTY: dict[str, tuple[str, str]] = {
     # in a sentinel form so Phase 3b's claim builder can re-parse with
     # the existing :func:`ingest_wikimedia.sdc.parse_dpla_date` helper.
     "date": ("P571", "time"),
-    # ``creator`` (or ``author``/``artist`` aliases) → P2093 (creator —
-    # stated as), string. Avoids the Wikidata-reconciliation complexity
-    # of P170 (creator) for the common case of a string-only credit;
-    # editors can promote individual statements to P170 manually later.
+    # ``creator`` (or ``author``/``artist`` aliases). NOTE: this entry no
+    # longer drives claim CONSTRUCTION — a free-text community creator is
+    # built as a P170 ``somevalue`` + P2093 *qualifier* statement by
+    # :func:`format_legacy_import_claim` (via :func:`_build_creator_stated_as_claim`),
+    # because on a Commons MediaInfo entity P2093 (author name string) is
+    # only ever a qualifier of P170; a top-level P2093 mainsnak is
+    # unconventional and Module:DPLA doesn't render it as a creator. The
+    # entry is retained solely so :func:`_community_value_unfit_for_sdc`
+    # can look up the ``"string"`` kind and route vertical-whitespace
+    # creator values to wikitext preservation before claim construction.
     "creator": ("P2093", "string"),
 }
 
@@ -669,6 +675,26 @@ _NARA_AUTHOR_RE = re.compile(r"^\s*\{\{\s*NARA-Author\s*\|", re.IGNORECASE)
 # treat them as opaque strings that happen not to match anything.
 _CREATOR_QID_PREFIX = "__creator_qid__:"
 _CREATOR_PAGE_PREFIX = "__creator_page__:"
+# ``{{Unknown|<role>}}`` — an editor's assertion that the creator is unknown
+# but of a known role (e.g. photographer). Captured as its own sentinel so the
+# claim-builder can emit a P170 ``somevalue`` + P3831 (object has role)
+# qualifier instead of dropping it as an unrecognised template.
+_CREATOR_UNKNOWN_PREFIX = "__creator_unknown__:"
+# The {{Unknown|role}} creator grammar, shared by the anchored whole-value
+# matcher (_parse_creator_shape) and the unanchored embedded matcher
+# (_split_unknown_from_creator), so the two never drift apart.
+_UNKNOWN_CREATOR_BODY = r"\{\{\s*[Uu]nknown\s*(?:\|\s*([^}|]*?)\s*)?\}\}"
+_UNKNOWN_CREATOR_RE = re.compile(r"^" + _UNKNOWN_CREATOR_BODY + r"$")
+# {{Unknown|<role>}} role name (casefolded) → the Wikidata role item for the
+# P3831 (object of statement has role) qualifier. Labels verified on Wikidata.
+_UNKNOWN_ROLE_QID = {
+    "photographer": "Q33231",
+    "artist": "Q483501",
+    "author": "Q482980",
+    "engraver": "Q329439",
+    "painter": "Q1028181",
+    "illustrator": "Q644687",
+}
 
 
 def _unwrap_infi_creator(value: str) -> str | None:
@@ -748,12 +774,69 @@ def _parse_creator_shape(value: str) -> str | None:
     m = _CREATOR_PAGE_RE.match(stripped)
     if m:
         return _CREATOR_PAGE_PREFIX + m.group(1).strip()
+    m = _UNKNOWN_CREATOR_RE.match(stripped)
+    if m:
+        # ``{{Unknown}}`` / ``{{Unknown|Photographer}}`` — creator unknown,
+        # optional role. Preserve as a P170 somevalue (+ P3831 role) rather
+        # than dropping it with the other unrecognised templates below.
+        return _CREATOR_UNKNOWN_PREFIX + (m.group(1) or "").strip()
     # Any remaining ``{{…}}`` template-shaped value we don't recognise
     # is dropped rather than passed through as a raw string. See the
     # returns-``None`` clause of the docstring for the rationale.
     if stripped.startswith("{{") and stripped.endswith("}}"):
         return None
     return stripped
+
+
+# {{Unknown|role}} embedded in a longer creator credit (e.g.
+# "{{unknown|author}} reprinted by Webster & Stevens") — as opposed to a bare
+# {{Unknown|role}}, which _parse_creator_shape already tags as the
+# unknown-creator sentinel. A compound value otherwise falls through as a plain
+# string and stores the literal template markup in the P2093 stated-as.
+_EMBEDDED_UNKNOWN_RE = re.compile(_UNKNOWN_CREATOR_BODY)
+
+
+def _creator_remainder(value: str, m: re.Match) -> str:
+    """The creator text left after removing the matched sub-template ``m``,
+    with dangling join punctuation/whitespace trimmed. Shared by the compound
+    creator splitters."""
+    return (value[: m.start()] + value[m.end() :]).strip(" ;,·—–-\t\n").strip()
+
+
+def _split_unknown_from_creator(value: str) -> tuple[str, str] | None:
+    """If ``value`` contains a ``{{Unknown|role}}`` template alongside other
+    text, return ``(role, remainder)`` so the caller can emit a P170 somevalue
+    (+ P3831 role) for the unknown creator and a separate P170 somevalue +
+    P2093 stated-as for ``remainder``. Returns ``None`` when there is no
+    embedded ``{{Unknown}}`` or when the template is the *entire* value (a bare
+    ``{{Unknown|role}}`` is handled by :func:`_parse_creator_shape`)."""
+    m = _EMBEDDED_UNKNOWN_RE.search(value)
+    if not m:
+        return None
+    remainder = _creator_remainder(value, m)
+    if not remainder:
+        return None
+    return (m.group(1) or "").strip(), remainder
+
+
+# {{Creator:PageName}} embedded in a longer free-text creator credit (e.g.
+# "Believed to be by Asahel Curtis, working for … {{Creator:Asahel Curtis}}").
+# A bare {{Creator:Foo}} is tagged by _parse_creator_shape as a page sentinel;
+# a compound value falls through as a plain string and would store the literal
+# {{Creator:…}} markup in the P2093 stated-as.
+_EMBEDDED_CREATOR_PAGE_RE = re.compile(r"\{\{\s*[Cc]reator\s*:\s*([^}|]+?)\s*\}\}")
+
+
+def _split_creator_page_from_text(value: str) -> tuple[str, str] | None:
+    """If ``value`` embeds a ``{{Creator:PageName}}`` transclusion, return
+    ``(page_title, remainder)`` so the caller can emit a P170 creator-page
+    claim (QID-resolved in the materializer) plus a P170 somevalue + P2093
+    stated-as for the remaining community text. ``remainder`` may be empty."""
+    m = _EMBEDDED_CREATOR_PAGE_RE.search(value)
+    if not m:
+        return None
+    remainder = _creator_remainder(value, m)
+    return m.group(1).strip(), remainder
 
 
 def _extract_institution_qid(value: str) -> str | None:
@@ -844,21 +927,28 @@ def _split_extension_extras(value: str, canonical: str) -> str | None:
 
 
 def _community_value_unfit_for_sdc(key: str, value: str) -> bool:
-    """True when a community value can't be posted as its SDC claim type
-    because it contains vertical whitespace.
+    """True when a community value can't be posted as an SDC claim and must be
+    preserved on the migrated template's param instead of dropped.
 
-    ``title``/``description`` (monolingualtext) and ``creator`` (string) go
-    through :func:`_validate_wikibase_text`, whose validator rejects
-    newlines/tabs/CR. A value with such whitespace that is *not* a
-    DPLA-prefixed extension (:func:`_split_extension_extras`) can't be an SDC
-    claim at all, so the caller preserves it on the migrated template's param
-    rather than erroring the whole import. ``date`` (time) is parsed, not
-    text-validated, so it's excluded; keys with no import mapping never reach
-    the text validator either.
+    Two cases:
+
+    * **No SDC import mapping at all** (``permission``, ``source``,
+      ``institution`` — not in :data:`LEGACY_IMPORT_PROPERTY`). These have no
+      Phase-3a claim builder, so a *community* override of one — e.g. a
+      hand-set ``permission = {{PD-old-auto-1923|deathyear=1922}}`` — would
+      otherwise land in ``community_imports`` and be silently dropped
+      (``format_legacy_import_claim`` returns ``None``). Preserve it on the
+      template param, where Module:DPLA renders it in the yellow box.
+    * **SDC-mappable but vertical-whitespace-bearing** (``title``/
+      ``description`` monolingualtext, ``creator`` string): the Wikibase text
+      validators reject newlines/tabs/CR, so a value with such whitespace that
+      is *not* a DPLA-prefixed extension (:func:`_split_extension_extras`)
+      can't be an SDC claim either. ``date`` (time) is parsed, not
+      text-validated, so a mapped time key is never unfit on whitespace.
     """
     mapping = LEGACY_IMPORT_PROPERTY.get(key)
     if mapping is None:
-        return False
+        return True
     _prop, kind = mapping
     return kind in ("monolingualtext", "string") and bool(
         _VERTICAL_WHITESPACE_RE.search(value)
@@ -912,6 +1002,84 @@ def _multi_value_subset_of_canonical(value: str, canonical: str) -> bool:
     return bool(value_parts) and value_parts.issubset(canonical_parts)
 
 
+# Bare Commons language templates ({{en|text}}, {{de|text}}, …) wrap a single
+# monolingual value in a language code. Only unwrap when the ENTIRE value is
+# one such template with a KNOWN language code — so non-language 2–3 letter
+# templates ({{PD|…}}) and values that merely contain a template are left
+# untouched.
+_KNOWN_LANG_CODES = frozenset(
+    {
+        "en",
+        "de",
+        "fr",
+        "es",
+        "it",
+        "nl",
+        "pt",
+        "sv",
+        "da",
+        "no",
+        "nb",
+        "nn",
+        "fi",
+        "is",
+        "pl",
+        "cs",
+        "sk",
+        "ru",
+        "uk",
+        "be",
+        "bg",
+        "sr",
+        "hr",
+        "sl",
+        "ja",
+        "zh",
+        "ko",
+        "ar",
+        "he",
+        "el",
+        "hu",
+        "ro",
+        "tr",
+        "ca",
+        "gl",
+        "eu",
+        "ga",
+        "cy",
+        "la",
+        "hi",
+        "fa",
+        "id",
+    }
+)
+
+
+def _unwrap_lang_template(value: str) -> tuple[str, str]:
+    """If ``value`` is exactly one bare ``{{<lang>|<text>}}`` language template
+    with a known ISO code, return ``(text, lang)``; otherwise ``(value,
+    "en")``. Lets a community title/description be stored as clean monolingual
+    text with the correct language code instead of literal ``{{en|…}}`` markup,
+    and reconciled against canonical's plain text."""
+    # Fast path: a value with no template markup can't be a bare language
+    # wrapper — skip the mwparserfromhell parse (this runs on every
+    # title/description value across the batch).
+    if "{{" not in value:
+        return value, "en"
+    parsed = mwparserfromhell.parse(value.strip())
+    templates = parsed.filter_templates(recursive=False)
+    if len(templates) == 1 and str(parsed).strip() == str(templates[0]).strip():
+        tpl = templates[0]
+        name = str(tpl.name).strip().casefold()
+        if name in _KNOWN_LANG_CODES:
+            for p in tpl.params:
+                if not p.showkey:
+                    return str(p.value).strip(), name
+            if tpl.has("1"):
+                return str(tpl.get("1").value).strip(), name
+    return value, "en"
+
+
 def _value_equivalent_to_canonical(key: str, value: str, canonical: str) -> bool:
     """Return True when ``value`` (from wikitext) and ``canonical`` (from
     DPLA) are the same fact for the purpose of migration-planning.
@@ -941,6 +1109,11 @@ def _value_equivalent_to_canonical(key: str, value: str, canonical: str) -> bool
     Keys outside those sets (other sub-template shapes) fall back to
     strict equality.
     """
+    if key in ("title", "description"):
+        # A community title/description wrapped in a bare language template
+        # ({{en|…}}) is the same fact as canonical's plain text — compare the
+        # unwrapped text so it isn't imported as a spurious community value.
+        value = _unwrap_lang_template(value)[0]
     if value == canonical:
         return True
     if key == "date" and dates_semantically_equal(value, canonical):
@@ -1125,7 +1298,7 @@ def format_legacy_import_claim(
     value: str,
     permalink: str,
     today: datetime.date | None = None,
-) -> dict | None:
+) -> dict | list[dict] | None:
     """Build a Wikibase ``wbeditentity``-ready claim dict for one
     legacy-imported value.
 
@@ -1149,6 +1322,11 @@ def format_legacy_import_claim(
     # can do the SDC comparison + resolution in the executor's
     # network-touching context, keeping :func:`plan_migration` pure.
     if canonical_key == "creator":
+
+        def _stated_as(text: str) -> dict:
+            _validate_wikibase_text(text, "P2093", canonical_key)
+            return _build_creator_stated_as_claim(text, permalink)
+
         if value.startswith(_CREATOR_QID_PREFIX):
             return {
                 "type": "statement",
@@ -1157,20 +1335,63 @@ def format_legacy_import_claim(
                 "_permalink": permalink,
             }
         if value.startswith(_CREATOR_PAGE_PREFIX):
-            return {
-                "type": "statement",
-                "rank": "normal",
-                "_phase3a_pending_creator_page": value[len(_CREATOR_PAGE_PREFIX) :],
-                "_permalink": permalink,
-            }
+            return _build_pending_creator_page_claim(
+                value[len(_CREATOR_PAGE_PREFIX) :], permalink
+            )
+        if value.startswith(_CREATOR_UNKNOWN_PREFIX):
+            # {{Unknown|<role>}} — creator unknown, optional role → P170
+            # somevalue + (recognised) P3831 role qualifier.
+            return _build_creator_unknown_claim(
+                value[len(_CREATOR_UNKNOWN_PREFIX) :], permalink
+            )
+        # A plain free-text creator credit — a stated-as name ("Jane Doe")
+        # or a descriptive line ("illustration photographed circa 1910 by
+        # Walter F. Piper") — with no {{Creator:}} page or {{creator|Wikidata=}}
+        # QID. Preserve it the conventional Commons way: a P170 (creator)
+        # ``somevalue`` statement qualified by P2093 (author name string),
+        # carrying the inferred-from-Wikitext reference. On a Commons
+        # MediaInfo entity P2093 is only ever a *qualifier* of P170 — a
+        # top-level P2093 mainsnak (the old ``LEGACY_IMPORT_PROPERTY``
+        # string mapping) is unconventional and Module:DPLA doesn't render
+        # it as a creator (so it silently failed to appear as one). This is
+        # the same shape the {{Creator:}}-no-QID fallback builds.
+        compound = _split_unknown_from_creator(value)
+        if compound is not None:
+            # Compound credit with an embedded {{Unknown|role}} (e.g.
+            # "{{unknown|author}} reprinted by Webster & Stevens"): split the
+            # unknown-role assertion from the remaining name so neither the raw
+            # template markup nor the role is lost — a P170 somevalue (+ P3831
+            # role) for the unknown creator plus a P170 somevalue + P2093
+            # stated-as for the remainder.
+            role, remainder = compound
+            return [
+                _build_creator_unknown_claim(role, permalink),
+                _stated_as(remainder),
+            ]
+        creator_page = _split_creator_page_from_text(value)
+        if creator_page is not None:
+            # Compound credit with an embedded {{Creator:PageName}}: the page
+            # transclusion becomes a QID-resolved P170 (via the materializer)
+            # and the remaining free text a P170 somevalue + P2093 stated-as,
+            # so neither the structured creator link nor the community's
+            # attribution note is lost to literal markup.
+            page_title, remainder = creator_page
+            result = [_build_pending_creator_page_claim(page_title, permalink)]
+            if remainder:
+                result.append(_stated_as(remainder))
+            return result
+        return _stated_as(value)
 
     mapping = LEGACY_IMPORT_PROPERTY.get(canonical_key)
     if mapping is None:
         return None
     prop, kind = mapping
     if kind == "monolingualtext":
-        _validate_wikibase_text(value, prop, canonical_key)
-        datavalue = _monolingualtext_datavalue(value)
+        # Unwrap a bare language template ({{en|…}}) so the monolingual value
+        # stores clean text with the right language code, not literal markup.
+        text, language = _unwrap_lang_template(value)
+        _validate_wikibase_text(text, prop, canonical_key)
+        datavalue = _monolingualtext_datavalue(text, language)
         datatype = "monolingualtext"
     elif kind == "string":
         _validate_wikibase_text(value, prop, canonical_key)
@@ -1221,7 +1442,11 @@ def build_legacy_import_claims(plan: MigrationPlan) -> list[dict]:
     claims: list[dict] = []
     for key, value in plan.community_imports.items():
         claim = format_legacy_import_claim(key, value, plan.source_permalink)
-        if claim is not None:
+        if claim is None:
+            continue
+        if isinstance(claim, list):
+            claims.extend(claim)
+        else:
             claims.append(claim)
     for filename in plan.related_image_imports:
         claims.append(
@@ -1259,19 +1484,32 @@ def fetch_revision_snapshots(file_page) -> list[RevisionSnapshot]:
     of :func:`plan_migration` is a small dict the executor walks
     cheaply.
 
-    Missing per-revision metadata (suppressed-author revisions, missing
-    text) is tolerated: empty user names become ``""`` and absent text
-    becomes ``""``, so :func:`parse_artwork_params` simply finds no
-    params and the revision contributes nothing to provenance.
+    A SUPPRESSED (RevDel) revision hides its author and content together
+    (``user is None``); it is tolerated — coerced to ``""`` so
+    :func:`parse_artwork_params` finds no params and it contributes nothing
+    to provenance. But a revision with a VISIBLE author and unloaded content
+    (``text is None`` while ``user`` is set) means the
+    ``revisions(content=True)`` fetch came back PARTIAL. That is raised, not
+    tolerated: silently coercing it to ``""`` would drop it from
+    :func:`trace_param_provenance`'s walk, mis-attributing an unchanged
+    DPLA-bot param to whichever later community editor's revision did load —
+    emitting a false "community" SDC import and a bogus "added by Wikimedia
+    users, not verified by the source institution" notice. The caller skips
+    and flags the file; a re-run with a complete fetch migrates it correctly.
     """
     snapshots: list[RevisionSnapshot] = []
     for rev in file_page.revisions(content=True):
-        snapshots.append(
-            RevisionSnapshot(
-                revid=getattr(rev, "revid", 0),
-                user=getattr(rev, "user", "") or "",
-                text=getattr(rev, "text", "") or "",
+        revid = getattr(rev, "revid", 0)
+        user = getattr(rev, "user", None)
+        text = getattr(rev, "text", None)
+        if text is None and user is not None:
+            raise RuntimeError(
+                f"incomplete revision content for {file_page.title()!r} "
+                f"(revid {revid}, user {user!r}): refusing to compute legacy "
+                f"provenance from a partial revision history"
             )
+        snapshots.append(
+            RevisionSnapshot(revid=revid, user=user or "", text=text or "")
         )
     return snapshots
 
@@ -1705,6 +1943,62 @@ def _build_creator_qid_claim(qid: str, permalink: str) -> dict:
             },
         },
         "references": [_reference_snaks(permalink)],
+    }
+
+
+def _build_creator_unknown_claim(role: str, permalink: str) -> dict:
+    """Build a P170 (creator) ``somevalue`` statement for an
+    ``{{Unknown|<role>}}`` community credit — an editor's assertion that the
+    creator is unknown but of a known role (e.g. photographer). A recognised
+    role (:data:`_UNKNOWN_ROLE_QID`) is recorded as a P3831 (object of
+    statement has role) qualifier; an absent or unrecognised role yields a
+    bare P170 somevalue. Carries the inferred-from-Wikitext reference.
+
+    NOTE: Module:DPLA does not yet render the P3831 role for a somevalue
+    creator (its creator renderer reads only the P2093 name-string
+    qualifier), so this statement is written correctly but renders blank
+    until the module is taught to surface ``{{Unknown|<role>}}`` from a
+    P170 somevalue + P3831. Tracked as the module-update follow-up.
+    """
+    claim = {
+        "type": "statement",
+        "rank": "normal",
+        "mainsnak": {
+            "snaktype": "somevalue",
+            "property": "P170",
+            "datatype": "wikibase-item",
+        },
+        "references": [_reference_snaks(permalink)],
+    }
+    role_qid = _UNKNOWN_ROLE_QID.get(role.casefold()) if role else None
+    if role_qid:
+        claim["qualifiers"] = {
+            "P3831": [
+                {
+                    "snaktype": "value",
+                    "property": "P3831",
+                    "datatype": "wikibase-item",
+                    "datavalue": {
+                        "type": "wikibase-entityid",
+                        "value": {"entity-type": "item", "id": role_qid},
+                    },
+                }
+            ]
+        }
+        claim["qualifiers-order"] = ["P3831"]
+    return claim
+
+
+def _build_pending_creator_page_claim(page_title: str, permalink: str) -> dict:
+    """Phase-3a placeholder for a Commons ``{{Creator:PageName}}`` transclusion.
+    :func:`materialize_import_claims` resolves it to a P170 QID (or a P170
+    somevalue + P2093 stated-as fallback when the Creator page has no Wikidata
+    link). Shared by the bare-``{{Creator:}}`` and compound-creator paths."""
+    return {
+        "type": "statement",
+        "rank": "normal",
+        "_phase3a_pending_creator_page": page_title,
+        "_permalink": permalink,
     }
 
 

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1358,6 +1358,17 @@ def dates_semantically_equal(a: str, b: str) -> bool:
     """
     if not a or not b:
         return False
+    # A maintenance-bot or community edit may have reformatted a bare display
+    # date ("1910?") into {{other date|...}} template markup
+    # ("{{other date|~|1910}}"). Reduce that markup to its plain display form
+    # first — parse_dpla_date only understands display strings, not raw
+    # template wikitext — so the reformatted value reconciles against the
+    # canonical date and is stripped, instead of being mistaken for a
+    # community date override. (Ranges like {{other date|between|X|Y}} return
+    # None from parse_other_date_template and pass through to the range
+    # matcher unchanged.)
+    a = parse_other_date_template(a) or parse_taken_on_template(a) or a
+    b = parse_other_date_template(b) or parse_taken_on_template(b) or b
     pa = parse_dpla_date(a)
     pb = parse_dpla_date(b)
     if pa is None or pb is None:
@@ -1680,6 +1691,36 @@ def parse_other_date_template(value: str) -> str | None:
     if modifier in ("s", "decade"):
         return f"{date_arg}s"
     return None
+
+
+# Commons "date taken" templates whose first positional argument is a plain
+# date: {{Taken on|1921-09-21}}, {{Taken in|1921}}, {{Taken circa|1921}}.
+# Reduce to the display string parse_dpla_date understands so a community
+# {{Taken on|…}} reconciles against the canonical date instead of importing a
+# duplicate P571. Named params (|location=…) are ignored. Conservative:
+# returns None for anything else so it can never widen a wrong dedup.
+_TAKEN_TEMPLATE_RE = re.compile(
+    r"^\{\{\s*taken[ _](on|in|circa)\s*\|(.+?)\}\}$", re.IGNORECASE | re.DOTALL
+)
+
+
+def parse_taken_on_template(value: str) -> str | None:
+    """Convert a ``{{Taken on|…}}`` / ``{{Taken in|…}}`` / ``{{Taken circa|…}}``
+    value into the plain display string :func:`parse_dpla_date` understands, or
+    ``None`` when the input isn't one of those templates."""
+    if not value:
+        return None
+    m = _TAKEN_TEMPLATE_RE.match(value.strip())
+    if not m:
+        return None
+    modifier = m.group(1).lower()
+    date_arg = next(
+        (a.strip() for a in m.group(2).split("|") if a.strip() and "=" not in a),
+        "",
+    )
+    if not date_arg:
+        return None
+    return f"circa {date_arg}" if modifier == "circa" else date_arg
 
 
 def _build_date_claim(

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -1700,7 +1700,8 @@ def parse_other_date_template(value: str) -> str | None:
 # duplicate P571. Named params (|location=…) are ignored. Conservative:
 # returns None for anything else so it can never widen a wrong dedup.
 _TAKEN_TEMPLATE_RE = re.compile(
-    r"^\{\{\s*taken[ _](on|in|circa)\s*\|(.+?)\}\}$", re.IGNORECASE | re.DOTALL
+    r"^\{\{\s*taken[\s_]+(on|in|circa)\s*\|(.+?)\}\}$",
+    re.IGNORECASE | re.DOTALL,
 )
 
 

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -3106,6 +3106,38 @@ def test_resolve_commons_creator_qid_reads_wikidata_param_when_no_sitelink():
     assert _resolve_commons_creator_qid(site, "Theodore E. Peiser") == "Q56159174"
 
 
+def test_resolve_commons_creator_qid_reads_formatversion2_content_payload():
+    """Under formatversion=2 the API returns ``pages`` as a list and revision
+    content under the ``content`` key (not ``*``). The resolver must read the
+    Wikidata param from that modern shape too, or a pywikibot/API formatversion
+    bump would silently drop every Creator-page QID to the name-only fallback."""
+    from unittest.mock import MagicMock
+
+    from ingest_wikimedia.legacy_artwork import _resolve_commons_creator_qid
+
+    site = MagicMock()
+    site.simple_request.return_value.submit.return_value = {
+        "query": {
+            "pages": [
+                {
+                    "title": "Creator:Theodore E. Peiser",
+                    "pageprops": {},  # no wikibase_item sitelink
+                    "revisions": [
+                        {
+                            "slots": {
+                                "main": {
+                                    "content": "{{Creator\n | Wikidata = Q56159174\n}}"
+                                }
+                            }
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    assert _resolve_commons_creator_qid(site, "Theodore E. Peiser") == "Q56159174"
+
+
 def test_resolve_commons_creator_qid_prefers_sitelink():
     """When a wikibase_item sitelink IS present, use it directly."""
     from unittest.mock import MagicMock

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -703,15 +703,18 @@ def test_format_claim_for_description_uses_p10358():
 
 
 def test_format_claim_for_creator_uses_p2093_string():
-    """``P2093`` (creator — stated as) is the string form, used when
-    we have no Wikidata item match. Editors can later promote to
-    P170 manually."""
+    """A free-text creator with no Wikidata item is stored as the
+    conventional Commons authorship shape: a P170 (creator) somevalue
+    mainsnak qualified by P2093 (author name string) — not a top-level
+    P2093 mainsnak, which Module:DPLA does not render as a creator."""
     claim = format_legacy_import_claim(
         "creator", "Jane Doe", "https://example/permalink"
     )
     assert claim is not None
-    assert claim["mainsnak"]["property"] == "P2093"
-    assert claim["mainsnak"]["datatype"] == "string"
+    assert claim["mainsnak"]["property"] == "P170"
+    assert claim["mainsnak"]["snaktype"] == "somevalue"
+    assert claim["qualifiers"]["P2093"][0]["datavalue"]["value"] == "Jane Doe"
+    assert claim["qualifiers"]["P2093"][0]["datatype"] == "string"
 
 
 def test_format_claim_for_date_emits_phase3a_placeholder():
@@ -746,7 +749,9 @@ def test_build_legacy_import_claims_iterates_community_imports():
     claims = build_legacy_import_claims(plan)
     assert len(claims) == 2
     props = {c["mainsnak"]["property"] for c in claims}
-    assert props == {"P1476", "P2093"}
+    # Bug 2: a free-text creator is a P170 somevalue (+ P2093 qualifier),
+    # not a top-level P2093 mainsnak.
+    assert props == {"P1476", "P170"}
 
 
 # ---------------------------------------------------------------------------
@@ -2560,7 +2565,10 @@ def test_plan_migration_still_imports_institution_that_differs():
         "File:Foo.jpg", revs, _canonical_params(institution="Q59661041")
     )
     assert plan is not None
-    assert "institution" in plan.community_imports
+    # Bug 4: institution has no SDC property mapping, so a differing community
+    # override is preserved on the wikitext template (yellow box) rather than
+    # dropped — not emitted as an SDC community_import.
+    assert "institution" in plan.wikitext_preserved_extras
 
 
 def test_plan_migration_extract_institution_qid_handles_flat_bare_qid():
@@ -3232,3 +3240,137 @@ def test_parse_creator_shape_passes_through_plain_names():
     # template) must still pass through — the guard checks bounds, not
     # substring occurrence.
     assert _parse_creator_shape("Smith, John (author)") == "Smith, John (author)"
+
+
+def test_unwrap_lang_template_unwraps_known_language_codes():
+    from ingest_wikimedia.legacy_artwork import _unwrap_lang_template
+
+    assert _unwrap_lang_template("{{en|Men standing before the depot}}") == (
+        "Men standing before the depot",
+        "en",
+    )
+    assert _unwrap_lang_template("{{de|Ein Foto}}") == ("Ein Foto", "de")
+    assert _unwrap_lang_template("A plain title") == ("A plain title", "en")
+    assert _unwrap_lang_template("{{PD-US}}") == ("{{PD-US}}", "en")
+    assert _unwrap_lang_template("{{en|Foo}} and more") == ("{{en|Foo}} and more", "en")
+
+
+def test_value_equivalent_unwraps_lang_template_for_title_description():
+    from ingest_wikimedia.legacy_artwork import _value_equivalent_to_canonical
+
+    assert _value_equivalent_to_canonical(
+        "title", "{{en|A Better Title}}", "A Better Title"
+    )
+    assert _value_equivalent_to_canonical("description", "{{en|A desc}}", "A desc")
+    assert not _value_equivalent_to_canonical("title", "{{en|Other}}", "A Better Title")
+
+
+def test_format_claim_title_unwraps_lang_template_into_monolingual_text():
+    claim = format_legacy_import_claim(
+        "title", "{{en|Men standing before the depot}}", "https://example/permalink"
+    )
+    assert claim is not None
+    assert claim["mainsnak"]["datavalue"]["value"] == {
+        "text": "Men standing before the depot",
+        "language": "en",
+    }
+
+
+def test_format_claim_free_text_creator_uses_p170_somevalue_p2093_qualifier():
+    claim = format_legacy_import_claim(
+        "creator", "Jane Doe", "https://example/permalink"
+    )
+    assert claim is not None and not isinstance(claim, list)
+    assert claim["mainsnak"]["property"] == "P170"
+    assert claim["mainsnak"]["snaktype"] == "somevalue"
+    assert claim["qualifiers"]["P2093"][0]["datavalue"]["value"] == "Jane Doe"
+
+
+def test_format_claim_bare_unknown_creator_emits_p170_somevalue_with_role():
+    claim = format_legacy_import_claim(
+        "creator", "__creator_unknown__:Photographer", "https://example/permalink"
+    )
+    assert claim is not None
+    assert claim["mainsnak"]["property"] == "P170"
+    assert claim["mainsnak"]["snaktype"] == "somevalue"
+    assert claim["qualifiers"]["P3831"][0]["datavalue"]["value"]["id"] == "Q33231"
+
+
+def test_split_unknown_from_creator_splits_compound_credit():
+    from ingest_wikimedia.legacy_artwork import _split_unknown_from_creator
+
+    assert _split_unknown_from_creator(
+        "{{unknown|author}} reprinted by Webster & Stevens"
+    ) == ("author", "reprinted by Webster & Stevens")
+    assert _split_unknown_from_creator(
+        "Webster & Stevens {{Unknown|photographer}}"
+    ) == ("photographer", "Webster & Stevens")
+    assert _split_unknown_from_creator("{{Unknown|author}}") is None
+    assert (
+        _split_unknown_from_creator("Boyd & Braas; reprinted by Webster & Stevens")
+        is None
+    )
+
+
+def test_format_claim_compound_unknown_creator_emits_two_p170_statements():
+    result = format_legacy_import_claim(
+        "creator",
+        "{{unknown|author}} reprinted by Webster & Stevens",
+        "https://example/permalink",
+    )
+    assert isinstance(result, list) and len(result) == 2
+    unknown_claim, stated_claim = result
+    assert unknown_claim["mainsnak"]["property"] == "P170"
+    assert unknown_claim["mainsnak"]["snaktype"] == "somevalue"
+    assert (
+        unknown_claim["qualifiers"]["P3831"][0]["datavalue"]["value"]["id"] == "Q482980"
+    )
+    assert (
+        stated_claim["qualifiers"]["P2093"][0]["datavalue"]["value"]
+        == "reprinted by Webster & Stevens"
+    )
+
+
+def test_split_creator_page_from_text_splits_embedded_creator_page():
+    from ingest_wikimedia.legacy_artwork import _split_creator_page_from_text
+
+    v = (
+        "Believed to be by Asahel Curtis, working for hydraulic contractors "
+        "Lewis & Wiley Co. {{Creator:Asahel Curtis}}"
+    )
+    rem = (
+        "Believed to be by Asahel Curtis, working for hydraulic contractors "
+        "Lewis & Wiley Co."
+    )
+    assert _split_creator_page_from_text(v) == ("Asahel Curtis", rem)
+    assert _split_creator_page_from_text("Jane Doe") is None
+
+
+def test_format_claim_compound_creator_page_emits_placeholder_and_clean_stated_as():
+    v = "Believed to be by Asahel Curtis {{Creator:Asahel Curtis}}"
+    result = format_legacy_import_claim("creator", v, "https://example/permalink")
+    assert isinstance(result, list) and len(result) == 2
+    assert result[0].get("_phase3a_pending_creator_page") == "Asahel Curtis"
+    p2093 = result[1]["qualifiers"]["P2093"][0]["datavalue"]["value"]
+    assert p2093 == "Believed to be by Asahel Curtis"
+    assert "{{" not in p2093
+
+
+def test_build_legacy_import_claims_flattens_compound_creator():
+    plan = MigrationPlan(
+        source_permalink="https://example/permalink",
+        community_imports={
+            "creator": "{{unknown|author}} reprinted by Webster & Stevens",
+        },
+    )
+    claims = build_legacy_import_claims(plan)
+    assert len(claims) == 2
+    assert all(c["mainsnak"]["property"] == "P170" for c in claims)
+
+
+def test_community_value_unfit_for_sdc_preserves_unmapped_keys():
+    from ingest_wikimedia.legacy_artwork import _community_value_unfit_for_sdc
+
+    assert _community_value_unfit_for_sdc("permission", "{{PD-US}}") is True
+    assert _community_value_unfit_for_sdc("source", "some source") is True
+    assert _community_value_unfit_for_sdc("title", "A clean single-line title") is False

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -3253,6 +3253,16 @@ def test_unwrap_lang_template_unwraps_known_language_codes():
     assert _unwrap_lang_template("A plain title") == ("A plain title", "en")
     assert _unwrap_lang_template("{{PD-US}}") == ("{{PD-US}}", "en")
     assert _unwrap_lang_template("{{en|Foo}} and more") == ("{{en|Foo}} and more", "en")
+    # Complete ISO 639-1 set: a valid code (eo) unwraps to its own language.
+    assert _unwrap_lang_template("{{eo|Teksto}}") == ("Teksto", "eo")
+    # Explicit 1= positional unwraps.
+    assert _unwrap_lang_template("{{en|1=Explicit}}") == ("Explicit", "en")
+    # Sole text param only: a multi-param template is NOT unwrapped (that would
+    # silently drop the extra parameters).
+    assert _unwrap_lang_template("{{en|First|Second}}") == (
+        "{{en|First|Second}}",
+        "en",
+    )
 
 
 def test_value_equivalent_unwraps_lang_template_for_title_description():
@@ -3296,20 +3306,31 @@ def test_format_claim_bare_unknown_creator_emits_p170_somevalue_with_role():
     assert claim["qualifiers"]["P3831"][0]["datavalue"]["value"]["id"] == "Q33231"
 
 
-def test_split_unknown_from_creator_splits_compound_credit():
-    from ingest_wikimedia.legacy_artwork import _split_unknown_from_creator
+def test_split_embedded_creator_templates_tokenizes_all():
+    from ingest_wikimedia.legacy_artwork import _split_embedded_creator_templates
 
-    assert _split_unknown_from_creator(
+    # single embedded {{Unknown}} + text remainder
+    assert _split_embedded_creator_templates(
         "{{unknown|author}} reprinted by Webster & Stevens"
-    ) == ("author", "reprinted by Webster & Stevens")
-    assert _split_unknown_from_creator(
-        "Webster & Stevens {{Unknown|photographer}}"
-    ) == ("photographer", "Webster & Stevens")
-    assert _split_unknown_from_creator("{{Unknown|author}}") is None
-    assert (
-        _split_unknown_from_creator("Boyd & Braas; reprinted by Webster & Stevens")
-        is None
+    ) == ([("unknown", "author")], "reprinted by Webster & Stevens")
+    # single embedded {{Creator:}} + text remainder
+    assert _split_embedded_creator_templates(
+        "Believed to be by Asahel Curtis {{Creator:Asahel Curtis}}"
+    ) == ([("page", "Asahel Curtis")], "Believed to be by Asahel Curtis")
+    # MULTIPLE templates: both consumed; connector-only remainder is dropped
+    assert _split_embedded_creator_templates("{{Creator:A}} and {{Creator:B}}") == (
+        [("page", "A"), ("page", "B")],
+        "",
     )
+    # both kinds in one value, in document order
+    assert _split_embedded_creator_templates("{{unknown|author}} {{Creator:B}}") == (
+        [("unknown", "author"), ("page", "B")],
+        "",
+    )
+    # no recognised embedded template → (None, value)
+    assert _split_embedded_creator_templates(
+        "Boyd & Braas; reprinted by Webster & Stevens"
+    ) == (None, "Boyd & Braas; reprinted by Webster & Stevens")
 
 
 def test_format_claim_compound_unknown_creator_emits_two_p170_statements():
@@ -3331,19 +3352,27 @@ def test_format_claim_compound_unknown_creator_emits_two_p170_statements():
     )
 
 
-def test_split_creator_page_from_text_splits_embedded_creator_page():
-    from ingest_wikimedia.legacy_artwork import _split_creator_page_from_text
-
-    v = (
-        "Believed to be by Asahel Curtis, working for hydraulic contractors "
-        "Lewis & Wiley Co. {{Creator:Asahel Curtis}}"
+def test_format_claim_compound_multiple_creator_templates_emits_claim_each():
+    # Two {{Creator:}} joined by "and": two QID-resolved page placeholders, no
+    # junk P2093 for the "and" connector.
+    result = format_legacy_import_claim(
+        "creator", "{{Creator:A}} and {{Creator:B}}", "https://example/permalink"
     )
-    rem = (
-        "Believed to be by Asahel Curtis, working for hydraulic contractors "
-        "Lewis & Wiley Co."
+    assert isinstance(result, list) and len(result) == 2
+    assert [c.get("_phase3a_pending_creator_page") for c in result] == ["A", "B"]
+    # {{Unknown|role}} + {{Creator:}}: an unknown-role P170 + a page placeholder.
+    result2 = format_legacy_import_claim(
+        "creator",
+        "{{unknown|photographer}} {{Creator:B}}",
+        "https://example/permalink",
     )
-    assert _split_creator_page_from_text(v) == ("Asahel Curtis", rem)
-    assert _split_creator_page_from_text("Jane Doe") is None
+    assert isinstance(result2, list) and len(result2) == 2
+    assert result2[0]["qualifiers"]["P3831"][0]["datavalue"]["value"]["id"] == "Q33231"
+    assert result2[1].get("_phase3a_pending_creator_page") == "B"
+    # no literal {{ markup survives into any emitted P2093 qualifier
+    for c in result + result2:
+        for q in c.get("qualifiers", {}).get("P2093", []):
+            assert "{{" not in q["datavalue"]["value"]
 
 
 def test_format_claim_compound_creator_page_emits_placeholder_and_clean_stated_as():
@@ -3374,3 +3403,31 @@ def test_community_value_unfit_for_sdc_preserves_unmapped_keys():
     assert _community_value_unfit_for_sdc("permission", "{{PD-US}}") is True
     assert _community_value_unfit_for_sdc("source", "some source") is True
     assert _community_value_unfit_for_sdc("title", "A clean single-line title") is False
+
+
+def test_community_value_unfit_for_sdc_preserves_unrecognized_lang_wrapper():
+    from ingest_wikimedia.legacy_artwork import _community_value_unfit_for_sdc
+
+    # lang-shaped but unrecognised code (3-letter / variant) → preserve as wikitext
+    assert _community_value_unfit_for_sdc("description", "{{nan|some text}}") is True
+    assert _community_value_unfit_for_sdc("description", "{{en-gb|colour}}") is True
+    # a recognised language wrapper is importable (unwrapped at claim-build)
+    assert _community_value_unfit_for_sdc("description", "{{en|clean text}}") is False
+    assert _community_value_unfit_for_sdc("title", "A clean single-line title") is False
+
+
+def test_parse_creator_shape_passes_through_embedded_creator_compound():
+    from ingest_wikimedia.legacy_artwork import _parse_creator_shape
+
+    # a {{…}}-bookended compound EMBEDDING recognised creator templates is passed
+    # through (not dropped) so the claim-builder can tokenise it.
+    assert (
+        _parse_creator_shape("{{unknown|author}} {{Creator:B}}")
+        == "{{unknown|author}} {{Creator:B}}"
+    )
+    assert (
+        _parse_creator_shape("{{Creator:A}} and {{Creator:B}}")
+        == "{{Creator:A}} and {{Creator:B}}"
+    )
+    # an unrecognised {{…}} template is still dropped
+    assert _parse_creator_shape("{{some-other-template|x}}") is None

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -3431,3 +3431,53 @@ def test_parse_creator_shape_passes_through_embedded_creator_compound():
     )
     # an unrecognised {{…}} template is still dropped
     assert _parse_creator_shape("{{some-other-template|x}}") is None
+
+
+def test_community_value_unfit_routes_multiparam_lang_wrapper_to_wikitext():
+    """A known-language wrapper that _unwrap_lang_template won't unwrap
+    (multi-param {{en|First|Second}}) must be routed to wikitext rather than
+    stored as a literal-markup monolingual claim. Sole-param wrappers stay
+    SDC-fit; unrecognised/non-language templates go to wikitext."""
+    from ingest_wikimedia.legacy_artwork import _community_value_unfit_for_sdc
+
+    assert _community_value_unfit_for_sdc("title", "{{en|First|Second}}") is True
+    assert _community_value_unfit_for_sdc("description", "{{en|First|Second}}") is True
+    assert _community_value_unfit_for_sdc("title", "{{en|Just one}}") is False
+    assert _community_value_unfit_for_sdc("description", "{{nan|text}}") is True
+    assert _community_value_unfit_for_sdc("title", "{{PD-US}}") is True
+    assert _community_value_unfit_for_sdc("title", "A plain title") is False
+
+
+def test_community_value_unfit_routes_rich_creator_to_wikitext():
+    """A creator value that keeps residual template/wikilink markup after
+    splitting recognised {{Creator:}}/{{Unknown}} templates (e.g. an
+    unrecognised {{Foo}} or a {{w|...}} link) can't be a clean SDC string, so
+    the whole value is routed to the wikitext creator param. Clean creators
+    (plain names, recognised-template compounds) stay SDC-fit."""
+    from ingest_wikimedia.legacy_artwork import (
+        _community_value_unfit_for_sdc,
+        _creator_sdc_clean,
+    )
+
+    # unrecognised template mixed with a recognised {{Creator:}} -> rich -> wikitext
+    assert _creator_sdc_clean("{{Foo}} {{Creator:B}}") is False
+    assert _community_value_unfit_for_sdc("creator", "{{Foo}} {{Creator:B}}") is True
+    # {{w|...}} wikilink in a compound creator -> wikitext
+    assert (
+        _community_value_unfit_for_sdc(
+            "creator", "Dorpat, Paul; photo by {{w|Jim Marshall}}"
+        )
+        is True
+    )
+    # clean creators stay SDC-fit
+    assert _creator_sdc_clean("Jane Doe") is True
+    assert _community_value_unfit_for_sdc("creator", "Jane Doe") is False
+    assert (
+        _creator_sdc_clean("Dorpat, Paul; graphics: {{Creator:Walt Crowley}}") is True
+    )
+    assert (
+        _community_value_unfit_for_sdc(
+            "creator", "Dorpat, Paul; graphics: {{Creator:Walt Crowley}}"
+        )
+        is False
+    )

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -2715,29 +2715,34 @@ def test_plan_migration_scalar_edit_stays_on_divergence_path():
     assert "date" not in plan.wikitext_preserved_extras
 
 
-def test_plan_migration_extension_prefix_must_match_canonical():
-    """A wikitext value that CONTAINS vertical whitespace but whose
-    prefix doesn't match canonical is not extension — it's a full
-    replacement that happens to have multiple lines. Falls through to
-    the ordinary community-import path (which will hit the pre-flight
-    validator and raise ``InvalidWikibaseTextValue``, catching the
-    unhandled shape loudly instead of silently mis-classifying it as
-    an extension)."""
+def test_plan_migration_full_replacement_multiline_value_preserved_as_wikitext():
+    """A wikitext value that contains vertical whitespace but whose prefix
+    doesn't match canonical is not a DPLA-prefixed extension — it's a full
+    community rewrite that happens to be multi-line (a multi-paragraph
+    description with an HR, italics, a wikilink). It can't be a monolingualtext
+    SDC claim, and there's no DPLA prefix to peel off, so it's preserved WHOLE
+    on the migrated template's param (``wikitext_preserved_extras``), NOT routed
+    to ``community_imports`` where build would raise ``InvalidWikibaseTextValue``.
+    (The validator stays as a belt-and-suspenders guard — see
+    ``test_format_legacy_import_claim_rejects_vertical_whitespace``.) Regression
+    for the drift-remediation Seattle-waterfront case."""
+    replacement = (
+        'Transcribed from photograph: "Seattle Waterfront. Ca. 1898."\n'
+        "----\n"
+        "The ''Tampico'' was launched in 1900. "
+        '[https://example.org/797 UW Libraries] says "between 1907 and 1911".'
+    )
     revs = _make_revs(
         (1, "DPLA_bot", f"{{{{Artwork|description={_DPLA_SENTENCE}}}}}"),
-        (
-            2,
-            "Editor1",
-            "{{Artwork|description=Totally different first line.\n"
-            "Followed by a second line.}}",
-        ),
+        (2, "Editor1", f"{{{{Artwork|description={replacement}}}}}"),
     )
     plan = plan_migration(
         "File:Foo.jpg", revs, _canonical_params(description=_DPLA_SENTENCE)
     )
     assert plan is not None
-    assert "description" in plan.community_imports
-    assert "description" not in plan.wikitext_preserved_extras
+    assert "description" not in plan.community_imports
+    assert plan.wikitext_preserved_extras.get("description") == replacement
+    build_legacy_import_claims(plan)  # must not raise
 
 
 def test_format_legacy_import_claim_rejects_vertical_whitespace():

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -3075,6 +3075,50 @@ def test_materialize_creator_page_placeholder_falls_back_to_stated_as_when_no_qi
     assert refs["P887"][0]["datavalue"]["value"]["id"] == "Q131783016"
 
 
+def test_resolve_commons_creator_qid_reads_wikidata_param_when_no_sitelink():
+    """Most Commons Creator: pages carry their Wikidata id in the
+    ``{{Creator | Wikidata = Q… }}`` param, NOT as a wikibase_item sitelink.
+    The resolver must read that param — otherwise the creator falls back to a
+    stated-as string and Module:DPLA can't render the {{Creator:…}} template
+    from SDC. Regression for Creator:Theodore E. Peiser → Q56159174."""
+    from unittest.mock import MagicMock
+
+    from ingest_wikimedia.legacy_artwork import _resolve_commons_creator_qid
+
+    site = MagicMock()
+    site.simple_request.return_value.submit.return_value = {
+        "query": {
+            "pages": {
+                "42": {
+                    "title": "Creator:Theodore E. Peiser",
+                    "pageprops": {},  # no wikibase_item sitelink
+                    "revisions": [
+                        {
+                            "slots": {
+                                "main": {"*": "{{Creator\n | Wikidata = Q56159174\n}}"}
+                            }
+                        }
+                    ],
+                }
+            }
+        }
+    }
+    assert _resolve_commons_creator_qid(site, "Theodore E. Peiser") == "Q56159174"
+
+
+def test_resolve_commons_creator_qid_prefers_sitelink():
+    """When a wikibase_item sitelink IS present, use it directly."""
+    from unittest.mock import MagicMock
+
+    from ingest_wikimedia.legacy_artwork import _resolve_commons_creator_qid
+
+    site = MagicMock()
+    site.simple_request.return_value.submit.return_value = {
+        "query": {"pages": {"7": {"pageprops": {"wikibase_item": "Q123"}}}}
+    }
+    assert _resolve_commons_creator_qid(site, "Somebody") == "Q123"
+
+
 def test_plan_migration_extracts_infi_creator_with_wikidata_qid():
     """Integration: a legacy Artwork upload with a community
     contribution wrapped in ``Other fields 1 = {{InFi|Creator|

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -1689,3 +1689,26 @@ def test_build_claims_for_doc_pins_p813_to_ingest_date():
     assert _p813_times(out_a) == _p813_times(out_b), (
         "identical doc must produce byte-identical P813 stamps"
     )
+
+
+def test_parse_taken_on_template_reduces_to_display_date():
+    from ingest_wikimedia.sdc import parse_taken_on_template
+
+    assert parse_taken_on_template("{{Taken on|1921-09-21}}") == "1921-09-21"
+    assert (
+        parse_taken_on_template("{{taken on|1921-09-21|location=Seattle}}")
+        == "1921-09-21"
+    )
+    assert parse_taken_on_template("{{Taken in|1921}}") == "1921"
+    assert parse_taken_on_template("{{Taken circa|1921}}") == "circa 1921"
+    assert parse_taken_on_template("{{other date|~|1921}}") is None
+    assert parse_taken_on_template("1921-09-21") is None
+    assert parse_taken_on_template("") is None
+
+
+def test_dates_semantically_equal_reconciles_taken_on_template():
+    from ingest_wikimedia.sdc import dates_semantically_equal
+
+    assert dates_semantically_equal("{{Taken on|1921-09-21}}", "1921-09-21")
+    assert dates_semantically_equal("{{Taken in|1959}}", "1959")
+    assert not dates_semantically_equal("{{Taken on|1921-09-21}}", "1930-01-01")

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -1712,3 +1712,11 @@ def test_dates_semantically_equal_reconciles_taken_on_template():
     assert dates_semantically_equal("{{Taken on|1921-09-21}}", "1921-09-21")
     assert dates_semantically_equal("{{Taken in|1959}}", "1959")
     assert not dates_semantically_equal("{{Taken on|1921-09-21}}", "1930-01-01")
+
+
+def test_parse_taken_on_template_tolerates_repeated_separator():
+    from ingest_wikimedia.sdc import dates_semantically_equal, parse_taken_on_template
+
+    assert parse_taken_on_template("{{Taken  on|1921-09-21}}") == "1921-09-21"
+    assert parse_taken_on_template("{{Taken_on|1921-09-21}}") == "1921-09-21"
+    assert dates_semantically_equal("{{Taken  on|1921-09-21}}", "1921-09-21")


### PR DESCRIPTION
## Problem
Surfaced by dry-running the drift-remediation script on the Seattle-waterfront file, whose community-edited **description** is a multi-paragraph transcription/analysis (newlines, a `----` HR, italics, a wikilink).

`plan_migration` already handles a **"DPLA value + appended structural content"** extension (gallery/wikitable/HR): `_split_extension_extras` peels the community remainder off, the DPLA prefix keeps its canonical SDC, and the remainder is preserved on the migrated `{{DPLA metadata}}` template param. But a value a community member **rewrote entirely** into multi-line prose has **no DPLA prefix to match**, so it fell through to the ordinary community-import path → `build_legacy_import_claims` → `_validate_wikibase_text` **raises `InvalidWikibaseTextValue`** on the vertical whitespace (P10358 monolingualtext rejects newlines) → **the whole file's migration fails.** #397 pinned this as "fail loudly on the unhandled shape."

This bites the **live** `migrate_legacy_file` too, not just the remediation — any file whose community description (or other monolingualtext/string field) is multi-line currently can't migrate.

## Fix
Generalize the existing "community content that can't be SDC → wikitext" handling: a community value that (a) isn't a DPLA-prefixed extension and (b) can't be an SDC claim of its type — i.e. contains vertical whitespace, for the `monolingualtext`/`string` fields — is preserved **whole** on the migrated `{{DPLA metadata}}` param (Module:DPLA renders it in the yellow box) instead of erroring. Same destination as the extension case; community content that can't be SDC lands in wikitext either way.

- New `_community_value_unfit_for_sdc(key, value)` gate — `title`/`description` (monolingualtext) and `creator` (string) with vertical whitespace. `date` (time) is parsed, not text-validated, so it's excluded; unmapped keys never reach the validator.
- The pre-flight `_validate_wikibase_text` **stays** as a belt-and-suspenders guard.
- **Unchanged**: single-line community edits still import to SDC; the DPLA-prefix extension case still splits as before.

## Tests
The former "fail loudly" test (`test_plan_migration_extension_prefix_must_match_canonical`) is rewritten to assert the new behavior — a full multi-line community rewrite is preserved in `wikitext_preserved_extras` (not `community_imports`), and `build_legacy_import_claims` no longer raises — using the realistic Seattle-waterfront description. Full suite green (**1270 passed**), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second fix (same testing): Creator-page QID resolution

`_resolve_commons_creator_qid` only checked the Creator page's `wikibase_item` **sitelink** — but most Commons `Creator:` pages carry their Wikidata id in the `{{Creator | Wikidata = Q… }}` **template param**, with no sitelink (so `wikibase_item` is empty). A community `{{Creator:Name}}` whose page uses the param therefore fell back to a P170 `somevalue` + P2093 stated-as string, and **Module:DPLA can't render the `{{Creator:…}}` template from that** — the QID never reached SDC.

Fix: query the Creator page's revisions content alongside `pageprops`; prefer the sitelink QID, else parse `| Wikidata = Q…`. `materialize` then builds the existing P170 → `wikibase-entityid` claim, which Module:DPLA renders as the Creator template. Surfaced live on `Creator:Theodore E. Peiser` → `Q56159174` (sitelink empty; QID in the param). Tests cover both the param path and the sitelink-preferred path.

Both fixes are `plan_migration`/`materialize` correctness for preserving community contributions during migration, found by end-to-end live-testing of the drift remediation. Full suite **1272 passed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes legacy artwork migration for two edge-case paths:
  - Preserves fully rewritten **multi-line** community-edited `title`, `description`, and `creator` values as wikitext (instead of raising `InvalidWikibaseTextValue`) by routing community values that are unfit for SDC into `wikitext_preserved_extras` during Phase 3 planning. Existing behavior remains for **single-line** community edits and **DPLA-prefixed extension extras**.
  - Resolves **Commons Creator QIDs** from `{{Creator|Wikidata=Q...}}` when no `wikibase_item` sitelink (pageprop QID) exists, while still preferring the sitelink QID when available—so the generated creator claim uses the correct `P170` entity claim shape.
- Broadens creator parsing/claim construction to handle additional templates/shapes (e.g., unknown-role sentinels, embedded/compound creator credits) and updates claim materialization accordingly.
- Improves date equivalence by normalizing `{{Taken on|...}}` / `{{Taken in|...}}` / `{{Taken circa|...}}` template markup before semantic comparison; adds `parse_taken_on_template` and corresponding test coverage.
- Makes MediaWiki revision snapshot fetching stricter by raising on partial revision payloads (visible `user` with `text is None`).

## Test status

- Test suite passed: **1,272** tests; `ruff` is clean.

## Operational impact

- No manual pipeline trigger or ECS redeployment required beyond normal deployment.
- No environment variables or AWS Secrets Manager keys added/removed/renamed.
- No database migration.
- No shared infrastructure configuration changes (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No public-facing API response shape changes or endpoint additions/removals.
- No security implications (no auth/credential changes; continues existing MediaWiki/Commons API data retrieval and parsing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->