### PR TITLE
legacy_artwork: drop DPLA/uploader-generated source & rights boilerplate

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -566,13 +566,14 @@ def plan_migration(
         if classified.get(key) == "community" and not _value_equivalent_to_canonical(
             key, value, canonical_value
         ):
-            # A value that is only a DPLA-managed source template ({{DPLA}} /
-            # {{DPLA metadata}}) is provenance already rendered from SDC — keeping
-            # it (as an SDC import or on the migrated template param) would just
-            # duplicate that render. Drop it outright, independent of the key's
-            # SDC mapping, so this stays correct if source/institution/permission
-            # gain mappings later.
-            if _is_redundant_dpla_source(value):
+            # A DPLA/uploader-generated boilerplate value (a bare {{DPLA}}
+            # template, an uploader source link, or a rights-statement string) is
+            # provenance already rendered from SDC — keeping it (as an SDC import
+            # or on the migrated template param) would just duplicate that
+            # render. Drop it outright, independent of the key's SDC mapping, so
+            # this stays correct if source/institution/permission gain mappings
+            # later. Conservative: community prose alongside it is preserved.
+            if _is_dpla_generated_extra(key, value):
                 continue
             # Only import community values that *differ* from canonical
             # — a community editor restating DPLA's title verbatim is
@@ -983,6 +984,74 @@ def _is_redundant_dpla_source(value: str) -> bool:
         else:
             return False  # a wikilink or other node -> not purely a DPLA template
     return saw_dpla_template
+
+
+# Known DPLA/uploader-generated rights boilerplate — an explicit allowlist,
+# expected to grow one partner at a time. Its failure mode is deliberately
+# benign: an unmatched variant is preserved (over-kept), never lost. If this
+# list grows large, prefer mapping rights to SDC over lengthening it.
+_RIGHTS_HOSTS = ("rightsstatements.org", "archives.gov/social-media/flickr-faqs")
+_CANNED_PD_BLURB = (
+    "Public Domain: This image is in the public domain and may be "
+    "used free of charge without permissions or fees."
+)
+
+
+def _only_external_links(value: str) -> bool:
+    """True when ``value`` is nothing but external link(s) plus whitespace /
+    ``<br>`` — no prose, templates, or wikilinks. A bare link like this is an
+    uploader-generated source pointer (it becomes the file's SDC source), not
+    community-authored context. Any prose alongside means it is NOT pure."""
+    saw = False
+    for node in mwparserfromhell.parse(value).nodes:
+        if isinstance(node, mwparserfromhell.nodes.ExternalLink):
+            saw = True
+        elif isinstance(node, mwparserfromhell.nodes.Text):
+            if node.value.strip():
+                return False
+        elif (
+            isinstance(node, mwparserfromhell.nodes.Tag)
+            and str(node.tag).strip().lower() == "br"
+        ):
+            continue
+        else:
+            return False
+    return saw
+
+
+def _is_dpla_generated_extra(key: str, value: str) -> bool:
+    """True when an unmapped community param value is DPLA/uploader-generated
+    boilerplate already represented in the file's structured data — preserving
+    it on the migrated ``{{DPLA metadata}}`` template only duplicates the SDC
+    render. Generalises :func:`_is_redundant_dpla_source` (the ``{{DPLA}}``
+    source template) to its sibling unmapped keys:
+
+    * any key: the value is only a ``{{DPLA}}``/``{{DPLA metadata}}`` template;
+    * ``source`` / ``institution``: the value is only external link(s) — an
+      uploader source pointer that the migration writes to SDC anyway;
+    * ``permission``: the value is only rights-statement link(s)
+      (rightsstatements.org, the NARA Flickr-Commons rights link), or the canned
+      DPLA public-domain blurb.
+
+    Conservative: any community prose alongside the boilerplate makes the value
+    NOT purely generated, so it is preserved (e.g. a rights template with a
+    ``deathyear``, or a source line with an institution note)."""
+    if _is_redundant_dpla_source(value):
+        return True
+    if key in ("source", "institution"):
+        return _only_external_links(value)
+    if key == "permission":
+        if casefold_for_compare(value) == casefold_for_compare(_CANNED_PD_BLURB):
+            return True
+        if not _only_external_links(value):
+            return False
+        urls = [
+            str(n.url)
+            for n in mwparserfromhell.parse(value).nodes
+            if isinstance(n, mwparserfromhell.nodes.ExternalLink)
+        ]
+        return all(any(h in u.lower() for h in _RIGHTS_HOSTS) for u in urls)
+    return False
 
 
 def _community_value_unfit_for_sdc(key: str, value: str) -> bool:

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -31,7 +31,7 @@ import json
 import re
 from dataclasses import dataclass, field
 from typing import Iterable
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 import mwparserfromhell
 
@@ -562,19 +562,19 @@ def plan_migration(
     wikitext_preserved_extras: dict[str, str] = {}
 
     for key, value in wikitext_params.items():
+        # A DPLA/uploader-generated boilerplate value (a bare {{DPLA}} template,
+        # an uploader source link, or a rights-statement string) is provenance
+        # already rendered from SDC — keeping it would just duplicate that
+        # render. Drop it outright BEFORE the provenance/canonical-equivalence
+        # branch, so it lands in NO output bucket (community_imports /
+        # wikitext_preserved_extras / dpla_originated_params) regardless of
+        # classification. Conservative: community prose alongside it is preserved.
+        if _is_dpla_generated_extra(key, value):
+            continue
         canonical_value = _canonical_value_for_key(canonical_params, key)
         if classified.get(key) == "community" and not _value_equivalent_to_canonical(
             key, value, canonical_value
         ):
-            # A DPLA/uploader-generated boilerplate value (a bare {{DPLA}}
-            # template, an uploader source link, or a rights-statement string) is
-            # provenance already rendered from SDC — keeping it (as an SDC import
-            # or on the migrated template param) would just duplicate that
-            # render. Drop it outright, independent of the key's SDC mapping, so
-            # this stays correct if source/institution/permission gain mappings
-            # later. Conservative: community prose alongside it is preserved.
-            if _is_dpla_generated_extra(key, value):
-                continue
             # Only import community values that *differ* from canonical
             # — a community editor restating DPLA's title verbatim is
             # not an import we want to record (it's redundant). Same
@@ -990,11 +990,23 @@ def _is_redundant_dpla_source(value: str) -> bool:
 # expected to grow one partner at a time. Its failure mode is deliberately
 # benign: an unmatched variant is preserved (over-kept), never lost. If this
 # list grows large, prefer mapping rights to SDC over lengthening it.
-_RIGHTS_HOSTS = ("rightsstatements.org", "archives.gov/social-media/flickr-faqs")
 _CANNED_PD_BLURB = (
     "Public Domain: This image is in the public domain and may be "
     "used free of charge without permissions or fees."
 )
+
+
+def _is_rights_url(url: str) -> bool:
+    """True for a DPLA/NARA rights-statement URL, matched by parsed host (and
+    path) rather than substring — so ``https://rightsstatements.org@evil.example/…``
+    or a URL merely containing the text elsewhere does NOT match."""
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if host == "rightsstatements.org" or host.endswith(".rightsstatements.org"):
+        return True
+    return (
+        host == "archives.gov" or host.endswith(".archives.gov")
+    ) and parsed.path.startswith("/social-media/flickr-faqs")
 
 
 def _only_external_links(value: str) -> bool:
@@ -1050,7 +1062,7 @@ def _is_dpla_generated_extra(key: str, value: str) -> bool:
             for n in mwparserfromhell.parse(value).nodes
             if isinstance(n, mwparserfromhell.nodes.ExternalLink)
         ]
-        return all(any(h in u.lower() for h in _RIGHTS_HOSTS) for u in urls)
+        return all(_is_rights_url(u) for u in urls)
     return False
 
 

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -3494,6 +3494,120 @@ def test_is_redundant_dpla_source():
     assert _is_redundant_dpla_source("") is False
 
 
+def test_is_dpla_generated_extra():
+    from ingest_wikimedia.legacy_artwork import _is_dpla_generated_extra
+
+    # only-{{DPLA}} template (any key)
+    assert _is_dpla_generated_extra("source", "{{DPLA|Q1|hub=Q2}}") is True
+    # source/institution: only external link(s) -> uploader source pointer
+    assert (
+        _is_dpla_generated_extra(
+            "source", "[https://www.flickr.com/photos/usnationalarchives/123 A Title]"
+        )
+        is True
+    )
+    assert (
+        _is_dpla_generated_extra("source", "https://catalog.archives.gov/id/306274")
+        is True
+    )
+    assert (
+        _is_dpla_generated_extra("institution", "[https://example.org/x label]") is True
+    )
+    # source with community prose alongside a URL -> kept
+    assert (
+        _is_dpla_generated_extra(
+            "source",
+            "Missouri History Museum<br>URL: http://images.mohistory.org/x.jpg",
+        )
+        is False
+    )
+    # permission: rights-statement link / canned PD blurb -> generated
+    assert (
+        _is_dpla_generated_extra(
+            "permission",
+            "[https://www.archives.gov/social-media/flickr-faqs.html#9 The U.S. National Archives @ Flickr Commons]",
+        )
+        is True
+    )
+    assert (
+        _is_dpla_generated_extra(
+            "permission",
+            "[http://rightsstatements.org/page/UND/1.0/?language=en Copyright undetermined]",
+        )
+        is True
+    )
+    assert (
+        _is_dpla_generated_extra(
+            "permission",
+            "Public Domain: This image is in the public domain and may be used free of charge without permissions or fees.",
+        )
+        is True
+    )
+    # permission with community content -> kept
+    assert (
+        _is_dpla_generated_extra("permission", "{{PD-old-auto-1923|deathyear=1922}}")
+        is False
+    )
+    assert (
+        _is_dpla_generated_extra(
+            "permission",
+            "UND - [http://rightsstatements.org/page/UND/1.0/ x]<br>[https://web.archive.org/y MHS Open Access]: You are welcome to download",
+        )
+        is False
+    )
+    # mapped/community keys unaffected
+    assert _is_dpla_generated_extra("description", "A community note") is False
+
+
+def test_plan_migration_drops_uploader_source_link():
+    """A community-set ``source`` that is only an external link is an uploader
+    source pointer (it becomes SDC) — plan_migration drops it entirely."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=A Title|source=x}}"),
+        (
+            2,
+            "Editor1",
+            "{{Artwork|title=A Title|source=[https://www.flickr.com/photos/usnationalarchives/123 A Title]}}",
+        ),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert "source" not in plan.community_imports
+    assert "source" not in plan.wikitext_preserved_extras
+    assert "source" not in plan.dpla_originated_params
+
+
+def test_plan_migration_drops_rights_boilerplate_permission():
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=A Title|permission=x}}"),
+        (
+            2,
+            "Editor1",
+            "{{Artwork|title=A Title|permission=[https://www.archives.gov/social-media/flickr-faqs.html#9 The U.S. National Archives @ Flickr Commons]}}",
+        ),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert "permission" not in plan.wikitext_preserved_extras
+
+
+def test_plan_migration_keeps_source_with_prose():
+    """A ``source`` with community prose (institution note) is preserved."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=A Title|source=x}}"),
+        (
+            2,
+            "Editor1",
+            "{{Artwork|title=A Title|source=Missouri History Museum<br>URL: http://images.mohistory.org/x.jpg}}",
+        ),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert plan.wikitext_preserved_extras.get("source", "").startswith(
+        "Missouri History Museum"
+    )
+
+
 def test_community_value_unfit_routes_rich_creator_to_wikitext():
     """A creator value that keeps residual template/wikilink markup after
     splitting recognised {{Creator:}}/{{Unknown}} templates (e.g. an

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -3557,6 +3557,41 @@ def test_is_dpla_generated_extra():
     )
     # mapped/community keys unaffected
     assert _is_dpla_generated_extra("description", "A community note") is False
+    # rights URLs match by parsed host/path, not substring — spoofs must NOT match
+    assert (
+        _is_dpla_generated_extra(
+            "permission", "[https://rightsstatements.org@evil.example/x label]"
+        )
+        is False
+    )
+    assert (
+        _is_dpla_generated_extra(
+            "permission", "[https://evil.example/?ref=rightsstatements.org label]"
+        )
+        is False
+    )
+    assert (
+        _is_dpla_generated_extra(
+            "permission", "[https://rightsstatements.org.evil.com/x label]"
+        )
+        is False
+    )
+
+
+def test_plan_migration_drops_generated_extra_when_dpla_originated():
+    """A generated boilerplate value (here a {{DPLA}} source set by the uploader,
+    so classified dpla / canonical-equivalent) is dropped from ALL buckets — the
+    check runs before the provenance/equivalence branch, so it is not parked in
+    dpla_originated_params."""
+    revs = _make_revs(
+        (1, "DPLA_bot", "{{Artwork|title=A Title|source={{DPLA|Q1|hub=Q2}}}}"),
+        (2, "DPLA_bot", "{{Artwork|title=A Title|source={{DPLA|Q1|hub=Q2}}}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert "source" not in plan.dpla_originated_params
+    assert "source" not in plan.community_imports
+    assert "source" not in plan.wikitext_preserved_extras
 
 
 def test_plan_migration_drops_uploader_source_link():


### PR DESCRIPTION
## Problem
The legacy→`{{DPLA metadata}}` migration preserves *unmapped* community params (`source`/`permission`/`institution`) so genuine overrides aren't lost (Bug-4). But for DPLA-uploaded legacy files, those params are often **uploader-generated boilerplate** — a `{{DPLA}}` source template, a bare source URL, a rights-statement string — that duplicates what `{{DPLA metadata}}` already renders from SDC. #401 closed only the `{{DPLA}}`-template sub-case; a `source=<flickr URL>` or `permission=<rightsstatements.org string>` slips through.

Discovered when the drift-remediation sweep re-injected these onto ~10 already-corrected files (corrected operationally; see below). Root cause is in the shared migration code, so a first-time migration would do the same.

## Fix
`plan_migration` now drops a community param value flagged by `_is_dpla_generated_extra(key, value)`:
- **any key** — only a `{{DPLA}}`/`{{DPLA metadata}}` template (existing `_is_redundant_dpla_source`);
- **source / institution** — the value is only external link(s) (an uploader source pointer that the migration writes to SDC anyway);
- **permission** — only rights-statement link(s) (`rightsstatements.org`, the NARA Flickr-Commons rights link) or the canned DPLA public-domain blurb.

**Conservative by construction:** any community prose alongside the boilerplate makes the value *not* purely generated, so it is preserved — e.g. a `{{PD-old-auto-1923|deathyear=1922}}` rights correction, or a `source` line with an institution note (`Missouri History Museum<br>URL: …`). The rights host-list / canned blurb are an explicit, expected-to-grow allowlist whose failure mode is over-*preservation*, never data loss.

Verified downstream: a dropped key lands in none of `community_imports` / `wikitext_preserved_extras` / `dpla_originated_params`, so it is written to neither SDC nor the migrated wikitext.

## Tests
- `_is_dpla_generated_extra` unit coverage (template / source-link / rights-link / canned-PD strip; prose-source, deathyear-permission, mixed-prose kept).
- `plan_migration` integration: drops an uploader source link and a rights-boilerplate permission; keeps a source with community prose.
- Full `tests/test_legacy_artwork.py` green (181), ruff clean, simplify review applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updates `legacy_artwork` migration logic to strip DPLA/uploader-generated boilerplate from unmapped community parameters when migrating to `{{DPLA metadata}}`.

- Drops `{{DPLA}}` / `{{DPLA metadata}}` templates from any parameter.
- Removes external-link-only values from `source` and `institution`.
- Removes approved rights-statement links and the canned public-domain permission text from `permission`, using parsed host+path matching to avoid spoofed/incidental string matches.
- Preserves values containing community prose/markup.
- Ensures generated values are removed before provenance and canonical-equivalence handling so they aren’t imported, preserved as wikitext extras, or duplicated in DPLA-originated parameters.
- Adds unit and migration regression tests covering DPLA-originated and uploader-only cases (with all `tests/test_legacy_artwork.py` passing) and ruff clean.

No manual pipeline trigger or ECS redeployment is required. No environment variables/secrets changes, no database migrations, no shared infrastructure configuration changes, no public API shape/endpoint changes, and no authentication/credential handling or other security-relevant changes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->