### PR TITLE
legacy_artwork: drop redundant DPLA source template on migration

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -566,6 +566,14 @@ def plan_migration(
         if classified.get(key) == "community" and not _value_equivalent_to_canonical(
             key, value, canonical_value
         ):
+            # A value that is only a DPLA-managed source template ({{DPLA}} /
+            # {{DPLA metadata}}) is provenance already rendered from SDC — keeping
+            # it (as an SDC import or on the migrated template param) would just
+            # duplicate that render. Drop it outright, independent of the key's
+            # SDC mapping, so this stays correct if source/institution/permission
+            # gain mappings later.
+            if _is_redundant_dpla_source(value):
+                continue
             # Only import community values that *differ* from canonical
             # — a community editor restating DPLA's title verbatim is
             # not an import we want to record (it's redundant). Same
@@ -949,6 +957,34 @@ def _split_extension_extras(value: str, canonical: str) -> str | None:
     return remainder
 
 
+_DPLA_MANAGED_TEMPLATE_NAMES = frozenset({"dpla", "dpla metadata"})
+
+
+def _is_redundant_dpla_source(value: str) -> bool:
+    """True when ``value`` is nothing but DPLA-managed source template(s)
+    (``{{DPLA|…}}`` / ``{{DPLA metadata|…}}``) plus whitespace.
+
+    Such a value is DPLA provenance already carried by the file's structured
+    data — re-adding it to the migrated ``{{DPLA metadata}}`` template only
+    duplicates what Module:DPLA already renders from SDC. Any community text or
+    markup alongside the template means the value is NOT purely redundant and is
+    still preserved."""
+    if "dpla" not in value.casefold():
+        return False  # cheap guard: a DPLA-managed name always contains "dpla"
+    saw_dpla_template = False
+    for node in mwparserfromhell.parse(value).nodes:
+        if isinstance(node, mwparserfromhell.nodes.Template):
+            if _template_name(node) not in _DPLA_MANAGED_TEMPLATE_NAMES:
+                return False
+            saw_dpla_template = True
+        elif isinstance(node, mwparserfromhell.nodes.Text):
+            if node.value.strip():
+                return False  # community text alongside the template
+        else:
+            return False  # a wikilink or other node -> not purely a DPLA template
+    return saw_dpla_template
+
+
 def _community_value_unfit_for_sdc(key: str, value: str) -> bool:
     """True when a community value can't be posted as an SDC claim and must be
     preserved on the migrated template's param instead of dropped.
@@ -959,6 +995,8 @@ def _community_value_unfit_for_sdc(key: str, value: str) -> bool:
       ``institution`` — not in :data:`LEGACY_IMPORT_PROPERTY`): no Phase-3a
       claim builder, so a community override would otherwise be silently
       dropped. Preserve it on the template param (Module:DPLA's yellow box).
+      (A value that is only a redundant DPLA source template is dropped earlier,
+      in :func:`plan_migration`, before it reaches this classifier.)
     * **Vertical whitespace** (``title``/``description`` monolingualtext,
       ``creator`` string): the Wikibase text validators reject newlines/tabs/CR.
       ``date`` (time) is parsed, not text-validated, so never unfit here.

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -3466,6 +3466,7 @@ def test_plan_migration_drops_redundant_dpla_source_template():
     assert plan is not None
     assert "source" not in plan.community_imports
     assert "source" not in plan.wikitext_preserved_extras
+    assert "source" not in plan.dpla_originated_params
 
 
 def test_plan_migration_preserves_genuine_community_source():

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -3448,6 +3448,51 @@ def test_community_value_unfit_routes_multiparam_lang_wrapper_to_wikitext():
     assert _community_value_unfit_for_sdc("title", "A plain title") is False
 
 
+def test_plan_migration_drops_redundant_dpla_source_template():
+    """A community-set ``source = {{DPLA|…}}`` value is DPLA provenance already
+    rendered from SDC — plan_migration must DROP it entirely (neither an SDC
+    community_import nor a preserved wikitext extra), so the migrated
+    {{DPLA metadata}} template doesn't duplicate the SDC render. Regression: the
+    Bug-4 unmapped-key preservation used to re-inject it onto the param."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=A Title|source=orig}}"),
+        (
+            2,
+            "Editor1",
+            "{{Artwork|title=A Title|source={{DPLA|Q69487884|hub=Q83878495|dpla_id=abc}}}}",
+        ),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert "source" not in plan.community_imports
+    assert "source" not in plan.wikitext_preserved_extras
+
+
+def test_plan_migration_preserves_genuine_community_source():
+    """A genuine community ``source`` override (not a DPLA template) is still
+    preserved on the migrated template param — the drop is narrow."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=A Title|source=orig}}"),
+        (2, "Editor1", "{{Artwork|title=A Title|source=Donated by the county museum}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert (
+        plan.wikitext_preserved_extras.get("source") == "Donated by the county museum"
+    )
+
+
+def test_is_redundant_dpla_source():
+    from ingest_wikimedia.legacy_artwork import _is_redundant_dpla_source
+
+    assert _is_redundant_dpla_source("{{DPLA|Q1|hub=Q2}}") is True
+    assert _is_redundant_dpla_source("  {{DPLA metadata|x=y}}  ") is True
+    assert _is_redundant_dpla_source("{{PD-US}}") is False
+    assert _is_redundant_dpla_source("plain text") is False
+    assert _is_redundant_dpla_source("{{DPLA|Q1}} extra text") is False
+    assert _is_redundant_dpla_source("") is False
+
+
 def test_community_value_unfit_routes_rich_creator_to_wikitext():
     """A creator value that keeps residual template/wikilink markup after
     splitting recognised {{Creator:}}/{{Unknown}} templates (e.g. an


### PR DESCRIPTION
## Problem
A legacy `{{Artwork}}`/`{{Photograph}}` `source` param is often the DPLA source template `{{DPLA|…}}`, which renders the same provider/rights/hub info that `{{DPLA metadata}}` already renders from SDC. The Bug-4 unmapped-key preservation (from #400) treated it as a community override and re-added it to the migrated template param, **duplicating the SDC render**.

This was found via the drift-remediation sweep, which re-injected it into ~570+ already-corrected files (e.g. [Empire Theater, Toledo](https://commons.wikimedia.org/w/index.php?title=File:Empire_Theater,_Toledo,_Ohio_(approximately_1900)_-_DPLA_-_cacf22387bdb92a3c01123533bd2c843.jpg&diff=prev&oldid=1246995330)) — but the root cause is in the shared migration code, so a first-time migration of any `{{Artwork}}`-with-`source={{DPLA}}` file would do the same.

## Fix
`plan_migration` now drops a community value that is **only** a DPLA-managed template (`{{DPLA}}` / `{{DPLA metadata}}`) outright — *before* the SDC-fit branching, so the drop is:
- **key-agnostic** — stays correct if `source`/`institution`/`permission` gain SDC mappings later (the deferred-mapping roadmap in `LEGACY_IMPORT_PROPERTY`), rather than overloading `_community_value_unfit_for_sdc`'s return value;
- **narrow** — a genuine community `source`/`permission`/`institution` override, or a DPLA template with community text alongside it, is still preserved.

`_is_redundant_dpla_source()` classifies the value by walking mwparserfromhell nodes (every node must be a DPLA-managed template or whitespace), erring toward *preserving* on any ambiguity.

## Tests
- `plan_migration` drops a redundant `source={{DPLA|…}}` (neither an SDC import nor a wikitext extra) and preserves a genuine community `source`.
- Unit coverage for `_is_redundant_dpla_source`.
- Full `tests/test_legacy_artwork.py` green (177), ruff clean.

## Follow-up (not in this PR)
A correction pass strips the already-injected redundant sources from affected Commons files (handled operationally in the remediation work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updates legacy `{{Artwork}}` / `{{Photograph}}` migration planning to drop `source` values that are *only* DPLA-managed templates (`{{DPLA|...}}` or `{{DPLA metadata|...}}`), avoiding duplicate provider/rights/hub information already rendered from `{{DPLA metadata}}`.
- Preserves community-authored or ambiguous `source` values when the wikitext contains anything beyond purely redundant DPLA template nodes.
- Adds an `_is_redundant_dpla_source()` classifier (wikitext-node aware) and wires it into the plan-migration flow before other SDC-fit branching.
- Extends `tests/test_legacy_artwork.py` to cover redundant-DPLA removal across the legacy migration dictionaries, preservation of genuine community sources, and prevention of regressions on the third migration path by asserting redundant sources are absent from `dpla_originated_params`.
- Full legacy artwork tests and Ruff checks pass.

## Operational impact

- No manual pipeline trigger or ECS redeployment required to apply this change.
- No environment variables or AWS Secrets Manager keys changed.
- No database migration.
- No shared infrastructure configuration changes (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No public-facing API/endpoint changes.
- No security/auth changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->