### PR TITLE
Case-2 community target: self-tag + rename via new deferral stage

### DIFF
--- a/ingest_wikimedia/await_target_free_sidecar.py
+++ b/ingest_wikimedia/await_target_free_sidecar.py
@@ -122,11 +122,24 @@ def _normalize_entry(raw: object) -> dict | None:
     expected_sha1 = raw.get("expected_sha1")
     if not isinstance(expected_sha1, str):
         return None
+    # ``tag_emitted`` is the workflow phase marker: True once the
+    # uploader has successfully written the {{Duplicate}} tag on the
+    # canonical file. Entries land with tag_emitted=False (from
+    # add_entry inside _tag_self_and_defer) and flip to True via
+    # mark_tag_emitted() after tag_as_duplicate() returns. Missing on
+    # an entry (an older sidecar shape written before this field
+    # existed) defaults to True — those entries came from a flow that
+    # always tagged before writing the sidecar, so treating them as
+    # fully queued is the correct backwards-compat choice.
+    tag_emitted = raw.get("tag_emitted")
+    if not isinstance(tag_emitted, bool):
+        tag_emitted = True
     return {
         "dpla_id": dpla_id,
         "ordinal": ordinal,
         "tagged_title": tagged_title,
         "community_title": community_title,
+        "tag_emitted": tag_emitted,
         "expected_sha1": expected_sha1,
     }
 
@@ -219,10 +232,45 @@ def has_entry(partner: str, dpla_id: str, ordinal: int) -> bool:
     actioned by a Commons admin) doesn't re-emit the tag or duplicate the
     sidecar entry.
     """
+    return get_entry(partner, dpla_id, ordinal) is not None
+
+
+def get_entry(partner: str, dpla_id: str, ordinal: int) -> dict | None:
+    """Return the sidecar entry for ``(dpla_id, ordinal)`` or ``None``
+    if absent. Callers that need to inspect ``tag_emitted`` (workflow
+    phase) use this instead of :func:`has_entry`; a plain existence
+    check would conflate the "in-progress" and "fully-queued" states.
+    """
     for entry in read_sidecar(partner):
         if entry["dpla_id"] == dpla_id and entry["ordinal"] == ordinal:
-            return True
-    return False
+            return entry
+    return None
+
+
+def mark_tag_emitted(partner: str, dpla_id: str, ordinal: int) -> bool:
+    """Flip the entry's ``tag_emitted`` phase marker to ``True``.
+
+    Called by the uploader after ``tag_as_duplicate`` has successfully
+    written the {{Duplicate}} template on the canonical file — the entry
+    is now durably queued for admin action, and drain-deferred is free
+    to advance it once admin acts.
+
+    Returns True if an entry existed and was updated (or was already
+    True); False if no matching entry was found. Serialized via
+    :func:`_locked_for_write` — safe to call from concurrent uploader
+    Pool workers.
+    """
+    with _locked_for_write(partner):
+        existing = read_sidecar(partner)
+        found = False
+        for entry in existing:
+            if entry["dpla_id"] == dpla_id and entry["ordinal"] == ordinal:
+                entry["tag_emitted"] = True
+                found = True
+                break
+        if found:
+            write_sidecar(partner, existing)
+        return found
 
 
 def add_entry(partner: str, entry: dict) -> list[dict]:

--- a/ingest_wikimedia/await_target_free_sidecar.py
+++ b/ingest_wikimedia/await_target_free_sidecar.py
@@ -1,47 +1,34 @@
-"""Persistent sidecar for the "await community-target free" deferral stage.
+"""Persistent "await community-target free" set.
 
-The uploader defers a Case-2 hash-drift resolution when the file whose title
-we intend to overwrite is a community upload (i.e. our S3 SHA1 already lives at
-a community-authored Commons title). Rather than tag the community's file for
-speedy deletion — the previous behaviour, which requested a Commons admin
-destroy an older community contribution — the uploader:
+Case-2 hash drift: our S3 source's SHA1 already lives at a
+community-authored Commons title. Rather than tag the community's file
+for deletion, the uploader uploads our bytes to the DPLA-canonical
+title, tags OUR file ``{{Duplicate|<community title>}}``, and records
+the ``(dpla_id, ordinal)`` here. A Commons admin then deletes or
+redirects our tagged file; once they do, the DPLA-canonical title is
+free and a plain **re-run of the uploader** resolves it through the
+existing title-drift machinery (empty canonical → Case-3 move of the
+community file into the freed title, preserving its history). This set
+exists only so the ``drain-deferred`` phase knows which items to keep
+re-running while we wait on the admin, and so the wait doesn't block the
+batch.
 
-  1. uploads the S3 bytes to the DPLA-canonical title (invariant satisfied),
-  2. tags OUR just-uploaded file as ``{{Duplicate|<community title>}}`` so
-     Commons admins can delete or redirect it, and
-  3. writes an entry to this sidecar naming the tagged (DPLA-canonical) file
-     and the community file we want to promote once the tagged file is gone.
+Design note — why this is just a set of keys, not a rich record:
+everything the resolution needs (the community title, the source SHA1,
+whether the tag is still pending) is re-derived from live Commons / S3
+state on each uploader re-run. The uploader is idempotent, so the drain
+is nothing more than "re-run the uploader on these IDs until they stop
+needing it" — the same pattern as :mod:`ingest_wikimedia.drain_sidecar`.
+There is no per-item state machine to keep crash-consistent. A lost set
+degrades gracefully: the tagged files still exist on Commons, and any
+future full partner run re-detects and resolves them (an admin deletion
+becomes an ordinary empty-canonical Case-3 move); the set only makes the
+polling prompt.
 
-The follow-on ``drain-deferred`` phase reads this sidecar, polls each tagged
-title, and — once the tag has been actioned (page deleted, or turned into a
-redirect) — executes a title-drift move of the community file into the freed
-DPLA-canonical title. The community file's revision history and curation
-survive the move; the invariant is satisfied again once the move completes.
-
-Distinct from :mod:`ingest_wikimedia.drain_sidecar` (the ``Category:Duplicate``
-capacity gate), because the wait conditions are per-item (each tagged title
-polled independently), not global (single boolean checked once per round).
-Keeping the two sidecars separate is additive — no schema evolution on the
-existing sidecar — and lets each stage evolve without disturbing the other.
-
-Per-partner scope: mirrors :mod:`drain_sidecar` — one sidecar file per partner
-under ``<partner>/await-target-free.json``, anchored at
-:data:`~ingest_wikimedia.drain_sidecar.INGEST_WIKI_ROOT`.
-
-Entry schema::
-
-    {
-        "dpla_id":         "22412cd0994d36f03c4fcf549db2b8e5",
-        "ordinal":         1,
-        "tagged_title":    "File:… - DPLA - 22412cd0….jpg",
-        "community_title": "File:….jpg",
-        "expected_sha1":   "9719e05a…",
-    }
-
-``expected_sha1`` is the S3 source SHA1 that was true at tag time; the drain
-phase re-validates it against the community file before executing the move so
-that partner-side content churn during the wait window is caught (and doesn't
-silently promote stale bytes into the canonical title).
+Entries are ``"<dpla_id>\\t<ordinal>"`` strings. Per-partner scope,
+stored at ``<partner>/await-target-free.json`` under
+:data:`~ingest_wikimedia.drain_sidecar.INGEST_WIKI_ROOT`, alongside the
+deferred-drain sidecar.
 """
 
 from __future__ import annotations
@@ -58,36 +45,34 @@ from ingest_wikimedia.drain_sidecar import partner_dir_path
 
 SIDECAR_FILENAME = "await-target-free.json"
 _LOCK_SUFFIX = ".lock"
+_KEY_SEP = "\t"
 
 
 def sidecar_path(partner: str) -> Path:
-    """Absolute path to the await-target-free sidecar for ``partner``.
+    """Absolute path to the await-target-free set for ``partner``.
 
-    Same anchor + partner-dir resolution as :mod:`drain_sidecar` so the
-    two sidecars sit alongside each other under the partner working
-    directory.
+    Same anchor + partner-dir resolution as :mod:`drain_sidecar`, so the
+    two sidecars sit alongside each other under the partner directory.
     """
     return partner_dir_path(partner) / SIDECAR_FILENAME
 
 
+def _key(dpla_id: str, ordinal: int) -> str:
+    return f"{dpla_id}{_KEY_SEP}{ordinal}"
+
+
 @contextlib.contextmanager
 def _locked_for_write(partner: str):
-    """Hold an exclusive ``fcntl.flock`` on the sidecar's companion
-    lockfile for the duration of the block.
+    """Hold an exclusive ``fcntl.flock`` on a companion lockfile for the
+    duration of the block.
 
     The uploader's ``multiprocessing.Pool`` fans work out to worker
-    processes that all call :func:`add_entry` / :func:`remove_entry`
-    concurrently. Without this lock, two workers can each read the
-    sidecar, dedupe locally, and race on the ``os.replace`` — one
-    replaces the other's write and the losing worker's entry is lost.
-
-    The lockfile is a separate path (``<sidecar>.lock``) rather than
-    the sidecar itself because :func:`write_sidecar` unlinks an empty
-    sidecar via ``os.replace`` / ``unlink``, and locking the sidecar
-    would leak the lock across those file-swap boundaries. The
-    lockfile is created on first use and never deleted; ``flock``
-    releases automatically on fd close, so a killed worker never
-    strands the lock.
+    processes that each call :func:`add_key` / :func:`remove_key`
+    concurrently; without this lock the read-modify-write races and a
+    worker's update can clobber a sibling's. The lockfile is a separate
+    path (``<sidecar>.lock``) because :func:`_write_keys` unlinks the
+    sidecar on empty, which would drop a lock held on the sidecar itself.
+    ``flock`` releases on fd close, so a killed worker never strands it.
     """
     path = sidecar_path(partner)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -100,114 +85,14 @@ def _locked_for_write(partner: str):
         os.close(fd)
 
 
-def _normalize_entry(raw: object) -> dict | None:
-    """Return ``raw`` as a validated entry dict, or ``None`` if it's
-    malformed. Guards against corrupt sidecar contents (a stray non-dict
-    element, missing required keys) rather than crashing the drain loop.
-    """
-    if not isinstance(raw, dict):
-        return None
-    dpla_id = raw.get("dpla_id")
-    tagged_title = raw.get("tagged_title")
-    community_title = raw.get("community_title")
-    if not (
-        isinstance(dpla_id, str)
-        and isinstance(tagged_title, str)
-        and isinstance(community_title, str)
-    ):
-        return None
-    ordinal = raw.get("ordinal")
-    if not isinstance(ordinal, int):
-        return None
-    expected_sha1 = raw.get("expected_sha1")
-    if not isinstance(expected_sha1, str):
-        return None
-    # ``tag_emitted`` is the workflow phase marker: True once the
-    # uploader has successfully written the {{Duplicate}} tag on the
-    # canonical file. Entries land with tag_emitted=False (from
-    # add_entry inside _tag_self_and_defer) and flip to True via
-    # mark_tag_emitted() after tag_as_duplicate() returns. Missing on
-    # an entry (an older sidecar shape written before this field
-    # existed) defaults to True — those entries came from a flow that
-    # always tagged before writing the sidecar, so treating them as
-    # fully queued is the correct backwards-compat choice.
-    tag_emitted = raw.get("tag_emitted")
-    if not isinstance(tag_emitted, bool):
-        tag_emitted = True
-    return {
-        "dpla_id": dpla_id,
-        "ordinal": ordinal,
-        "tagged_title": tagged_title,
-        "community_title": community_title,
-        "tag_emitted": tag_emitted,
-        "expected_sha1": expected_sha1,
-    }
+def read_keys(partner: str) -> list[str]:
+    """Return the queued ``"<dpla_id>\\t<ordinal>"`` keys, or an empty
+    list if the file is missing or unreadable.
 
-
-def _quarantine_corrupt_file(path: Path, reason: str) -> None:
-    """Move a damaged sidecar aside to a preserved ``.corrupt`` path and
-    log loudly.
-
-    A missing sidecar is the normal empty state, but an *existing* file
-    that can't be read or whose top-level shape is wrong is a
-    data-integrity event: the queue it represents holds deferred
-    community-file promotions that must NOT be silently dropped. If we
-    just returned ``[]`` and carried on, the patient drain would report
-    "complete" while queued work sat unnoticed, and the next
-    :func:`add_entry` would ``os.replace`` the corrupt bytes away
-    entirely. Quarantining instead (a) preserves the bytes for manual
-    recovery, (b) surfaces a loud ERROR the operator can act on, and
-    (c) still lets the process continue rather than crashing the
-    uploader hot path (``add_entry`` calls this indirectly).
-
-    Picks the first free ``<name>.corrupt`` / ``.corrupt.1`` / … so a
-    second corruption never clobbers an earlier quarantine. A concurrent
-    reader that already moved the file loses the race harmlessly
-    (``FileNotFoundError`` — nothing left to quarantine).
-    """
-    suffix = ".corrupt"
-    candidate = path.with_name(path.name + suffix)
-    n = 1
-    while candidate.exists():
-        candidate = path.with_name(f"{path.name}{suffix}.{n}")
-        n += 1
-    try:
-        os.replace(path, candidate)
-    except FileNotFoundError:
-        return
-    except OSError as ex:
-        logging.error(
-            "await-target-free sidecar at %s is damaged (%s) AND could not be "
-            "quarantined (%s); leaving in place — queued work may be stranded",
-            path,
-            reason,
-            ex,
-        )
-        return
-    logging.error(
-        "await-target-free sidecar at %s is damaged (%s); quarantined to %s. "
-        "Queued deferred-move entries were NOT processed — inspect and restore "
-        "the quarantined file to recover them.",
-        path,
-        reason,
-        candidate,
-    )
-
-
-def read_sidecar(partner: str) -> list[dict]:
-    """Return the list of pending entries in the sidecar.
-
-    A *missing* sidecar is the normal empty state → ``[]``. An
-    *existing* file that is unreadable, unparseable, or structurally
-    wrong is a damaged queue, NOT an empty one: it is quarantined (see
-    :func:`_quarantine_corrupt_file`) and ``[]`` is returned only after
-    the damage has been surfaced and the bytes preserved.
-
-    Per-entry malformation is handled separately and tolerantly: a
-    single bad element (schema drift, a stray non-dict) is skipped while
-    the well-formed entries in the same file still surface. Only
-    whole-file damage triggers quarantine — one drifted entry must not
-    strand the rest of the queue.
+    Missing is the normal empty state. A present-but-unparseable file is
+    treated as empty (like :func:`drain_sidecar.read_sidecar`): the set
+    is reconstructable from Commons, so a mid-write crash mustn't wedge
+    the drain — the operator can inspect the file if it lingers.
     """
     path = sidecar_path(partner)
     if not path.exists():
@@ -216,51 +101,40 @@ def read_sidecar(partner: str) -> list[dict]:
         with open(path) as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError) as ex:
-        _quarantine_corrupt_file(path, f"unreadable: {ex}")
+        logging.warning(
+            "await-target-free set at %s is unreadable (%s); treating as empty",
+            path,
+            ex,
+        )
         return []
-    entries = data.get("entries") if isinstance(data, dict) else None
-    if not isinstance(entries, list):
-        _quarantine_corrupt_file(path, "top-level shape is not {'entries': [...]}")
+    keys = data.get("awaiting") if isinstance(data, dict) else None
+    if not isinstance(keys, list):
         return []
-    out: list[dict] = []
-    for raw in entries:
-        normalized = _normalize_entry(raw)
-        if normalized is not None:
-            out.append(normalized)
-    return out
+    return [k for k in keys if isinstance(k, str) and _KEY_SEP in k]
 
 
-def write_sidecar(partner: str, entries: list[dict]) -> None:
-    """Overwrite the sidecar with ``entries``. Removes the file when the
-    list is empty so an empty state is unambiguous (missing = nothing
-    pending). Deduplicates by ``(dpla_id, ordinal)`` preserving order.
-
-    Atomic write via tempfile + ``os.replace`` — matches
-    :func:`drain_sidecar.write_sidecar`'s guarantees.
+def _write_keys(partner: str, keys: list[str]) -> None:
+    """Overwrite the set with ``keys`` (deduped, order-preserving);
+    remove the file when empty so the empty state is unambiguous. Atomic
+    via tempfile + ``os.replace``. Caller holds :func:`_locked_for_write`.
     """
     path = sidecar_path(partner)
-    if not entries:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for k in keys:
+        if isinstance(k, str) and _KEY_SEP in k and k not in seen:
+            seen.add(k)
+            ordered.append(k)
+    if not ordered:
         try:
             path.unlink(missing_ok=True)
         except OSError as ex:
             logging.warning(
-                "failed to remove empty await-target-free sidecar at %s: %s",
-                path,
-                ex,
+                "failed to remove empty await-target-free set at %s: %s", path, ex
             )
         return
     path.parent.mkdir(parents=True, exist_ok=True)
-    seen: set[tuple[str, int]] = set()
-    ordered: list[dict] = []
-    for entry in entries:
-        normalized = _normalize_entry(entry)
-        if normalized is None:
-            continue
-        key = (normalized["dpla_id"], normalized["ordinal"])
-        if key not in seen:
-            seen.add(key)
-            ordered.append(normalized)
-    payload = {"partner": partner, "entries": ordered}
+    payload = {"partner": partner, "awaiting": ordered}
     tempname: str | None = None
     try:
         with tempfile.NamedTemporaryFile(
@@ -281,88 +155,44 @@ def write_sidecar(partner: str, entries: list[dict]) -> None:
         raise
 
 
-def has_entry(partner: str, dpla_id: str, ordinal: int) -> bool:
-    """True iff an entry for ``(dpla_id, ordinal)`` is currently queued.
-
-    Idempotency guard: the uploader consults this before enqueuing a new
-    entry so a re-run of the same partner (before the tagged file is
-    actioned by a Commons admin) doesn't re-emit the tag or duplicate the
-    sidecar entry.
-    """
-    return get_entry(partner, dpla_id, ordinal) is not None
+def has_key(partner: str, dpla_id: str, ordinal: int) -> bool:
+    """True iff ``(dpla_id, ordinal)`` is currently awaiting admin action."""
+    return _key(dpla_id, ordinal) in read_keys(partner)
 
 
-def get_entry(partner: str, dpla_id: str, ordinal: int) -> dict | None:
-    """Return the sidecar entry for ``(dpla_id, ordinal)`` or ``None``
-    if absent. Callers that need to inspect ``tag_emitted`` (workflow
-    phase) use this instead of :func:`has_entry`; a plain existence
-    check would conflate the "in-progress" and "fully-queued" states.
-    """
-    for entry in read_sidecar(partner):
-        if entry["dpla_id"] == dpla_id and entry["ordinal"] == ordinal:
-            return entry
-    return None
-
-
-def mark_tag_emitted(partner: str, dpla_id: str, ordinal: int) -> bool:
-    """Flip the entry's ``tag_emitted`` phase marker to ``True``.
-
-    Called by the uploader after ``tag_as_duplicate`` has successfully
-    written the {{Duplicate}} template on the canonical file — the entry
-    is now durably queued for admin action, and drain-deferred is free
-    to advance it once admin acts.
-
-    Returns True if an entry existed and was updated (or was already
-    True); False if no matching entry was found. Serialized via
-    :func:`_locked_for_write` — safe to call from concurrent uploader
-    Pool workers.
+def add_key(partner: str, dpla_id: str, ordinal: int) -> None:
+    """Record that ``(dpla_id, ordinal)`` is awaiting admin action.
+    Idempotent; serialized across processes via :func:`_locked_for_write`.
     """
     with _locked_for_write(partner):
-        existing = read_sidecar(partner)
-        found = False
-        for entry in existing:
-            if entry["dpla_id"] == dpla_id and entry["ordinal"] == ordinal:
-                entry["tag_emitted"] = True
-                found = True
-                break
-        if found:
-            write_sidecar(partner, existing)
-        return found
+        keys = read_keys(partner)
+        k = _key(dpla_id, ordinal)
+        if k not in keys:
+            keys.append(k)
+            _write_keys(partner, keys)
 
 
-def add_entry(partner: str, entry: dict) -> list[dict]:
-    """Add ``entry`` to the sidecar, deduping by ``(dpla_id, ordinal)``,
-    and return the resulting combined list. If an entry for that key
-    already exists, the sidecar is left unchanged.
-
-    Serialized across processes via :func:`_locked_for_write` so
-    concurrent uploader Pool workers can't lose each other's writes.
-    """
-    normalized = _normalize_entry(entry)
-    if normalized is None:
-        raise ValueError(f"malformed entry rejected: {entry!r}")
-    key = (normalized["dpla_id"], normalized["ordinal"])
-    with _locked_for_write(partner):
-        existing = read_sidecar(partner)
-        if any((e["dpla_id"], e["ordinal"]) == key for e in existing):
-            return existing
-        combined = [*existing, normalized]
-        write_sidecar(partner, combined)
-        return combined
-
-
-def remove_entry(partner: str, dpla_id: str, ordinal: int) -> list[dict]:
-    """Drop the entry keyed by ``(dpla_id, ordinal)`` from the sidecar
-    and return the remaining list. Absent entries are a no-op.
-
-    Serialized across processes via :func:`_locked_for_write` so a
-    concurrent :func:`add_entry` can't be silently overwritten.
+def remove_key(partner: str, dpla_id: str, ordinal: int) -> None:
+    """Drop ``(dpla_id, ordinal)`` from the set (no-op if absent).
+    Serialized across processes via :func:`_locked_for_write`.
     """
     with _locked_for_write(partner):
-        remaining = [
-            e
-            for e in read_sidecar(partner)
-            if not (e["dpla_id"] == dpla_id and e["ordinal"] == ordinal)
-        ]
-        write_sidecar(partner, remaining)
-        return remaining
+        k = _key(dpla_id, ordinal)
+        keys = read_keys(partner)
+        if k in keys:
+            _write_keys(partner, [x for x in keys if x != k])
+
+
+def awaiting_dpla_ids(partner: str) -> list[str]:
+    """Return the unique DPLA IDs with at least one awaiting ordinal, in
+    first-seen order. The drain re-runs the uploader per DPLA ID (its
+    unit of work is the item), so it dedupes the per-ordinal keys here.
+    """
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for k in read_keys(partner):
+        dpla_id = k.split(_KEY_SEP, 1)[0]
+        if dpla_id not in seen:
+            seen.add(dpla_id)
+            ordered.append(dpla_id)
+    return ordered

--- a/ingest_wikimedia/await_target_free_sidecar.py
+++ b/ingest_wikimedia/await_target_free_sidecar.py
@@ -47,6 +47,7 @@ silently promote stale bytes into the canonical title).
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import json
 import logging
 import os
@@ -56,6 +57,7 @@ from pathlib import Path
 from ingest_wikimedia.drain_sidecar import partner_dir_path
 
 SIDECAR_FILENAME = "await-target-free.json"
+_LOCK_SUFFIX = ".lock"
 
 
 def sidecar_path(partner: str) -> Path:
@@ -66,6 +68,36 @@ def sidecar_path(partner: str) -> Path:
     directory.
     """
     return partner_dir_path(partner) / SIDECAR_FILENAME
+
+
+@contextlib.contextmanager
+def _locked_for_write(partner: str):
+    """Hold an exclusive ``fcntl.flock`` on the sidecar's companion
+    lockfile for the duration of the block.
+
+    The uploader's ``multiprocessing.Pool`` fans work out to worker
+    processes that all call :func:`add_entry` / :func:`remove_entry`
+    concurrently. Without this lock, two workers can each read the
+    sidecar, dedupe locally, and race on the ``os.replace`` — one
+    replaces the other's write and the losing worker's entry is lost.
+
+    The lockfile is a separate path (``<sidecar>.lock``) rather than
+    the sidecar itself because :func:`write_sidecar` unlinks an empty
+    sidecar via ``os.replace`` / ``unlink``, and locking the sidecar
+    would leak the lock across those file-swap boundaries. The
+    lockfile is created on first use and never deleted; ``flock``
+    releases automatically on fd close, so a killed worker never
+    strands the lock.
+    """
+    path = sidecar_path(partner)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + _LOCK_SUFFIX)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        os.close(fd)
 
 
 def _normalize_entry(raw: object) -> dict | None:
@@ -197,27 +229,35 @@ def add_entry(partner: str, entry: dict) -> list[dict]:
     """Add ``entry`` to the sidecar, deduping by ``(dpla_id, ordinal)``,
     and return the resulting combined list. If an entry for that key
     already exists, the sidecar is left unchanged.
+
+    Serialized across processes via :func:`_locked_for_write` so
+    concurrent uploader Pool workers can't lose each other's writes.
     """
     normalized = _normalize_entry(entry)
     if normalized is None:
         raise ValueError(f"malformed entry rejected: {entry!r}")
-    existing = read_sidecar(partner)
     key = (normalized["dpla_id"], normalized["ordinal"])
-    if any((e["dpla_id"], e["ordinal"]) == key for e in existing):
-        return existing
-    combined = [*existing, normalized]
-    write_sidecar(partner, combined)
-    return combined
+    with _locked_for_write(partner):
+        existing = read_sidecar(partner)
+        if any((e["dpla_id"], e["ordinal"]) == key for e in existing):
+            return existing
+        combined = [*existing, normalized]
+        write_sidecar(partner, combined)
+        return combined
 
 
 def remove_entry(partner: str, dpla_id: str, ordinal: int) -> list[dict]:
     """Drop the entry keyed by ``(dpla_id, ordinal)`` from the sidecar
     and return the remaining list. Absent entries are a no-op.
+
+    Serialized across processes via :func:`_locked_for_write` so a
+    concurrent :func:`add_entry` can't be silently overwritten.
     """
-    remaining = [
-        e
-        for e in read_sidecar(partner)
-        if not (e["dpla_id"] == dpla_id and e["ordinal"] == ordinal)
-    ]
-    write_sidecar(partner, remaining)
-    return remaining
+    with _locked_for_write(partner):
+        remaining = [
+            e
+            for e in read_sidecar(partner)
+            if not (e["dpla_id"] == dpla_id and e["ordinal"] == ordinal)
+        ]
+        write_sidecar(partner, remaining)
+        return remaining

--- a/ingest_wikimedia/await_target_free_sidecar.py
+++ b/ingest_wikimedia/await_target_free_sidecar.py
@@ -1,0 +1,223 @@
+"""Persistent sidecar for the "await community-target free" deferral stage.
+
+The uploader defers a Case-2 hash-drift resolution when the file whose title
+we intend to overwrite is a community upload (i.e. our S3 SHA1 already lives at
+a community-authored Commons title). Rather than tag the community's file for
+speedy deletion — the previous behaviour, which requested a Commons admin
+destroy an older community contribution — the uploader:
+
+  1. uploads the S3 bytes to the DPLA-canonical title (invariant satisfied),
+  2. tags OUR just-uploaded file as ``{{Duplicate|<community title>}}`` so
+     Commons admins can delete or redirect it, and
+  3. writes an entry to this sidecar naming the tagged (DPLA-canonical) file
+     and the community file we want to promote once the tagged file is gone.
+
+The follow-on ``drain-deferred`` phase reads this sidecar, polls each tagged
+title, and — once the tag has been actioned (page deleted, or turned into a
+redirect) — executes a title-drift move of the community file into the freed
+DPLA-canonical title. The community file's revision history and curation
+survive the move; the invariant is satisfied again once the move completes.
+
+Distinct from :mod:`ingest_wikimedia.drain_sidecar` (the ``Category:Duplicate``
+capacity gate), because the wait conditions are per-item (each tagged title
+polled independently), not global (single boolean checked once per round).
+Keeping the two sidecars separate is additive — no schema evolution on the
+existing sidecar — and lets each stage evolve without disturbing the other.
+
+Per-partner scope: mirrors :mod:`drain_sidecar` — one sidecar file per partner
+under ``<partner>/await-target-free.json``, anchored at
+:data:`~ingest_wikimedia.drain_sidecar.INGEST_WIKI_ROOT`.
+
+Entry schema::
+
+    {
+        "dpla_id":         "22412cd0994d36f03c4fcf549db2b8e5",
+        "ordinal":         1,
+        "tagged_title":    "File:… - DPLA - 22412cd0….jpg",
+        "community_title": "File:….jpg",
+        "expected_sha1":   "9719e05a…",
+    }
+
+``expected_sha1`` is the S3 source SHA1 that was true at tag time; the drain
+phase re-validates it against the community file before executing the move so
+that partner-side content churn during the wait window is caught (and doesn't
+silently promote stale bytes into the canonical title).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from ingest_wikimedia.drain_sidecar import partner_dir_path
+
+SIDECAR_FILENAME = "await-target-free.json"
+
+
+def sidecar_path(partner: str) -> Path:
+    """Absolute path to the await-target-free sidecar for ``partner``.
+
+    Same anchor + partner-dir resolution as :mod:`drain_sidecar` so the
+    two sidecars sit alongside each other under the partner working
+    directory.
+    """
+    return partner_dir_path(partner) / SIDECAR_FILENAME
+
+
+def _normalize_entry(raw: object) -> dict | None:
+    """Return ``raw`` as a validated entry dict, or ``None`` if it's
+    malformed. Guards against corrupt sidecar contents (a stray non-dict
+    element, missing required keys) rather than crashing the drain loop.
+    """
+    if not isinstance(raw, dict):
+        return None
+    dpla_id = raw.get("dpla_id")
+    tagged_title = raw.get("tagged_title")
+    community_title = raw.get("community_title")
+    if not (
+        isinstance(dpla_id, str)
+        and isinstance(tagged_title, str)
+        and isinstance(community_title, str)
+    ):
+        return None
+    ordinal = raw.get("ordinal")
+    if not isinstance(ordinal, int):
+        return None
+    expected_sha1 = raw.get("expected_sha1")
+    if not isinstance(expected_sha1, str):
+        return None
+    return {
+        "dpla_id": dpla_id,
+        "ordinal": ordinal,
+        "tagged_title": tagged_title,
+        "community_title": community_title,
+        "expected_sha1": expected_sha1,
+    }
+
+
+def read_sidecar(partner: str) -> list[dict]:
+    """Return the list of pending entries in the sidecar, or an empty
+    list if the file is missing / unreadable / malformed. Missing sidecar
+    is the normal empty state.
+    """
+    path = sidecar_path(partner)
+    if not path.exists():
+        return []
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as ex:
+        logging.warning(
+            "await-target-free sidecar at %s is unreadable (%s); treating as empty",
+            path,
+            ex,
+        )
+        return []
+    entries = data.get("entries") if isinstance(data, dict) else None
+    if not isinstance(entries, list):
+        return []
+    out: list[dict] = []
+    for raw in entries:
+        normalized = _normalize_entry(raw)
+        if normalized is not None:
+            out.append(normalized)
+    return out
+
+
+def write_sidecar(partner: str, entries: list[dict]) -> None:
+    """Overwrite the sidecar with ``entries``. Removes the file when the
+    list is empty so an empty state is unambiguous (missing = nothing
+    pending). Deduplicates by ``(dpla_id, ordinal)`` preserving order.
+
+    Atomic write via tempfile + ``os.replace`` — matches
+    :func:`drain_sidecar.write_sidecar`'s guarantees.
+    """
+    path = sidecar_path(partner)
+    if not entries:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as ex:
+            logging.warning(
+                "failed to remove empty await-target-free sidecar at %s: %s",
+                path,
+                ex,
+            )
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    seen: set[tuple[str, int]] = set()
+    ordered: list[dict] = []
+    for entry in entries:
+        normalized = _normalize_entry(entry)
+        if normalized is None:
+            continue
+        key = (normalized["dpla_id"], normalized["ordinal"])
+        if key not in seen:
+            seen.add(key)
+            ordered.append(normalized)
+    payload = {"partner": partner, "entries": ordered}
+    tempname: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            dir=str(path.parent),
+            prefix=".await-target-free-",
+            suffix=".tmp",
+            delete=False,
+        ) as tf:
+            tempname = tf.name
+            json.dump(payload, tf, indent=2)
+            tf.write("\n")
+        os.replace(tempname, path)
+    except Exception:
+        if tempname is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(tempname)
+        raise
+
+
+def has_entry(partner: str, dpla_id: str, ordinal: int) -> bool:
+    """True iff an entry for ``(dpla_id, ordinal)`` is currently queued.
+
+    Idempotency guard: the uploader consults this before enqueuing a new
+    entry so a re-run of the same partner (before the tagged file is
+    actioned by a Commons admin) doesn't re-emit the tag or duplicate the
+    sidecar entry.
+    """
+    for entry in read_sidecar(partner):
+        if entry["dpla_id"] == dpla_id and entry["ordinal"] == ordinal:
+            return True
+    return False
+
+
+def add_entry(partner: str, entry: dict) -> list[dict]:
+    """Add ``entry`` to the sidecar, deduping by ``(dpla_id, ordinal)``,
+    and return the resulting combined list. If an entry for that key
+    already exists, the sidecar is left unchanged.
+    """
+    normalized = _normalize_entry(entry)
+    if normalized is None:
+        raise ValueError(f"malformed entry rejected: {entry!r}")
+    existing = read_sidecar(partner)
+    key = (normalized["dpla_id"], normalized["ordinal"])
+    if any((e["dpla_id"], e["ordinal"]) == key for e in existing):
+        return existing
+    combined = [*existing, normalized]
+    write_sidecar(partner, combined)
+    return combined
+
+
+def remove_entry(partner: str, dpla_id: str, ordinal: int) -> list[dict]:
+    """Drop the entry keyed by ``(dpla_id, ordinal)`` from the sidecar
+    and return the remaining list. Absent entries are a no-op.
+    """
+    remaining = [
+        e
+        for e in read_sidecar(partner)
+        if not (e["dpla_id"] == dpla_id and e["ordinal"] == ordinal)
+    ]
+    write_sidecar(partner, remaining)
+    return remaining

--- a/ingest_wikimedia/await_target_free_sidecar.py
+++ b/ingest_wikimedia/await_target_free_sidecar.py
@@ -144,10 +144,70 @@ def _normalize_entry(raw: object) -> dict | None:
     }
 
 
+def _quarantine_corrupt_file(path: Path, reason: str) -> None:
+    """Move a damaged sidecar aside to a preserved ``.corrupt`` path and
+    log loudly.
+
+    A missing sidecar is the normal empty state, but an *existing* file
+    that can't be read or whose top-level shape is wrong is a
+    data-integrity event: the queue it represents holds deferred
+    community-file promotions that must NOT be silently dropped. If we
+    just returned ``[]`` and carried on, the patient drain would report
+    "complete" while queued work sat unnoticed, and the next
+    :func:`add_entry` would ``os.replace`` the corrupt bytes away
+    entirely. Quarantining instead (a) preserves the bytes for manual
+    recovery, (b) surfaces a loud ERROR the operator can act on, and
+    (c) still lets the process continue rather than crashing the
+    uploader hot path (``add_entry`` calls this indirectly).
+
+    Picks the first free ``<name>.corrupt`` / ``.corrupt.1`` / … so a
+    second corruption never clobbers an earlier quarantine. A concurrent
+    reader that already moved the file loses the race harmlessly
+    (``FileNotFoundError`` — nothing left to quarantine).
+    """
+    suffix = ".corrupt"
+    candidate = path.with_name(path.name + suffix)
+    n = 1
+    while candidate.exists():
+        candidate = path.with_name(f"{path.name}{suffix}.{n}")
+        n += 1
+    try:
+        os.replace(path, candidate)
+    except FileNotFoundError:
+        return
+    except OSError as ex:
+        logging.error(
+            "await-target-free sidecar at %s is damaged (%s) AND could not be "
+            "quarantined (%s); leaving in place — queued work may be stranded",
+            path,
+            reason,
+            ex,
+        )
+        return
+    logging.error(
+        "await-target-free sidecar at %s is damaged (%s); quarantined to %s. "
+        "Queued deferred-move entries were NOT processed — inspect and restore "
+        "the quarantined file to recover them.",
+        path,
+        reason,
+        candidate,
+    )
+
+
 def read_sidecar(partner: str) -> list[dict]:
-    """Return the list of pending entries in the sidecar, or an empty
-    list if the file is missing / unreadable / malformed. Missing sidecar
-    is the normal empty state.
+    """Return the list of pending entries in the sidecar.
+
+    A *missing* sidecar is the normal empty state → ``[]``. An
+    *existing* file that is unreadable, unparseable, or structurally
+    wrong is a damaged queue, NOT an empty one: it is quarantined (see
+    :func:`_quarantine_corrupt_file`) and ``[]`` is returned only after
+    the damage has been surfaced and the bytes preserved.
+
+    Per-entry malformation is handled separately and tolerantly: a
+    single bad element (schema drift, a stray non-dict) is skipped while
+    the well-formed entries in the same file still surface. Only
+    whole-file damage triggers quarantine — one drifted entry must not
+    strand the rest of the queue.
     """
     path = sidecar_path(partner)
     if not path.exists():
@@ -156,14 +216,11 @@ def read_sidecar(partner: str) -> list[dict]:
         with open(path) as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError) as ex:
-        logging.warning(
-            "await-target-free sidecar at %s is unreadable (%s); treating as empty",
-            path,
-            ex,
-        )
+        _quarantine_corrupt_file(path, f"unreadable: {ex}")
         return []
     entries = data.get("entries") if isinstance(data, dict) else None
     if not isinstance(entries, list):
+        _quarantine_corrupt_file(path, "top-level shape is not {'entries': [...]}")
         return []
     out: list[dict] = []
     for raw in entries:

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -1068,9 +1068,9 @@ def merge_preserved_wikitext(existing_text: str, new_wikitext: str) -> str:
 DUPLICATE_TAG_RE = re.compile(r"\{\{\s*duplicate\s*(?:\||\}\})", re.IGNORECASE)
 
 
-def first_uploader(site: BaseSite, file_page: FilePage) -> str | None:
+def first_uploader(file_page: FilePage) -> str | None:
     """Return the username that made the first (oldest) upload of
-    ``file_page``, or ``None`` if the history is empty or the API call
+    ``file_page``, or ``None`` if the history is empty or the lookup
     fails.
 
     Used by the uploader's Case-2 hash-drift subclassification to
@@ -1081,36 +1081,23 @@ def first_uploader(site: BaseSite, file_page: FilePage) -> str | None:
     the community file gets promoted to the DPLA-canonical title via
     the await-target-free deferral flow).
 
-    Queries the oldest file-history revision explicitly (``iidir=newer``
-    + ``iilimit=1``) so we look at the ORIGINAL upload, not the most
-    recent one — a re-upload by DPLA bot on top of a community-uploaded
-    file MUST NOT flip the classification. One API call per Case 2 hit;
-    Case 2 is already the rare path, so the cost is negligible.
+    Reads pywikibot's ``oldest_file_info`` — the earliest file-history
+    revision — so a later re-upload (e.g. a DPLA-bot re-upload on top of
+    a community-authored file) never flips the classification. pywikibot
+    fetches and orders the imageinfo history internally, so we don't
+    hand-roll the query direction. One lookup per Case-2 hit, an already
+    rare path.
     """
     try:
-        request = site.simple_request(
-            action="query",
-            titles=file_page.title(),
-            prop="imageinfo",
-            iiprop="user",
-            iilimit=1,
-            iidir="newer",
-        )
-        data = request.submit()
+        user = file_page.oldest_file_info.user
     except Exception as ex:  # pragma: no cover — defensive
         logging.warning(
-            "first_uploader: query failed for [[File:%s]]: %s",
+            "first_uploader: could not read file history for [[File:%s]]: %s",
             file_page.title(with_ns=False),
             ex,
         )
         return None
-    pages = (data.get("query") or {}).get("pages") or {}
-    for page in pages.values():
-        for ii in page.get("imageinfo") or []:
-            user = ii.get("user")
-            if isinstance(user, str) and user:
-                return user
-    return None
+    return user if isinstance(user, str) and user else None
 
 
 def tag_as_duplicate(

--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -1065,19 +1065,68 @@ def merge_preserved_wikitext(existing_text: str, new_wikitext: str) -> str:
 # non-whitespace token is the parameter pipe or the template's closing
 # braces. IGNORECASE handles both `Duplicate` and the `{{duplicate}}`
 # variant some Commons editors use.
-_DUPLICATE_TAG_RE = re.compile(r"\{\{\s*duplicate\s*(?:\||\}\})", re.IGNORECASE)
+DUPLICATE_TAG_RE = re.compile(r"\{\{\s*duplicate\s*(?:\||\}\})", re.IGNORECASE)
+
+
+def first_uploader(site: BaseSite, file_page: FilePage) -> str | None:
+    """Return the username that made the first (oldest) upload of
+    ``file_page``, or ``None`` if the history is empty or the API call
+    fails.
+
+    Used by the uploader's Case-2 hash-drift subclassification to
+    distinguish stranded old DPLA-bot uploads (first uploader is a
+    known bot account — safe to tag for admin cleanup) from
+    community-authored uploads that predate DPLA involvement
+    (first uploader is a real editor — must not be tagged; instead
+    the community file gets promoted to the DPLA-canonical title via
+    the await-target-free deferral flow).
+
+    Queries the oldest file-history revision explicitly (``iidir=newer``
+    + ``iilimit=1``) so we look at the ORIGINAL upload, not the most
+    recent one — a re-upload by DPLA bot on top of a community-uploaded
+    file MUST NOT flip the classification. One API call per Case 2 hit;
+    Case 2 is already the rare path, so the cost is negligible.
+    """
+    try:
+        request = site.simple_request(
+            action="query",
+            titles=file_page.title(),
+            prop="imageinfo",
+            iiprop="user",
+            iilimit=1,
+            iidir="newer",
+        )
+        data = request.submit()
+    except Exception as ex:  # pragma: no cover — defensive
+        logging.warning(
+            "first_uploader: query failed for [[File:%s]]: %s",
+            file_page.title(with_ns=False),
+            ex,
+        )
+        return None
+    pages = (data.get("query") or {}).get("pages") or {}
+    for page in pages.values():
+        for ii in page.get("imageinfo") or []:
+            user = ii.get("user")
+            if isinstance(user, str) and user:
+                return user
+    return None
 
 
 def tag_as_duplicate(
     site: BaseSite,
     file_page: FilePage,
     correct_filename: str,
-    reason: str,
+    reason: str = "",
 ) -> None:
     """Prepend {{Duplicate}} to file_page, flagging it for speedy deletion.
 
     correct_filename should be bare (no 'File:' prefix).
-    reason is the free-text reason shown in the template.
+    reason is the free-text reason shown in the template. When empty
+    (the default), the tag is emitted as ``{{Duplicate|<filename>}}`` —
+    a single-arg form that lets Commons's own default template text
+    speak for the tag, instead of a caller-supplied reason that would be
+    largely duplicative of the template's built-in wording.
 
     Idempotent: if the page already carries a {{Duplicate}} (or
     {{duplicate}}) template, this is a no-op. Two distinct uploader code
@@ -1094,7 +1143,7 @@ def tag_as_duplicate(
     that the pure-prependtext path avoided, but skipping a redundant
     write is worth the single read.
     """
-    if _DUPLICATE_TAG_RE.search(file_page.text or ""):
+    if DUPLICATE_TAG_RE.search(file_page.text or ""):
         logging.info(
             f"Skipping duplicate tag on [[File:{file_page.title(with_ns=False)}]] — "
             f"already tagged as duplicate."
@@ -1102,11 +1151,14 @@ def tag_as_duplicate(
         return
     # Escape `=` so a filename or reason containing literal equals signs
     # doesn't break the template — see escape_template_param.
-    tag = (
-        f"{{{{Duplicate"
-        f"|{escape_template_param(correct_filename)}"
-        f"|{escape_template_param(reason)}}}}}"
-    )
+    if reason:
+        tag = (
+            f"{{{{Duplicate"
+            f"|{escape_template_param(correct_filename)}"
+            f"|{escape_template_param(reason)}}}}}"
+        )
+    else:
+        tag = f"{{{{Duplicate|{escape_template_param(correct_filename)}}}}}"
     summary = f"Tagging as duplicate: correct title is [[File:{correct_filename}]]"
     # Trailing newline so the tag sits on its own line above whatever
     # wikitext currently starts the page.

--- a/tests/test_await_target_free_sidecar.py
+++ b/tests/test_await_target_free_sidecar.py
@@ -74,11 +74,13 @@ def test_write_dedupes_by_dpla_id_and_ordinal():
     ]
 
 
-def test_read_tolerates_malformed_entries():
-    """Corrupt sidecar (missing keys, wrong types) is treated as empty
-    for the malformed entries; well-formed entries in the same file
-    still surface. Keeps the drain loop resilient rather than crashing
-    on a mid-write truncation."""
+def test_read_tolerates_per_entry_malformation_without_quarantine():
+    """PER-ENTRY malformation is handled tolerantly: a single bad
+    element (schema drift, stray non-dict) is skipped while the
+    well-formed entries in the same file still surface, and the file
+    is NOT quarantined — one drifted entry must not strand the rest of
+    the queue. Only WHOLE-FILE damage triggers quarantine (see the
+    tests below)."""
     path = await_target_free_sidecar.sidecar_path("nara")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -97,13 +99,65 @@ def test_read_tolerates_malformed_entries():
     )
     stored = await_target_free_sidecar.read_sidecar("nara")
     assert [e["dpla_id"] for e in stored] == ["good", "also-good"]
+    # File left in place — not quarantined.
+    assert path.exists()
+    assert not path.with_name(path.name + ".corrupt").exists()
 
 
-def test_read_tolerates_unparseable_file():
+def test_read_quarantines_unparseable_file_instead_of_silent_empty():
+    """A WHOLE-FILE-unparseable existing sidecar is a damaged queue,
+    not an empty one. read_sidecar must quarantine it (move aside,
+    preserving the bytes) and return [] only after — never silently
+    treat the damaged queue as 'nothing pending'."""
     path = await_target_free_sidecar.sidecar_path("nara")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("{ this is not json")
     assert await_target_free_sidecar.read_sidecar("nara") == []
+    # Original path cleared; bytes preserved in the quarantine file.
+    assert not path.exists()
+    quarantined = path.with_name(path.name + ".corrupt")
+    assert quarantined.exists()
+    assert quarantined.read_text() == "{ this is not json"
+
+
+def test_read_quarantines_wrong_toplevel_shape():
+    """An existing file whose top-level shape isn't
+    ``{'entries': [...]}`` (e.g. a bare list, or a dict missing the
+    key) is also a damaged queue and must be quarantined, not treated
+    as empty."""
+    path = await_target_free_sidecar.sidecar_path("nara")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(["unexpected", "top-level", "list"]))
+    assert await_target_free_sidecar.read_sidecar("nara") == []
+    assert not path.exists()
+    assert path.with_name(path.name + ".corrupt").exists()
+
+
+def test_quarantine_does_not_clobber_a_prior_quarantine():
+    """A second corruption event must not overwrite the first
+    quarantine — the recovery bytes from BOTH events survive under
+    distinct ``.corrupt`` / ``.corrupt.1`` names."""
+    path = await_target_free_sidecar.sidecar_path("nara")
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    path.write_text("first corruption")
+    await_target_free_sidecar.read_sidecar("nara")
+    path.write_text("second corruption")
+    await_target_free_sidecar.read_sidecar("nara")
+
+    first = path.with_name(path.name + ".corrupt")
+    second = path.with_name(path.name + ".corrupt.1")
+    assert first.read_text() == "first corruption"
+    assert second.read_text() == "second corruption"
+
+
+def test_read_missing_file_is_silent_empty_not_quarantined():
+    """The normal empty state — a missing sidecar — must NOT log a
+    corruption error or create a quarantine file. This is the case the
+    damaged-queue handling must stay distinct from."""
+    path = await_target_free_sidecar.sidecar_path("nara")
+    assert await_target_free_sidecar.read_sidecar("nara") == []
+    assert not path.with_name(path.name + ".corrupt").exists()
 
 
 def test_has_entry_matches_only_on_dpla_id_and_ordinal():

--- a/tests/test_await_target_free_sidecar.py
+++ b/tests/test_await_target_free_sidecar.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
+import multiprocessing
+import os
 
 import pytest
 
@@ -166,3 +169,108 @@ def test_sidecar_path_uses_partner_dir_mapping_for_smithsonian():
     ``sidecar_path`` reuses ``drain_sidecar.partner_dir_path``. Same
     guarantee as ``drain_sidecar.sidecar_path``."""
     assert await_target_free_sidecar.sidecar_path("si").parent.name == "smithsonian"
+
+
+def _child_add_entry(root: str, dpla_id: str, ordinal: int) -> None:
+    """Spawn-safe helper: re-anchor the sidecar root in the child, then
+    add one entry. Runs in a fresh Python interpreter under
+    ``multiprocessing.get_context('spawn')`` so state isn't inherited
+    from the test process."""
+    from pathlib import Path
+
+    from ingest_wikimedia import await_target_free_sidecar as sidecar
+    from ingest_wikimedia import drain_sidecar as ds
+
+    ds.INGEST_WIKI_ROOT = Path(root)
+    sidecar.add_entry(
+        "nara",
+        {
+            "dpla_id": dpla_id,
+            "ordinal": ordinal,
+            "tagged_title": f"File:X - DPLA - {dpla_id}.jpg",
+            "community_title": "File:X.jpg",
+            "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
+        },
+    )
+
+
+def test_add_entry_serializes_concurrent_writers_across_processes(tmp_path):
+    """The uploader's ``multiprocessing.Pool`` fans work out to workers
+    that each call ``add_entry`` concurrently. Without a cross-process
+    lock, the read → dedupe → write sequence races and one worker's
+    write silently overwrites another's. Two spawned children each
+    add a distinct entry — both must survive.
+    """
+    ctx = multiprocessing.get_context("spawn")
+    workers = [
+        ctx.Process(target=_child_add_entry, args=(str(tmp_path), f"id-{i:02d}", 1))
+        for i in range(8)
+    ]
+    for w in workers:
+        w.start()
+    for w in workers:
+        w.join(timeout=30)
+        assert w.exitcode == 0, f"child worker failed (exit {w.exitcode})"
+
+    # All 8 distinct entries must be present — none silently lost.
+    # (Autouse fixture already anchors the parent test at tmp_path.)
+    stored = await_target_free_sidecar.read_sidecar("nara")
+    ids = sorted(e["dpla_id"] for e in stored)
+    assert ids == [f"id-{i:02d}" for i in range(8)], (
+        f"expected all 8 concurrent adds to survive; got {ids!r}"
+    )
+
+
+def test_add_entry_blocks_while_lock_is_held_and_proceeds_when_freed(
+    tmp_path, monkeypatch
+):
+    """Direct check on the ``_locked_for_write`` gate: while a foreign
+    fd holds the companion lockfile's ``fcntl.LOCK_EX``, ``add_entry``
+    must block; once the foreign holder releases, it proceeds. Uses
+    a thread + a manually-held fd, exploiting POSIX ``flock`` semantics
+    where two open file descriptions to the same file block each other
+    even inside one process.
+    """
+    import threading
+
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path)
+    # Materialise the partner dir so the lockfile can be created.
+    sidecar_json = await_target_free_sidecar.sidecar_path("nara")
+    sidecar_json.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = sidecar_json.with_suffix(sidecar_json.suffix + ".lock")
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+
+    proceeded = threading.Event()
+
+    def worker():
+        await_target_free_sidecar.add_entry("nara", _entry("aaa", 1))
+        proceeded.set()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    try:
+        # While the foreign fd holds the lock, add_entry must NOT proceed.
+        assert not proceeded.wait(timeout=0.5), (
+            "add_entry entered its critical section despite the lockfile "
+            "being held by a foreign fd"
+        )
+    finally:
+        # Release; the worker should now complete.
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+    assert proceeded.wait(timeout=3), (
+        "add_entry did not proceed after the lockfile was released"
+    )
+    t.join(timeout=1)
+    # And the entry actually landed.
+    stored = await_target_free_sidecar.read_sidecar("nara")
+    assert [e["dpla_id"] for e in stored] == ["aaa"]
+
+
+# Some CI runners may lack a `spawn` context that can find the test
+# module — mark the spawn-based test to skip if we can't import from a
+# fresh interpreter. In-process tests still exercise the lock via the
+# threading test above.
+if not hasattr(multiprocessing, "get_context"):  # pragma: no cover
+    pytestmark = pytest.mark.skip(reason="multiprocessing.get_context unavailable")

--- a/tests/test_await_target_free_sidecar.py
+++ b/tests/test_await_target_free_sidecar.py
@@ -15,12 +15,16 @@ from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
 
 def _entry(dpla_id: str = "22412cd0", ordinal: int = 1, **overrides) -> dict:
     """Canonical entry factory. Fill defaults; individual fields overridable
-    via keyword args."""
+    via keyword args. Default state is fully queued (``tag_emitted=True``);
+    tests exercising the in-progress workflow phase set ``tag_emitted=False``
+    explicitly.
+    """
     base = {
         "dpla_id": dpla_id,
         "ordinal": ordinal,
         "tagged_title": f"File:X - DPLA - {dpla_id}.jpg",
         "community_title": "File:X.jpg",
+        "tag_emitted": True,
         "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
     }
     base.update(overrides)
@@ -161,6 +165,133 @@ def test_sidecar_is_partner_scoped():
     assert [e["dpla_id"] for e in await_target_free_sidecar.read_sidecar("texas")] == [
         "bbb"
     ]
+
+
+def test_add_entry_records_explicit_tag_emitted_false():
+    """New entries can land with ``tag_emitted=False`` — the
+    in-progress phase before the uploader has actually written the
+    Commons tag. Ensure the field round-trips faithfully rather than
+    being clobbered by the ``_normalize_entry`` default.
+    """
+    await_target_free_sidecar.add_entry(
+        "nara",
+        {
+            "dpla_id": "aaa",
+            "ordinal": 1,
+            "tagged_title": "File:T.jpg",
+            "community_title": "File:C.jpg",
+            "expected_sha1": "0" * 40,
+            "tag_emitted": False,
+        },
+    )
+    stored = await_target_free_sidecar.read_sidecar("nara")
+    assert stored[0]["tag_emitted"] is False
+
+
+def test_read_sidecar_defaults_missing_tag_emitted_to_true():
+    """Backwards-compat: entries written before the ``tag_emitted``
+    field existed must be treated as fully queued (True), not as
+    in-progress — the old flow always emitted the tag before writing
+    the entry, so absence of the field is the fully-queued state.
+    """
+    path = await_target_free_sidecar.sidecar_path("nara")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "partner": "nara",
+                "entries": [
+                    {
+                        "dpla_id": "legacy",
+                        "ordinal": 1,
+                        "tagged_title": "File:T.jpg",
+                        "community_title": "File:C.jpg",
+                        "expected_sha1": "0" * 40,
+                    }
+                ],
+            }
+        )
+    )
+    stored = await_target_free_sidecar.read_sidecar("nara")
+    assert stored[0]["tag_emitted"] is True
+
+
+def test_mark_tag_emitted_flips_flag():
+    """After the uploader successfully writes the Commons tag, it
+    calls ``mark_tag_emitted`` — the sidecar entry's phase flag flips
+    to True, and drain-deferred is now free to advance it.
+    """
+    await_target_free_sidecar.add_entry(
+        "nara",
+        {
+            "dpla_id": "aaa",
+            "ordinal": 1,
+            "tagged_title": "File:T.jpg",
+            "community_title": "File:C.jpg",
+            "expected_sha1": "0" * 40,
+            "tag_emitted": False,
+        },
+    )
+    result = await_target_free_sidecar.mark_tag_emitted("nara", "aaa", 1)
+    assert result is True
+    entry = await_target_free_sidecar.get_entry("nara", "aaa", 1)
+    assert entry is not None
+    assert entry["tag_emitted"] is True
+
+
+def test_mark_tag_emitted_missing_entry_returns_false():
+    """A crash-recovery re-run that calls mark_tag_emitted on a
+    (dpla_id, ordinal) with no sidecar entry gets a False back
+    rather than raising — the sidecar being absent is a legitimate
+    state to observe.
+    """
+    result = await_target_free_sidecar.mark_tag_emitted("nara", "ghost", 1)
+    assert result is False
+
+
+def test_mark_tag_emitted_is_idempotent():
+    """Re-flipping an already-True entry is a no-op that still returns
+    True. Lets the uploader's tag-emit retry path call
+    mark_tag_emitted unconditionally on success without special-casing
+    the "was already emitted" branch.
+    """
+    await_target_free_sidecar.add_entry(
+        "nara",
+        {
+            "dpla_id": "aaa",
+            "ordinal": 1,
+            "tagged_title": "File:T.jpg",
+            "community_title": "File:C.jpg",
+            "expected_sha1": "0" * 40,
+            "tag_emitted": True,
+        },
+    )
+    assert await_target_free_sidecar.mark_tag_emitted("nara", "aaa", 1) is True
+    assert await_target_free_sidecar.get_entry("nara", "aaa", 1)["tag_emitted"] is True
+
+
+def test_get_entry_returns_full_entry_or_none():
+    """``get_entry`` returns the entry dict (with all fields including
+    ``tag_emitted``) for a match, or None for a miss — the callers
+    that need to inspect the phase use this instead of ``has_entry``,
+    which conflates in-progress and fully-queued states.
+    """
+    await_target_free_sidecar.add_entry(
+        "nara",
+        {
+            "dpla_id": "aaa",
+            "ordinal": 1,
+            "tagged_title": "File:T.jpg",
+            "community_title": "File:C.jpg",
+            "expected_sha1": "0" * 40,
+            "tag_emitted": False,
+        },
+    )
+    match = await_target_free_sidecar.get_entry("nara", "aaa", 1)
+    assert match is not None
+    assert match["tag_emitted"] is False
+    assert await_target_free_sidecar.get_entry("nara", "aaa", 2) is None
+    assert await_target_free_sidecar.get_entry("nara", "bbb", 1) is None
 
 
 def test_sidecar_path_uses_partner_dir_mapping_for_smithsonian():

--- a/tests/test_await_target_free_sidecar.py
+++ b/tests/test_await_target_free_sidecar.py
@@ -1,34 +1,16 @@
-"""Tests for the await-target-free sidecar
+"""Tests for the await-target-free set
 (:mod:`ingest_wikimedia.await_target_free_sidecar`)."""
 
 from __future__ import annotations
 
 import fcntl
-import json
 import multiprocessing
 import os
+from pathlib import Path
 
 import pytest
 
 from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
-
-
-def _entry(dpla_id: str = "22412cd0", ordinal: int = 1, **overrides) -> dict:
-    """Canonical entry factory. Fill defaults; individual fields overridable
-    via keyword args. Default state is fully queued (``tag_emitted=True``);
-    tests exercising the in-progress workflow phase set ``tag_emitted=False``
-    explicitly.
-    """
-    base = {
-        "dpla_id": dpla_id,
-        "ordinal": ordinal,
-        "tagged_title": f"File:X - DPLA - {dpla_id}.jpg",
-        "community_title": "File:X.jpg",
-        "tag_emitted": True,
-        "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
-    }
-    base.update(overrides)
-    return base
 
 
 @pytest.fixture(autouse=True)
@@ -41,354 +23,118 @@ def override_root(tmp_path, monkeypatch):
 
 
 def test_read_missing_returns_empty_list():
-    assert await_target_free_sidecar.read_sidecar("nara") == []
+    assert await_target_free_sidecar.read_keys("nara") == []
+    assert await_target_free_sidecar.awaiting_dpla_ids("nara") == []
 
 
-def test_write_then_read_roundtrip():
-    entries = [_entry("aaa", 1), _entry("bbb", 1)]
-    await_target_free_sidecar.write_sidecar("nara", entries)
-    assert await_target_free_sidecar.read_sidecar("nara") == entries
+def test_add_then_has_and_read_roundtrip():
+    await_target_free_sidecar.add_key("nara", "aaa", 1)
+    assert await_target_free_sidecar.has_key("nara", "aaa", 1)
+    assert await_target_free_sidecar.read_keys("nara") == ["aaa\t1"]
 
 
-def test_write_empty_removes_file():
-    await_target_free_sidecar.write_sidecar("nara", [_entry("aaa", 1)])
+def test_has_key_matches_on_dpla_id_and_ordinal():
+    await_target_free_sidecar.add_key("nara", "aaa", 1)
+    await_target_free_sidecar.add_key("nara", "bbb", 2)
+    assert await_target_free_sidecar.has_key("nara", "aaa", 1)
+    assert await_target_free_sidecar.has_key("nara", "bbb", 2)
+    # Same DPLA id, wrong ordinal → not a match.
+    assert not await_target_free_sidecar.has_key("nara", "aaa", 2)
+    assert not await_target_free_sidecar.has_key("nara", "ccc", 1)
+
+
+def test_add_key_is_idempotent():
+    await_target_free_sidecar.add_key("nara", "aaa", 1)
+    await_target_free_sidecar.add_key("nara", "aaa", 1)
+    assert await_target_free_sidecar.read_keys("nara") == ["aaa\t1"]
+
+
+def test_remove_key_drops_only_the_matching_ordinal():
+    await_target_free_sidecar.add_key("nara", "aaa", 1)
+    await_target_free_sidecar.add_key("nara", "aaa", 2)
+    await_target_free_sidecar.remove_key("nara", "aaa", 1)
+    assert await_target_free_sidecar.read_keys("nara") == ["aaa\t2"]
+    assert await_target_free_sidecar.has_key("nara", "aaa", 2)
+    assert not await_target_free_sidecar.has_key("nara", "aaa", 1)
+
+
+def test_remove_absent_key_is_noop():
+    await_target_free_sidecar.add_key("nara", "aaa", 1)
+    await_target_free_sidecar.remove_key("nara", "not-there", 9)
+    assert await_target_free_sidecar.read_keys("nara") == ["aaa\t1"]
+
+
+def test_remove_last_key_deletes_the_file():
+    await_target_free_sidecar.add_key("nara", "aaa", 1)
     assert await_target_free_sidecar.sidecar_path("nara").exists()
-    await_target_free_sidecar.write_sidecar("nara", [])
+    await_target_free_sidecar.remove_key("nara", "aaa", 1)
     assert not await_target_free_sidecar.sidecar_path("nara").exists()
-    assert await_target_free_sidecar.read_sidecar("nara") == []
+    assert await_target_free_sidecar.read_keys("nara") == []
 
 
-def test_write_dedupes_by_dpla_id_and_ordinal():
-    entries = [
-        _entry("aaa", 1),
-        _entry("aaa", 2),  # same dpla_id, different ordinal → distinct
-        _entry("aaa", 1),  # dupe → suppressed
-        _entry("bbb", 1),
-    ]
-    await_target_free_sidecar.write_sidecar("nara", entries)
-    stored = await_target_free_sidecar.read_sidecar("nara")
-    assert [(e["dpla_id"], e["ordinal"]) for e in stored] == [
-        ("aaa", 1),
-        ("aaa", 2),
-        ("bbb", 1),
-    ]
+def test_awaiting_dpla_ids_dedupes_ordinals_preserving_order():
+    await_target_free_sidecar.add_key("nara", "aaa", 1)
+    await_target_free_sidecar.add_key("nara", "aaa", 2)  # same item, 2nd ordinal
+    await_target_free_sidecar.add_key("nara", "bbb", 1)
+    # Unique DPLA ids, first-seen order — this is what the drain re-runs.
+    assert await_target_free_sidecar.awaiting_dpla_ids("nara") == ["aaa", "bbb"]
 
 
-def test_read_tolerates_per_entry_malformation_without_quarantine():
-    """PER-ENTRY malformation is handled tolerantly: a single bad
-    element (schema drift, stray non-dict) is skipped while the
-    well-formed entries in the same file still surface, and the file
-    is NOT quarantined — one drifted entry must not strand the rest of
-    the queue. Only WHOLE-FILE damage triggers quarantine (see the
-    tests below)."""
-    path = await_target_free_sidecar.sidecar_path("nara")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(
-            {
-                "partner": "nara",
-                "entries": [
-                    _entry("good", 1),
-                    "not a dict",
-                    {"dpla_id": "missing-titles"},  # required keys absent
-                    {**_entry("bad-ordinal", 1), "ordinal": "one"},
-                    _entry("also-good", 1),
-                ],
-            }
-        )
-    )
-    stored = await_target_free_sidecar.read_sidecar("nara")
-    assert [e["dpla_id"] for e in stored] == ["good", "also-good"]
-    # File left in place — not quarantined.
-    assert path.exists()
-    assert not path.with_name(path.name + ".corrupt").exists()
-
-
-def test_read_quarantines_unparseable_file_instead_of_silent_empty():
-    """A WHOLE-FILE-unparseable existing sidecar is a damaged queue,
-    not an empty one. read_sidecar must quarantine it (move aside,
-    preserving the bytes) and return [] only after — never silently
-    treat the damaged queue as 'nothing pending'."""
+def test_read_tolerates_unparseable_file():
+    """A present-but-unparseable file is treated as empty (like
+    drain_sidecar): the set is reconstructable from Commons, so a
+    mid-write crash mustn't wedge the drain."""
     path = await_target_free_sidecar.sidecar_path("nara")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("{ this is not json")
-    assert await_target_free_sidecar.read_sidecar("nara") == []
-    # Original path cleared; bytes preserved in the quarantine file.
-    assert not path.exists()
-    quarantined = path.with_name(path.name + ".corrupt")
-    assert quarantined.exists()
-    assert quarantined.read_text() == "{ this is not json"
+    assert await_target_free_sidecar.read_keys("nara") == []
 
 
-def test_read_quarantines_wrong_toplevel_shape():
-    """An existing file whose top-level shape isn't
-    ``{'entries': [...]}`` (e.g. a bare list, or a dict missing the
-    key) is also a damaged queue and must be quarantined, not treated
-    as empty."""
-    path = await_target_free_sidecar.sidecar_path("nara")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(["unexpected", "top-level", "list"]))
-    assert await_target_free_sidecar.read_sidecar("nara") == []
-    assert not path.exists()
-    assert path.with_name(path.name + ".corrupt").exists()
+def test_read_ignores_malformed_keys():
+    """Entries without the key separator are skipped, not returned."""
+    import json
 
-
-def test_quarantine_does_not_clobber_a_prior_quarantine():
-    """A second corruption event must not overwrite the first
-    quarantine — the recovery bytes from BOTH events survive under
-    distinct ``.corrupt`` / ``.corrupt.1`` names."""
-    path = await_target_free_sidecar.sidecar_path("nara")
-    path.parent.mkdir(parents=True, exist_ok=True)
-
-    path.write_text("first corruption")
-    await_target_free_sidecar.read_sidecar("nara")
-    path.write_text("second corruption")
-    await_target_free_sidecar.read_sidecar("nara")
-
-    first = path.with_name(path.name + ".corrupt")
-    second = path.with_name(path.name + ".corrupt.1")
-    assert first.read_text() == "first corruption"
-    assert second.read_text() == "second corruption"
-
-
-def test_read_missing_file_is_silent_empty_not_quarantined():
-    """The normal empty state — a missing sidecar — must NOT log a
-    corruption error or create a quarantine file. This is the case the
-    damaged-queue handling must stay distinct from."""
-    path = await_target_free_sidecar.sidecar_path("nara")
-    assert await_target_free_sidecar.read_sidecar("nara") == []
-    assert not path.with_name(path.name + ".corrupt").exists()
-
-
-def test_has_entry_matches_only_on_dpla_id_and_ordinal():
-    await_target_free_sidecar.write_sidecar(
-        "nara", [_entry("aaa", 1), _entry("bbb", 2)]
-    )
-    assert await_target_free_sidecar.has_entry("nara", "aaa", 1)
-    assert await_target_free_sidecar.has_entry("nara", "bbb", 2)
-    # Wrong ordinal on same DPLA ID → not a match.
-    assert not await_target_free_sidecar.has_entry("nara", "aaa", 2)
-    assert not await_target_free_sidecar.has_entry("nara", "ccc", 1)
-
-
-def test_add_entry_dedupes_by_key():
-    await_target_free_sidecar.add_entry("nara", _entry("aaa", 1))
-    # Second add with same (dpla_id, ordinal) is a no-op (returns existing).
-    result = await_target_free_sidecar.add_entry(
-        "nara",
-        _entry("aaa", 1, tagged_title="File:different tag.jpg"),
-    )
-    assert len(result) == 1
-    # The FIRST add's fields win; the second add is discarded.
-    assert result[0]["tagged_title"] == "File:X - DPLA - aaa.jpg"
-
-
-def test_add_entry_rejects_malformed():
-    with pytest.raises(ValueError):
-        await_target_free_sidecar.add_entry("nara", {"dpla_id": "no-titles"})
-
-
-def test_remove_entry_by_key():
-    await_target_free_sidecar.write_sidecar(
-        "nara", [_entry("aaa", 1), _entry("bbb", 1), _entry("ccc", 1)]
-    )
-    remaining = await_target_free_sidecar.remove_entry("nara", "bbb", 1)
-    assert [e["dpla_id"] for e in remaining] == ["aaa", "ccc"]
-
-
-def test_remove_entry_absent_key_is_noop():
-    await_target_free_sidecar.write_sidecar("nara", [_entry("aaa", 1)])
-    remaining = await_target_free_sidecar.remove_entry("nara", "not-there", 1)
-    assert [e["dpla_id"] for e in remaining] == ["aaa"]
-
-
-def test_remove_entry_empty_remainder_deletes_file():
-    await_target_free_sidecar.write_sidecar("nara", [_entry("aaa", 1)])
-    await_target_free_sidecar.remove_entry("nara", "aaa", 1)
-    assert not await_target_free_sidecar.sidecar_path("nara").exists()
-
-
-def test_sidecar_is_partner_scoped():
-    """Two partners' sidecars live in different files and don't
-    cross-contaminate — same guarantee as ``drain_sidecar``."""
-    await_target_free_sidecar.write_sidecar("nara", [_entry("aaa", 1)])
-    await_target_free_sidecar.write_sidecar("texas", [_entry("bbb", 1)])
-    assert [e["dpla_id"] for e in await_target_free_sidecar.read_sidecar("nara")] == [
-        "aaa"
-    ]
-    assert [e["dpla_id"] for e in await_target_free_sidecar.read_sidecar("texas")] == [
-        "bbb"
-    ]
-
-
-def test_add_entry_records_explicit_tag_emitted_false():
-    """New entries can land with ``tag_emitted=False`` — the
-    in-progress phase before the uploader has actually written the
-    Commons tag. Ensure the field round-trips faithfully rather than
-    being clobbered by the ``_normalize_entry`` default.
-    """
-    await_target_free_sidecar.add_entry(
-        "nara",
-        {
-            "dpla_id": "aaa",
-            "ordinal": 1,
-            "tagged_title": "File:T.jpg",
-            "community_title": "File:C.jpg",
-            "expected_sha1": "0" * 40,
-            "tag_emitted": False,
-        },
-    )
-    stored = await_target_free_sidecar.read_sidecar("nara")
-    assert stored[0]["tag_emitted"] is False
-
-
-def test_read_sidecar_defaults_missing_tag_emitted_to_true():
-    """Backwards-compat: entries written before the ``tag_emitted``
-    field existed must be treated as fully queued (True), not as
-    in-progress — the old flow always emitted the tag before writing
-    the entry, so absence of the field is the fully-queued state.
-    """
     path = await_target_free_sidecar.sidecar_path("nara")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        json.dumps(
-            {
-                "partner": "nara",
-                "entries": [
-                    {
-                        "dpla_id": "legacy",
-                        "ordinal": 1,
-                        "tagged_title": "File:T.jpg",
-                        "community_title": "File:C.jpg",
-                        "expected_sha1": "0" * 40,
-                    }
-                ],
-            }
-        )
+        json.dumps({"partner": "nara", "awaiting": ["aaa\t1", "no-sep", 42, "bbb\t3"]})
     )
-    stored = await_target_free_sidecar.read_sidecar("nara")
-    assert stored[0]["tag_emitted"] is True
+    assert await_target_free_sidecar.read_keys("nara") == ["aaa\t1", "bbb\t3"]
 
 
-def test_mark_tag_emitted_flips_flag():
-    """After the uploader successfully writes the Commons tag, it
-    calls ``mark_tag_emitted`` — the sidecar entry's phase flag flips
-    to True, and drain-deferred is now free to advance it.
-    """
-    await_target_free_sidecar.add_entry(
-        "nara",
-        {
-            "dpla_id": "aaa",
-            "ordinal": 1,
-            "tagged_title": "File:T.jpg",
-            "community_title": "File:C.jpg",
-            "expected_sha1": "0" * 40,
-            "tag_emitted": False,
-        },
-    )
-    result = await_target_free_sidecar.mark_tag_emitted("nara", "aaa", 1)
-    assert result is True
-    entry = await_target_free_sidecar.get_entry("nara", "aaa", 1)
-    assert entry is not None
-    assert entry["tag_emitted"] is True
-
-
-def test_mark_tag_emitted_missing_entry_returns_false():
-    """A crash-recovery re-run that calls mark_tag_emitted on a
-    (dpla_id, ordinal) with no sidecar entry gets a False back
-    rather than raising — the sidecar being absent is a legitimate
-    state to observe.
-    """
-    result = await_target_free_sidecar.mark_tag_emitted("nara", "ghost", 1)
-    assert result is False
-
-
-def test_mark_tag_emitted_is_idempotent():
-    """Re-flipping an already-True entry is a no-op that still returns
-    True. Lets the uploader's tag-emit retry path call
-    mark_tag_emitted unconditionally on success without special-casing
-    the "was already emitted" branch.
-    """
-    await_target_free_sidecar.add_entry(
-        "nara",
-        {
-            "dpla_id": "aaa",
-            "ordinal": 1,
-            "tagged_title": "File:T.jpg",
-            "community_title": "File:C.jpg",
-            "expected_sha1": "0" * 40,
-            "tag_emitted": True,
-        },
-    )
-    assert await_target_free_sidecar.mark_tag_emitted("nara", "aaa", 1) is True
-    assert await_target_free_sidecar.get_entry("nara", "aaa", 1)["tag_emitted"] is True
-
-
-def test_get_entry_returns_full_entry_or_none():
-    """``get_entry`` returns the entry dict (with all fields including
-    ``tag_emitted``) for a match, or None for a miss — the callers
-    that need to inspect the phase use this instead of ``has_entry``,
-    which conflates in-progress and fully-queued states.
-    """
-    await_target_free_sidecar.add_entry(
-        "nara",
-        {
-            "dpla_id": "aaa",
-            "ordinal": 1,
-            "tagged_title": "File:T.jpg",
-            "community_title": "File:C.jpg",
-            "expected_sha1": "0" * 40,
-            "tag_emitted": False,
-        },
-    )
-    match = await_target_free_sidecar.get_entry("nara", "aaa", 1)
-    assert match is not None
-    assert match["tag_emitted"] is False
-    assert await_target_free_sidecar.get_entry("nara", "aaa", 2) is None
-    assert await_target_free_sidecar.get_entry("nara", "bbb", 1) is None
+def test_set_is_partner_scoped():
+    await_target_free_sidecar.add_key("nara", "aaa", 1)
+    await_target_free_sidecar.add_key("texas", "bbb", 1)
+    assert await_target_free_sidecar.awaiting_dpla_ids("nara") == ["aaa"]
+    assert await_target_free_sidecar.awaiting_dpla_ids("texas") == ["bbb"]
 
 
 def test_sidecar_path_uses_partner_dir_mapping_for_smithsonian():
     """The ``si`` → ``smithsonian`` mapping in
     :data:`ingest_wikimedia.partners.PARTNER_DIR` is honoured, since
-    ``sidecar_path`` reuses ``drain_sidecar.partner_dir_path``. Same
-    guarantee as ``drain_sidecar.sidecar_path``."""
+    ``sidecar_path`` reuses ``drain_sidecar.partner_dir_path``."""
     assert await_target_free_sidecar.sidecar_path("si").parent.name == "smithsonian"
 
 
-def _child_add_entry(root: str, dpla_id: str, ordinal: int) -> None:
-    """Spawn-safe helper: re-anchor the sidecar root in the child, then
-    add one entry. Runs in a fresh Python interpreter under
-    ``multiprocessing.get_context('spawn')`` so state isn't inherited
-    from the test process."""
-    from pathlib import Path
-
+def _child_add_key(root: str, dpla_id: str, ordinal: int) -> None:
+    """Spawn-safe helper: re-anchor the root in the child, then add one
+    key. Runs in a fresh interpreter under
+    ``multiprocessing.get_context('spawn')`` so no state is inherited."""
     from ingest_wikimedia import await_target_free_sidecar as sidecar
     from ingest_wikimedia import drain_sidecar as ds
 
     ds.INGEST_WIKI_ROOT = Path(root)
-    sidecar.add_entry(
-        "nara",
-        {
-            "dpla_id": dpla_id,
-            "ordinal": ordinal,
-            "tagged_title": f"File:X - DPLA - {dpla_id}.jpg",
-            "community_title": "File:X.jpg",
-            "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
-        },
-    )
+    sidecar.add_key("nara", dpla_id, ordinal)
 
 
-def test_add_entry_serializes_concurrent_writers_across_processes(tmp_path):
-    """The uploader's ``multiprocessing.Pool`` fans work out to workers
-    that each call ``add_entry`` concurrently. Without a cross-process
-    lock, the read → dedupe → write sequence races and one worker's
-    write silently overwrites another's. Two spawned children each
-    add a distinct entry — both must survive.
-    """
+def test_add_key_serializes_concurrent_writers_across_processes(tmp_path):
+    """The uploader's multiprocessing.Pool fans work out to workers that
+    each call add_key concurrently. Without the cross-process flock, the
+    read-modify-write races and a worker's key is lost. Eight spawned
+    children each add a distinct key — all must survive."""
     ctx = multiprocessing.get_context("spawn")
     workers = [
-        ctx.Process(target=_child_add_entry, args=(str(tmp_path), f"id-{i:02d}", 1))
+        ctx.Process(target=_child_add_key, args=(str(tmp_path), f"id-{i:02d}", 1))
         for i in range(8)
     ]
     for w in workers:
@@ -396,30 +142,21 @@ def test_add_entry_serializes_concurrent_writers_across_processes(tmp_path):
     for w in workers:
         w.join(timeout=30)
         assert w.exitcode == 0, f"child worker failed (exit {w.exitcode})"
-
-    # All 8 distinct entries must be present — none silently lost.
-    # (Autouse fixture already anchors the parent test at tmp_path.)
-    stored = await_target_free_sidecar.read_sidecar("nara")
-    ids = sorted(e["dpla_id"] for e in stored)
+    ids = sorted(await_target_free_sidecar.awaiting_dpla_ids("nara"))
     assert ids == [f"id-{i:02d}" for i in range(8)], (
         f"expected all 8 concurrent adds to survive; got {ids!r}"
     )
 
 
-def test_add_entry_blocks_while_lock_is_held_and_proceeds_when_freed(
+def test_add_key_blocks_while_lock_is_held_and_proceeds_when_freed(
     tmp_path, monkeypatch
 ):
-    """Direct check on the ``_locked_for_write`` gate: while a foreign
-    fd holds the companion lockfile's ``fcntl.LOCK_EX``, ``add_entry``
-    must block; once the foreign holder releases, it proceeds. Uses
-    a thread + a manually-held fd, exploiting POSIX ``flock`` semantics
-    where two open file descriptions to the same file block each other
-    even inside one process.
-    """
+    """Direct check on the _locked_for_write gate: while a foreign fd
+    holds the companion lockfile's flock, add_key blocks; once released,
+    it proceeds."""
     import threading
 
     monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path)
-    # Materialise the partner dir so the lockfile can be created.
     sidecar_json = await_target_free_sidecar.sidecar_path("nara")
     sidecar_json.parent.mkdir(parents=True, exist_ok=True)
     lock_path = sidecar_json.with_suffix(sidecar_json.suffix + ".lock")
@@ -429,25 +166,18 @@ def test_add_entry_blocks_while_lock_is_held_and_proceeds_when_freed(
     proceeded = threading.Event()
 
     def worker():
-        await_target_free_sidecar.add_entry("nara", _entry("aaa", 1))
+        await_target_free_sidecar.add_key("nara", "aaa", 1)
         proceeded.set()
 
     t = threading.Thread(target=worker)
     t.start()
     try:
-        # While the foreign fd holds the lock, add_entry must NOT proceed.
         assert not proceeded.wait(timeout=0.5), (
-            "add_entry entered its critical section despite the lockfile "
-            "being held by a foreign fd"
+            "add_key entered its critical section despite the lockfile being held"
         )
     finally:
-        # Release; the worker should now complete.
         fcntl.flock(fd, fcntl.LOCK_UN)
         os.close(fd)
-    assert proceeded.wait(timeout=3), (
-        "add_entry did not proceed after the lockfile was released"
-    )
+    assert proceeded.wait(timeout=3), "add_key did not proceed after lock release"
     t.join(timeout=1)
-    # And the entry actually landed.
-    stored = await_target_free_sidecar.read_sidecar("nara")
-    assert [e["dpla_id"] for e in stored] == ["aaa"]
+    assert await_target_free_sidecar.read_keys("nara") == ["aaa\t1"]

--- a/tests/test_await_target_free_sidecar.py
+++ b/tests/test_await_target_free_sidecar.py
@@ -266,11 +266,3 @@ def test_add_entry_blocks_while_lock_is_held_and_proceeds_when_freed(
     # And the entry actually landed.
     stored = await_target_free_sidecar.read_sidecar("nara")
     assert [e["dpla_id"] for e in stored] == ["aaa"]
-
-
-# Some CI runners may lack a `spawn` context that can find the test
-# module — mark the spawn-based test to skip if we can't import from a
-# fresh interpreter. In-process tests still exercise the lock via the
-# threading test above.
-if not hasattr(multiprocessing, "get_context"):  # pragma: no cover
-    pytestmark = pytest.mark.skip(reason="multiprocessing.get_context unavailable")

--- a/tests/test_await_target_free_sidecar.py
+++ b/tests/test_await_target_free_sidecar.py
@@ -1,0 +1,168 @@
+"""Tests for the await-target-free sidecar
+(:mod:`ingest_wikimedia.await_target_free_sidecar`)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
+
+
+def _entry(dpla_id: str = "22412cd0", ordinal: int = 1, **overrides) -> dict:
+    """Canonical entry factory. Fill defaults; individual fields overridable
+    via keyword args."""
+    base = {
+        "dpla_id": dpla_id,
+        "ordinal": ordinal,
+        "tagged_title": f"File:X - DPLA - {dpla_id}.jpg",
+        "community_title": "File:X.jpg",
+        "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture(autouse=True)
+def override_root(tmp_path, monkeypatch):
+    """Isolate each test at a tmp root — same pattern as
+    ``test_drain_sidecar``. Both modules resolve paths via
+    :data:`drain_sidecar.INGEST_WIKI_ROOT`, so patching there is enough."""
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path)
+    return tmp_path
+
+
+def test_read_missing_returns_empty_list():
+    assert await_target_free_sidecar.read_sidecar("nara") == []
+
+
+def test_write_then_read_roundtrip():
+    entries = [_entry("aaa", 1), _entry("bbb", 1)]
+    await_target_free_sidecar.write_sidecar("nara", entries)
+    assert await_target_free_sidecar.read_sidecar("nara") == entries
+
+
+def test_write_empty_removes_file():
+    await_target_free_sidecar.write_sidecar("nara", [_entry("aaa", 1)])
+    assert await_target_free_sidecar.sidecar_path("nara").exists()
+    await_target_free_sidecar.write_sidecar("nara", [])
+    assert not await_target_free_sidecar.sidecar_path("nara").exists()
+    assert await_target_free_sidecar.read_sidecar("nara") == []
+
+
+def test_write_dedupes_by_dpla_id_and_ordinal():
+    entries = [
+        _entry("aaa", 1),
+        _entry("aaa", 2),  # same dpla_id, different ordinal → distinct
+        _entry("aaa", 1),  # dupe → suppressed
+        _entry("bbb", 1),
+    ]
+    await_target_free_sidecar.write_sidecar("nara", entries)
+    stored = await_target_free_sidecar.read_sidecar("nara")
+    assert [(e["dpla_id"], e["ordinal"]) for e in stored] == [
+        ("aaa", 1),
+        ("aaa", 2),
+        ("bbb", 1),
+    ]
+
+
+def test_read_tolerates_malformed_entries():
+    """Corrupt sidecar (missing keys, wrong types) is treated as empty
+    for the malformed entries; well-formed entries in the same file
+    still surface. Keeps the drain loop resilient rather than crashing
+    on a mid-write truncation."""
+    path = await_target_free_sidecar.sidecar_path("nara")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "partner": "nara",
+                "entries": [
+                    _entry("good", 1),
+                    "not a dict",
+                    {"dpla_id": "missing-titles"},  # required keys absent
+                    {**_entry("bad-ordinal", 1), "ordinal": "one"},
+                    _entry("also-good", 1),
+                ],
+            }
+        )
+    )
+    stored = await_target_free_sidecar.read_sidecar("nara")
+    assert [e["dpla_id"] for e in stored] == ["good", "also-good"]
+
+
+def test_read_tolerates_unparseable_file():
+    path = await_target_free_sidecar.sidecar_path("nara")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{ this is not json")
+    assert await_target_free_sidecar.read_sidecar("nara") == []
+
+
+def test_has_entry_matches_only_on_dpla_id_and_ordinal():
+    await_target_free_sidecar.write_sidecar(
+        "nara", [_entry("aaa", 1), _entry("bbb", 2)]
+    )
+    assert await_target_free_sidecar.has_entry("nara", "aaa", 1)
+    assert await_target_free_sidecar.has_entry("nara", "bbb", 2)
+    # Wrong ordinal on same DPLA ID → not a match.
+    assert not await_target_free_sidecar.has_entry("nara", "aaa", 2)
+    assert not await_target_free_sidecar.has_entry("nara", "ccc", 1)
+
+
+def test_add_entry_dedupes_by_key():
+    await_target_free_sidecar.add_entry("nara", _entry("aaa", 1))
+    # Second add with same (dpla_id, ordinal) is a no-op (returns existing).
+    result = await_target_free_sidecar.add_entry(
+        "nara",
+        _entry("aaa", 1, tagged_title="File:different tag.jpg"),
+    )
+    assert len(result) == 1
+    # The FIRST add's fields win; the second add is discarded.
+    assert result[0]["tagged_title"] == "File:X - DPLA - aaa.jpg"
+
+
+def test_add_entry_rejects_malformed():
+    with pytest.raises(ValueError):
+        await_target_free_sidecar.add_entry("nara", {"dpla_id": "no-titles"})
+
+
+def test_remove_entry_by_key():
+    await_target_free_sidecar.write_sidecar(
+        "nara", [_entry("aaa", 1), _entry("bbb", 1), _entry("ccc", 1)]
+    )
+    remaining = await_target_free_sidecar.remove_entry("nara", "bbb", 1)
+    assert [e["dpla_id"] for e in remaining] == ["aaa", "ccc"]
+
+
+def test_remove_entry_absent_key_is_noop():
+    await_target_free_sidecar.write_sidecar("nara", [_entry("aaa", 1)])
+    remaining = await_target_free_sidecar.remove_entry("nara", "not-there", 1)
+    assert [e["dpla_id"] for e in remaining] == ["aaa"]
+
+
+def test_remove_entry_empty_remainder_deletes_file():
+    await_target_free_sidecar.write_sidecar("nara", [_entry("aaa", 1)])
+    await_target_free_sidecar.remove_entry("nara", "aaa", 1)
+    assert not await_target_free_sidecar.sidecar_path("nara").exists()
+
+
+def test_sidecar_is_partner_scoped():
+    """Two partners' sidecars live in different files and don't
+    cross-contaminate — same guarantee as ``drain_sidecar``."""
+    await_target_free_sidecar.write_sidecar("nara", [_entry("aaa", 1)])
+    await_target_free_sidecar.write_sidecar("texas", [_entry("bbb", 1)])
+    assert [e["dpla_id"] for e in await_target_free_sidecar.read_sidecar("nara")] == [
+        "aaa"
+    ]
+    assert [e["dpla_id"] for e in await_target_free_sidecar.read_sidecar("texas")] == [
+        "bbb"
+    ]
+
+
+def test_sidecar_path_uses_partner_dir_mapping_for_smithsonian():
+    """The ``si`` → ``smithsonian`` mapping in
+    :data:`ingest_wikimedia.partners.PARTNER_DIR` is honoured, since
+    ``sidecar_path`` reuses ``drain_sidecar.partner_dir_path``. Same
+    guarantee as ``drain_sidecar.sidecar_path``."""
+    assert await_target_free_sidecar.sidecar_path("si").parent.name == "smithsonian"

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -10,8 +10,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-import pywikibot
-
 from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
 from tools import drain_deferred
 
@@ -376,7 +374,6 @@ def test_acquire_host_lock_nonblocking_skips_when_held():
     drain already holds it, ``_acquire_host_lock(blocking=False)`` returns None
     (so the pass skips) instead of blocking behind a patient drain that can
     hold the lock for hours. Regression for the drain-lock-blocking bug."""
-    import fcntl
 
     # Hold the lock via an independent fd (separate open file description, so
     # flock genuinely conflicts even within this process).
@@ -393,483 +390,186 @@ def test_acquire_host_lock_nonblocking_skips_when_held():
     os.close(fd)
 
 
-def test_no_wait_skips_when_host_lock_held():
-    """When another drain holds the host lock, the opportunistic pass must skip
-    immediately — no throttle, no subprocesses — leaving the sidecar for the
-    terminal drain. Regression: the blocking acquire kept finished sessions
-    open for hours behind a patient drain."""
+def test_no_wait_skips_category_when_host_lock_held_but_still_attempts_await():
+    """Opportunistic pass, host lock held by a peer: the category round
+    is skipped (the holder covers it) but the await round is still
+    attempted — await work is not gated behind category work / the host
+    lock. (The await round then also skips if it can't get the lock; the
+    point is that main() TRIES it.)"""
     drain_sidecar.write_sidecar("nara", ["id-1"])
     with (
-        patch(
-            "tools.drain_deferred._acquire_host_lock", return_value=None
-        ) as lock_mock,
+        patch("tools.drain_deferred._acquire_host_lock", return_value=None),
         patch("tools.drain_deferred._drain_opportunistic_once") as opp,
-        patch("tools.drain_deferred.DuplicateCategoryThrottle") as throttle_ctor,
+        patch("tools.drain_deferred._run_await_round") as await_round,
+        patch("tools.drain_deferred.DuplicateCategoryThrottle"),
         patch("tools.drain_deferred.subprocess.run") as sp,
     ):
         result = CliRunner().invoke(drain_deferred.main, ["--no-wait", "nara"])
     assert result.exit_code == 0, result.output
-    lock_mock.assert_called_once_with(blocking=False)
-    opp.assert_not_called()
-    throttle_ctor.assert_not_called()
+    opp.assert_not_called()  # category round skipped (lock held)
+    await_round.assert_called_once_with("nara", blocking=False)  # still attempted
     sp.assert_not_called()
     assert drain_sidecar.read_sidecar("nara") == ["id-1"]
 
 
-# ---------------------------------------------------------------------------
-# await-target-free stage-2 handler
-# ---------------------------------------------------------------------------
+def test_no_wait_runs_one_await_round(lock_fd):
+    """Opportunistic pass with await work and a free lock: exactly one
+    await round runs (re-invoke uploader + sdc-sync on the awaiting IDs),
+    no patient loop."""
+    await_target_free_sidecar.add_key("nara", "id-1", 1)
 
-
-def _await_entry(**overrides) -> dict:
-    """Sidecar entry factory for stage-2 tests. Default is the fully
-    queued state (``tag_emitted=True``) — the phase drain is designed
-    to advance from; tests exercising the in-progress phase override
-    to False.
-    """
-    base = {
-        "dpla_id": "22412cd0",
-        "ordinal": 1,
-        "tagged_title": "Angus - DPLA - 22412cd0.jpg",
-        "community_title": "Angus.jpg",
-        "tag_emitted": True,
-        "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
-    }
-    base.update(overrides)
-    return base
-
-
-def _tagged_page(*, exists=True, is_redirect=False, text="") -> MagicMock:
-    """MagicMock ``pywikibot.FilePage`` for the drift-target (our tagged
-    DPLA-canonical file). Callers customise via kwargs."""
-    p = MagicMock()
-    p.exists.return_value = exists
-    p.isRedirectPage.return_value = is_redirect
-    type(p).text = property(lambda self: text)
-    p.title.return_value = "File:Angus - DPLA - 22412cd0.jpg"
-    return p
-
-
-def _community_page(
-    *,
-    exists=True,
-    is_redirect=False,
-    sha1="9719e05ab718aac6d400b239792ceeb45a766954",
-) -> MagicMock:
-    """MagicMock for the community file — pre-loaded with a valid sha1."""
-    p = MagicMock()
-    p.exists.return_value = exists
-    p.isRedirectPage.return_value = is_redirect
-    p.latest_file_info.sha1 = sha1
-    p.title.return_value = "File:Angus.jpg"
-    return p
-
-
-def test_advance_pending_when_tag_still_present():
-    """State machine: tagged file exists, {{Duplicate}} template still
-    on the page → keep entry queued for the next drain round."""
-    site = MagicMock()
-    tagged = _tagged_page(
-        exists=True,
-        is_redirect=False,
-        text="{{Duplicate|Angus.jpg}}\n== filedesc ==\n",
-    )
-    with patch("tools.drain_deferred.get_page", return_value=tagged):
-        should_remove, note = drain_deferred._advance_await_target_free_entry(
-            _await_entry(), site
-        )
-    assert should_remove is False
-    assert note is not None and note.startswith("PENDING:")
-
-
-def test_advance_fail_when_tag_removed_but_page_exists():
-    """An editor decline: tag stripped but page kept. Drop entry and
-    log FAIL — the community-file rename can't proceed against a page
-    the community affirmatively kept."""
-    site = MagicMock()
-    tagged = _tagged_page(
-        exists=True,
-        is_redirect=False,
-        text="== filedesc ==\n{{DPLA metadata}}\n",  # no {{Duplicate}}
-    )
-    with patch("tools.drain_deferred.get_page", return_value=tagged):
-        should_remove, note = drain_deferred._advance_await_target_free_entry(
-            _await_entry(), site
-        )
-    assert should_remove is True
-    assert note is not None and note.startswith("FAIL:")
-    assert "Duplicate" in note
-
-
-def test_advance_executes_move_when_tagged_file_deleted():
-    """Deletion (page no longer exists on Commons) → execute move of
-    community file into the freed canonical title, post the
-    CommonsDelinker relink."""
-    site = MagicMock()
-    tagged = _tagged_page(exists=False, is_redirect=False)
-    community = _community_page(exists=True)
-    with (
-        patch(
-            "tools.drain_deferred.get_page",
-            side_effect=lambda _site, title: (
-                tagged if "22412cd0" in title else community
-            ),
-        ),
-        patch("tools.drain_deferred.file_has_inbound_usage", return_value=True),
-        patch("tools.drain_deferred.post_commonsdelinker_request") as delinker,
-        patch(
-            "tools.drain_deferred.with_csrf_recovery",
-            side_effect=lambda _s, _l, fn: fn(),
-        ),
-        patch(
-            "tools.drain_deferred.build_title_drift_move_reason",
-            return_value="reason",
-        ),
-    ):
-        should_remove, note = drain_deferred._advance_await_target_free_entry(
-            _await_entry(), site
-        )
-    assert should_remove is True
-    assert note is None
-    community.move.assert_called_once()
-    delinker.assert_called_once()
-
-
-def test_advance_executes_move_when_tagged_file_became_redirect():
-    """Redirect (admin merged rather than deleting) is a first-class
-    advance signal — move-onto-a-redirect is a normal pywikibot
-    operation, same as move-into-empty-slot. Per the design, this is
-    NOT an edge case; admins commonly redirect."""
-    site = MagicMock()
-    tagged = _tagged_page(exists=True, is_redirect=True)
-    community = _community_page(exists=True)
-    with (
-        patch(
-            "tools.drain_deferred.get_page",
-            side_effect=lambda _site, title: (
-                tagged if "22412cd0" in title else community
-            ),
-        ),
-        patch("tools.drain_deferred.file_has_inbound_usage", return_value=False),
-        patch("tools.drain_deferred.post_commonsdelinker_request"),
-        patch(
-            "tools.drain_deferred.with_csrf_recovery",
-            side_effect=lambda _s, _l, fn: fn(),
-        ),
-        patch(
-            "tools.drain_deferred.build_title_drift_move_reason",
-            return_value="reason",
-        ),
-    ):
-        should_remove, note = drain_deferred._advance_await_target_free_entry(
-            _await_entry(), site
-        )
-    assert should_remove is True
-    assert note is None
-    community.move.assert_called_once()
-
-
-def test_advance_fail_when_community_file_missing():
-    """Third-party action removed the community file during the wait
-    window — nothing to move. Drop entry with FAIL."""
-    site = MagicMock()
-    tagged = _tagged_page(exists=False)
-    community = _community_page(exists=False)
-    with patch(
-        "tools.drain_deferred.get_page",
-        side_effect=lambda _site, title: tagged if "22412cd0" in title else community,
-    ):
-        should_remove, note = drain_deferred._advance_await_target_free_entry(
-            _await_entry(), site
-        )
-    assert should_remove is True
-    assert note is not None and note.startswith("FAIL:")
-    assert "community file" in note
-
-
-def test_advance_fail_when_move_blocked_by_article_exists_conflict():
-    """A stale redirect or page history at the tagged title makes the
-    move raise ``ArticleExistsConflictError``. The invariant is already
-    satisfied via the tagged title's current state, and retrying every
-    poll would spam the API. Drop the entry with a decisive FAIL."""
-    site = MagicMock()
-    tagged = _tagged_page(exists=True, is_redirect=True)
-    community = _community_page(exists=True)
-
-    def raise_conflict(_title, **_kwargs):
-        raise pywikibot.exceptions.ArticleExistsConflictError("blocked")
-
-    community.move.side_effect = raise_conflict
-    with (
-        patch(
-            "tools.drain_deferred.get_page",
-            side_effect=lambda _site, title: (
-                tagged if "22412cd0" in title else community
-            ),
-        ),
-        patch("tools.drain_deferred.file_has_inbound_usage", return_value=False),
-        patch("tools.drain_deferred.post_commonsdelinker_request") as relink,
-        patch(
-            "tools.drain_deferred.with_csrf_recovery",
-            side_effect=lambda _s, _l, fn: fn(),
-        ),
-        patch(
-            "tools.drain_deferred.build_title_drift_move_reason",
-            return_value="reason",
-        ),
-    ):
-        should_remove, note = drain_deferred._advance_await_target_free_entry(
-            _await_entry(), site
-        )
-    assert should_remove is True
-    assert note is not None and note.startswith("FAIL:")
-    assert "ArticleExistsConflictError" in note
-    relink.assert_not_called()
-
-
-def test_advance_pending_when_tag_emitted_is_false():
-    """Workflow phase gate: an entry recorded by the uploader but whose
-    tag_as_duplicate call never completed carries ``tag_emitted=False``.
-    Drain MUST NOT treat the missing tag as an editor-decline and drop
-    the entry — that would strand community history. Return PENDING so
-    the next uploader run retries the tag and flips the phase.
-    """
-    site = MagicMock()
-    # No page fetches should happen when we short-circuit on the phase gate.
-    with patch("tools.drain_deferred.get_page") as get_page:
-        should_remove, note = drain_deferred._advance_await_target_free_entry(
-            _await_entry(tag_emitted=False), site
-        )
-    assert should_remove is False
-    assert note is not None and note.startswith("PENDING:")
-    assert "tag_emitted=False" in note
-    # No Commons state was consulted; the gate lives above every fetch.
-    get_page.assert_not_called()
-
-
-def test_advance_fail_when_community_page_is_redirect():
-    """An admin (or an editor) redirected the community file during the
-    wait window — most likely, redirected it to our tagged canonical.
-    The invariant is satisfied either way (our canonical holds the S3
-    SHA1); there is no move to perform. Drop the entry as a decisive
-    FAIL rather than trying to move a redirect page around.
-    """
-    site = MagicMock()
-    tagged = _tagged_page(exists=False)
-    community = _community_page(exists=True, is_redirect=True)
-    with patch(
-        "tools.drain_deferred.get_page",
-        side_effect=lambda _site, title: tagged if "22412cd0" in title else community,
-    ):
-        should_remove, note = drain_deferred._advance_await_target_free_entry(
-            _await_entry(), site
-        )
-    assert should_remove is True
-    assert note is not None and note.startswith("FAIL:")
-    assert "redirected" in note
-    # The move must not have been attempted.
-    community.move.assert_not_called()
-
-
-def test_advance_fail_when_community_sha1_drifted():
-    """Content drift on the community side during the wait window —
-    the file no longer holds the S3 SHA1 we saw at tag time. Refuse
-    to move stale bytes into the canonical title."""
-    site = MagicMock()
-    tagged = _tagged_page(exists=False)
-    community = _community_page(
-        exists=True, sha1="ffffffffffffffffffffffffffffffffffffffff"
-    )
-    with patch(
-        "tools.drain_deferred.get_page",
-        side_effect=lambda _site, title: tagged if "22412cd0" in title else community,
-    ):
-        should_remove, note = drain_deferred._advance_await_target_free_entry(
-            _await_entry(), site
-        )
-    assert should_remove is True
-    assert note is not None and note.startswith("FAIL:")
-    assert "SHA1 drifted" in note
-
-
-def test_process_await_target_free_advances_and_removes(override_root):
-    """End-to-end: an entry that advances is removed from the sidecar."""
-    await_target_free_sidecar.write_sidecar("nara", [_await_entry()])
-    with patch(
-        "tools.drain_deferred._advance_await_target_free_entry",
-        return_value=(True, None),
-    ):
-        drain_deferred._process_await_target_free("nara", MagicMock())
-    assert await_target_free_sidecar.read_sidecar("nara") == []
-
-
-def test_process_await_target_free_keeps_pending_entries(override_root):
-    """Entry that returns PENDING stays queued for the next drain round."""
-    await_target_free_sidecar.write_sidecar("nara", [_await_entry()])
-    with patch(
-        "tools.drain_deferred._advance_await_target_free_entry",
-        return_value=(False, "PENDING: tagged file still present"),
-    ):
-        drain_deferred._process_await_target_free("nara", MagicMock())
-    assert len(await_target_free_sidecar.read_sidecar("nara")) == 1
-
-
-def test_patient_mode_loops_stage2_until_sidecar_empty(lock_fd, monkeypatch):
-    """Patient mode must poll stage-2 (await-target-free) until its
-    sidecar is empty, sleeping between rounds — mirroring the
-    category-capacity loop's semantics. Two entries here; round 1
-    advances one and leaves one queued, round 2 advances the last.
-    """
-    # Seed only the await sidecar; the category-capacity sidecar is empty
-    # so the outer drain loop skips (but patient-mode still runs stage 2).
-    await_target_free_sidecar.write_sidecar(
-        "nara", [_await_entry(dpla_id="aaa"), _await_entry(dpla_id="bbb")]
-    )
-
-    throttle = MagicMock()
-    throttle.wait_for_capacity.return_value = True
-    throttle.resume_below = 900
-    throttle.poll_secs = 0  # keep the test fast — no real waiting
-    throttle.category_size.return_value = 0
-
-    advance_calls = []
-
-    def fake_advance(entry, _site):
-        advance_calls.append(entry["dpla_id"])
-        # Round 1: only "aaa" advances; "bbb" stays PENDING.
-        # Round 2: "bbb" advances too.
-        if entry["dpla_id"] == "bbb" and advance_calls.count("bbb") == 1:
-            return (False, "PENDING: waiting")
-        return (True, None)
+    def clear_on_rerun(partner, ids):
+        for dpla_id in ids:
+            await_target_free_sidecar.remove_key(partner, dpla_id, 1)
 
     with (
         patch("tools.drain_deferred._acquire_host_lock", return_value=lock_fd),
         patch(
-            "tools.drain_deferred.DuplicateCategoryThrottle",
-            return_value=throttle,
-        ),
-        patch("tools.drain_deferred.notify_drain_phase_start"),
-        patch("tools.drain_deferred.notify_drain_phase_complete"),
-        patch(
-            "tools.drain_deferred._advance_await_target_free_entry",
-            side_effect=fake_advance,
-        ),
-        # Prevent time.sleep from stalling the test (poll_secs=0 already,
-        # but be defensive if anything else calls sleep).
-        monkeypatch.context() as m,
+            "tools.drain_deferred._run_deferred_items", side_effect=clear_on_rerun
+        ) as run,
+        patch("tools.drain_deferred.DuplicateCategoryThrottle"),
     ):
-        m.setattr("tools.drain_deferred.time.sleep", lambda *_a, **_k: None)
-        result = CliRunner().invoke(drain_deferred.main, ["nara"])
+        result = CliRunner().invoke(drain_deferred.main, ["--no-wait", "nara"])
     assert result.exit_code == 0, result.output
-    # Sidecar drained.
-    assert await_target_free_sidecar.read_sidecar("nara") == []
-    # bbb was polled twice (once per round); aaa only once.
-    assert advance_calls.count("bbb") == 2
-    assert advance_calls.count("aaa") == 1
+    run.assert_called_once()
+    assert run.call_args.args[1] == ["id-1"]
+    assert await_target_free_sidecar.awaiting_dpla_ids("nara") == []
 
 
-def test_patient_mode_stops_when_only_unemitted_entries_remain(lock_fd, monkeypatch):
-    """A ``tag_emitted=False`` entry can only be finished by a future
-    uploader run (stage-2 does not emit tags). Patient mode must NOT
-    spin forever waiting on admin action that can't apply — if every
-    still-pending entry is unemitted, it breaks and leaves them queued.
-    """
-    # One entry, stuck tag_emitted=False. Real _advance would return
-    # PENDING for it (no admin advance possible), so use the real path.
-    await_target_free_sidecar.write_sidecar(
-        "nara", [_await_entry(dpla_id="stuck", tag_emitted=False)]
-    )
+def test_await_round_skips_when_host_lock_held(override_root):
+    """_run_await_round returns False without running the uploader when
+    the (non-blocking) host lock is held by another drain."""
+    await_target_free_sidecar.add_key("nara", "id-1", 1)
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", return_value=None),
+        patch("tools.drain_deferred._run_deferred_items") as run,
+    ):
+        ran = drain_deferred._run_await_round("nara", blocking=False)
+    assert ran is False
+    run.assert_not_called()
+    # Set untouched, left for the terminal drain.
+    assert await_target_free_sidecar.awaiting_dpla_ids("nara") == ["id-1"]
+
+
+def test_await_round_reruns_uploader_on_unique_dpla_ids(override_root, lock_fd):
+    """_run_await_round dedupes per-ordinal keys to unique DPLA IDs (the
+    uploader's unit of work is the item) and re-runs the uploader on
+    them under the host lock."""
+    await_target_free_sidecar.add_key("nara", "id-1", 1)
+    await_target_free_sidecar.add_key("nara", "id-1", 2)  # same item, 2nd ordinal
+    await_target_free_sidecar.add_key("nara", "id-2", 1)
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", return_value=lock_fd),
+        patch("tools.drain_deferred._run_deferred_items") as run,
+    ):
+        ran = drain_deferred._run_await_round("nara", blocking=True)
+    assert ran is True
+    run.assert_called_once()
+    assert run.call_args.args[1] == ["id-1", "id-2"]
+
+
+def test_patient_drains_await_when_uploader_rerun_clears_keys(lock_fd, monkeypatch):
+    """Patient mode, await-only: re-running the uploader resolves the
+    awaiting items (the uploader clears the keys — e.g. an admin freed
+    the canonical and the empty-canonical Case-3 move promoted the
+    community file). The loop terminates once the set empties."""
+    await_target_free_sidecar.add_key("nara", "id-1", 1)
+    await_target_free_sidecar.add_key("nara", "id-2", 1)
+
+    def clear_on_rerun(partner, ids):
+        # Simulate the uploader resolving every awaiting item this round.
+        for dpla_id in ids:
+            await_target_free_sidecar.remove_key(partner, dpla_id, 1)
 
     throttle = MagicMock()
-    throttle.wait_for_capacity.return_value = True
-    throttle.resume_below = 900
     throttle.poll_secs = 0
-    throttle.category_size.return_value = 0
-
-    sleep_calls = {"n": 0}
 
     with (
         patch("tools.drain_deferred._acquire_host_lock", return_value=lock_fd),
+        patch(
+            "tools.drain_deferred._run_deferred_items", side_effect=clear_on_rerun
+        ) as run,
         patch("tools.drain_deferred.DuplicateCategoryThrottle", return_value=throttle),
-        patch("tools.drain_deferred.notify_drain_phase_start"),
-        patch("tools.drain_deferred.notify_drain_phase_complete"),
-        patch("tools.drain_deferred.get_page") as get_page,
-        monkeypatch.context() as m,
+        patch("tools.drain_deferred.notify_drain_phase_start") as start_ping,
+        patch("tools.drain_deferred.notify_drain_phase_complete") as done_ping,
     ):
-        # If the loop ever sleeps, it's spinning — fail loudly instead
-        # of hanging the suite.
-        def _tracked_sleep(*_a, **_k):
-            sleep_calls["n"] += 1
-            if sleep_calls["n"] > 3:
-                raise AssertionError("patient loop is spinning on an unemitted entry")
-
-        m.setattr("tools.drain_deferred.time.sleep", _tracked_sleep)
         result = CliRunner().invoke(drain_deferred.main, ["nara"])
     assert result.exit_code == 0, result.output
-    # Phase gate short-circuits before any Commons fetch.
-    get_page.assert_not_called()
-    # Entry left queued for the next uploader run; loop did not spin.
-    remaining = await_target_free_sidecar.read_sidecar("nara")
-    assert [e["dpla_id"] for e in remaining] == ["stuck"]
-    assert sleep_calls["n"] == 0
+    run.assert_called_once()  # one round cleared both items
+    assert await_target_free_sidecar.awaiting_dpla_ids("nara") == []
+    # Await-only drain (no category work): start/complete pings are for
+    # category work, so neither fires here.
+    start_ping.assert_not_called()
+    done_ping.assert_not_called()
 
 
-def test_run_stage2_once_skips_when_partner_lock_held(override_root):
-    """The partner-scoped stage-2 lock serializes same-partner stage-2
-    rounds. When a foreign holder has it, ``_run_stage2_once`` must
-    non-blocking-skip rather than blocking — the peer round covers our
-    work and we shouldn't wait on it.
-    """
-    await_target_free_sidecar.write_sidecar("nara", [_await_entry()])
-    partner_dir = drain_sidecar.partner_dir_path("nara")
-    partner_dir.mkdir(parents=True, exist_ok=True)
-    lock_path = partner_dir / ".stage2-drain.lock"
-    foreign_fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
-    fcntl.flock(foreign_fd, fcntl.LOCK_EX)
-    try:
-        with patch("tools.drain_deferred._process_await_target_free") as inner:
-            drain_deferred._run_stage2_once("nara", MagicMock())
-        inner.assert_not_called()
-    finally:
-        fcntl.flock(foreign_fd, fcntl.LOCK_UN)
-        os.close(foreign_fd)
+class _StopLoop(Exception):
+    pass
 
 
-def test_run_stage2_once_acquires_and_releases_the_partner_lock(override_root):
-    """Sanity check on the fd lifecycle: after ``_run_stage2_once``
-    completes, the partner-scoped lock is released so a peer drain
-    can acquire it — a leaked fd would break same-partner
-    serialization for the whole process lifetime.
-    """
-    await_target_free_sidecar.write_sidecar("nara", [_await_entry()])
-    with patch("tools.drain_deferred._process_await_target_free"):
-        drain_deferred._run_stage2_once("nara", MagicMock())
-    # If the lock leaked, a subsequent non-blocking acquire would fail.
-    fd = drain_deferred._acquire_stage2_lock("nara", blocking=False)
-    assert fd is not None, "stage-2 lock leaked across the call boundary"
-    os.close(fd)
+def test_patient_await_loop_waits_and_does_not_falsely_complete(lock_fd, monkeypatch):
+    """When the awaiting items are NOT resolved by a re-run (admin hasn't
+    acted), the patient loop keeps waiting — it must NOT signal
+    completion while items remain. We break the otherwise-unbounded loop
+    on the first sleep and assert no completion ping fired."""
+    await_target_free_sidecar.add_key("nara", "id-1", 1)
 
+    throttle = MagicMock()
+    throttle.poll_secs = 0
 
-def test_process_await_target_free_isolates_per_entry_exceptions(override_root, caplog):
-    """A single entry that raises must NOT stop the loop from
-    processing the others — same isolation contract as ``_run_one_round``.
-    The failing entry stays queued."""
-    entries = [_await_entry(dpla_id="bbb"), _await_entry(dpla_id="ccc")]
-    await_target_free_sidecar.write_sidecar("nara", entries)
+    def boom(*_a, **_k):
+        raise _StopLoop
 
-    def side_effect(entry, _site):
-        if entry["dpla_id"] == "bbb":
-            raise RuntimeError("boom")
-        return (True, None)  # ccc advances cleanly
-
-    with patch(
-        "tools.drain_deferred._advance_await_target_free_entry",
-        side_effect=side_effect,
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", return_value=lock_fd),
+        patch("tools.drain_deferred._run_deferred_items"),  # no-op: key remains
+        patch("tools.drain_deferred.DuplicateCategoryThrottle", return_value=throttle),
+        patch("tools.drain_deferred.notify_drain_phase_complete") as done_ping,
+        patch("tools.drain_deferred.time.sleep", side_effect=boom),
     ):
-        drain_deferred._process_await_target_free("nara", MagicMock())
+        result = CliRunner().invoke(drain_deferred.main, ["nara"])
+    # The loop kept waiting (hit sleep) rather than completing.
+    assert isinstance(result.exception, _StopLoop)
+    done_ping.assert_not_called()
+    assert await_target_free_sidecar.awaiting_dpla_ids("nara") == ["id-1"]
 
-    remaining_ids = [
-        e["dpla_id"] for e in await_target_free_sidecar.read_sidecar("nara")
-    ]
-    # bbb stayed (raised); ccc removed (advanced).
-    assert remaining_ids == ["bbb"]
+
+def test_patient_category_then_await_both_drain_and_complete(lock_fd, monkeypatch):
+    """Patient mode with BOTH queues: category drains first (under the
+    host lock, start ping fires), then await drains; completion pings
+    once both are empty."""
+    drain_sidecar.write_sidecar("nara", ["cat-1"])
+    await_target_free_sidecar.add_key("nara", "await-1", 1)
+
+    throttle = MagicMock()
+    throttle.poll_secs = 0
+    throttle.resume_below = 900
+    throttle.category_size.return_value = 100
+    throttle.wait_for_capacity.return_value = True
+
+    def rerun(partner, ids):
+        # Category round: the ids came from drain_sidecar (already removed
+        # by _run_one_round before calling us) — nothing to re-defer.
+        # Await round: clear the awaiting key.
+        for dpla_id in ids:
+            await_target_free_sidecar.remove_key(partner, dpla_id, 1)
+
+    # main() acquires the host lock once for the category phase and again
+    # per await round, closing each fd — so hand out a FRESH fd per call
+    # (the real _acquire_host_lock opens a new fd each time).
+    def fresh_lock(**_kw):
+        return os.open(os.devnull, os.O_RDONLY)
+
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", side_effect=fresh_lock),
+        patch("tools.drain_deferred._run_deferred_items", side_effect=rerun),
+        patch("tools.drain_deferred.DuplicateCategoryThrottle", return_value=throttle),
+        patch("tools.drain_deferred.notify_drain_phase_start") as start_ping,
+        patch("tools.drain_deferred.notify_drain_phase_complete") as done_ping,
+    ):
+        result = CliRunner().invoke(drain_deferred.main, ["nara"])
+    assert result.exit_code == 0, result.output
+    start_ping.assert_called_once()
+    done_ping.assert_called_once()
+    assert drain_sidecar.read_sidecar("nara") == []
+    assert await_target_free_sidecar.awaiting_dpla_ids("nara") == []

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import os
 from unittest.mock import MagicMock, patch
 
@@ -421,12 +422,17 @@ def test_no_wait_skips_when_host_lock_held():
 
 
 def _await_entry(**overrides) -> dict:
-    """Sidecar entry factory for stage-2 tests."""
+    """Sidecar entry factory for stage-2 tests. Default is the fully
+    queued state (``tag_emitted=True``) — the phase drain is designed
+    to advance from; tests exercising the in-progress phase override
+    to False.
+    """
     base = {
         "dpla_id": "22412cd0",
         "ordinal": 1,
         "tagged_title": "Angus - DPLA - 22412cd0.jpg",
         "community_title": "Angus.jpg",
+        "tag_emitted": True,
         "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
     }
     base.update(overrides)
@@ -621,6 +627,26 @@ def test_advance_fail_when_move_blocked_by_article_exists_conflict():
     relink.assert_not_called()
 
 
+def test_advance_pending_when_tag_emitted_is_false():
+    """Workflow phase gate: an entry recorded by the uploader but whose
+    tag_as_duplicate call never completed carries ``tag_emitted=False``.
+    Drain MUST NOT treat the missing tag as an editor-decline and drop
+    the entry — that would strand community history. Return PENDING so
+    the next uploader run retries the tag and flips the phase.
+    """
+    site = MagicMock()
+    # No page fetches should happen when we short-circuit on the phase gate.
+    with patch("tools.drain_deferred.get_page") as get_page:
+        should_remove, note = drain_deferred._advance_await_target_free_entry(
+            _await_entry(tag_emitted=False), site
+        )
+    assert should_remove is False
+    assert note is not None and note.startswith("PENDING:")
+    assert "tag_emitted=False" in note
+    # No Commons state was consulted; the gate lives above every fetch.
+    get_page.assert_not_called()
+
+
 def test_advance_fail_when_community_page_is_redirect():
     """An admin (or an editor) redirected the community file during the
     wait window — most likely, redirected it to our tagged canonical.
@@ -740,6 +766,42 @@ def test_patient_mode_loops_stage2_until_sidecar_empty(lock_fd, monkeypatch):
     # bbb was polled twice (once per round); aaa only once.
     assert advance_calls.count("bbb") == 2
     assert advance_calls.count("aaa") == 1
+
+
+def test_run_stage2_once_skips_when_partner_lock_held(override_root):
+    """The partner-scoped stage-2 lock serializes same-partner stage-2
+    rounds. When a foreign holder has it, ``_run_stage2_once`` must
+    non-blocking-skip rather than blocking — the peer round covers our
+    work and we shouldn't wait on it.
+    """
+    await_target_free_sidecar.write_sidecar("nara", [_await_entry()])
+    partner_dir = drain_sidecar.partner_dir_path("nara")
+    partner_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = partner_dir / ".stage2-drain.lock"
+    foreign_fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(foreign_fd, fcntl.LOCK_EX)
+    try:
+        with patch("tools.drain_deferred._process_await_target_free") as inner:
+            drain_deferred._run_stage2_once("nara", MagicMock())
+        inner.assert_not_called()
+    finally:
+        fcntl.flock(foreign_fd, fcntl.LOCK_UN)
+        os.close(foreign_fd)
+
+
+def test_run_stage2_once_acquires_and_releases_the_partner_lock(override_root):
+    """Sanity check on the fd lifecycle: after ``_run_stage2_once``
+    completes, the partner-scoped lock is released so a peer drain
+    can acquire it — a leaked fd would break same-partner
+    serialization for the whole process lifetime.
+    """
+    await_target_free_sidecar.write_sidecar("nara", [_await_entry()])
+    with patch("tools.drain_deferred._process_await_target_free"):
+        drain_deferred._run_stage2_once("nara", MagicMock())
+    # If the lock leaked, a subsequent non-blocking acquire would fail.
+    fd = drain_deferred._acquire_stage2_lock("nara", blocking=False)
+    assert fd is not None, "stage-2 lock leaked across the call boundary"
+    os.close(fd)
 
 
 def test_process_await_target_free_isolates_per_entry_exceptions(override_root, caplog):

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -445,11 +445,15 @@ def _tagged_page(*, exists=True, is_redirect=False, text="") -> MagicMock:
 
 
 def _community_page(
-    *, exists=True, sha1="9719e05ab718aac6d400b239792ceeb45a766954"
+    *,
+    exists=True,
+    is_redirect=False,
+    sha1="9719e05ab718aac6d400b239792ceeb45a766954",
 ) -> MagicMock:
     """MagicMock for the community file — pre-loaded with a valid sha1."""
     p = MagicMock()
     p.exists.return_value = exists
+    p.isRedirectPage.return_value = is_redirect
     p.latest_file_info.sha1 = sha1
     p.title.return_value = "File:Angus.jpg"
     return p
@@ -617,6 +621,30 @@ def test_advance_fail_when_move_blocked_by_article_exists_conflict():
     relink.assert_not_called()
 
 
+def test_advance_fail_when_community_page_is_redirect():
+    """An admin (or an editor) redirected the community file during the
+    wait window — most likely, redirected it to our tagged canonical.
+    The invariant is satisfied either way (our canonical holds the S3
+    SHA1); there is no move to perform. Drop the entry as a decisive
+    FAIL rather than trying to move a redirect page around.
+    """
+    site = MagicMock()
+    tagged = _tagged_page(exists=False)
+    community = _community_page(exists=True, is_redirect=True)
+    with patch(
+        "tools.drain_deferred.get_page",
+        side_effect=lambda _site, title: tagged if "22412cd0" in title else community,
+    ):
+        should_remove, note = drain_deferred._advance_await_target_free_entry(
+            _await_entry(), site
+        )
+    assert should_remove is True
+    assert note is not None and note.startswith("FAIL:")
+    assert "redirected" in note
+    # The move must not have been attempted.
+    community.move.assert_not_called()
+
+
 def test_advance_fail_when_community_sha1_drifted():
     """Content drift on the community side during the wait window —
     the file no longer holds the S3 SHA1 we saw at tag time. Refuse
@@ -658,6 +686,60 @@ def test_process_await_target_free_keeps_pending_entries(override_root):
     ):
         drain_deferred._process_await_target_free("nara", MagicMock())
     assert len(await_target_free_sidecar.read_sidecar("nara")) == 1
+
+
+def test_patient_mode_loops_stage2_until_sidecar_empty(lock_fd, monkeypatch):
+    """Patient mode must poll stage-2 (await-target-free) until its
+    sidecar is empty, sleeping between rounds — mirroring the
+    category-capacity loop's semantics. Two entries here; round 1
+    advances one and leaves one queued, round 2 advances the last.
+    """
+    # Seed only the await sidecar; the category-capacity sidecar is empty
+    # so the outer drain loop skips (but patient-mode still runs stage 2).
+    await_target_free_sidecar.write_sidecar(
+        "nara", [_await_entry(dpla_id="aaa"), _await_entry(dpla_id="bbb")]
+    )
+
+    throttle = MagicMock()
+    throttle.wait_for_capacity.return_value = True
+    throttle.resume_below = 900
+    throttle.poll_secs = 0  # keep the test fast — no real waiting
+    throttle.category_size.return_value = 0
+
+    advance_calls = []
+
+    def fake_advance(entry, _site):
+        advance_calls.append(entry["dpla_id"])
+        # Round 1: only "aaa" advances; "bbb" stays PENDING.
+        # Round 2: "bbb" advances too.
+        if entry["dpla_id"] == "bbb" and advance_calls.count("bbb") == 1:
+            return (False, "PENDING: waiting")
+        return (True, None)
+
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", return_value=lock_fd),
+        patch(
+            "tools.drain_deferred.DuplicateCategoryThrottle",
+            return_value=throttle,
+        ),
+        patch("tools.drain_deferred.notify_drain_phase_start"),
+        patch("tools.drain_deferred.notify_drain_phase_complete"),
+        patch(
+            "tools.drain_deferred._advance_await_target_free_entry",
+            side_effect=fake_advance,
+        ),
+        # Prevent time.sleep from stalling the test (poll_secs=0 already,
+        # but be defensive if anything else calls sleep).
+        monkeypatch.context() as m,
+    ):
+        m.setattr("tools.drain_deferred.time.sleep", lambda *_a, **_k: None)
+        result = CliRunner().invoke(drain_deferred.main, ["nara"])
+    assert result.exit_code == 0, result.output
+    # Sidecar drained.
+    assert await_target_free_sidecar.read_sidecar("nara") == []
+    # bbb was polled twice (once per round); aaa only once.
+    assert advance_calls.count("bbb") == 2
+    assert advance_calls.count("aaa") == 1
 
 
 def test_process_await_target_free_isolates_per_entry_exceptions(override_root, caplog):

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+import pywikibot
+
 from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
 from tools import drain_deferred
 
@@ -573,6 +575,46 @@ def test_advance_fail_when_community_file_missing():
     assert should_remove is True
     assert note is not None and note.startswith("FAIL:")
     assert "community file" in note
+
+
+def test_advance_fail_when_move_blocked_by_article_exists_conflict():
+    """A stale redirect or page history at the tagged title makes the
+    move raise ``ArticleExistsConflictError``. The invariant is already
+    satisfied via the tagged title's current state, and retrying every
+    poll would spam the API. Drop the entry with a decisive FAIL."""
+    site = MagicMock()
+    tagged = _tagged_page(exists=True, is_redirect=True)
+    community = _community_page(exists=True)
+
+    def raise_conflict(_title, **_kwargs):
+        raise pywikibot.exceptions.ArticleExistsConflictError("blocked")
+
+    community.move.side_effect = raise_conflict
+    with (
+        patch(
+            "tools.drain_deferred.get_page",
+            side_effect=lambda _site, title: (
+                tagged if "22412cd0" in title else community
+            ),
+        ),
+        patch("tools.drain_deferred.file_has_inbound_usage", return_value=False),
+        patch("tools.drain_deferred.post_commonsdelinker_request") as relink,
+        patch(
+            "tools.drain_deferred.with_csrf_recovery",
+            side_effect=lambda _s, _l, fn: fn(),
+        ),
+        patch(
+            "tools.drain_deferred.build_title_drift_move_reason",
+            return_value="reason",
+        ),
+    ):
+        should_remove, note = drain_deferred._advance_await_target_free_entry(
+            _await_entry(), site
+        )
+    assert should_remove is True
+    assert note is not None and note.startswith("FAIL:")
+    assert "ArticleExistsConflictError" in note
+    relink.assert_not_called()
 
 
 def test_advance_fail_when_community_sha1_drifted():

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from ingest_wikimedia import drain_sidecar
+from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
 from tools import drain_deferred
 
 
@@ -411,3 +411,233 @@ def test_no_wait_skips_when_host_lock_held():
     throttle_ctor.assert_not_called()
     sp.assert_not_called()
     assert drain_sidecar.read_sidecar("nara") == ["id-1"]
+
+
+# ---------------------------------------------------------------------------
+# await-target-free stage-2 handler
+# ---------------------------------------------------------------------------
+
+
+def _await_entry(**overrides) -> dict:
+    """Sidecar entry factory for stage-2 tests."""
+    base = {
+        "dpla_id": "22412cd0",
+        "ordinal": 1,
+        "tagged_title": "Angus - DPLA - 22412cd0.jpg",
+        "community_title": "Angus.jpg",
+        "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
+    }
+    base.update(overrides)
+    return base
+
+
+def _tagged_page(*, exists=True, is_redirect=False, text="") -> MagicMock:
+    """MagicMock ``pywikibot.FilePage`` for the drift-target (our tagged
+    DPLA-canonical file). Callers customise via kwargs."""
+    p = MagicMock()
+    p.exists.return_value = exists
+    p.isRedirectPage.return_value = is_redirect
+    type(p).text = property(lambda self: text)
+    p.title.return_value = "File:Angus - DPLA - 22412cd0.jpg"
+    return p
+
+
+def _community_page(
+    *, exists=True, sha1="9719e05ab718aac6d400b239792ceeb45a766954"
+) -> MagicMock:
+    """MagicMock for the community file — pre-loaded with a valid sha1."""
+    p = MagicMock()
+    p.exists.return_value = exists
+    p.latest_file_info.sha1 = sha1
+    p.title.return_value = "File:Angus.jpg"
+    return p
+
+
+def test_advance_pending_when_tag_still_present():
+    """State machine: tagged file exists, {{Duplicate}} template still
+    on the page → keep entry queued for the next drain round."""
+    site = MagicMock()
+    tagged = _tagged_page(
+        exists=True,
+        is_redirect=False,
+        text="{{Duplicate|Angus.jpg}}\n== filedesc ==\n",
+    )
+    with patch("tools.drain_deferred.get_page", return_value=tagged):
+        should_remove, note = drain_deferred._advance_await_target_free_entry(
+            _await_entry(), site
+        )
+    assert should_remove is False
+    assert note is not None and note.startswith("PENDING:")
+
+
+def test_advance_fail_when_tag_removed_but_page_exists():
+    """An editor decline: tag stripped but page kept. Drop entry and
+    log FAIL — the community-file rename can't proceed against a page
+    the community affirmatively kept."""
+    site = MagicMock()
+    tagged = _tagged_page(
+        exists=True,
+        is_redirect=False,
+        text="== filedesc ==\n{{DPLA metadata}}\n",  # no {{Duplicate}}
+    )
+    with patch("tools.drain_deferred.get_page", return_value=tagged):
+        should_remove, note = drain_deferred._advance_await_target_free_entry(
+            _await_entry(), site
+        )
+    assert should_remove is True
+    assert note is not None and note.startswith("FAIL:")
+    assert "Duplicate" in note
+
+
+def test_advance_executes_move_when_tagged_file_deleted():
+    """Deletion (page no longer exists on Commons) → execute move of
+    community file into the freed canonical title, post the
+    CommonsDelinker relink."""
+    site = MagicMock()
+    tagged = _tagged_page(exists=False, is_redirect=False)
+    community = _community_page(exists=True)
+    with (
+        patch(
+            "tools.drain_deferred.get_page",
+            side_effect=lambda _site, title: (
+                tagged if "22412cd0" in title else community
+            ),
+        ),
+        patch("tools.drain_deferred.file_has_inbound_usage", return_value=True),
+        patch("tools.drain_deferred.post_commonsdelinker_request") as delinker,
+        patch(
+            "tools.drain_deferred.with_csrf_recovery",
+            side_effect=lambda _s, _l, fn: fn(),
+        ),
+        patch(
+            "tools.drain_deferred.build_title_drift_move_reason",
+            return_value="reason",
+        ),
+    ):
+        should_remove, note = drain_deferred._advance_await_target_free_entry(
+            _await_entry(), site
+        )
+    assert should_remove is True
+    assert note is None
+    community.move.assert_called_once()
+    delinker.assert_called_once()
+
+
+def test_advance_executes_move_when_tagged_file_became_redirect():
+    """Redirect (admin merged rather than deleting) is a first-class
+    advance signal — move-onto-a-redirect is a normal pywikibot
+    operation, same as move-into-empty-slot. Per the design, this is
+    NOT an edge case; admins commonly redirect."""
+    site = MagicMock()
+    tagged = _tagged_page(exists=True, is_redirect=True)
+    community = _community_page(exists=True)
+    with (
+        patch(
+            "tools.drain_deferred.get_page",
+            side_effect=lambda _site, title: (
+                tagged if "22412cd0" in title else community
+            ),
+        ),
+        patch("tools.drain_deferred.file_has_inbound_usage", return_value=False),
+        patch("tools.drain_deferred.post_commonsdelinker_request"),
+        patch(
+            "tools.drain_deferred.with_csrf_recovery",
+            side_effect=lambda _s, _l, fn: fn(),
+        ),
+        patch(
+            "tools.drain_deferred.build_title_drift_move_reason",
+            return_value="reason",
+        ),
+    ):
+        should_remove, note = drain_deferred._advance_await_target_free_entry(
+            _await_entry(), site
+        )
+    assert should_remove is True
+    assert note is None
+    community.move.assert_called_once()
+
+
+def test_advance_fail_when_community_file_missing():
+    """Third-party action removed the community file during the wait
+    window — nothing to move. Drop entry with FAIL."""
+    site = MagicMock()
+    tagged = _tagged_page(exists=False)
+    community = _community_page(exists=False)
+    with patch(
+        "tools.drain_deferred.get_page",
+        side_effect=lambda _site, title: tagged if "22412cd0" in title else community,
+    ):
+        should_remove, note = drain_deferred._advance_await_target_free_entry(
+            _await_entry(), site
+        )
+    assert should_remove is True
+    assert note is not None and note.startswith("FAIL:")
+    assert "community file" in note
+
+
+def test_advance_fail_when_community_sha1_drifted():
+    """Content drift on the community side during the wait window —
+    the file no longer holds the S3 SHA1 we saw at tag time. Refuse
+    to move stale bytes into the canonical title."""
+    site = MagicMock()
+    tagged = _tagged_page(exists=False)
+    community = _community_page(
+        exists=True, sha1="ffffffffffffffffffffffffffffffffffffffff"
+    )
+    with patch(
+        "tools.drain_deferred.get_page",
+        side_effect=lambda _site, title: tagged if "22412cd0" in title else community,
+    ):
+        should_remove, note = drain_deferred._advance_await_target_free_entry(
+            _await_entry(), site
+        )
+    assert should_remove is True
+    assert note is not None and note.startswith("FAIL:")
+    assert "SHA1 drifted" in note
+
+
+def test_process_await_target_free_advances_and_removes(override_root):
+    """End-to-end: an entry that advances is removed from the sidecar."""
+    await_target_free_sidecar.write_sidecar("nara", [_await_entry()])
+    with patch(
+        "tools.drain_deferred._advance_await_target_free_entry",
+        return_value=(True, None),
+    ):
+        drain_deferred._process_await_target_free("nara", MagicMock())
+    assert await_target_free_sidecar.read_sidecar("nara") == []
+
+
+def test_process_await_target_free_keeps_pending_entries(override_root):
+    """Entry that returns PENDING stays queued for the next drain round."""
+    await_target_free_sidecar.write_sidecar("nara", [_await_entry()])
+    with patch(
+        "tools.drain_deferred._advance_await_target_free_entry",
+        return_value=(False, "PENDING: tagged file still present"),
+    ):
+        drain_deferred._process_await_target_free("nara", MagicMock())
+    assert len(await_target_free_sidecar.read_sidecar("nara")) == 1
+
+
+def test_process_await_target_free_isolates_per_entry_exceptions(override_root, caplog):
+    """A single entry that raises must NOT stop the loop from
+    processing the others — same isolation contract as ``_run_one_round``.
+    The failing entry stays queued."""
+    entries = [_await_entry(dpla_id="bbb"), _await_entry(dpla_id="ccc")]
+    await_target_free_sidecar.write_sidecar("nara", entries)
+
+    def side_effect(entry, _site):
+        if entry["dpla_id"] == "bbb":
+            raise RuntimeError("boom")
+        return (True, None)  # ccc advances cleanly
+
+    with patch(
+        "tools.drain_deferred._advance_await_target_free_entry",
+        side_effect=side_effect,
+    ):
+        drain_deferred._process_await_target_free("nara", MagicMock())
+
+    remaining_ids = [
+        e["dpla_id"] for e in await_target_free_sidecar.read_sidecar("nara")
+    ]
+    # bbb stayed (raised); ccc removed (advanced).
+    assert remaining_ids == ["bbb"]

--- a/tests/test_drain_deferred.py
+++ b/tests/test_drain_deferred.py
@@ -768,6 +768,52 @@ def test_patient_mode_loops_stage2_until_sidecar_empty(lock_fd, monkeypatch):
     assert advance_calls.count("aaa") == 1
 
 
+def test_patient_mode_stops_when_only_unemitted_entries_remain(lock_fd, monkeypatch):
+    """A ``tag_emitted=False`` entry can only be finished by a future
+    uploader run (stage-2 does not emit tags). Patient mode must NOT
+    spin forever waiting on admin action that can't apply — if every
+    still-pending entry is unemitted, it breaks and leaves them queued.
+    """
+    # One entry, stuck tag_emitted=False. Real _advance would return
+    # PENDING for it (no admin advance possible), so use the real path.
+    await_target_free_sidecar.write_sidecar(
+        "nara", [_await_entry(dpla_id="stuck", tag_emitted=False)]
+    )
+
+    throttle = MagicMock()
+    throttle.wait_for_capacity.return_value = True
+    throttle.resume_below = 900
+    throttle.poll_secs = 0
+    throttle.category_size.return_value = 0
+
+    sleep_calls = {"n": 0}
+
+    with (
+        patch("tools.drain_deferred._acquire_host_lock", return_value=lock_fd),
+        patch("tools.drain_deferred.DuplicateCategoryThrottle", return_value=throttle),
+        patch("tools.drain_deferred.notify_drain_phase_start"),
+        patch("tools.drain_deferred.notify_drain_phase_complete"),
+        patch("tools.drain_deferred.get_page") as get_page,
+        monkeypatch.context() as m,
+    ):
+        # If the loop ever sleeps, it's spinning — fail loudly instead
+        # of hanging the suite.
+        def _tracked_sleep(*_a, **_k):
+            sleep_calls["n"] += 1
+            if sleep_calls["n"] > 3:
+                raise AssertionError("patient loop is spinning on an unemitted entry")
+
+        m.setattr("tools.drain_deferred.time.sleep", _tracked_sleep)
+        result = CliRunner().invoke(drain_deferred.main, ["nara"])
+    assert result.exit_code == 0, result.output
+    # Phase gate short-circuits before any Commons fetch.
+    get_page.assert_not_called()
+    # Entry left queued for the next uploader run; loop did not spin.
+    remaining = await_target_free_sidecar.read_sidecar("nara")
+    assert [e["dpla_id"] for e in remaining] == ["stuck"]
+    assert sleep_calls["n"] == 0
+
+
 def test_run_stage2_once_skips_when_partner_lock_held(override_root):
     """The partner-scoped stage-2 lock serializes same-partner stage-2
     rounds. When a foreign holder has it, ``_run_stage2_once`` must

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -863,12 +863,14 @@ def test_resolve_hash_drift_case2_stays_upload_and_tag_when_target_is_dpla_bot_u
     assert action == "upload_and_tag"
 
 
-def test_resolve_hash_drift_case2_stays_upload_and_tag_when_first_uploader_unknown():
-    """When first_uploader can't identify the original uploader (API
-    failure, empty history), default to the conservative UPLOAD_AND_TAG
-    path — same as the pre-fix behaviour. Ensures the new subclass
-    check doesn't regress into a silent no-op when first_uploader is
-    None."""
+def test_resolve_hash_drift_case2_routes_unknown_uploader_to_self_tag_defer():
+    """When ``first_uploader`` can't identify the original uploader (API
+    failure, empty history), route through the non-destructive
+    ``UPLOAD_AND_SELF_TAG_DEFER`` path rather than the destructive
+    ``UPLOAD_AND_TAG`` path. An unknown provenance doesn't prove
+    bot-authorship, so the safer default is to tag OUR own file and let
+    the drain phase resolve, rather than requesting admin deletion of a
+    possibly-community upload."""
     uploader = _build_uploader_with_dpla()
     existing_title = "Some File.jpg"
     intended_title = "Some File - DPLA - abc.jpg"
@@ -886,7 +888,7 @@ def test_resolve_hash_drift_case2_stays_upload_and_tag_when_first_uploader_unkno
             dpla_id="abc" + "a" * 29,
             ordinal=1,
         )
-    assert action == "upload_and_tag"
+    assert action == "upload_and_self_tag_defer"
 
 
 def test_tag_self_and_defer_enqueues_sidecar_entry_with_partner_from_caller(
@@ -939,6 +941,63 @@ def test_tag_self_and_defer_enqueues_sidecar_entry_with_partner_from_caller(
 
     # Other partners' sidecars remain untouched.
     assert await_target_free_sidecar.read_sidecar("bpl") == []
+
+
+def test_tag_self_and_defer_records_sidecar_entry_before_tagging(tmp_path, monkeypatch):
+    """Durability: the sidecar entry MUST land before the Commons tag,
+    so a tag-side failure never leaves the canonical file marked for
+    deletion without a queued intent to promote the community file.
+    Assert order via the call sequence, and confirm that a tag failure
+    leaves the sidecar entry intact for the drain phase (or a re-run)
+    to pick up."""
+    from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
+
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
+
+    uploader = _build_uploader_with_dpla()
+
+    call_order: list[str] = []
+    real_add_entry = await_target_free_sidecar.add_entry
+
+    def add_entry_stub(partner, entry):
+        call_order.append("sidecar_add")
+        # Delegate to the underlying implementation (captured before the
+        # patch) so we don't recurse into our own stub.
+        return real_add_entry(partner, entry)
+
+    def tag_stub(*_a, **_kw):
+        call_order.append("tag_as_duplicate")
+        raise RuntimeError("simulated Commons write failure")
+
+    with (
+        patch("tools.uploader.get_page") as get_page,
+        patch(
+            "tools.uploader.await_target_free_sidecar.add_entry",
+            side_effect=add_entry_stub,
+        ),
+        patch("tools.uploader.tag_as_duplicate", side_effect=tag_stub),
+    ):
+        get_page.return_value = MagicMock(text="")
+        # Should NOT raise — the tag failure is caught and logged, since
+        # the sidecar entry (added first) already carries the durable intent.
+        uploader._tag_self_and_defer(
+            partner="heartland",
+            dpla_canonical_title="Foo - DPLA - abc.jpg",
+            community_title="Foo.jpg",
+            dpla_id="abc" + "a" * 29,
+            ordinal=1,
+            expected_sha1="9719e05ab718aac6d400b239792ceeb45a766954",
+        )
+
+    # Order: sidecar_add first, then tag_as_duplicate.
+    assert call_order == ["sidecar_add", "tag_as_duplicate"], (
+        f"sidecar entry must be persisted before the Commons tag is emitted; "
+        f"got {call_order!r}"
+    )
+    # And the sidecar entry survives the tag-side crash.
+    entries = await_target_free_sidecar.read_sidecar("heartland")
+    assert len(entries) == 1
+    assert entries[0]["dpla_id"] == "abc" + "a" * 29
 
 
 def _build_uploader_with_dpla_raising(exc: Exception) -> "object":

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -781,7 +781,12 @@ def test_resolve_hash_drift_case2_still_tags_when_existing_is_true_orphan():
     intended_page.exists.return_value = True
     intended_page.isRedirectPage.return_value = False
     intended_page.title.return_value = intended_title
-    with patch("tools.uploader.get_page", return_value=intended_page):
+    # A `- DPLA -` orphan of our own item was uploaded by our bot, so
+    # provenance resolves to a DPLA-adjacent bot → UPLOAD_AND_TAG.
+    with (
+        patch("tools.uploader.get_page", return_value=intended_page),
+        patch("tools.uploader.first_uploader", return_value="DPLA bot"),
+    ):
         action = uploader._resolve_hash_drift(
             existing_file=_drift_existing_file(existing_title),
             page_title=intended_title,
@@ -802,7 +807,10 @@ def test_resolve_hash_drift_case2_tags_when_expected_titles_is_none():
     intended_page.exists.return_value = True
     intended_page.isRedirectPage.return_value = False
     intended_page.title.return_value = intended_title
-    with patch("tools.uploader.get_page", return_value=intended_page):
+    with (
+        patch("tools.uploader.get_page", return_value=intended_page),
+        patch("tools.uploader.first_uploader", return_value="DPLA bot"),
+    ):
         action = uploader._resolve_hash_drift(
             existing_file=_drift_existing_file(existing_title),
             page_title=intended_title,
@@ -833,6 +841,36 @@ def test_resolve_hash_drift_case2_defers_when_target_is_community_authored():
             existing_file=_drift_existing_file(existing_title),
             page_title=intended_title,
             dpla_id="abc" + "a" * 29,
+            ordinal=1,
+        )
+    assert action == "upload_and_self_tag_defer"
+
+
+def test_resolve_hash_drift_case2_community_first_uploader_beats_dpla_shaped_title():
+    """Provenance is decided by ``first_uploader``, NOT the filename. A
+    file whose title carries a ``- DPLA -`` suffix but whose FIRST
+    uploader is a community editor (e.g. an editor renamed it into that
+    form) must still route to the non-destructive self-tag/defer path —
+    the filename must never force the destructive tag-for-deletion path.
+    """
+    uploader = _build_uploader_with_dpla()
+    dpla_id = "abc" + "a" * 29
+    # DPLA-suffixed title (same item id), but a community editor is the
+    # first uploader — e.g. they renamed their file into the DPLA form.
+    existing_title = f"Angus - DPLA - {dpla_id} (page 9).jpg"
+    intended_title = f"Angus - DPLA - {dpla_id}.jpg"
+    intended_page = MagicMock()
+    intended_page.exists.return_value = True
+    intended_page.isRedirectPage.return_value = False
+    intended_page.title.return_value = intended_title
+    with (
+        patch("tools.uploader.get_page", return_value=intended_page),
+        patch("tools.uploader.first_uploader", return_value="Fæ"),
+    ):
+        action = uploader._resolve_hash_drift(
+            existing_file=_drift_existing_file(existing_title),
+            page_title=intended_title,
+            dpla_id=dpla_id,
             ordinal=1,
         )
     assert action == "upload_and_self_tag_defer"

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1086,6 +1086,128 @@ def test_tag_self_and_defer_second_call_reflips_tag_emitted_after_prior_failure(
     assert entries[0]["tag_emitted"] is True
 
 
+def test_resume_self_tag_if_pending_finishes_tag_for_uploaded_but_untagged(
+    tmp_path, monkeypatch
+):
+    """The stranding CR flagged: a prior run uploaded the canonical file
+    (so ``find_file_by_hash`` finds it at page_title and the fast-path
+    skip fires) but died before tagging, leaving the sidecar entry
+    ``tag_emitted=False``. ``_resume_self_tag_if_pending`` must finish
+    the tag and flip the phase — otherwise drain-deferred sits on the
+    entry forever.
+    """
+    from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
+
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
+    await_target_free_sidecar.add_entry(
+        "heartland",
+        {
+            "dpla_id": "abc" + "a" * 29,
+            "ordinal": 1,
+            "tagged_title": "Foo - DPLA - abc.jpg",
+            "community_title": "Foo.jpg",
+            "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
+            "tag_emitted": False,
+        },
+    )
+    uploader = _build_uploader_with_dpla()
+    with (
+        patch("tools.uploader.get_page") as get_page,
+        patch("tools.uploader.tag_as_duplicate") as tag,
+    ):
+        get_page.return_value = MagicMock(text="")
+        uploader._resume_self_tag_if_pending(
+            partner="heartland",
+            page_title="Foo - DPLA - abc.jpg",
+            dpla_id="abc" + "a" * 29,
+            ordinal=1,
+        )
+    tag.assert_called_once()
+    entries = await_target_free_sidecar.read_sidecar("heartland")
+    assert entries[0]["tag_emitted"] is True
+
+
+def test_resume_self_tag_if_pending_noop_when_already_emitted(tmp_path, monkeypatch):
+    """A fully-queued entry (``tag_emitted=True``) needs no retry — the
+    resume helper must not re-tag."""
+    from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
+
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
+    await_target_free_sidecar.add_entry(
+        "heartland",
+        {
+            "dpla_id": "abc" + "a" * 29,
+            "ordinal": 1,
+            "tagged_title": "Foo - DPLA - abc.jpg",
+            "community_title": "Foo.jpg",
+            "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
+            "tag_emitted": True,
+        },
+    )
+    uploader = _build_uploader_with_dpla()
+    with patch("tools.uploader.tag_as_duplicate") as tag:
+        uploader._resume_self_tag_if_pending(
+            partner="heartland",
+            page_title="Foo - DPLA - abc.jpg",
+            dpla_id="abc" + "a" * 29,
+            ordinal=1,
+        )
+    tag.assert_not_called()
+
+
+def test_resume_self_tag_if_pending_noop_when_no_entry(tmp_path, monkeypatch):
+    """No sidecar entry (e.g. a genuine already-done file with no pending
+    workflow) → the resume helper is a clean no-op, never touching
+    Commons."""
+    from ingest_wikimedia import drain_sidecar
+
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
+    uploader = _build_uploader_with_dpla()
+    with patch("tools.uploader.tag_as_duplicate") as tag:
+        uploader._resume_self_tag_if_pending(
+            partner="heartland",
+            page_title="Foo - DPLA - abc.jpg",
+            dpla_id="abc" + "a" * 29,
+            ordinal=1,
+        )
+    tag.assert_not_called()
+
+
+def test_resume_self_tag_if_pending_respects_throttle_capacity(tmp_path, monkeypatch):
+    """When Category:Duplicate is at capacity, the resume must NOT emit
+    the tag — it leaves the entry ``tag_emitted=False`` for a later run,
+    exactly like the first-time path defers rather than overflowing the
+    admins' queue."""
+    from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
+
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
+    await_target_free_sidecar.add_entry(
+        "heartland",
+        {
+            "dpla_id": "abc" + "a" * 29,
+            "ordinal": 1,
+            "tagged_title": "Foo - DPLA - abc.jpg",
+            "community_title": "Foo.jpg",
+            "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
+            "tag_emitted": False,
+        },
+    )
+    uploader = _build_uploader_with_dpla()
+    throttle = MagicMock()
+    throttle.try_acquire.return_value = False  # category at capacity
+    uploader.dup_throttle = throttle
+    with patch("tools.uploader.tag_as_duplicate") as tag:
+        uploader._resume_self_tag_if_pending(
+            partner="heartland",
+            page_title="Foo - DPLA - abc.jpg",
+            dpla_id="abc" + "a" * 29,
+            ordinal=1,
+        )
+    tag.assert_not_called()
+    entries = await_target_free_sidecar.read_sidecar("heartland")
+    assert entries[0]["tag_emitted"] is False
+
+
 def _build_uploader_with_dpla_raising(exc: Exception) -> "object":
     """Like ``_build_uploader_with_dpla`` but DPLA API raises ``exc`` on
     every ``get_item_metadata`` call. Used to exercise the "colliding

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -812,6 +812,83 @@ def test_resolve_hash_drift_case2_tags_when_expected_titles_is_none():
     assert action == "upload_and_tag"
 
 
+def test_resolve_hash_drift_case2_defers_when_target_is_community_authored():
+    """New Case-2 sub-classification: when the drift target's FIRST
+    upload was by a real editor (not a DPLA-adjacent bot), return
+    UPLOAD_AND_SELF_TAG_DEFER instead of tagging the community file
+    for admin deletion. Guards against the Bartlett incident."""
+    uploader = _build_uploader_with_dpla()
+    existing_title = "Angus F. Bartlett.jpg"  # no DPLA- suffix → community-titled
+    intended_title = "Angus F. Bartlett - DPLA - abc.jpg"
+    intended_page = MagicMock()
+    intended_page.exists.return_value = True
+    intended_page.isRedirectPage.return_value = False
+    intended_page.title.return_value = intended_title
+    # Force first_uploader to report a real editor.
+    with (
+        patch("tools.uploader.get_page", return_value=intended_page),
+        patch("tools.uploader.first_uploader", return_value="Fæ"),
+    ):
+        action = uploader._resolve_hash_drift(
+            existing_file=_drift_existing_file(existing_title),
+            page_title=intended_title,
+            dpla_id="abc" + "a" * 29,
+            ordinal=1,
+        )
+    assert action == "upload_and_self_tag_defer"
+
+
+def test_resolve_hash_drift_case2_stays_upload_and_tag_when_target_is_dpla_bot_upload():
+    """A stranded DPLA-bot upload (e.g. pre-normalization title) has a
+    DPLA-adjacent bot as its first uploader — must stay on the legacy
+    UPLOAD_AND_TAG path, not divert to the community-defer flow. Same
+    fixture as the community test, only the first_uploader mock flips."""
+    uploader = _build_uploader_with_dpla()
+    existing_title = "Some Old Title.jpg"  # no DPLA suffix, but bot-authored
+    intended_title = "Some Old Title - DPLA - abc.jpg"
+    intended_page = MagicMock()
+    intended_page.exists.return_value = True
+    intended_page.isRedirectPage.return_value = False
+    intended_page.title.return_value = intended_title
+    with (
+        patch("tools.uploader.get_page", return_value=intended_page),
+        patch("tools.uploader.first_uploader", return_value="DPLA bot"),
+    ):
+        action = uploader._resolve_hash_drift(
+            existing_file=_drift_existing_file(existing_title),
+            page_title=intended_title,
+            dpla_id="abc" + "a" * 29,
+            ordinal=1,
+        )
+    assert action == "upload_and_tag"
+
+
+def test_resolve_hash_drift_case2_stays_upload_and_tag_when_first_uploader_unknown():
+    """When first_uploader can't identify the original uploader (API
+    failure, empty history), default to the conservative UPLOAD_AND_TAG
+    path — same as the pre-fix behaviour. Ensures the new subclass
+    check doesn't regress into a silent no-op when first_uploader is
+    None."""
+    uploader = _build_uploader_with_dpla()
+    existing_title = "Some File.jpg"
+    intended_title = "Some File - DPLA - abc.jpg"
+    intended_page = MagicMock()
+    intended_page.exists.return_value = True
+    intended_page.isRedirectPage.return_value = False
+    intended_page.title.return_value = intended_title
+    with (
+        patch("tools.uploader.get_page", return_value=intended_page),
+        patch("tools.uploader.first_uploader", return_value=None),
+    ):
+        action = uploader._resolve_hash_drift(
+            existing_file=_drift_existing_file(existing_title),
+            page_title=intended_title,
+            dpla_id="abc" + "a" * 29,
+            ordinal=1,
+        )
+    assert action == "upload_and_tag"
+
+
 def _build_uploader_with_dpla_raising(exc: Exception) -> "object":
     """Like ``_build_uploader_with_dpla`` but DPLA API raises ``exc`` on
     every ``get_item_metadata`` call. Used to exercise the "colliding

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -891,25 +891,14 @@ def test_resolve_hash_drift_case2_routes_unknown_uploader_to_self_tag_defer():
     assert action == "upload_and_self_tag_defer"
 
 
-def test_tag_self_and_defer_enqueues_sidecar_entry_with_partner_from_caller(
-    tmp_path, monkeypatch
-):
-    """CR-review regression: ``_tag_self_and_defer`` used ``self.partner``,
-    which doesn't exist on ``Uploader``. Fix: partner is threaded through
-    from ``process_file``'s caller-provided arg. Verify the sidecar
-    ``add_entry`` call receives that ``partner`` value AND records the
-    ``(dpla_id, ordinal, tagged_title, community_title, expected_sha1)``
-    tuple the drain-deferred stage-2 handler will consume."""
+def test_tag_self_and_defer_records_key_and_tags(tmp_path, monkeypatch):
+    """``_tag_self_and_defer`` records the (dpla_id, ordinal) in the
+    await set and tags OUR canonical file ``{{Duplicate|<community>}}``.
+    The set entry is the marker the drain re-runs on."""
     from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
 
-    # Point the sidecar at tmp_path so the test doesn't touch the real
-    # /home/ec2-user tree — same fixture pattern the sidecar's own tests use.
-    monkeypatch.setattr(drain_sidecar, "INGEST_WIKIMEDIA_ROOT", tmp_path, raising=False)
     monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
-
     uploader = _build_uploader_with_dpla()
-    # ``tag_as_duplicate`` calls into pywikibot's editpage — stub the wire
-    # write entirely so this test only exercises the enqueue contract.
     with (
         patch("tools.uploader.get_page") as get_page,
         patch("tools.uploader.tag_as_duplicate") as tag,
@@ -921,49 +910,31 @@ def test_tag_self_and_defer_enqueues_sidecar_entry_with_partner_from_caller(
             community_title="Foo.jpg",
             dpla_id="abc" + "a" * 29,
             ordinal=1,
-            expected_sha1="9719e05ab718aac6d400b239792ceeb45a766954",
         )
-    # tag_as_duplicate got called with the community title as the pointer.
     tag.assert_called_once()
     _, kwargs = tag.call_args
     assert kwargs.get("correct_filename") == "Foo.jpg"
-
-    # Sidecar recorded the entry against the partner arg (not a bogus
-    # ``self.partner``).
-    entries = await_target_free_sidecar.read_sidecar("heartland")
-    assert len(entries) == 1
-    e = entries[0]
-    assert e["dpla_id"] == "abc" + "a" * 29
-    assert e["ordinal"] == 1
-    assert e["tagged_title"] == "Foo - DPLA - abc.jpg"
-    assert e["community_title"] == "Foo.jpg"
-    assert e["expected_sha1"] == "9719e05ab718aac6d400b239792ceeb45a766954"
-
-    # Other partners' sidecars remain untouched.
-    assert await_target_free_sidecar.read_sidecar("bpl") == []
+    assert await_target_free_sidecar.has_key("heartland", "abc" + "a" * 29, 1)
+    # Other partners untouched.
+    assert await_target_free_sidecar.awaiting_dpla_ids("bpl") == []
 
 
-def test_tag_self_and_defer_records_sidecar_entry_before_tagging(tmp_path, monkeypatch):
-    """Durability: the sidecar entry MUST land before the Commons tag,
-    so a tag-side failure never leaves the canonical file marked for
-    deletion without a queued intent to promote the community file.
-    Assert order via the call sequence, and confirm that a tag failure
-    leaves the sidecar entry intact for the drain phase (or a re-run)
-    to pick up."""
+def test_tag_self_and_defer_records_key_before_tagging(tmp_path, monkeypatch):
+    """Order: the await key is recorded BEFORE the (remote, failure-prone)
+    tag write, so a tag that lands is always backed by a queued marker. A
+    tag failure is swallowed (best-effort) and the key remains for a
+    re-run / reconcile to handle."""
     from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
 
     monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
-
     uploader = _build_uploader_with_dpla()
 
     call_order: list[str] = []
-    real_add_entry = await_target_free_sidecar.add_entry
+    real_add_key = await_target_free_sidecar.add_key
 
-    def add_entry_stub(partner, entry):
-        call_order.append("sidecar_add")
-        # Delegate to the underlying implementation (captured before the
-        # patch) so we don't recurse into our own stub.
-        return real_add_entry(partner, entry)
+    def add_key_stub(partner, dpla_id, ordinal):
+        call_order.append("add_key")
+        return real_add_key(partner, dpla_id, ordinal)
 
     def tag_stub(*_a, **_kw):
         call_order.append("tag_as_duplicate")
@@ -972,240 +943,71 @@ def test_tag_self_and_defer_records_sidecar_entry_before_tagging(tmp_path, monke
     with (
         patch("tools.uploader.get_page") as get_page,
         patch(
-            "tools.uploader.await_target_free_sidecar.add_entry",
-            side_effect=add_entry_stub,
+            "tools.uploader.await_target_free_sidecar.add_key",
+            side_effect=add_key_stub,
         ),
         patch("tools.uploader.tag_as_duplicate", side_effect=tag_stub),
     ):
         get_page.return_value = MagicMock(text="")
-        # Should NOT raise — the tag failure is caught and logged, since
-        # the sidecar entry (added first) already carries the durable intent.
+        # Tag failure must NOT propagate — the upload already satisfied
+        # the invariant; the deferred rename is a follow-up.
         uploader._tag_self_and_defer(
             partner="heartland",
             dpla_canonical_title="Foo - DPLA - abc.jpg",
             community_title="Foo.jpg",
             dpla_id="abc" + "a" * 29,
             ordinal=1,
-            expected_sha1="9719e05ab718aac6d400b239792ceeb45a766954",
         )
-
-    # Order: sidecar_add first, then tag_as_duplicate.
-    assert call_order == ["sidecar_add", "tag_as_duplicate"], (
-        f"sidecar entry must be persisted before the Commons tag is emitted; "
-        f"got {call_order!r}"
+    assert call_order == ["add_key", "tag_as_duplicate"], (
+        f"await key must be recorded before the tag write; got {call_order!r}"
     )
-    # And the sidecar entry survives the tag-side crash.
-    entries = await_target_free_sidecar.read_sidecar("heartland")
-    assert len(entries) == 1
-    assert entries[0]["dpla_id"] == "abc" + "a" * 29
-    # Phase marker stays ``tag_emitted=False`` — the tag write didn't
-    # complete, so drain must not treat this entry as ready to advance.
-    # A subsequent uploader run will retry the tag and flip the phase.
-    assert entries[0]["tag_emitted"] is False
+    # Key survives the tag-side crash.
+    assert await_target_free_sidecar.has_key("heartland", "abc" + "a" * 29, 1)
 
 
-def test_tag_self_and_defer_marks_tag_emitted_true_on_tag_success(
-    tmp_path, monkeypatch
-):
-    """Successful ``tag_as_duplicate`` MUST flip the sidecar entry's
-    ``tag_emitted`` flag to True. Without this, drain-deferred would
-    stay in the PENDING-tag branch forever and never advance the
-    entry.
-    """
+def test_reconcile_awaiting_skip_keeps_key_while_still_tagged(tmp_path, monkeypatch):
+    """On the already-exists skip path, an awaiting ordinal whose
+    canonical still carries {{Duplicate}} is kept queued (admin hasn't
+    acted). No write to Commons."""
     from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
 
     monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
+    await_target_free_sidecar.add_key("heartland", "abc" + "a" * 29, 1)
     uploader = _build_uploader_with_dpla()
-    with (
-        patch("tools.uploader.get_page") as get_page,
-        patch("tools.uploader.tag_as_duplicate"),
-    ):
-        get_page.return_value = MagicMock(text="")
-        uploader._tag_self_and_defer(
-            partner="heartland",
-            dpla_canonical_title="Foo - DPLA - abc.jpg",
-            community_title="Foo.jpg",
-            dpla_id="abc" + "a" * 29,
-            ordinal=1,
-            expected_sha1="9719e05ab718aac6d400b239792ceeb45a766954",
-        )
-    entries = await_target_free_sidecar.read_sidecar("heartland")
-    assert len(entries) == 1
-    assert entries[0]["tag_emitted"] is True
-
-
-def test_tag_self_and_defer_second_call_reflips_tag_emitted_after_prior_failure(
-    tmp_path, monkeypatch
-):
-    """End-to-end recoverability: first call fails at the tag step
-    (sidecar entry lands with ``tag_emitted=False``); second call
-    succeeds and flips the phase to True. Simulates the uploader
-    resume path CR asked us to cover.
-    """
-    from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
-
-    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
-    uploader = _build_uploader_with_dpla()
-
-    # First call — tag raises.
-    with (
-        patch("tools.uploader.get_page") as get_page,
-        patch(
-            "tools.uploader.tag_as_duplicate",
-            side_effect=RuntimeError("transient Commons flake"),
-        ),
-    ):
-        get_page.return_value = MagicMock(text="")
-        uploader._tag_self_and_defer(
-            partner="heartland",
-            dpla_canonical_title="Foo - DPLA - abc.jpg",
-            community_title="Foo.jpg",
-            dpla_id="abc" + "a" * 29,
-            ordinal=1,
-            expected_sha1="9719e05ab718aac6d400b239792ceeb45a766954",
-        )
-    entries = await_target_free_sidecar.read_sidecar("heartland")
-    assert entries[0]["tag_emitted"] is False
-
-    # Second call — tag succeeds. Sidecar entry survives; phase flips.
-    with (
-        patch("tools.uploader.get_page") as get_page,
-        patch("tools.uploader.tag_as_duplicate"),
-    ):
-        get_page.return_value = MagicMock(text="")
-        uploader._tag_self_and_defer(
-            partner="heartland",
-            dpla_canonical_title="Foo - DPLA - abc.jpg",
-            community_title="Foo.jpg",
-            dpla_id="abc" + "a" * 29,
-            ordinal=1,
-            expected_sha1="9719e05ab718aac6d400b239792ceeb45a766954",
-        )
-    entries = await_target_free_sidecar.read_sidecar("heartland")
-    assert len(entries) == 1, "add_entry must have been idempotent on retry"
-    assert entries[0]["tag_emitted"] is True
-
-
-def test_resume_self_tag_if_pending_finishes_tag_for_uploaded_but_untagged(
-    tmp_path, monkeypatch
-):
-    """The stranding CR flagged: a prior run uploaded the canonical file
-    (so ``find_file_by_hash`` finds it at page_title and the fast-path
-    skip fires) but died before tagging, leaving the sidecar entry
-    ``tag_emitted=False``. ``_resume_self_tag_if_pending`` must finish
-    the tag and flip the phase — otherwise drain-deferred sits on the
-    entry forever.
-    """
-    from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
-
-    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
-    await_target_free_sidecar.add_entry(
-        "heartland",
-        {
-            "dpla_id": "abc" + "a" * 29,
-            "ordinal": 1,
-            "tagged_title": "Foo - DPLA - abc.jpg",
-            "community_title": "Foo.jpg",
-            "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
-            "tag_emitted": False,
-        },
+    existing = MagicMock()
+    existing.text = "{{Duplicate|Foo.jpg}}\n== filedesc ==\n"
+    existing.title.return_value = "File:Foo - DPLA - abc.jpg"
+    uploader._reconcile_awaiting_skip(
+        partner="heartland",
+        existing_file=existing,
+        dpla_id="abc" + "a" * 29,
+        ordinal=1,
     )
-    uploader = _build_uploader_with_dpla()
-    with (
-        patch("tools.uploader.get_page") as get_page,
-        patch("tools.uploader.tag_as_duplicate") as tag,
-    ):
-        get_page.return_value = MagicMock(text="")
-        uploader._resume_self_tag_if_pending(
-            partner="heartland",
-            page_title="Foo - DPLA - abc.jpg",
-            dpla_id="abc" + "a" * 29,
-            ordinal=1,
-        )
-    tag.assert_called_once()
-    entries = await_target_free_sidecar.read_sidecar("heartland")
-    assert entries[0]["tag_emitted"] is True
+    assert await_target_free_sidecar.has_key("heartland", "abc" + "a" * 29, 1)
 
 
-def test_resume_self_tag_if_pending_noop_when_already_emitted(tmp_path, monkeypatch):
-    """A fully-queued entry (``tag_emitted=True``) needs no retry — the
-    resume helper must not re-tag."""
+def test_reconcile_awaiting_skip_drops_key_when_tag_removed(tmp_path, monkeypatch):
+    """When the canonical no longer carries {{Duplicate}} (an editor
+    declined the dedup without deleting the file), the await key is
+    dropped — the two files coexist (corollary 1). Read-only: no tag is
+    re-emitted, so we never edit-war with the editor."""
     from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
 
     monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
-    await_target_free_sidecar.add_entry(
-        "heartland",
-        {
-            "dpla_id": "abc" + "a" * 29,
-            "ordinal": 1,
-            "tagged_title": "Foo - DPLA - abc.jpg",
-            "community_title": "Foo.jpg",
-            "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
-            "tag_emitted": True,
-        },
-    )
+    await_target_free_sidecar.add_key("heartland", "abc" + "a" * 29, 1)
     uploader = _build_uploader_with_dpla()
+    existing = MagicMock()
+    existing.text = "== filedesc ==\nno duplicate tag here\n"
+    existing.title.return_value = "File:Foo - DPLA - abc.jpg"
     with patch("tools.uploader.tag_as_duplicate") as tag:
-        uploader._resume_self_tag_if_pending(
+        uploader._reconcile_awaiting_skip(
             partner="heartland",
-            page_title="Foo - DPLA - abc.jpg",
+            existing_file=existing,
             dpla_id="abc" + "a" * 29,
             ordinal=1,
         )
     tag.assert_not_called()
-
-
-def test_resume_self_tag_if_pending_noop_when_no_entry(tmp_path, monkeypatch):
-    """No sidecar entry (e.g. a genuine already-done file with no pending
-    workflow) → the resume helper is a clean no-op, never touching
-    Commons."""
-    from ingest_wikimedia import drain_sidecar
-
-    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
-    uploader = _build_uploader_with_dpla()
-    with patch("tools.uploader.tag_as_duplicate") as tag:
-        uploader._resume_self_tag_if_pending(
-            partner="heartland",
-            page_title="Foo - DPLA - abc.jpg",
-            dpla_id="abc" + "a" * 29,
-            ordinal=1,
-        )
-    tag.assert_not_called()
-
-
-def test_resume_self_tag_if_pending_respects_throttle_capacity(tmp_path, monkeypatch):
-    """When Category:Duplicate is at capacity, the resume must NOT emit
-    the tag — it leaves the entry ``tag_emitted=False`` for a later run,
-    exactly like the first-time path defers rather than overflowing the
-    admins' queue."""
-    from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
-
-    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
-    await_target_free_sidecar.add_entry(
-        "heartland",
-        {
-            "dpla_id": "abc" + "a" * 29,
-            "ordinal": 1,
-            "tagged_title": "Foo - DPLA - abc.jpg",
-            "community_title": "Foo.jpg",
-            "expected_sha1": "9719e05ab718aac6d400b239792ceeb45a766954",
-            "tag_emitted": False,
-        },
-    )
-    uploader = _build_uploader_with_dpla()
-    throttle = MagicMock()
-    throttle.try_acquire.return_value = False  # category at capacity
-    uploader.dup_throttle = throttle
-    with patch("tools.uploader.tag_as_duplicate") as tag:
-        uploader._resume_self_tag_if_pending(
-            partner="heartland",
-            page_title="Foo - DPLA - abc.jpg",
-            dpla_id="abc" + "a" * 29,
-            ordinal=1,
-        )
-    tag.assert_not_called()
-    entries = await_target_free_sidecar.read_sidecar("heartland")
-    assert entries[0]["tag_emitted"] is False
+    assert not await_target_free_sidecar.has_key("heartland", "abc" + "a" * 29, 1)
 
 
 def _build_uploader_with_dpla_raising(exc: Exception) -> "object":

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -998,6 +998,92 @@ def test_tag_self_and_defer_records_sidecar_entry_before_tagging(tmp_path, monke
     entries = await_target_free_sidecar.read_sidecar("heartland")
     assert len(entries) == 1
     assert entries[0]["dpla_id"] == "abc" + "a" * 29
+    # Phase marker stays ``tag_emitted=False`` — the tag write didn't
+    # complete, so drain must not treat this entry as ready to advance.
+    # A subsequent uploader run will retry the tag and flip the phase.
+    assert entries[0]["tag_emitted"] is False
+
+
+def test_tag_self_and_defer_marks_tag_emitted_true_on_tag_success(
+    tmp_path, monkeypatch
+):
+    """Successful ``tag_as_duplicate`` MUST flip the sidecar entry's
+    ``tag_emitted`` flag to True. Without this, drain-deferred would
+    stay in the PENDING-tag branch forever and never advance the
+    entry.
+    """
+    from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
+
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
+    uploader = _build_uploader_with_dpla()
+    with (
+        patch("tools.uploader.get_page") as get_page,
+        patch("tools.uploader.tag_as_duplicate"),
+    ):
+        get_page.return_value = MagicMock(text="")
+        uploader._tag_self_and_defer(
+            partner="heartland",
+            dpla_canonical_title="Foo - DPLA - abc.jpg",
+            community_title="Foo.jpg",
+            dpla_id="abc" + "a" * 29,
+            ordinal=1,
+            expected_sha1="9719e05ab718aac6d400b239792ceeb45a766954",
+        )
+    entries = await_target_free_sidecar.read_sidecar("heartland")
+    assert len(entries) == 1
+    assert entries[0]["tag_emitted"] is True
+
+
+def test_tag_self_and_defer_second_call_reflips_tag_emitted_after_prior_failure(
+    tmp_path, monkeypatch
+):
+    """End-to-end recoverability: first call fails at the tag step
+    (sidecar entry lands with ``tag_emitted=False``); second call
+    succeeds and flips the phase to True. Simulates the uploader
+    resume path CR asked us to cover.
+    """
+    from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
+
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
+    uploader = _build_uploader_with_dpla()
+
+    # First call — tag raises.
+    with (
+        patch("tools.uploader.get_page") as get_page,
+        patch(
+            "tools.uploader.tag_as_duplicate",
+            side_effect=RuntimeError("transient Commons flake"),
+        ),
+    ):
+        get_page.return_value = MagicMock(text="")
+        uploader._tag_self_and_defer(
+            partner="heartland",
+            dpla_canonical_title="Foo - DPLA - abc.jpg",
+            community_title="Foo.jpg",
+            dpla_id="abc" + "a" * 29,
+            ordinal=1,
+            expected_sha1="9719e05ab718aac6d400b239792ceeb45a766954",
+        )
+    entries = await_target_free_sidecar.read_sidecar("heartland")
+    assert entries[0]["tag_emitted"] is False
+
+    # Second call — tag succeeds. Sidecar entry survives; phase flips.
+    with (
+        patch("tools.uploader.get_page") as get_page,
+        patch("tools.uploader.tag_as_duplicate"),
+    ):
+        get_page.return_value = MagicMock(text="")
+        uploader._tag_self_and_defer(
+            partner="heartland",
+            dpla_canonical_title="Foo - DPLA - abc.jpg",
+            community_title="Foo.jpg",
+            dpla_id="abc" + "a" * 29,
+            ordinal=1,
+            expected_sha1="9719e05ab718aac6d400b239792ceeb45a766954",
+        )
+    entries = await_target_free_sidecar.read_sidecar("heartland")
+    assert len(entries) == 1, "add_entry must have been idempotent on retry"
+    assert entries[0]["tag_emitted"] is True
 
 
 def _build_uploader_with_dpla_raising(exc: Exception) -> "object":

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -889,6 +889,58 @@ def test_resolve_hash_drift_case2_stays_upload_and_tag_when_first_uploader_unkno
     assert action == "upload_and_tag"
 
 
+def test_tag_self_and_defer_enqueues_sidecar_entry_with_partner_from_caller(
+    tmp_path, monkeypatch
+):
+    """CR-review regression: ``_tag_self_and_defer`` used ``self.partner``,
+    which doesn't exist on ``Uploader``. Fix: partner is threaded through
+    from ``process_file``'s caller-provided arg. Verify the sidecar
+    ``add_entry`` call receives that ``partner`` value AND records the
+    ``(dpla_id, ordinal, tagged_title, community_title, expected_sha1)``
+    tuple the drain-deferred stage-2 handler will consume."""
+    from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
+
+    # Point the sidecar at tmp_path so the test doesn't touch the real
+    # /home/ec2-user tree — same fixture pattern the sidecar's own tests use.
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKIMEDIA_ROOT", tmp_path, raising=False)
+    monkeypatch.setattr(drain_sidecar, "INGEST_WIKI_ROOT", tmp_path, raising=False)
+
+    uploader = _build_uploader_with_dpla()
+    # ``tag_as_duplicate`` calls into pywikibot's editpage — stub the wire
+    # write entirely so this test only exercises the enqueue contract.
+    with (
+        patch("tools.uploader.get_page") as get_page,
+        patch("tools.uploader.tag_as_duplicate") as tag,
+    ):
+        get_page.return_value = MagicMock(text="")
+        uploader._tag_self_and_defer(
+            partner="heartland",
+            dpla_canonical_title="Foo - DPLA - abc.jpg",
+            community_title="Foo.jpg",
+            dpla_id="abc" + "a" * 29,
+            ordinal=1,
+            expected_sha1="9719e05ab718aac6d400b239792ceeb45a766954",
+        )
+    # tag_as_duplicate got called with the community title as the pointer.
+    tag.assert_called_once()
+    _, kwargs = tag.call_args
+    assert kwargs.get("correct_filename") == "Foo.jpg"
+
+    # Sidecar recorded the entry against the partner arg (not a bogus
+    # ``self.partner``).
+    entries = await_target_free_sidecar.read_sidecar("heartland")
+    assert len(entries) == 1
+    e = entries[0]
+    assert e["dpla_id"] == "abc" + "a" * 29
+    assert e["ordinal"] == 1
+    assert e["tagged_title"] == "Foo - DPLA - abc.jpg"
+    assert e["community_title"] == "Foo.jpg"
+    assert e["expected_sha1"] == "9719e05ab718aac6d400b239792ceeb45a766954"
+
+    # Other partners' sidecars remain untouched.
+    assert await_target_free_sidecar.read_sidecar("bpl") == []
+
+
 def _build_uploader_with_dpla_raising(exc: Exception) -> "object":
     """Like ``_build_uploader_with_dpla`` but DPLA API raises ``exc`` on
     every ``get_item_metadata`` call. Used to exercise the "colliding

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, PropertyMock
 from ingest_wikimedia.wikimedia import (
     COMMONSDELINKER_PAGE,
     MAX_COMMENT_BYTES,
@@ -1605,47 +1605,28 @@ def test_first_uploader_returns_original_uploader_from_oldest_revision():
     """The first-uploader check must look at the ORIGINAL upload, not
     the most recent one — otherwise a DPLA-bot re-upload on top of a
     community-authored file would misclassify the community file as
-    bot-owned. Uses ``iidir=newer`` + ``iilimit=1`` to fetch the oldest
-    file-history entry."""
+    bot-owned. Reads pywikibot's ``oldest_file_info`` (earliest history
+    entry), which orders the history internally."""
     from ingest_wikimedia.wikimedia import first_uploader
 
-    site = MagicMock()
     file_page = MagicMock()
     file_page.title.return_value = "File:Angus F. Bartlett.jpg"
-    fake_request = MagicMock()
-    fake_request.submit.return_value = {
-        "query": {
-            "pages": {
-                "61693477": {
-                    "imageinfo": [{"user": "Fæ"}],
-                }
-            }
-        }
-    }
-    site.simple_request.return_value = fake_request
-
-    assert first_uploader(site, file_page) == "Fæ"
-    # Confirm we queried the OLDEST revision, not the most recent one.
-    _, kwargs = site.simple_request.call_args
-    assert kwargs.get("iidir") == "newer", (
-        f"first_uploader must fetch the oldest history entry via iidir=newer; "
-        f"got kwargs={kwargs!r}"
-    )
-    assert kwargs.get("iilimit") == 1
+    file_page.oldest_file_info.user = "Fæ"
+    assert first_uploader(file_page) == "Fæ"
 
 
-def test_first_uploader_none_when_no_history():
-    """API returned no ``imageinfo`` entries → ``None`` (no first
-    uploader identifiable). Caller falls back to the safe path."""
+def test_first_uploader_none_when_history_unavailable():
+    """When the file history can't be read (empty history / API error,
+    surfaced by pywikibot raising on ``oldest_file_info``), return
+    ``None`` so the caller falls back to the safe self-tag/defer path."""
     from ingest_wikimedia.wikimedia import first_uploader
 
-    site = MagicMock()
     file_page = MagicMock()
     file_page.title.return_value = "File:Missing.jpg"
-    fake_request = MagicMock()
-    fake_request.submit.return_value = {"query": {"pages": {"0": {}}}}
-    site.simple_request.return_value = fake_request
-    assert first_uploader(site, file_page) is None
+    type(file_page).oldest_file_info = PropertyMock(
+        side_effect=Exception("no file history")
+    )
+    assert first_uploader(file_page) is None
 
 
 def test_post_commonsdelinker_request_escapes_equals_in_filenames():

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -1581,6 +1581,73 @@ def test_tag_as_duplicate_escapes_equals_in_reason():
     assert "?id=42" not in rendered.replace("?id{{=}}42", "")
 
 
+def test_tag_as_duplicate_without_reason_emits_single_arg_form():
+    """Passing an empty reason drops the second positional param, so the
+    Duplicate template's own default text speaks — the previous
+    caller-supplied reason ("Other file has the correct title.") was
+    largely duplicative of what the template already says."""
+    from ingest_wikimedia.wikimedia import tag_as_duplicate
+
+    site = MagicMock()
+    file_page = MagicMock()
+    type(file_page).text = property(lambda self: "")
+    file_page.title.return_value = "Stranded.jpg"
+
+    tag_as_duplicate(site, file_page, correct_filename="Correct.jpg")
+
+    rendered = site.editpage.call_args.kwargs["prependtext"]
+    assert rendered.startswith("{{Duplicate|Correct.jpg}}"), rendered
+    # And critically: no trailing empty-reason pipe.
+    assert "{{Duplicate|Correct.jpg|}}" not in rendered
+
+
+def test_first_uploader_returns_original_uploader_from_oldest_revision():
+    """The first-uploader check must look at the ORIGINAL upload, not
+    the most recent one — otherwise a DPLA-bot re-upload on top of a
+    community-authored file would misclassify the community file as
+    bot-owned. Uses ``iidir=newer`` + ``iilimit=1`` to fetch the oldest
+    file-history entry."""
+    from ingest_wikimedia.wikimedia import first_uploader
+
+    site = MagicMock()
+    file_page = MagicMock()
+    file_page.title.return_value = "File:Angus F. Bartlett.jpg"
+    fake_request = MagicMock()
+    fake_request.submit.return_value = {
+        "query": {
+            "pages": {
+                "61693477": {
+                    "imageinfo": [{"user": "Fæ"}],
+                }
+            }
+        }
+    }
+    site.simple_request.return_value = fake_request
+
+    assert first_uploader(site, file_page) == "Fæ"
+    # Confirm we queried the OLDEST revision, not the most recent one.
+    _, kwargs = site.simple_request.call_args
+    assert kwargs.get("iidir") == "newer", (
+        f"first_uploader must fetch the oldest history entry via iidir=newer; "
+        f"got kwargs={kwargs!r}"
+    )
+    assert kwargs.get("iilimit") == 1
+
+
+def test_first_uploader_none_when_no_history():
+    """API returned no ``imageinfo`` entries → ``None`` (no first
+    uploader identifiable). Caller falls back to the safe path."""
+    from ingest_wikimedia.wikimedia import first_uploader
+
+    site = MagicMock()
+    file_page = MagicMock()
+    file_page.title.return_value = "File:Missing.jpg"
+    fake_request = MagicMock()
+    fake_request.submit.return_value = {"query": {"pages": {"0": {}}}}
+    site.simple_request.return_value = fake_request
+    assert first_uploader(site, file_page) is None
+
+
 def test_post_commonsdelinker_request_escapes_equals_in_filenames():
     """Same `=` escape contract applies to the
     ``{{universal replace|<old>|<new>|reason=...}}`` template that

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -34,10 +34,16 @@ The command has two modes:
     target's chain. One best-effort round of each queue; never blocks.
 
 Concurrency: uploader/sdc-sync invocations across the box are serialized
-by a host-level ``flock`` (``_DRAIN_LOCK_PATH``) held only while a round
-runs — released across the patient waits so one partner's multi-day wait
-never blocks another's drain. Cancellation is operator-driven
-(``tmux kill-session``); both queues persist across kills.
+by a host-level ``flock`` (``_DRAIN_LOCK_PATH``). The **await** queue
+acquires it per round and releases it before each patient sleep, so one
+partner's multi-day admin wait never blocks another's await drain. The
+**category** queue holds it across its ``wait_for_capacity`` wait — a
+pre-existing behavior: the category drain blocks on Category:Duplicate
+while holding the lock. (Scoping the category lock per round, and
+interleaving the two queues so await progresses while category is
+capacity-blocked, is a worthwhile follow-up but out of scope here.)
+Cancellation is operator-driven (``tmux kill-session``); both queues
+persist across kills.
 """
 
 from __future__ import annotations

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -71,6 +71,17 @@ from ingest_wikimedia.wikimedia import (
 # drains serialize.
 _DRAIN_LOCK_PATH = "/home/ec2-user/ingest-wikimedia/.drain-lock"
 
+# Partner-scoped stage-2 lock file name. Placed under each partner's
+# working directory. Held only for the duration of a single stage-2
+# poll round so multiple partners' stage-2 drains run concurrently
+# (the host-wide lock is released before stage-2 begins). Serializes
+# stage-2 rounds for THE SAME partner against another drain-deferred
+# or a concurrent uploader that races on the same sidecar entry —
+# without this, two rounds could both read an entry with
+# tag_emitted=True, both call ``community_page.move``, and one would
+# race a torn "no such source" error on Commons.
+_STAGE2_LOCK_FILENAME = ".stage2-drain.lock"
+
 
 def _acquire_host_lock(blocking: bool = True):
     """Return a file descriptor holding an exclusive ``flock`` on
@@ -103,6 +114,33 @@ def _acquire_host_lock(blocking: bool = True):
         os.close(fd)
         return None
     logging.info("Drain-phase host lock acquired.")
+    return fd
+
+
+def _acquire_stage2_lock(partner: str, blocking: bool = True):
+    """Acquire the partner-scoped stage-2 ``flock``. Returns a held fd
+    or ``None`` when ``blocking=False`` and another drain holds it.
+
+    Scope is one partner: stage-2 for partner A runs concurrently with
+    stage-2 for partner B (they touch different sidecars and different
+    Commons files). What this lock serializes is same-partner rounds —
+    without it, two drain-deferred processes running stage-2 for the
+    same partner could both read an entry with tag_emitted=True, both
+    call community_page.move, and race on Commons.
+
+    Companion behaviour to :func:`_acquire_host_lock`: created lazily,
+    never deleted, released on fd close (so crashes free it).
+    """
+    partner_dir = drain_sidecar.partner_dir_path(partner)
+    partner_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = partner_dir / _STAGE2_LOCK_FILENAME
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
+    try:
+        fcntl.flock(fd, flags)
+    except BlockingIOError:
+        os.close(fd)
+        return None
     return fd
 
 
@@ -210,6 +248,20 @@ def _advance_await_target_free_entry(
     tagged_title = entry["tagged_title"]
     community_title = entry["community_title"]
     expected_sha1 = entry["expected_sha1"]
+
+    # Workflow phase gate: an entry with tag_emitted=False was recorded
+    # by the uploader but the corresponding tag_as_duplicate call never
+    # completed. Drain must NOT try to advance it — the canonical file
+    # carries no tag, no admin action is possible, and treating the
+    # absent tag as an editor-decline (the untagged FAIL path below)
+    # would prematurely drop a still-in-progress workflow. Keep the
+    # entry queued; the next uploader run for this partner will retry
+    # the tag and flip the phase to True.
+    if not entry.get("tag_emitted", True):
+        return False, (
+            "PENDING: tag not yet emitted by the uploader "
+            "(tag_emitted=False); leaving queued for the uploader to retry."
+        )
 
     tagged_page = get_page(site, f"File:{tagged_title}")
     exists = tagged_page.exists()
@@ -378,6 +430,64 @@ def _process_await_target_free(partner: str, site: object) -> None:
     )
 
 
+def _run_stage2_once(partner: str, site: object) -> None:
+    """Run one stage-2 round under the partner-scoped stage-2 lock.
+
+    Held only for the duration of the round (not across sleeps), so
+    concurrent drains for OTHER partners are unaffected and same-
+    partner rounds serialize cleanly. Non-blocking: if another drain
+    is mid-round for this partner, skip — its work covers ours.
+    """
+    stage2_fd = _acquire_stage2_lock(partner, blocking=False)
+    if stage2_fd is None:
+        logging.info(
+            "Await-target-free: partner-scoped stage-2 lock held by another "
+            "drain for partner %s; skipping this round.",
+            partner,
+        )
+        return
+    try:
+        _process_await_target_free(partner, site)
+    finally:
+        os.close(stage2_fd)
+
+
+def _run_stage2_patient_loop(
+    partner: str, site: object, throttle: DuplicateCategoryThrottle
+) -> None:
+    """Patient stage-2 wait loop: drain until the sidecar is empty,
+    sleeping ``throttle.poll_secs`` between rounds.
+
+    The partner-scoped lock is acquired PER ROUND and released before
+    sleeping — so a peer drain-deferred can also run stage-2 for this
+    partner during our sleep window, and neither has to wait on the
+    other for a full poll cycle. Entries mid-workflow (tag_emitted=
+    False) are treated as PENDING; the next uploader run flips them
+    to True, and the following round advances them.
+
+    An entry that a Commons admin never actions loops forever — same
+    contract as the category-capacity loop: patient mode is designed
+    to wait days/weeks and the operator ends it via
+    ``tmux kill-session`` if needed (sidecar persists across kills).
+    """
+    while True:
+        pending = await_target_free_sidecar.read_sidecar(partner)
+        if not pending:
+            break
+        _run_stage2_once(partner, site)
+        still_pending = await_target_free_sidecar.read_sidecar(partner)
+        if not still_pending:
+            break
+        logging.info(
+            "Await-target-free: %d entry(ies) still pending for partner "
+            "%s; sleeping %ds before next round.",
+            len(still_pending),
+            partner,
+            int(throttle.poll_secs),
+        )
+        time.sleep(throttle.poll_secs)
+
+
 def _run_one_round(partner: str, pending: list[str]) -> int:
     """Execute one drain round: clear ``pending`` from the sidecar,
     invoke uploader + sdc-sync on those IDs, return how many the
@@ -537,7 +647,15 @@ def main(no_wait: bool, partner: str) -> None:
 
         if no_wait:
             _drain_opportunistic_once(partner, throttle)
-            _process_await_target_free(partner, site)
+            # Release the host lock before stage-2. Stage-2 talks to
+            # partner-local resources only (the await sidecar and this
+            # partner's Commons files); holding the host-wide lock
+            # across it would prevent other partners' drains from
+            # running for minutes. Serialization for same-partner
+            # stage-2 rounds is handled by the partner-scoped lock.
+            os.close(lock_fd)
+            lock_fd = None
+            _run_stage2_once(partner, site)
             return
 
         # Patient mode: Slack-notify start (so the operator knows the
@@ -546,36 +664,15 @@ def main(no_wait: bool, partner: str) -> None:
         initial_category_size = throttle.category_size()
         notify_drain_phase_start(partner, len(initial_ids), initial_category_size)
         total_emitted = _drain_loop(partner, throttle)
-        # Stage-2 handling: poll and advance await-target-free entries.
-        # Runs AFTER the patient category-capacity loop so any Case-2
-        # tag emissions this round produced (via _drain_loop → uploader
-        # re-invocation → self-tag path) can be picked up in the same
-        # invocation instead of having to wait for the next partner
-        # session's drain.
-        #
-        # Patient loop: same "wait for human admin action" semantics as
-        # the category-capacity loop above — sleep ``throttle.poll_secs``
-        # between rounds and drain until the sidecar is empty. An entry
-        # that never gets actioned would loop forever; that's acceptable
-        # because patient mode is explicitly designed to wait days/weeks
-        # on Commons volunteers, and the operator ends it via
-        # ``tmux kill-session`` if needed (sidecar persists across kills).
-        while True:
-            pending = await_target_free_sidecar.read_sidecar(partner)
-            if not pending:
-                break
-            _process_await_target_free(partner, site)
-            still_pending = await_target_free_sidecar.read_sidecar(partner)
-            if not still_pending:
-                break
-            logging.info(
-                "Await-target-free: %d entry(ies) still pending for partner "
-                "%s; sleeping %ds before next round.",
-                len(still_pending),
-                partner,
-                int(throttle.poll_secs),
-            )
-            time.sleep(throttle.poll_secs)
+        # Release the host-wide lock before entering the patient
+        # stage-2 wait loop — holding it across days/weeks of polling
+        # for one partner's Commons-admin action would block every
+        # other partner's patient drain and force opportunistic
+        # passes to skip. Stage-2 uses a partner-scoped lock instead
+        # (per-round, so it doesn't hold across sleep).
+        os.close(lock_fd)
+        lock_fd = None
+        _run_stage2_patient_loop(partner, site, throttle)
         elapsed = time.monotonic() - started_at
         logging.info(
             "Drain-deferred: complete. Emitted %d item(s) over %.0f seconds.",
@@ -584,7 +681,8 @@ def main(no_wait: bool, partner: str) -> None:
         )
         notify_drain_phase_complete(partner, elapsed, total_emitted)
     finally:
-        os.close(lock_fd)
+        if lock_fd is not None:
+            os.close(lock_fd)
 
 
 if __name__ == "__main__":

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -46,6 +46,7 @@ import time
 from pathlib import Path
 
 import click
+import pywikibot
 
 from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
 from ingest_wikimedia.csrf import with_csrf_recovery
@@ -259,16 +260,31 @@ def _advance_await_target_free_entry(
         community_title,
         tagged_title,
     )
-    with_csrf_recovery(
-        site,
-        f"move {community_page.title()} → {intended_page.title()}",
-        lambda: community_page.move(
-            intended_page.title(),
-            reason=reason,
-            movetalk=False,
-            noredirect=False,
-        ),
-    )
+    try:
+        with_csrf_recovery(
+            site,
+            f"move {community_page.title()} → {intended_page.title()}",
+            lambda: community_page.move(
+                intended_page.title(),
+                reason=reason,
+                movetalk=False,
+                noredirect=False,
+            ),
+        )
+    except pywikibot.exceptions.ArticleExistsConflictError as ex:
+        # A stale redirect or page history at the tagged title blocks
+        # the move. The invariant is still satisfied — either the
+        # redirect resolves to the community file (which holds the S3
+        # SHA1) or admin left content we cannot displace. Retrying every
+        # poll would spam the API with a call that cannot succeed, so
+        # treat this as a decisive FAIL: drop the sidecar entry and let
+        # the community file remain at its original title.
+        return True, (
+            f"FAIL: move to canonical title blocked by "
+            f"ArticleExistsConflictError ({ex}) — community file left "
+            f"in place; invariant already satisfied via the tagged "
+            f"title's current state."
+        )
     if needs_relink:
         post_commonsdelinker_request(
             site, community_title, tagged_title, check_usage=False

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -239,6 +239,22 @@ def _advance_await_target_free_entry(
             "action removed it during the wait window."
         )
 
+    # An admin (or an editor) may have redirected the community file
+    # during the wait window — most likely, redirected it to our tagged
+    # canonical. That means admin already did the merge, just in the
+    # opposite direction from the one we intended. The invariant is
+    # satisfied either way (our canonical holds the S3 SHA1); there is
+    # no move for us to perform. Drop the entry as a decisive
+    # "already-actioned" FAIL rather than blindly moving a redirect
+    # page around and risking a broken redirect chain.
+    if community_page.isRedirectPage():
+        return True, (
+            "FAIL: community file was redirected during the wait window "
+            "— admin (or an editor) already merged it; there is nothing "
+            "for the drain phase to move. Invariant satisfied via the "
+            "existing redirect."
+        )
+
     # Re-validate SHA1 against content drift on the community side.
     actual_sha1 = community_page.latest_file_info.sha1
     if actual_sha1 != expected_sha1:
@@ -536,7 +552,30 @@ def main(no_wait: bool, partner: str) -> None:
         # re-invocation → self-tag path) can be picked up in the same
         # invocation instead of having to wait for the next partner
         # session's drain.
-        _process_await_target_free(partner, site)
+        #
+        # Patient loop: same "wait for human admin action" semantics as
+        # the category-capacity loop above — sleep ``throttle.poll_secs``
+        # between rounds and drain until the sidecar is empty. An entry
+        # that never gets actioned would loop forever; that's acceptable
+        # because patient mode is explicitly designed to wait days/weeks
+        # on Commons volunteers, and the operator ends it via
+        # ``tmux kill-session`` if needed (sidecar persists across kills).
+        while True:
+            pending = await_target_free_sidecar.read_sidecar(partner)
+            if not pending:
+                break
+            _process_await_target_free(partner, site)
+            still_pending = await_target_free_sidecar.read_sidecar(partner)
+            if not still_pending:
+                break
+            logging.info(
+                "Await-target-free: %d entry(ies) still pending for partner "
+                "%s; sleeping %ds before next round.",
+                len(still_pending),
+                partner,
+                int(throttle.poll_secs),
+            )
+            time.sleep(throttle.poll_secs)
         elapsed = time.monotonic() - started_at
         logging.info(
             "Drain-deferred: complete. Emitted %d item(s) over %.0f seconds.",

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -461,14 +461,25 @@ def _run_stage2_patient_loop(
     The partner-scoped lock is acquired PER ROUND and released before
     sleeping — so a peer drain-deferred can also run stage-2 for this
     partner during our sleep window, and neither has to wait on the
-    other for a full poll cycle. Entries mid-workflow (tag_emitted=
-    False) are treated as PENDING; the next uploader run flips them
-    to True, and the following round advances them.
+    other for a full poll cycle.
 
-    An entry that a Commons admin never actions loops forever — same
-    contract as the category-capacity loop: patient mode is designed
-    to wait days/weeks and the operator ends it via
-    ``tmux kill-session`` if needed (sidecar persists across kills).
+    Two distinct "pending" states, and the loop treats them
+    differently:
+
+      * ``tag_emitted=True`` — the {{Duplicate}} tag is on Commons and
+        the entry is waiting on a human admin to action it. This is the
+        genuine patient wait: loop and sleep, possibly for days/weeks,
+        until admin acts (operator ends it via ``tmux kill-session`` if
+        needed; the sidecar persists across kills).
+
+      * ``tag_emitted=False`` — the uploader recorded the intent but the
+        tag write never landed. Stage-2 CANNOT advance these and does
+        NOT emit tags itself; only a subsequent uploader pass finishes
+        them (via ``_resume_self_tag_if_pending``). Looping on them here
+        would spin forever with no possible progress. So if EVERY
+        still-pending entry is ``tag_emitted=False``, stop waiting and
+        leave them queued for the next uploader run — no data loss, and
+        no infinite in-batch loop.
     """
     while True:
         pending = await_target_free_sidecar.read_sidecar(partner)
@@ -478,11 +489,24 @@ def _run_stage2_patient_loop(
         still_pending = await_target_free_sidecar.read_sidecar(partner)
         if not still_pending:
             break
+        advanceable = [e for e in still_pending if e.get("tag_emitted", True)]
+        if not advanceable:
+            logging.warning(
+                "Await-target-free: %d entry(ies) for partner %s are still "
+                "tag_emitted=False (the {{Duplicate}} tag never landed); "
+                "stage-2 cannot advance these — it does not emit tags. "
+                "Leaving them queued for the next uploader run to finish "
+                "rather than waiting on admin action that can't apply.",
+                len(still_pending),
+                partner,
+            )
+            break
         logging.info(
             "Await-target-free: %d entry(ies) still pending for partner "
-            "%s; sleeping %ds before next round.",
+            "%s (%d awaiting admin action); sleeping %ds before next round.",
             len(still_pending),
             partner,
+            len(advanceable),
             int(throttle.poll_secs),
         )
         time.sleep(throttle.poll_secs)

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -47,14 +47,22 @@ from pathlib import Path
 
 import click
 
-from ingest_wikimedia import drain_sidecar
+from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
+from ingest_wikimedia.csrf import with_csrf_recovery
 from ingest_wikimedia.dup_throttle import DuplicateCategoryThrottle
 from ingest_wikimedia.logs import setup_logging
 from ingest_wikimedia.slack import (
     notify_drain_phase_complete,
     notify_drain_phase_start,
 )
-from ingest_wikimedia.wikimedia import get_site
+from ingest_wikimedia.wikimedia import (
+    DUPLICATE_TAG_RE,
+    build_title_drift_move_reason,
+    file_has_inbound_usage,
+    get_page,
+    get_site,
+    post_commonsdelinker_request,
+)
 
 # Host-level lock file. One drain-deferred process at a time across the
 # shared EC2 instance — see module docstring for the concurrency
@@ -172,6 +180,172 @@ def _run_deferred_items(partner: str, dpla_ids: list[str]) -> None:
             )
 
 
+def _advance_await_target_free_entry(
+    entry: dict, site: object
+) -> tuple[bool, str | None]:
+    """Attempt to advance one await-target-free entry.
+
+    Returns ``(should_remove, note)``:
+
+      * ``(True, None)`` — entry advanced successfully (community file
+        moved into the freed DPLA-canonical title). Caller drops it.
+      * ``(True, "FAIL: <reason>")`` — entry is a dead-end and must NOT
+        stay queued (tag was removed by an editor without deletion,
+        community file has disappeared, etc.). Caller drops it and logs
+        the reason.
+      * ``(False, "PENDING: <reason>")`` — entry is still waiting (tag
+        still present, admin hasn't acted). Caller keeps it queued for
+        the next drain round.
+
+    The advancement action itself — moving the community file into the
+    freed canonical title — mirrors ``Uploader._move_to_correct_title``
+    line-for-line: the same reason string, same CommonsDelinker relink,
+    same title-drift semantics. The two implementations share a
+    conceptual contract (invariant satisfied post-move) even though the
+    code isn't unified — a shared helper is a reasonable future
+    refactor.
+    """
+    dpla_id = entry["dpla_id"]
+    tagged_title = entry["tagged_title"]
+    community_title = entry["community_title"]
+    expected_sha1 = entry["expected_sha1"]
+
+    tagged_page = get_page(site, f"File:{tagged_title}")
+    exists = tagged_page.exists()
+
+    # State machine over the tagged page. Poll order matters:
+    #   1. Doesn't exist → admin deleted, advance.
+    #   2. Redirect → admin merged, advance (move_to_title handles redirects).
+    #   3. Exists with tag → still waiting.
+    #   4. Exists WITHOUT tag → admin (or an editor) removed the tag
+    #      without deleting the page. Treat as decisive decline: drop
+    #      the entry and log FAIL.
+    if exists and not tagged_page.isRedirectPage():
+        text = tagged_page.text or ""
+        if DUPLICATE_TAG_RE.search(text):
+            return False, "PENDING: tagged file still present with Duplicate template"
+        return True, (
+            "FAIL: tagged file still exists but {{Duplicate}} template was "
+            "removed by a Commons editor without deletion — treating as a "
+            "decline and giving up on the rename."
+        )
+
+    # Advance path (deletion OR redirect).
+    community_page = get_page(site, f"File:{community_title}")
+    if not community_page.exists():
+        return True, (
+            "FAIL: community file no longer exists on Commons — a third-party "
+            "action removed it during the wait window."
+        )
+
+    # Re-validate SHA1 against content drift on the community side.
+    actual_sha1 = community_page.latest_file_info.sha1
+    if actual_sha1 != expected_sha1:
+        return True, (
+            f"FAIL: community file SHA1 drifted during the wait window "
+            f"(expected {expected_sha1[:16]}…, now {actual_sha1[:16]}…) — "
+            f"refusing to move stale bytes into the canonical title."
+        )
+
+    # Move community file into the freed canonical title.
+    intended_page = get_page(site, f"File:{tagged_title}")
+    reason = build_title_drift_move_reason(
+        community_title, tagged_title, dpla_id, site.user()
+    )
+    needs_relink = file_has_inbound_usage(site, community_title)
+    logging.info(
+        "Await-target-free advance for %s: moving [[File:%s]] → [[File:%s]]",
+        dpla_id,
+        community_title,
+        tagged_title,
+    )
+    with_csrf_recovery(
+        site,
+        f"move {community_page.title()} → {intended_page.title()}",
+        lambda: community_page.move(
+            intended_page.title(),
+            reason=reason,
+            movetalk=False,
+            noredirect=False,
+        ),
+    )
+    if needs_relink:
+        post_commonsdelinker_request(
+            site, community_title, tagged_title, check_usage=False
+        )
+    return True, None
+
+
+def _process_await_target_free(partner: str, site: object) -> None:
+    """Poll every await-target-free sidecar entry and advance the ones
+    whose tagged file has been actioned by a Commons admin.
+
+    Idempotent — safe to run whether patient or opportunistic. An entry
+    that isn't ready this round stays queued for the next round. Same
+    isolation contract as ``_run_one_round``: a per-item failure
+    (network blip, pywikibot exception) is logged and the entry stays
+    queued.
+    """
+    pending = await_target_free_sidecar.read_sidecar(partner)
+    if not pending:
+        return
+    logging.info(
+        "Await-target-free: polling %d entry(ies) for partner %s.",
+        len(pending),
+        partner,
+    )
+    advanced = 0
+    failed = 0
+    for entry in pending:
+        try:
+            should_remove, note = _advance_await_target_free_entry(entry, site)
+        except Exception as ex:
+            logging.warning(
+                "Await-target-free: entry %s (%s → %s) raised %s; leaving queued.",
+                entry["dpla_id"],
+                entry["community_title"],
+                entry["tagged_title"],
+                ex,
+            )
+            continue
+        if not should_remove:
+            logging.info(
+                "Await-target-free: entry %s (%s → %s) %s.",
+                entry["dpla_id"],
+                entry["community_title"],
+                entry["tagged_title"],
+                note,
+            )
+            continue
+        await_target_free_sidecar.remove_entry(
+            partner, entry["dpla_id"], entry["ordinal"]
+        )
+        if note and note.startswith("FAIL:"):
+            failed += 1
+            logging.warning(
+                "Await-target-free: entry %s (%s → %s) dropped — %s",
+                entry["dpla_id"],
+                entry["community_title"],
+                entry["tagged_title"],
+                note,
+            )
+        else:
+            advanced += 1
+            logging.info(
+                "Await-target-free: entry %s (%s → %s) advanced — community "
+                "file moved into freed canonical title.",
+                entry["dpla_id"],
+                entry["community_title"],
+                entry["tagged_title"],
+            )
+    logging.info(
+        "Await-target-free: %d advanced, %d failed, %d still pending.",
+        advanced,
+        failed,
+        len(pending) - advanced - failed,
+    )
+
+
 def _run_one_round(partner: str, pending: list[str]) -> int:
     """Execute one drain round: clear ``pending`` from the sidecar,
     invoke uploader + sdc-sync on those IDs, return how many the
@@ -285,19 +459,22 @@ def main(no_wait: bool, partner: str) -> None:
     setup_logging(partner, event_type, logging.INFO)
 
     initial_ids = drain_sidecar.read_sidecar(partner)
-    if not initial_ids:
+    initial_await = await_target_free_sidecar.read_sidecar(partner)
+    if not initial_ids and not initial_await:
         logging.info(
-            "Drain-deferred: sidecar for partner %s is empty (or missing); nothing to do.",
+            "Drain-deferred: both sidecars for partner %s are empty (or missing); "
+            "nothing to do.",
             partner,
         )
         return
 
     mode_label = "opportunistic" if no_wait else "patient"
     logging.info(
-        "Drain-deferred: sidecar for partner %s has %d item(s) queued; "
-        "acquiring host lock (mode: %s).",
+        "Drain-deferred: partner %s has %d category-capacity item(s) and %d "
+        "await-target-free entry(ies) queued; acquiring host lock (mode: %s).",
         partner,
         len(initial_ids),
+        len(initial_await),
         mode_label,
     )
 
@@ -312,8 +489,10 @@ def main(no_wait: bool, partner: str) -> None:
     if lock_fd is None:
         logging.info(
             "Drain-deferred (opportunistic): host lock held by another drain; "
-            "skipping this pass — %d item(s) remain queued for the terminal drain.",
+            "skipping this pass — %d category-capacity item(s) and %d "
+            "await-target-free entry(ies) remain queued for the terminal drain.",
             len(initial_ids),
+            len(initial_await),
         )
         return
     try:
@@ -321,10 +500,12 @@ def main(no_wait: bool, partner: str) -> None:
         # ``get_site()`` — same helper the uploader/retirer/fix-categories
         # tools use; also runs ``site.login()``. The throttle requires a
         # non-None site (see :class:`DuplicateCategoryThrottle` guard).
-        throttle = DuplicateCategoryThrottle(get_site())
+        site = get_site()
+        throttle = DuplicateCategoryThrottle(site)
 
         if no_wait:
             _drain_opportunistic_once(partner, throttle)
+            _process_await_target_free(partner, site)
             return
 
         # Patient mode: Slack-notify start (so the operator knows the
@@ -333,6 +514,13 @@ def main(no_wait: bool, partner: str) -> None:
         initial_category_size = throttle.category_size()
         notify_drain_phase_start(partner, len(initial_ids), initial_category_size)
         total_emitted = _drain_loop(partner, throttle)
+        # Stage-2 handling: poll and advance await-target-free entries.
+        # Runs AFTER the patient category-capacity loop so any Case-2
+        # tag emissions this round produced (via _drain_loop → uploader
+        # re-invocation → self-tag path) can be picked up in the same
+        # invocation instead of having to wait for the next partner
+        # session's drain.
+        _process_await_target_free(partner, site)
         elapsed = time.monotonic() - started_at
         logging.info(
             "Drain-deferred: complete. Emitted %d item(s) over %.0f seconds.",

--- a/tools/drain_deferred.py
+++ b/tools/drain_deferred.py
@@ -1,38 +1,43 @@
-"""Drain the per-partner deferred-drain sidecar.
+"""Drain the per-partner deferred queues by re-running the uploader.
 
-The uploader defers Case-2 hash-drift upload+tag operations as an
-atomic unit whenever ``Category:Duplicate`` on Commons is at capacity,
-persisting the deferred DPLA IDs to a per-partner sidecar (see
-``ingest_wikimedia.drain_sidecar``). The drain-deferred command comes
-in two modes:
+Two independent queues, both per-partner, both drained by the same
+mechanism — **re-invoke the idempotent uploader (and sdc-sync) on the
+queued DPLA IDs until the queue empties.** The uploader re-derives all
+state from live S3 / Commons on each run, so the drain holds no per-item
+logic of its own.
 
-  * **Patient (default)** — the terminal phase of a batch. Acquires a
-    host-level ``flock`` and loops until the sidecar is empty,
-    polling ``Category:Duplicate`` (every ``DEFAULT_POLL_SECS`` = 5
-    min by default) with no time budget — designed to wait days or
-    weeks on human-admin category clearing. Emits Slack
-    start/complete notifications so the operator knows the session
-    is in this state.
+  * **Category-capacity queue** (``ingest_wikimedia.drain_sidecar``) —
+    Case-2 hash-drift upload+tag operations the uploader deferred
+    because ``Category:Duplicate`` was at capacity. Drained only while
+    the category is below its resume threshold (the throttle gate).
 
-  * **``--no-wait`` (opportunistic)** — the interstitial phase
-    embedded in each target's upload chain. Runs a single best-effort
-    round: if ``Category:Duplicate`` is currently below the
-    throttle's resume threshold, drain what fits and return; if it's
-    at capacity, exit immediately without waiting. Never blocks
-    subsequent targets in the batch. No Slack notifications — this
-    pass is a bonus, not a milestone. Items that don't clear here
-    stay in the sidecar for the batch's final patient drain.
+  * **Await-target-free set** (``ingest_wikimedia.await_target_free_sidecar``)
+    — Case-2 community-target items where we uploaded our bytes to the
+    DPLA-canonical title and self-tagged ``{{Duplicate|<community>}}``,
+    now waiting on a Commons admin to delete or redirect our tagged
+    file. A re-run of the uploader resolves whatever the admin did:
+    once the canonical title is freed, the empty-canonical Case-3
+    title-drift move promotes the community file into it (history
+    intact); if the admin removed the tag instead (declining), the
+    uploader drops the key and the two files coexist. No capacity gate
+    — an awaiting re-run emits no new tag, so category size is
+    irrelevant to it.
 
-Cancellation is operator-driven — ``tmux kill-session`` at any time.
-The sidecar persists across kills, so a subsequent partner run picks
-up wherever this left off.
+The command has two modes:
 
-See the launcher (``scripts/wikimedia_launch.py``) for the chain
-ordering: per-target opportunistic drains run inside each target's
-chain (so a partner whose Category:Duplicate happened to clear
-mid-run gets its deferrals actioned before the next partner starts),
-and a per-partner patient drain runs at the end of the whole batch
-(so no partner sits idle waiting on Commons volunteers).
+  * **Patient (default)** — the terminal phase of a batch. Drains the
+    category queue (waiting on ``Category:Duplicate`` with no time
+    budget) then the await set (waiting on Commons admins), looping for
+    as long as it takes. Emits Slack start/complete notifications.
+
+  * **``--no-wait`` (opportunistic)** — the interstitial phase in each
+    target's chain. One best-effort round of each queue; never blocks.
+
+Concurrency: uploader/sdc-sync invocations across the box are serialized
+by a host-level ``flock`` (``_DRAIN_LOCK_PATH``) held only while a round
+runs — released across the patient waits so one partner's multi-day wait
+never blocks another's drain. Cancellation is operator-driven
+(``tmux kill-session``); both queues persist across kills.
 """
 
 from __future__ import annotations
@@ -46,41 +51,22 @@ import time
 from pathlib import Path
 
 import click
-import pywikibot
 
 from ingest_wikimedia import await_target_free_sidecar, drain_sidecar
-from ingest_wikimedia.csrf import with_csrf_recovery
 from ingest_wikimedia.dup_throttle import DuplicateCategoryThrottle
 from ingest_wikimedia.logs import setup_logging
 from ingest_wikimedia.slack import (
     notify_drain_phase_complete,
     notify_drain_phase_start,
 )
-from ingest_wikimedia.wikimedia import (
-    DUPLICATE_TAG_RE,
-    build_title_drift_move_reason,
-    file_has_inbound_usage,
-    get_page,
-    get_site,
-    post_commonsdelinker_request,
-)
+from ingest_wikimedia.wikimedia import get_site
 
-# Host-level lock file. One drain-deferred process at a time across the
-# shared EC2 instance — see module docstring for the concurrency
-# rationale. Path is host-scoped (not partner-scoped) so cross-partner
-# drains serialize.
+# Host-level lock file. One uploader-heavy drain round at a time across
+# the shared EC2 instance, so concurrent rounds don't oversubscribe
+# Commons. Path is host-scoped (not partner-scoped) so cross-partner
+# drains serialize. Held only for the duration of a round — never across
+# a patient wait.
 _DRAIN_LOCK_PATH = "/home/ec2-user/ingest-wikimedia/.drain-lock"
-
-# Partner-scoped stage-2 lock file name. Placed under each partner's
-# working directory. Held only for the duration of a single stage-2
-# poll round so multiple partners' stage-2 drains run concurrently
-# (the host-wide lock is released before stage-2 begins). Serializes
-# stage-2 rounds for THE SAME partner against another drain-deferred
-# or a concurrent uploader that races on the same sidecar entry —
-# without this, two rounds could both read an entry with
-# tag_emitted=True, both call ``community_page.move``, and one would
-# race a torn "no such source" error on Commons.
-_STAGE2_LOCK_FILENAME = ".stage2-drain.lock"
 
 
 def _acquire_host_lock(blocking: bool = True):
@@ -92,13 +78,11 @@ def _acquire_host_lock(blocking: bool = True):
     crashed drain doesn't leave a stuck lock. The lock file itself is
     created (empty) if missing; it never grows.
 
-    ``blocking=True`` (patient/terminal drain) waits until the lock frees —
-    it legitimately holds the lock for hours while a human clears
-    ``Category:Duplicate``. ``blocking=False`` (opportunistic ``--no-wait``
-    pass) tries once (``LOCK_NB``) and returns ``None`` if the lock is held:
-    the opportunistic pass is a fire-and-forget interstitial round and must
-    NOT block its target's chain behind a long-running patient drain (that
-    was keeping finished sessions open for hours — see the drain-lock bug).
+    ``blocking=True`` (patient drain) waits until the lock frees.
+    ``blocking=False`` (opportunistic ``--no-wait`` pass) tries once
+    (``LOCK_NB``) and returns ``None`` if held: the opportunistic pass is
+    fire-and-forget and must never block its target's chain behind
+    another drain.
     """
     Path(_DRAIN_LOCK_PATH).parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(_DRAIN_LOCK_PATH, os.O_RDWR | os.O_CREAT, 0o644)
@@ -114,33 +98,6 @@ def _acquire_host_lock(blocking: bool = True):
         os.close(fd)
         return None
     logging.info("Drain-phase host lock acquired.")
-    return fd
-
-
-def _acquire_stage2_lock(partner: str, blocking: bool = True):
-    """Acquire the partner-scoped stage-2 ``flock``. Returns a held fd
-    or ``None`` when ``blocking=False`` and another drain holds it.
-
-    Scope is one partner: stage-2 for partner A runs concurrently with
-    stage-2 for partner B (they touch different sidecars and different
-    Commons files). What this lock serializes is same-partner rounds —
-    without it, two drain-deferred processes running stage-2 for the
-    same partner could both read an entry with tag_emitted=True, both
-    call community_page.move, and race on Commons.
-
-    Companion behaviour to :func:`_acquire_host_lock`: created lazily,
-    never deleted, released on fd close (so crashes free it).
-    """
-    partner_dir = drain_sidecar.partner_dir_path(partner)
-    partner_dir.mkdir(parents=True, exist_ok=True)
-    lock_path = partner_dir / _STAGE2_LOCK_FILENAME
-    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
-    flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
-    try:
-        fcntl.flock(fd, flags)
-    except BlockingIOError:
-        os.close(fd)
-        return None
     return fd
 
 
@@ -219,302 +176,14 @@ def _run_deferred_items(partner: str, dpla_ids: list[str]) -> None:
             )
 
 
-def _advance_await_target_free_entry(
-    entry: dict, site: object
-) -> tuple[bool, str | None]:
-    """Attempt to advance one await-target-free entry.
-
-    Returns ``(should_remove, note)``:
-
-      * ``(True, None)`` — entry advanced successfully (community file
-        moved into the freed DPLA-canonical title). Caller drops it.
-      * ``(True, "FAIL: <reason>")`` — entry is a dead-end and must NOT
-        stay queued (tag was removed by an editor without deletion,
-        community file has disappeared, etc.). Caller drops it and logs
-        the reason.
-      * ``(False, "PENDING: <reason>")`` — entry is still waiting (tag
-        still present, admin hasn't acted). Caller keeps it queued for
-        the next drain round.
-
-    The advancement action itself — moving the community file into the
-    freed canonical title — mirrors ``Uploader._move_to_correct_title``
-    line-for-line: the same reason string, same CommonsDelinker relink,
-    same title-drift semantics. The two implementations share a
-    conceptual contract (invariant satisfied post-move) even though the
-    code isn't unified — a shared helper is a reasonable future
-    refactor.
-    """
-    dpla_id = entry["dpla_id"]
-    tagged_title = entry["tagged_title"]
-    community_title = entry["community_title"]
-    expected_sha1 = entry["expected_sha1"]
-
-    # Workflow phase gate: an entry with tag_emitted=False was recorded
-    # by the uploader but the corresponding tag_as_duplicate call never
-    # completed. Drain must NOT try to advance it — the canonical file
-    # carries no tag, no admin action is possible, and treating the
-    # absent tag as an editor-decline (the untagged FAIL path below)
-    # would prematurely drop a still-in-progress workflow. Keep the
-    # entry queued; the next uploader run for this partner will retry
-    # the tag and flip the phase to True.
-    if not entry.get("tag_emitted", True):
-        return False, (
-            "PENDING: tag not yet emitted by the uploader "
-            "(tag_emitted=False); leaving queued for the uploader to retry."
-        )
-
-    tagged_page = get_page(site, f"File:{tagged_title}")
-    exists = tagged_page.exists()
-
-    # State machine over the tagged page. Poll order matters:
-    #   1. Doesn't exist → admin deleted, advance.
-    #   2. Redirect → admin merged, advance (move_to_title handles redirects).
-    #   3. Exists with tag → still waiting.
-    #   4. Exists WITHOUT tag → admin (or an editor) removed the tag
-    #      without deleting the page. Treat as decisive decline: drop
-    #      the entry and log FAIL.
-    if exists and not tagged_page.isRedirectPage():
-        text = tagged_page.text or ""
-        if DUPLICATE_TAG_RE.search(text):
-            return False, "PENDING: tagged file still present with Duplicate template"
-        return True, (
-            "FAIL: tagged file still exists but {{Duplicate}} template was "
-            "removed by a Commons editor without deletion — treating as a "
-            "decline and giving up on the rename."
-        )
-
-    # Advance path (deletion OR redirect).
-    community_page = get_page(site, f"File:{community_title}")
-    if not community_page.exists():
-        return True, (
-            "FAIL: community file no longer exists on Commons — a third-party "
-            "action removed it during the wait window."
-        )
-
-    # An admin (or an editor) may have redirected the community file
-    # during the wait window — most likely, redirected it to our tagged
-    # canonical. That means admin already did the merge, just in the
-    # opposite direction from the one we intended. The invariant is
-    # satisfied either way (our canonical holds the S3 SHA1); there is
-    # no move for us to perform. Drop the entry as a decisive
-    # "already-actioned" FAIL rather than blindly moving a redirect
-    # page around and risking a broken redirect chain.
-    if community_page.isRedirectPage():
-        return True, (
-            "FAIL: community file was redirected during the wait window "
-            "— admin (or an editor) already merged it; there is nothing "
-            "for the drain phase to move. Invariant satisfied via the "
-            "existing redirect."
-        )
-
-    # Re-validate SHA1 against content drift on the community side.
-    actual_sha1 = community_page.latest_file_info.sha1
-    if actual_sha1 != expected_sha1:
-        return True, (
-            f"FAIL: community file SHA1 drifted during the wait window "
-            f"(expected {expected_sha1[:16]}…, now {actual_sha1[:16]}…) — "
-            f"refusing to move stale bytes into the canonical title."
-        )
-
-    # Move community file into the freed canonical title.
-    intended_page = get_page(site, f"File:{tagged_title}")
-    reason = build_title_drift_move_reason(
-        community_title, tagged_title, dpla_id, site.user()
-    )
-    needs_relink = file_has_inbound_usage(site, community_title)
-    logging.info(
-        "Await-target-free advance for %s: moving [[File:%s]] → [[File:%s]]",
-        dpla_id,
-        community_title,
-        tagged_title,
-    )
-    try:
-        with_csrf_recovery(
-            site,
-            f"move {community_page.title()} → {intended_page.title()}",
-            lambda: community_page.move(
-                intended_page.title(),
-                reason=reason,
-                movetalk=False,
-                noredirect=False,
-            ),
-        )
-    except pywikibot.exceptions.ArticleExistsConflictError as ex:
-        # A stale redirect or page history at the tagged title blocks
-        # the move. The invariant is still satisfied — either the
-        # redirect resolves to the community file (which holds the S3
-        # SHA1) or admin left content we cannot displace. Retrying every
-        # poll would spam the API with a call that cannot succeed, so
-        # treat this as a decisive FAIL: drop the sidecar entry and let
-        # the community file remain at its original title.
-        return True, (
-            f"FAIL: move to canonical title blocked by "
-            f"ArticleExistsConflictError ({ex}) — community file left "
-            f"in place; invariant already satisfied via the tagged "
-            f"title's current state."
-        )
-    if needs_relink:
-        post_commonsdelinker_request(
-            site, community_title, tagged_title, check_usage=False
-        )
-    return True, None
-
-
-def _process_await_target_free(partner: str, site: object) -> None:
-    """Poll every await-target-free sidecar entry and advance the ones
-    whose tagged file has been actioned by a Commons admin.
-
-    Idempotent — safe to run whether patient or opportunistic. An entry
-    that isn't ready this round stays queued for the next round. Same
-    isolation contract as ``_run_one_round``: a per-item failure
-    (network blip, pywikibot exception) is logged and the entry stays
-    queued.
-    """
-    pending = await_target_free_sidecar.read_sidecar(partner)
-    if not pending:
-        return
-    logging.info(
-        "Await-target-free: polling %d entry(ies) for partner %s.",
-        len(pending),
-        partner,
-    )
-    advanced = 0
-    failed = 0
-    for entry in pending:
-        try:
-            should_remove, note = _advance_await_target_free_entry(entry, site)
-        except Exception as ex:
-            logging.warning(
-                "Await-target-free: entry %s (%s → %s) raised %s; leaving queued.",
-                entry["dpla_id"],
-                entry["community_title"],
-                entry["tagged_title"],
-                ex,
-            )
-            continue
-        if not should_remove:
-            logging.info(
-                "Await-target-free: entry %s (%s → %s) %s.",
-                entry["dpla_id"],
-                entry["community_title"],
-                entry["tagged_title"],
-                note,
-            )
-            continue
-        await_target_free_sidecar.remove_entry(
-            partner, entry["dpla_id"], entry["ordinal"]
-        )
-        if note and note.startswith("FAIL:"):
-            failed += 1
-            logging.warning(
-                "Await-target-free: entry %s (%s → %s) dropped — %s",
-                entry["dpla_id"],
-                entry["community_title"],
-                entry["tagged_title"],
-                note,
-            )
-        else:
-            advanced += 1
-            logging.info(
-                "Await-target-free: entry %s (%s → %s) advanced — community "
-                "file moved into freed canonical title.",
-                entry["dpla_id"],
-                entry["community_title"],
-                entry["tagged_title"],
-            )
-    logging.info(
-        "Await-target-free: %d advanced, %d failed, %d still pending.",
-        advanced,
-        failed,
-        len(pending) - advanced - failed,
-    )
-
-
-def _run_stage2_once(partner: str, site: object) -> None:
-    """Run one stage-2 round under the partner-scoped stage-2 lock.
-
-    Held only for the duration of the round (not across sleeps), so
-    concurrent drains for OTHER partners are unaffected and same-
-    partner rounds serialize cleanly. Non-blocking: if another drain
-    is mid-round for this partner, skip — its work covers ours.
-    """
-    stage2_fd = _acquire_stage2_lock(partner, blocking=False)
-    if stage2_fd is None:
-        logging.info(
-            "Await-target-free: partner-scoped stage-2 lock held by another "
-            "drain for partner %s; skipping this round.",
-            partner,
-        )
-        return
-    try:
-        _process_await_target_free(partner, site)
-    finally:
-        os.close(stage2_fd)
-
-
-def _run_stage2_patient_loop(
-    partner: str, site: object, throttle: DuplicateCategoryThrottle
-) -> None:
-    """Patient stage-2 wait loop: drain until the sidecar is empty,
-    sleeping ``throttle.poll_secs`` between rounds.
-
-    The partner-scoped lock is acquired PER ROUND and released before
-    sleeping — so a peer drain-deferred can also run stage-2 for this
-    partner during our sleep window, and neither has to wait on the
-    other for a full poll cycle.
-
-    Two distinct "pending" states, and the loop treats them
-    differently:
-
-      * ``tag_emitted=True`` — the {{Duplicate}} tag is on Commons and
-        the entry is waiting on a human admin to action it. This is the
-        genuine patient wait: loop and sleep, possibly for days/weeks,
-        until admin acts (operator ends it via ``tmux kill-session`` if
-        needed; the sidecar persists across kills).
-
-      * ``tag_emitted=False`` — the uploader recorded the intent but the
-        tag write never landed. Stage-2 CANNOT advance these and does
-        NOT emit tags itself; only a subsequent uploader pass finishes
-        them (via ``_resume_self_tag_if_pending``). Looping on them here
-        would spin forever with no possible progress. So if EVERY
-        still-pending entry is ``tag_emitted=False``, stop waiting and
-        leave them queued for the next uploader run — no data loss, and
-        no infinite in-batch loop.
-    """
-    while True:
-        pending = await_target_free_sidecar.read_sidecar(partner)
-        if not pending:
-            break
-        _run_stage2_once(partner, site)
-        still_pending = await_target_free_sidecar.read_sidecar(partner)
-        if not still_pending:
-            break
-        advanceable = [e for e in still_pending if e.get("tag_emitted", True)]
-        if not advanceable:
-            logging.warning(
-                "Await-target-free: %d entry(ies) for partner %s are still "
-                "tag_emitted=False (the {{Duplicate}} tag never landed); "
-                "stage-2 cannot advance these — it does not emit tags. "
-                "Leaving them queued for the next uploader run to finish "
-                "rather than waiting on admin action that can't apply.",
-                len(still_pending),
-                partner,
-            )
-            break
-        logging.info(
-            "Await-target-free: %d entry(ies) still pending for partner "
-            "%s (%d awaiting admin action); sleeping %ds before next round.",
-            len(still_pending),
-            partner,
-            len(advanceable),
-            int(throttle.poll_secs),
-        )
-        time.sleep(throttle.poll_secs)
+# --------------------------------------------------------------------------
+# Category-capacity queue (drain_sidecar)
+# --------------------------------------------------------------------------
 
 
 def _run_one_round(partner: str, pending: list[str]) -> int:
-    """Execute one drain round: clear ``pending`` from the sidecar,
-    invoke uploader + sdc-sync on those IDs, return how many the
+    """Execute one category-queue round: clear ``pending`` from the
+    sidecar, invoke uploader + sdc-sync on those IDs, return how many the
     round emitted (``pre - post``).
 
     Taking the round's IDs out BEFORE the subprocess is load-bearing
@@ -534,11 +203,10 @@ def _run_one_round(partner: str, pending: list[str]) -> int:
 
 
 def _drain_loop(partner: str, throttle: DuplicateCategoryThrottle) -> int:
-    """Patient drain loop for ``partner``. Blocks on
+    """Patient category-queue loop for ``partner``. Blocks on
     :meth:`DuplicateCategoryThrottle.wait_for_capacity` between rounds;
-    returns the total number of items emitted (drained from the
-    sidecar) once it's empty. See module docstring for the rationale
-    on the unbounded wait."""
+    returns the total number of items emitted once the sidecar is empty.
+    Caller holds the host lock for the duration."""
     total_emitted = 0
     while True:
         pending = drain_sidecar.read_sidecar(partner)
@@ -563,10 +231,10 @@ def _drain_loop(partner: str, throttle: DuplicateCategoryThrottle) -> int:
             )
         else:
             # A round that made no progress despite reported capacity is
-            # not fatal here (unlike the old bounded drain that would
-            # abort). Category:Duplicate may have refilled while we were
-            # processing, or the round hit unrelated per-item failures.
-            # Loop back to wait_for_capacity; next round will re-observe.
+            # not fatal. Category:Duplicate may have refilled while we
+            # were processing, or the round hit unrelated per-item
+            # failures. Loop back to wait_for_capacity; next round
+            # re-observes.
             logging.warning(
                 "Drain-deferred: round made no progress (%d item(s) still "
                 "pending). Continuing to wait; category may have refilled.",
@@ -575,20 +243,10 @@ def _drain_loop(partner: str, throttle: DuplicateCategoryThrottle) -> int:
 
 
 def _drain_opportunistic_once(partner: str, throttle: DuplicateCategoryThrottle) -> int:
-    """Single best-effort drain round for ``partner``. If
-    ``Category:Duplicate`` is below the resume threshold RIGHT NOW,
-    drain what's queued; if it's at capacity, exit immediately without
-    waiting. Never blocks the caller.
-
-    Returns the number of items drained (0 if the round didn't fire,
-    positive if it did).
-
-    The opportunistic pass exists so a partner whose category clears
-    mid-batch (a Commons volunteer processes some entries between the
-    partner's upload phase and end-of-batch) gets its deferrals
-    actioned as part of its own chain — before the next target starts
-    — rather than waiting on the batch's terminal patient drain.
-    """
+    """Single best-effort category-queue round for ``partner``. If
+    ``Category:Duplicate`` is below the resume threshold RIGHT NOW, drain
+    what's queued; if it's at capacity, exit immediately. Never blocks.
+    Returns the number of items drained (0 if the round didn't fire)."""
     pending = drain_sidecar.read_sidecar(partner)
     if not pending:
         return 0
@@ -608,27 +266,102 @@ def _drain_opportunistic_once(partner: str, throttle: DuplicateCategoryThrottle)
     return emitted
 
 
+# --------------------------------------------------------------------------
+# Await-target-free set
+# --------------------------------------------------------------------------
+#
+# Draining this set is *exactly* the category-queue pattern — re-run the
+# idempotent uploader on the queued DPLA IDs — with two differences:
+#   * no Category:Duplicate capacity gate (an awaiting re-run emits no
+#     new tag; it only moves the community file into a freed canonical
+#     title, skips while still waiting, or drops a declined key), and
+#   * the uploader OWNS the set (it adds/removes keys as it resolves each
+#     ordinal), so the drain never removes-before-run; it just re-runs
+#     and re-reads until the set empties.
+
+
+def _run_await_round(partner: str, blocking: bool) -> bool:
+    """Run one await round: re-invoke the uploader + sdc-sync on the
+    DPLA IDs with at least one awaiting ordinal, under the host lock.
+
+    Returns ``True`` if the round ran, ``False`` if the set was empty or
+    (opportunistic) the host lock was held by another drain. The host
+    lock is acquired only for the round and released before returning, so
+    a patient await wait never holds it across sleeps.
+    """
+    ids = await_target_free_sidecar.awaiting_dpla_ids(partner)
+    if not ids:
+        return False
+    lock_fd = _acquire_host_lock(blocking=blocking)
+    if lock_fd is None:
+        logging.info(
+            "Await drain (opportunistic): host lock held by another drain; "
+            "skipping — %d item(s) remain awaiting for the terminal drain.",
+            len(ids),
+        )
+        return False
+    try:
+        logging.info(
+            "Await drain: re-running uploader on %d awaiting item(s) for %s.",
+            len(ids),
+            partner,
+        )
+        _run_deferred_items(partner, ids)
+    finally:
+        os.close(lock_fd)
+    return True
+
+
+def _drain_await_patient(partner: str, throttle: DuplicateCategoryThrottle) -> None:
+    """Patient await-target-free loop: re-run the uploader on awaiting
+    items until the set empties, sleeping ``throttle.poll_secs`` between
+    rounds while items remain (they're waiting on a Commons admin).
+
+    Terminates only when the set is empty — the uploader clears each key
+    as it resolves (admin deletion → Case-3 move; admin de-tag → key
+    dropped). A key whose admin never acts keeps the loop alive by
+    design (same unbounded-patience contract as the category loop);
+    the operator ends it via ``tmux kill-session`` (the set persists).
+    """
+    while True:
+        if not await_target_free_sidecar.awaiting_dpla_ids(partner):
+            return
+        _run_await_round(partner, blocking=True)
+        remaining = await_target_free_sidecar.awaiting_dpla_ids(partner)
+        if not remaining:
+            return
+        logging.info(
+            "Await drain: %d item(s) for %s still awaiting Commons admin "
+            "action; sleeping %ds before the next round.",
+            len(remaining),
+            partner,
+            int(throttle.poll_secs),
+        )
+        time.sleep(throttle.poll_secs)
+
+
 @click.command()
 @click.option(
     "--no-wait",
     is_flag=True,
     help=(
-        "Best-effort single-round drain: if Category:Duplicate is at capacity, "
-        "exit immediately rather than waiting. For the per-target opportunistic "
-        "phase; the batch's terminal patient drain runs without this flag."
+        "Best-effort single round of each queue: if Category:Duplicate is at "
+        "capacity (or the host lock is held) skip rather than waiting. For the "
+        "per-target opportunistic phase; the batch's terminal drain runs "
+        "without this flag."
     ),
 )
 @click.argument("partner")
 def main(no_wait: bool, partner: str) -> None:
-    """Drain the deferred-drain sidecar for ``partner``. See module docstring."""
+    """Drain the deferred queues for ``partner``. See module docstring."""
     event_type = "drain-deferred-opportunistic" if no_wait else "drain-deferred"
     setup_logging(partner, event_type, logging.INFO)
 
     initial_ids = drain_sidecar.read_sidecar(partner)
-    initial_await = await_target_free_sidecar.read_sidecar(partner)
+    initial_await = await_target_free_sidecar.awaiting_dpla_ids(partner)
     if not initial_ids and not initial_await:
         logging.info(
-            "Drain-deferred: both sidecars for partner %s are empty (or missing); "
+            "Drain-deferred: both queues for partner %s are empty (or missing); "
             "nothing to do.",
             partner,
         )
@@ -637,76 +370,84 @@ def main(no_wait: bool, partner: str) -> None:
     mode_label = "opportunistic" if no_wait else "patient"
     logging.info(
         "Drain-deferred: partner %s has %d category-capacity item(s) and %d "
-        "await-target-free entry(ies) queued; acquiring host lock (mode: %s).",
+        "await-target-free item(s) queued (mode: %s).",
         partner,
         len(initial_ids),
         len(initial_await),
         mode_label,
     )
 
-    # Advisory host-level lock. The patient (terminal) drain BLOCKS until
-    # it's free (it can hold the lock for hours/days while a human clears
-    # Category:Duplicate). The opportunistic (--no-wait) pass acquires
-    # NON-BLOCKING and skips if another drain holds it — it must never block
-    # its target's chain behind a patient drain. The ``finally`` below closes
-    # the fd (releasing the flock) on normal exit or exception; a kill
-    # releases it on process exit.
-    lock_fd = _acquire_host_lock(blocking=not no_wait)
-    if lock_fd is None:
-        logging.info(
-            "Drain-deferred (opportunistic): host lock held by another drain; "
-            "skipping this pass — %d category-capacity item(s) and %d "
-            "await-target-free entry(ies) remain queued for the terminal drain.",
-            len(initial_ids),
-            len(initial_await),
-        )
+    # ``get_site()`` also runs ``site.login()``; the throttle requires a
+    # non-None site (see :class:`DuplicateCategoryThrottle` guard).
+    site = get_site()
+    throttle = DuplicateCategoryThrottle(site)
+
+    if no_wait:
+        # One best-effort round of each queue, each acquiring the host
+        # lock non-blocking (skip if a peer holds it). The two queues are
+        # independent: a held lock or a full category doesn't stop the
+        # await round from being attempted.
+        if initial_ids:
+            lock_fd = _acquire_host_lock(blocking=False)
+            if lock_fd is None:
+                logging.info(
+                    "Drain-deferred (opportunistic): host lock held; skipping "
+                    "the category round — %d item(s) remain for the terminal "
+                    "drain.",
+                    len(initial_ids),
+                )
+            else:
+                try:
+                    _drain_opportunistic_once(partner, throttle)
+                finally:
+                    os.close(lock_fd)
+        _run_await_round(partner, blocking=False)
         return
-    try:
-        started_at = time.monotonic()
-        # ``get_site()`` — same helper the uploader/retirer/fix-categories
-        # tools use; also runs ``site.login()``. The throttle requires a
-        # non-None site (see :class:`DuplicateCategoryThrottle` guard).
-        site = get_site()
-        throttle = DuplicateCategoryThrottle(site)
 
-        if no_wait:
-            _drain_opportunistic_once(partner, throttle)
-            # Release the host lock before stage-2. Stage-2 talks to
-            # partner-local resources only (the await sidecar and this
-            # partner's Commons files); holding the host-wide lock
-            # across it would prevent other partners' drains from
-            # running for minutes. Serialization for same-partner
-            # stage-2 rounds is handled by the partner-scoped lock.
+    # Patient mode. Slack-notify start only when there's category work to
+    # announce (the start ping carries the category size / deferred
+    # count). Each phase acquires the host lock only while a round runs.
+    started_at = time.monotonic()
+    notified_start = False
+    total_emitted = 0
+    if initial_ids:
+        lock_fd = _acquire_host_lock(blocking=True)
+        try:
+            notify_drain_phase_start(
+                partner, len(initial_ids), throttle.category_size()
+            )
+            notified_start = True
+            total_emitted = _drain_loop(partner, throttle)
+        finally:
             os.close(lock_fd)
-            lock_fd = None
-            _run_stage2_once(partner, site)
-            return
 
-        # Patient mode: Slack-notify start (so the operator knows the
-        # session is waiting on human-admin category clearing), loop
-        # until empty, Slack-notify complete.
-        initial_category_size = throttle.category_size()
-        notify_drain_phase_start(partner, len(initial_ids), initial_category_size)
-        total_emitted = _drain_loop(partner, throttle)
-        # Release the host-wide lock before entering the patient
-        # stage-2 wait loop — holding it across days/weeks of polling
-        # for one partner's Commons-admin action would block every
-        # other partner's patient drain and force opportunistic
-        # passes to skip. Stage-2 uses a partner-scoped lock instead
-        # (per-round, so it doesn't hold across sleep).
-        os.close(lock_fd)
-        lock_fd = None
-        _run_stage2_patient_loop(partner, site, throttle)
-        elapsed = time.monotonic() - started_at
+    _drain_await_patient(partner, throttle)
+
+    # Only claim completion when BOTH queues are actually empty. The await
+    # loop returns only when its set is empty, but the category sidecar
+    # could have been re-populated by a concurrent session; check both.
+    remaining_ids = drain_sidecar.read_sidecar(partner)
+    remaining_await = await_target_free_sidecar.awaiting_dpla_ids(partner)
+    elapsed = time.monotonic() - started_at
+    if remaining_ids or remaining_await:
+        logging.warning(
+            "Drain-deferred: finished this pass with %d category + %d await "
+            "item(s) still queued for partner %s; NOT signalling completion.",
+            len(remaining_ids),
+            len(remaining_await),
+            partner,
+        )
+    elif notified_start:
         logging.info(
             "Drain-deferred: complete. Emitted %d item(s) over %.0f seconds.",
             total_emitted,
             elapsed,
         )
         notify_drain_phase_complete(partner, elapsed, total_emitted)
-    finally:
-        if lock_fd is not None:
-            os.close(lock_fd)
+    else:
+        logging.info(
+            "Drain-deferred: await-only drain complete for partner %s.", partner
+        )
 
 
 if __name__ == "__main__":

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -96,6 +96,7 @@ from ingest_wikimedia.slack import (
 )
 from ingest_wikimedia.wikimedia import (
     WMC_UPLOAD_CHUNK_SIZE,
+    DUPLICATE_TAG_RE,
     IGNORE_WIKIMEDIA_WARNINGS,
     MIME_UNKNOWN_EXT,
     build_title_drift_move_reason,
@@ -795,23 +796,24 @@ class Uploader:
             )
             if existing_file is not None:
                 if existing_file.title(with_ns=False) == page_title:
-                    # Resume guard for a partially-completed Case-2
-                    # self-tag-defer. If a prior run uploaded these bytes
-                    # to the canonical title and then died before writing
-                    # the {{Duplicate}} tag, the await-target-free entry is
-                    # still ``tag_emitted=False`` and drain-deferred will
-                    # sit on it forever (it treats un-emitted entries as
-                    # PENDING, not advanceable). ``find_file_by_hash`` with
-                    # ``preferred_title=page_title`` returns THIS canonical
-                    # file, so control would otherwise skip straight past
-                    # the self-tag-defer branch below and never retry the
-                    # tag. Finish the tag here before returning SKIPPED —
-                    # the upload itself is genuinely already done, only the
-                    # tag needs completing.
-                    if not dry_run:
-                        self._resume_self_tag_if_pending(
+                    # Our bytes are already at the canonical title. If this
+                    # ordinal is in the await-target-free set (we self-tagged
+                    # it on a prior run and are waiting on a Commons admin),
+                    # reconcile the set against live state before skipping:
+                    #   * canonical still carries {{Duplicate}} → admin
+                    #     hasn't acted; keep it queued for the drain.
+                    #   * tag gone (admin removed it — declined the dedup —
+                    #     without deleting the file) → drop it; the two
+                    #     files coexist (corollary 1), nothing more to do.
+                    # A deleted/redirected canonical never reaches here (the
+                    # file no longer exists at page_title), so it is resolved
+                    # by the empty-canonical Case-3 move on this same re-run.
+                    if not dry_run and await_target_free_sidecar.has_key(
+                        partner, dpla_id, ordinal
+                    ):
+                        self._reconcile_awaiting_skip(
                             partner=partner,
-                            page_title=page_title,
+                            existing_file=existing_file,
                             dpla_id=dpla_id,
                             ordinal=ordinal,
                         )
@@ -882,6 +884,15 @@ class Uploader:
                         )
                         if drift_action == DriftResolution.MOVED:
                             self.tracker.increment(Result.UPLOADED)
+                            # A move into an empty/redirect canonical title
+                            # is exactly how an awaiting Case-2 item resolves
+                            # once a Commons admin frees the tagged title: the
+                            # community file gets promoted here. Drop it from
+                            # the await set (no-op for ordinary title-drift
+                            # moves that were never awaiting).
+                            await_target_free_sidecar.remove_key(
+                                partner, dpla_id, ordinal
+                            )
                             # After a successful move the same file page lives
                             # at page_title; existing_file.pageid is preserved
                             # by MediaWiki across moves so we can stamp it here.
@@ -948,66 +959,28 @@ class Uploader:
                             force_ignore_warnings = True
                         elif drift_action == DriftResolution.UPLOAD_AND_SELF_TAG_DEFER:
                             # Community upload lives at the drift target title
-                            # (revision history's first uploader is a real
-                            # editor, not a DPLA-adjacent bot). Upload our S3
-                            # bytes to the DPLA-canonical title, tag OUR fresh
-                            # file as ``{{Duplicate|<community title>}}``, and
-                            # enqueue an await-target-free entry. The
-                            # drain-deferred phase watches the tagged title;
-                            # once a Commons admin has acted (deletion or
-                            # redirect), it moves the community file into the
-                            # freed DPLA-canonical title, restoring the
-                            # invariant with the community file's history
-                            # intact. Same Category:Duplicate capacity gate
-                            # as UPLOAD_AND_TAG — this ends up in the same
-                            # category and shouldn't add to it if the category
-                            # is already saturated.
-                            # Reconcile against any prior partial run of
-                            # this same (dpla_id, ordinal). Two states:
+                            # (its first uploader is a real editor, not a
+                            # DPLA-adjacent bot). Upload our S3 bytes to the
+                            # DPLA-canonical title, tag OUR fresh file as
+                            # ``{{Duplicate|<community title>}}``, and record
+                            # the (dpla_id, ordinal) in the await-target-free
+                            # set. Once a Commons admin acts on our tagged
+                            # file, the DPLA-canonical title is freed and a
+                            # plain uploader re-run resolves it through the
+                            # normal title-drift machinery (empty canonical →
+                            # Case-3 move of the community file into the freed
+                            # title, history intact).
                             #
-                            #   * fully queued (entry exists and
-                            #     ``tag_emitted=True``) — the tag is
-                            #     already on Commons, drain-deferred
-                            #     owns the next transition, nothing to
-                            #     do this run. SKIPPED, no throttle
-                            #     grant consumed.
-                            #
-                            #   * partially queued (entry exists but
-                            #     ``tag_emitted=False``) — a prior run
-                            #     recorded the sidecar entry but the
-                            #     ``tag_as_duplicate`` call didn't
-                            #     complete (network flake, CSRF, disk
-                            #     full, kill). Fall through to the full
-                            #     path so the throttle+tag retry runs
-                            #     and ``mark_tag_emitted`` flips the
-                            #     phase to True. add_entry inside
-                            #     _tag_self_and_defer is idempotent, so
-                            #     no duplicate sidecar row appears.
-                            existing_entry = await_target_free_sidecar.get_entry(
-                                partner, dpla_id, ordinal
-                            )
-                            if existing_entry and existing_entry.get(
-                                "tag_emitted", False
-                            ):
-                                logging.info(
-                                    f"Skipping {dpla_id} {ordinal}: "
-                                    f"await-target-free entry already fully "
-                                    f"queued for [[File:{page_title}]] "
-                                    f"(drain-deferred owns the next transition)."
-                                )
-                                self.tracker.increment(Result.SKIPPED)
-                                return {
-                                    "status": ORDINAL_SKIPPED,
-                                    "title": page_title,
-                                    "pageid": None,
-                                }
-                            if existing_entry is not None:
-                                logging.info(
-                                    f"Resuming {dpla_id} {ordinal}: "
-                                    f"await-target-free entry exists but "
-                                    f"tag was not emitted on the prior run; "
-                                    f"retrying the tag write."
-                                )
+                            # No idempotency check is needed here: a re-run
+                            # while we're still waiting finds our bytes already
+                            # at page_title and short-circuits at the
+                            # "Already exists on commons" skip far above, never
+                            # reaching this branch. So this path only runs the
+                            # first time, when the canonical is still occupied
+                            # by the other file's content. Same Category:
+                            # Duplicate capacity gate as UPLOAD_AND_TAG — the
+                            # tag lands in that category, so don't add to it
+                            # when saturated; the category drain retries.
                             if (
                                 self.dup_throttle is not None
                                 and not self.dup_throttle.try_acquire()
@@ -1396,7 +1369,6 @@ class Uploader:
                         community_title=self_tag_community_title,
                         dpla_id=dpla_id,
                         ordinal=ordinal,
-                        expected_sha1=sha1,
                     )
                 self.tracker.increment(Result.UPLOADED)
                 self.tracker.increment(Result.BYTES, file_size)
@@ -2223,49 +2195,47 @@ class Uploader:
         except Exception as ex:
             logging.warning(f"Failed to tag [[File:{old_filename}]] as duplicate: {ex}")
 
-    def _resume_self_tag_if_pending(
-        self, *, partner: str, page_title: str, dpla_id: str, ordinal: int
+    def _reconcile_awaiting_skip(
+        self, *, partner, existing_file, dpla_id: str, ordinal: int
     ) -> None:
-        """Finish a Case-2 self-tag-defer that a prior run left mid-flight.
+        """Reconcile an await-target-free entry against live Commons state
+        on the "already exists at canonical title" skip path.
 
-        Called from the "already exists on Commons" skip path: if an
-        await-target-free entry for ``(dpla_id, ordinal)`` exists with
-        ``tag_emitted=False``, the prior run uploaded the canonical bytes
-        but died before writing the {{Duplicate}} tag. Re-drive the tag
-        via :meth:`_tag_self_and_defer` (whose steps are all idempotent:
-        ``add_entry`` dedupes, ``tag_as_duplicate`` skips an already-
-        tagged page, ``mark_tag_emitted`` is a no-op if already True).
+        Only called for ordinals that ARE in the await set. The canonical
+        file exists at the intended title (that's why we're skipping);
+        the one thing that determines whether we're still waiting is
+        whether it still carries the ``{{Duplicate}}`` tag:
 
-        No pending entry, or one already ``tag_emitted=True`` → nothing
-        to do. Respects the Category:Duplicate throttle exactly like the
-        first-time path: if the category is at capacity, leave the entry
-        ``tag_emitted=False`` and let a later uploader run (or the drain
-        pass, which re-invokes the uploader) retry — never emit a tag
-        that overflows the admins' queue.
+          * still tagged → the admin hasn't acted yet; keep the entry
+            queued so the drain keeps re-running us.
+          * tag gone (admin removed it, declining the dedup, without
+            deleting the file) → the two files legitimately coexist
+            (corollary 1); drop the entry so the drain stops tracking it.
+
+        A read-only reconciliation — it emits no tag and never re-touches
+        the file, so an admin who removed the tag is never edit-warred
+        with. (A deleted or redirected canonical doesn't reach this path:
+        the file no longer exists at the intended title, so the empty-
+        canonical Case-3 move handles it on the same re-run.)
         """
-        pending = await_target_free_sidecar.get_entry(partner, dpla_id, ordinal)
-        if pending is None or pending.get("tag_emitted", True):
-            return
-        if self.dup_throttle is not None and not self.dup_throttle.try_acquire():
-            logging.info(
-                f"Deferring self-tag retry for {dpla_id} {ordinal}: "
-                f"Category:Duplicate at capacity; entry stays tag_emitted="
-                f"False for a later run to finish."
+        try:
+            still_tagged = bool(DUPLICATE_TAG_RE.search(existing_file.text or ""))
+        except Exception as ex:  # noqa: BLE001 — reconciliation is best-effort
+            logging.warning(
+                f"Could not read tag state of [[File:"
+                f"{existing_file.title(with_ns=False)}]] for {dpla_id} "
+                f"{ordinal}; leaving await entry queued: {ex}"
             )
             return
+        if still_tagged:
+            return
         logging.info(
-            f"Resuming self-tag for {dpla_id} {ordinal}: canonical file "
-            f"[[File:{page_title}]] already uploaded on a prior run but the "
-            f"{{{{Duplicate}}}} tag was never emitted; retrying the tag."
+            f"Await-target-free: [[File:{existing_file.title(with_ns=False)}]] "
+            f"({dpla_id} {ordinal}) no longer carries a {{{{Duplicate}}}} tag — "
+            f"a Commons editor declined the dedup. Dropping the await entry; "
+            f"the two files coexist (invariant satisfied at the canonical title)."
         )
-        self._tag_self_and_defer(
-            partner=partner,
-            dpla_canonical_title=page_title,
-            community_title=pending["community_title"],
-            dpla_id=dpla_id,
-            ordinal=ordinal,
-            expected_sha1=pending["expected_sha1"],
-        )
+        await_target_free_sidecar.remove_key(partner, dpla_id, ordinal)
 
     def _tag_self_and_defer(
         self,
@@ -2275,60 +2245,31 @@ class Uploader:
         community_title: str,
         dpla_id: str,
         ordinal: int,
-        expected_sha1: str,
     ) -> None:
-        """Tag OUR just-uploaded DPLA-canonical file as a duplicate of the
-        community file whose bytes we just matched, and enqueue an
-        await-target-free sidecar entry so ``drain-deferred`` can complete
-        the flow after a Commons admin acts on the tag.
+        """Tag OUR just-uploaded DPLA-canonical file
+        ``{{Duplicate|<community title>}}`` and record ``(dpla_id,
+        ordinal)`` in the await-target-free set.
 
-        Emits ``{{Duplicate|<community title>}}`` (single-arg form — the
-        Duplicate template's own default text is more informative than any
-        reason we'd supply). Best-effort like ``_tag_drift_duplicate``: a
-        failure to write the tag or the sidecar entry is logged but does
-        NOT propagate, because the primary upload has already succeeded
-        and the invariant is satisfied — the deferred rename is a
-        follow-up, not a rollback of anything.
+        Once a Commons admin acts on the tag, the DPLA-canonical title is
+        freed and a plain uploader re-run finishes the job: an empty
+        canonical becomes a Case-3 title-drift move of the community file
+        into the freed title (history intact), and the drain drops the
+        entry. Nothing here needs to be crash-consistent beyond "the tag
+        is on Commons and the ID is in the set" — both are re-derivable
+        and idempotent, so a partial failure just retries on the next run.
 
-        The sidecar entry carries the expected community-file SHA1 at
-        tag time so the drain-deferred handler can re-validate against
-        content drift on the community side during the wait window
-        (arbitrary duration — hours to weeks — depending on when a
-        Commons admin actions the tag).
+        Order: record the ID first, then emit the tag. The set entry is
+        the cheap local marker that tells the drain to keep re-running us;
+        emitting it before the (remote, failure-prone) tag write means a
+        tag that lands is always backed by a queued marker. If the tag
+        write fails, the marker lingers harmlessly — a re-run re-enters
+        this path (the canonical is still occupied by the other file until
+        we succeed) and retries; if it never succeeds, the marker is
+        cleaned up by :meth:`_reconcile_awaiting_skip` once our bytes do
+        land. Best-effort like ``_tag_drift_duplicate``: a tag failure is
+        logged, not raised — the upload already satisfied the invariant.
         """
-        # Two-phase persistence keeps the workflow resumable across
-        # partial failures in either direction:
-        #
-        #   Phase 1: sidecar entry with ``tag_emitted=False`` — records
-        #     the intent to promote the community file. Drain-deferred
-        #     honours the phase marker: entries with tag_emitted=False
-        #     stay PENDING (they're mid-workflow, not ready for admin
-        #     advance).
-        #   Phase 2: tag_as_duplicate on Commons — the durable side
-        #     effect that exposes the canonical file to admin deletion.
-        #   Phase 3: mark_tag_emitted flips the phase to True — drain
-        #     is now free to advance the entry once admin acts.
-        #
-        # If phase 2 fails, phase 3 doesn't run, the entry stays
-        # tag_emitted=False, and the next uploader run for this
-        # (dpla_id, ordinal) will re-enter this function (via the
-        # "Resuming" branch upstream) and retry cleanly — add_entry is
-        # idempotent (dedupe), tag_as_duplicate is idempotent (skips
-        # already-tagged files), so the retry is safe even if phase 2
-        # SUCCEEDED but this process died before phase 3 ran.
-        await_target_free_sidecar.add_entry(
-            partner,
-            {
-                "dpla_id": dpla_id,
-                "ordinal": ordinal,
-                "tagged_title": dpla_canonical_title,
-                "community_title": community_title,
-                "expected_sha1": expected_sha1,
-                "tag_emitted": False,
-            },
-        )
-
-        # Phase 2: emit the {{Duplicate}} tag on Commons.
+        await_target_free_sidecar.add_key(partner, dpla_id, ordinal)
         try:
             self_page = get_page(self.site, f"File:{dpla_canonical_title}")
             tag_as_duplicate(
@@ -2346,15 +2287,9 @@ class Uploader:
         except Exception as ex:
             logging.warning(
                 f"Failed to self-tag [[File:{dpla_canonical_title}]] as "
-                f"duplicate of [[File:{community_title}]]: {ex}. Sidecar "
-                f"entry left with tag_emitted=False; a subsequent uploader "
-                f"run for this partner will retry the tag write."
+                f"duplicate of [[File:{community_title}]]: {ex}. A subsequent "
+                f"uploader run for this partner will retry the tag."
             )
-            return
-
-        # Phase 3: flip the workflow phase to fully queued. Drain-deferred
-        # will now advance this entry once a Commons admin actions the tag.
-        await_target_free_sidecar.mark_tag_emitted(partner, dpla_id, ordinal)
 
     def _persist_upload_result(
         self,

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -820,7 +820,6 @@ class Uploader:
                 # tagging the community file — the ``drift_old_filename`` /
                 # ``self_tag_community_title`` variables are mutually exclusive.
                 self_tag_community_title: str | None = None
-                self_tag_expected_sha1: str | None = None
                 drift_action: str | None = None
                 force_ignore_warnings = False
                 if existing_file is not None:
@@ -943,22 +942,38 @@ class Uploader:
                             # as UPLOAD_AND_TAG — this ends up in the same
                             # category and shouldn't add to it if the category
                             # is already saturated.
-                            # Idempotency: if an await-target-free entry for
-                            # this (dpla_id, ordinal) already exists, we've
-                            # already emitted the tag on a prior run and are
-                            # waiting for the admin. Don't re-upload, re-tag,
-                            # or consume a throttle grant for a tag that's
-                            # already in Category:Duplicate; short-circuit
-                            # AHEAD of the throttle gate so re-runs don't
-                            # over-consume headroom.
-                            if await_target_free_sidecar.has_entry(
+                            # Reconcile against any prior partial run of
+                            # this same (dpla_id, ordinal). Two states:
+                            #
+                            #   * fully queued (entry exists and
+                            #     ``tag_emitted=True``) — the tag is
+                            #     already on Commons, drain-deferred
+                            #     owns the next transition, nothing to
+                            #     do this run. SKIPPED, no throttle
+                            #     grant consumed.
+                            #
+                            #   * partially queued (entry exists but
+                            #     ``tag_emitted=False``) — a prior run
+                            #     recorded the sidecar entry but the
+                            #     ``tag_as_duplicate`` call didn't
+                            #     complete (network flake, CSRF, disk
+                            #     full, kill). Fall through to the full
+                            #     path so the throttle+tag retry runs
+                            #     and ``mark_tag_emitted`` flips the
+                            #     phase to True. add_entry inside
+                            #     _tag_self_and_defer is idempotent, so
+                            #     no duplicate sidecar row appears.
+                            existing_entry = await_target_free_sidecar.get_entry(
                                 partner, dpla_id, ordinal
+                            )
+                            if existing_entry and existing_entry.get(
+                                "tag_emitted", False
                             ):
                                 logging.info(
                                     f"Skipping {dpla_id} {ordinal}: "
-                                    f"await-target-free entry already pending "
-                                    f"for [[File:{page_title}]] (drain-deferred "
-                                    f"owns the next transition)."
+                                    f"await-target-free entry already fully "
+                                    f"queued for [[File:{page_title}]] "
+                                    f"(drain-deferred owns the next transition)."
                                 )
                                 self.tracker.increment(Result.SKIPPED)
                                 return {
@@ -966,6 +981,13 @@ class Uploader:
                                     "title": page_title,
                                     "pageid": None,
                                 }
+                            if existing_entry is not None:
+                                logging.info(
+                                    f"Resuming {dpla_id} {ordinal}: "
+                                    f"await-target-free entry exists but "
+                                    f"tag was not emitted on the prior run; "
+                                    f"retrying the tag write."
+                                )
                             if (
                                 self.dup_throttle is not None
                                 and not self.dup_throttle.try_acquire()
@@ -986,7 +1008,6 @@ class Uploader:
                             self_tag_community_title = existing_file.title(
                                 with_ns=False
                             )
-                            self_tag_expected_sha1 = existing_file.latest_file_info.sha1
                             force_ignore_warnings = True
                         else:  # "leave_others_alone"
                             force_ignore_warnings = True
@@ -1355,7 +1376,7 @@ class Uploader:
                         community_title=self_tag_community_title,
                         dpla_id=dpla_id,
                         ordinal=ordinal,
-                        expected_sha1=self_tag_expected_sha1 or "",
+                        expected_sha1=sha1,
                     )
                 self.tracker.increment(Result.UPLOADED)
                 self.tracker.increment(Result.BYTES, file_size)
@@ -2211,20 +2232,26 @@ class Uploader:
         (arbitrary duration — hours to weeks — depending on when a
         Commons admin actions the tag).
         """
-        # Order matters: enqueue the sidecar entry BEFORE emitting the
-        # {{Duplicate}} tag on Commons. The tag is a durable side effect
-        # that exposes the canonical file to admin deletion; the sidecar
-        # entry is the ONLY record that tells drain-deferred to promote
-        # the community file into the freed canonical title once admin
-        # acts. If the tag succeeded but the sidecar-add failed (disk
-        # full, flock crash), an admin could delete the canonical file
-        # while we have no queued intent to promote the community file
-        # into its place — community history would be stranded.
+        # Two-phase persistence keeps the workflow resumable across
+        # partial failures in either direction:
         #
-        # Sidecar-first ordering preserves the invariant that any Commons
-        # {{Duplicate}} tag we emit is backed by a durable retry-queue
-        # entry. If sidecar-add fails, we abort with no tag and no
-        # side effects; the whole item retries cleanly next run.
+        #   Phase 1: sidecar entry with ``tag_emitted=False`` — records
+        #     the intent to promote the community file. Drain-deferred
+        #     honours the phase marker: entries with tag_emitted=False
+        #     stay PENDING (they're mid-workflow, not ready for admin
+        #     advance).
+        #   Phase 2: tag_as_duplicate on Commons — the durable side
+        #     effect that exposes the canonical file to admin deletion.
+        #   Phase 3: mark_tag_emitted flips the phase to True — drain
+        #     is now free to advance the entry once admin acts.
+        #
+        # If phase 2 fails, phase 3 doesn't run, the entry stays
+        # tag_emitted=False, and the next uploader run for this
+        # (dpla_id, ordinal) will re-enter this function (via the
+        # "Resuming" branch upstream) and retry cleanly — add_entry is
+        # idempotent (dedupe), tag_as_duplicate is idempotent (skips
+        # already-tagged files), so the retry is safe even if phase 2
+        # SUCCEEDED but this process died before phase 3 ran.
         await_target_free_sidecar.add_entry(
             partner,
             {
@@ -2233,11 +2260,11 @@ class Uploader:
                 "tagged_title": dpla_canonical_title,
                 "community_title": community_title,
                 "expected_sha1": expected_sha1,
+                "tag_emitted": False,
             },
         )
 
-        # Tag our own uploaded file. Idempotent inside ``tag_as_duplicate``
-        # (checks for an existing {{Duplicate}} template before prepending).
+        # Phase 2: emit the {{Duplicate}} tag on Commons.
         try:
             self_page = get_page(self.site, f"File:{dpla_canonical_title}")
             tag_as_duplicate(
@@ -2256,10 +2283,14 @@ class Uploader:
             logging.warning(
                 f"Failed to self-tag [[File:{dpla_canonical_title}]] as "
                 f"duplicate of [[File:{community_title}]]: {ex}. Sidecar "
-                f"entry already recorded; a re-run (uploader idempotency "
-                f"check) or the drain pass will detect the untagged "
-                f"canonical and drop the entry as a decline."
+                f"entry left with tag_emitted=False; a subsequent uploader "
+                f"run for this partner will retry the tag write."
             )
+            return
+
+        # Phase 3: flip the workflow phase to fully queued. Drain-deferred
+        # will now advance this entry once a Commons admin actions the tag.
+        await_target_free_sidecar.mark_tag_emitted(partner, dpla_id, ordinal)
 
     def _persist_upload_result(
         self,

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1984,24 +1984,55 @@ class Uploader:
         # Net effect: the community file's history survives under the
         # DPLA-canonical title; the invariant is restored via the standard
         # title-drift-move machinery.
-        first = first_uploader(self.site, existing_file)
-        if first is not None and _normalize_account(first) not in _NORMALIZED_DPLA_BOTS:
+        # Decide whether the sha1-sibling is stranded-DPLA-bot (safe to
+        # tag for admin deletion) or community-authored (must NOT be
+        # tagged; instead defer to drain-deferred stage 2). Two signals:
+        #
+        #   1. A DPLA-canonical title suffix (``... - DPLA - <id>``) is
+        #      a definitive fingerprint of a bot upload — no community
+        #      editor uses that naming — so we short-circuit to
+        #      UPLOAD_AND_TAG without any API call. Covers the orphan-
+        #      within-item case (our SHA1 lives at "(page 99)" while
+        #      the intended title is "(page 4)").
+        #   2. Otherwise, query ``first_uploader``. If it resolves to a
+        #      known DPLA-adjacent bot, still UPLOAD_AND_TAG. Every
+        #      other outcome — community editor, empty history, or an
+        #      API failure — routes through the non-destructive
+        #      UPLOAD_AND_SELF_TAG_DEFER path. Unknown provenance does
+        #      NOT prove bot-authorship, so defaulting to community-tag
+        #      would be aggressive on ambiguous input.
+        actual_dpla_id = extract_dpla_id_from_commons_title(actual_filename)
+        if actual_dpla_id is not None:
             logging.info(
-                f"Title drift (Case 2 → upload_and_self_tag_defer): "
-                f"[[File:{intended_page.title(with_ns=False)}]] has a different "
-                f"hash and our SHA1 currently lives at community-authored "
-                f"[[File:{actual_filename}]] (first upload by {first!r}). "
-                f"Will upload correct hash to canonical title, tag OUR file "
-                f"as duplicate, and defer the rename to drain-deferred."
+                f"Title drift (Case 2): [[File:{intended_page.title(with_ns=False)}]] "
+                f"has a different hash; will upload correct hash and tag "
+                f"stranded DPLA-bot file [[File:{actual_filename}]] as duplicate."
             )
-            return DriftResolution.UPLOAD_AND_SELF_TAG_DEFER
+            return DriftResolution.UPLOAD_AND_TAG
 
-        logging.info(
-            f"Title drift (Case 2): [[File:{intended_page.title(with_ns=False)}]] "
-            f"has a different hash; will upload correct hash and tag "
-            f"[[File:{actual_filename}]] as duplicate."
+        first = first_uploader(self.site, existing_file)
+        first_is_dpla_bot = (
+            first is not None and _normalize_account(first) in _NORMALIZED_DPLA_BOTS
         )
-        return DriftResolution.UPLOAD_AND_TAG
+        if first_is_dpla_bot:
+            logging.info(
+                f"Title drift (Case 2): [[File:{intended_page.title(with_ns=False)}]] "
+                f"has a different hash; will upload correct hash and tag "
+                f"stranded DPLA-bot file [[File:{actual_filename}]] as "
+                f"duplicate (first upload by {first!r})."
+            )
+            return DriftResolution.UPLOAD_AND_TAG
+
+        provenance = f"first upload by {first!r}" if first else "uploader unknown"
+        logging.info(
+            f"Title drift (Case 2 → upload_and_self_tag_defer): "
+            f"[[File:{intended_page.title(with_ns=False)}]] has a different "
+            f"hash and our SHA1 currently lives at "
+            f"[[File:{actual_filename}]] ({provenance}). "
+            f"Will upload correct hash to canonical title, tag OUR file "
+            f"as duplicate, and defer the rename to drain-deferred."
+        )
+        return DriftResolution.UPLOAD_AND_SELF_TAG_DEFER
 
     def _tag_drift_duplicate(
         self,
@@ -2180,6 +2211,31 @@ class Uploader:
         (arbitrary duration — hours to weeks — depending on when a
         Commons admin actions the tag).
         """
+        # Order matters: enqueue the sidecar entry BEFORE emitting the
+        # {{Duplicate}} tag on Commons. The tag is a durable side effect
+        # that exposes the canonical file to admin deletion; the sidecar
+        # entry is the ONLY record that tells drain-deferred to promote
+        # the community file into the freed canonical title once admin
+        # acts. If the tag succeeded but the sidecar-add failed (disk
+        # full, flock crash), an admin could delete the canonical file
+        # while we have no queued intent to promote the community file
+        # into its place — community history would be stranded.
+        #
+        # Sidecar-first ordering preserves the invariant that any Commons
+        # {{Duplicate}} tag we emit is backed by a durable retry-queue
+        # entry. If sidecar-add fails, we abort with no tag and no
+        # side effects; the whole item retries cleanly next run.
+        await_target_free_sidecar.add_entry(
+            partner,
+            {
+                "dpla_id": dpla_id,
+                "ordinal": ordinal,
+                "tagged_title": dpla_canonical_title,
+                "community_title": community_title,
+                "expected_sha1": expected_sha1,
+            },
+        )
+
         # Tag our own uploaded file. Idempotent inside ``tag_as_duplicate``
         # (checks for an existing {{Duplicate}} template before prepending).
         try:
@@ -2199,31 +2255,10 @@ class Uploader:
         except Exception as ex:
             logging.warning(
                 f"Failed to self-tag [[File:{dpla_canonical_title}]] as "
-                f"duplicate of [[File:{community_title}]]: {ex}"
-            )
-            # Fall through anyway — if we DID somehow already tag on a
-            # previous run and this call raced with a Commons-side edit,
-            # we still want the sidecar entry so drain-deferred can
-            # complete the flow.
-
-        # Enqueue for drain-deferred stage-2 handling. Idempotent via
-        # ``add_entry``'s (dpla_id, ordinal) dedupe.
-        try:
-            await_target_free_sidecar.add_entry(
-                partner,
-                {
-                    "dpla_id": dpla_id,
-                    "ordinal": ordinal,
-                    "tagged_title": dpla_canonical_title,
-                    "community_title": community_title,
-                    "expected_sha1": expected_sha1,
-                },
-            )
-        except Exception as ex:
-            logging.warning(
-                f"Failed to enqueue await-target-free entry for "
-                f"[[File:{dpla_canonical_title}]] → [[File:{community_title}]] "
-                f"(DPLA ID {dpla_id}): {ex}"
+                f"duplicate of [[File:{community_title}]]: {ex}. Sidecar "
+                f"entry already recorded; a re-run (uploader idempotency "
+                f"check) or the drain pass will detect the untagged "
+                f"canonical and drop the entry as a decline."
             )
 
     def _persist_upload_result(

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -106,6 +106,7 @@ from ingest_wikimedia.wikimedia import (
     wikimedia_url,
     find_file_by_hash,
     extract_dpla_id_from_commons_title,
+    first_uploader,
     is_same_item_redirect_relic,
     tag_as_duplicate,
     check_content_type,
@@ -122,8 +123,19 @@ from ingest_wikimedia.wikimedia import (
     post_commonsdelinker_request,
 )
 from ingest_wikimedia.legacy_artwork import (
+    DPLA_BOT_ACCOUNTS,
+    _normalize_account,
     import_cross_page_community_sdc,
     rescue_wikitext,
+)
+from ingest_wikimedia import await_target_free_sidecar
+
+# Pre-normalized set of DPLA-adjacent bot usernames, used by the Case-2
+# sub-classification in ``_resolve_hash_drift`` (community vs. stranded-bot
+# authorship of the drift target). Pre-computed at module load so the
+# per-item check is a single set-membership test.
+_NORMALIZED_DPLA_BOTS: frozenset[str] = frozenset(
+    _normalize_account(name) for name in DPLA_BOT_ACCOUNTS
 )
 
 MAX_UPLOAD_RETRIES = 3
@@ -261,6 +273,7 @@ class DriftResolution(str, Enum):
 
     MOVED = "moved"
     UPLOAD_AND_TAG = "upload_and_tag"
+    UPLOAD_AND_SELF_TAG_DEFER = "upload_and_self_tag_defer"
     LEAVE_OTHERS_ALONE = "leave_others_alone"
     ALREADY_CORRECT = "already_correct"
 
@@ -800,6 +813,14 @@ class Uploader:
                 # Resolve hash drift before downloading — Case 3 (simple move)
                 # needs no file download, so detecting it first avoids wasted I/O.
                 drift_old_filename: str | None = None
+                # Community-target Case 2 (see UPLOAD_AND_SELF_TAG_DEFER
+                # dispatch below): title of the community-authored file that
+                # currently holds our S3 SHA1. The post-upload block reads
+                # this to decide whether to tag OUR uploaded file rather than
+                # tagging the community file — the ``drift_old_filename`` /
+                # ``self_tag_community_title`` variables are mutually exclusive.
+                self_tag_community_title: str | None = None
+                self_tag_expected_sha1: str | None = None
                 drift_action: str | None = None
                 force_ignore_warnings = False
                 if existing_file is not None:
@@ -905,6 +926,64 @@ class Uploader:
                                     "pageid": None,
                                 }
                             drift_old_filename = existing_file.title(with_ns=False)
+                            force_ignore_warnings = True
+                        elif drift_action == DriftResolution.UPLOAD_AND_SELF_TAG_DEFER:
+                            # Community upload lives at the drift target title
+                            # (revision history's first uploader is a real
+                            # editor, not a DPLA-adjacent bot). Upload our S3
+                            # bytes to the DPLA-canonical title, tag OUR fresh
+                            # file as ``{{Duplicate|<community title>}}``, and
+                            # enqueue an await-target-free entry. The
+                            # drain-deferred phase watches the tagged title;
+                            # once a Commons admin has acted (deletion or
+                            # redirect), it moves the community file into the
+                            # freed DPLA-canonical title, restoring the
+                            # invariant with the community file's history
+                            # intact. Same Category:Duplicate capacity gate
+                            # as UPLOAD_AND_TAG — this ends up in the same
+                            # category and shouldn't add to it if the category
+                            # is already saturated.
+                            if (
+                                self.dup_throttle is not None
+                                and not self.dup_throttle.try_acquire()
+                            ):
+                                logging.info(
+                                    f"Deferring {dpla_id} {ordinal}: "
+                                    f"Category:Duplicate at capacity; will retry "
+                                    f"upload + self-tag-defer in the drain pass."
+                                )
+                                self.tracker.increment(
+                                    Result.UPLOAD_DEFERRED_DUP_CATEGORY
+                                )
+                                return {
+                                    "status": ORDINAL_DEFERRED,
+                                    "title": page_title,
+                                    "pageid": None,
+                                }
+                            # Idempotency: if an await-target-free entry for
+                            # this (dpla_id, ordinal) already exists, we've
+                            # already emitted the tag on a prior run and are
+                            # waiting for the admin. Don't re-upload or
+                            # re-tag; short-circuit to SKIPPED.
+                            if await_target_free_sidecar.has_entry(
+                                self.partner, dpla_id, ordinal
+                            ):
+                                logging.info(
+                                    f"Skipping {dpla_id} {ordinal}: "
+                                    f"await-target-free entry already pending "
+                                    f"for [[File:{page_title}]] (drain-deferred "
+                                    f"owns the next transition)."
+                                )
+                                self.tracker.increment(Result.SKIPPED)
+                                return {
+                                    "status": ORDINAL_SKIPPED,
+                                    "title": page_title,
+                                    "pageid": None,
+                                }
+                            self_tag_community_title = existing_file.title(
+                                with_ns=False
+                            )
+                            self_tag_expected_sha1 = existing_file.latest_file_info.sha1
                             force_ignore_warnings = True
                         else:  # "leave_others_alone"
                             force_ignore_warnings = True
@@ -1265,6 +1344,14 @@ class Uploader:
                         item_metadata=item_metadata,
                         provider=provider,
                         data_provider=data_provider,
+                    )
+                elif self_tag_community_title:
+                    self._tag_self_and_defer(
+                        dpla_canonical_title=page_title,
+                        community_title=self_tag_community_title,
+                        dpla_id=dpla_id,
+                        ordinal=ordinal,
+                        expected_sha1=self_tag_expected_sha1 or "",
                     )
                 self.tracker.increment(Result.UPLOADED)
                 self.tracker.increment(Result.BYTES, file_size)
@@ -1875,6 +1962,36 @@ class Uploader:
             )
             return DriftResolution.LEAVE_OTHERS_ALONE
 
+        # Case 2 sub-classification: is the file at ``actual_filename`` a
+        # community-authored upload (its FIRST revision made by a non-bot
+        # user) rather than a stranded DPLA-adjacent bot upload? If yes,
+        # tagging IT for admin deletion would be a destructive imposition
+        # on the community — the file may have years of curation, external
+        # references, and the editor may be aware of the DPLA relationship
+        # already (the Bartlett incident: the community wikitext linked
+        # DPLA as ``other versions =``, deliberately not merged).
+        #
+        # Instead, upload our S3 bytes to the DPLA-canonical title so the
+        # invariant is satisfied AND tag OUR just-uploaded file as
+        # ``{{Duplicate|<community title>}}``. A Commons admin then chooses
+        # deletion or redirection; the ``drain-deferred`` phase watches for
+        # that resolution and, once the tagged (DPLA-canonical) title is
+        # freed, executes a title-drift move of the community file into it.
+        # Net effect: the community file's history survives under the
+        # DPLA-canonical title; the invariant is restored via the standard
+        # title-drift-move machinery.
+        first = first_uploader(self.site, existing_file)
+        if first is not None and _normalize_account(first) not in _NORMALIZED_DPLA_BOTS:
+            logging.info(
+                f"Title drift (Case 2 → upload_and_self_tag_defer): "
+                f"[[File:{intended_page.title(with_ns=False)}]] has a different "
+                f"hash and our SHA1 currently lives at community-authored "
+                f"[[File:{actual_filename}]] (first upload by {first!r}). "
+                f"Will upload correct hash to canonical title, tag OUR file "
+                f"as duplicate, and defer the rename to drain-deferred."
+            )
+            return DriftResolution.UPLOAD_AND_SELF_TAG_DEFER
+
         logging.info(
             f"Title drift (Case 2): [[File:{intended_page.title(with_ns=False)}]] "
             f"has a different hash; will upload correct hash and tag "
@@ -2029,6 +2146,80 @@ class Uploader:
             raise
         except Exception as ex:
             logging.warning(f"Failed to tag [[File:{old_filename}]] as duplicate: {ex}")
+
+    def _tag_self_and_defer(
+        self,
+        *,
+        dpla_canonical_title: str,
+        community_title: str,
+        dpla_id: str,
+        ordinal: int,
+        expected_sha1: str,
+    ) -> None:
+        """Tag OUR just-uploaded DPLA-canonical file as a duplicate of the
+        community file whose bytes we just matched, and enqueue an
+        await-target-free sidecar entry so ``drain-deferred`` can complete
+        the flow after a Commons admin acts on the tag.
+
+        Emits ``{{Duplicate|<community title>}}`` (single-arg form — the
+        Duplicate template's own default text is more informative than any
+        reason we'd supply). Best-effort like ``_tag_drift_duplicate``: a
+        failure to write the tag or the sidecar entry is logged but does
+        NOT propagate, because the primary upload has already succeeded
+        and the invariant is satisfied — the deferred rename is a
+        follow-up, not a rollback of anything.
+
+        The sidecar entry carries the expected community-file SHA1 at
+        tag time so the drain-deferred handler can re-validate against
+        content drift on the community side during the wait window
+        (arbitrary duration — hours to weeks — depending on when a
+        Commons admin actions the tag).
+        """
+        # Tag our own uploaded file. Idempotent inside ``tag_as_duplicate``
+        # (checks for an existing {{Duplicate}} template before prepending).
+        try:
+            self_page = get_page(self.site, f"File:{dpla_canonical_title}")
+            tag_as_duplicate(
+                self.site,
+                self_page,
+                correct_filename=community_title,
+            )
+            logging.info(
+                f"Tagged [[File:{dpla_canonical_title}]] as duplicate of "
+                f"community-authored [[File:{community_title}]] (DPLA ID "
+                f"{dpla_id}); awaiting Commons admin action."
+            )
+        except CsrfRecoveryFailed:
+            raise
+        except Exception as ex:
+            logging.warning(
+                f"Failed to self-tag [[File:{dpla_canonical_title}]] as "
+                f"duplicate of [[File:{community_title}]]: {ex}"
+            )
+            # Fall through anyway — if we DID somehow already tag on a
+            # previous run and this call raced with a Commons-side edit,
+            # we still want the sidecar entry so drain-deferred can
+            # complete the flow.
+
+        # Enqueue for drain-deferred stage-2 handling. Idempotent via
+        # ``add_entry``'s (dpla_id, ordinal) dedupe.
+        try:
+            await_target_free_sidecar.add_entry(
+                self.partner,
+                {
+                    "dpla_id": dpla_id,
+                    "ordinal": ordinal,
+                    "tagged_title": dpla_canonical_title,
+                    "community_title": community_title,
+                    "expected_sha1": expected_sha1,
+                },
+            )
+        except Exception as ex:
+            logging.warning(
+                f"Failed to enqueue await-target-free entry for "
+                f"[[File:{dpla_canonical_title}]] → [[File:{community_title}]] "
+                f"(DPLA ID {dpla_id}): {ex}"
+            )
 
     def _persist_upload_result(
         self,

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -966,7 +966,7 @@ class Uploader:
                             # waiting for the admin. Don't re-upload or
                             # re-tag; short-circuit to SKIPPED.
                             if await_target_free_sidecar.has_entry(
-                                self.partner, dpla_id, ordinal
+                                partner, dpla_id, ordinal
                             ):
                                 logging.info(
                                     f"Skipping {dpla_id} {ordinal}: "
@@ -1347,6 +1347,7 @@ class Uploader:
                     )
                 elif self_tag_community_title:
                     self._tag_self_and_defer(
+                        partner=partner,
                         dpla_canonical_title=page_title,
                         community_title=self_tag_community_title,
                         dpla_id=dpla_id,
@@ -2150,6 +2151,7 @@ class Uploader:
     def _tag_self_and_defer(
         self,
         *,
+        partner: str,
         dpla_canonical_title: str,
         community_title: str,
         dpla_id: str,
@@ -2205,7 +2207,7 @@ class Uploader:
         # ``add_entry``'s (dpla_id, ordinal) dedupe.
         try:
             await_target_free_sidecar.add_entry(
-                self.partner,
+                partner,
                 {
                     "dpla_id": dpla_id,
                     "ordinal": ordinal,

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -2012,7 +2012,7 @@ class Uploader:
         # DPLA-adjacent bot for our own stranded orphans anyway (e.g. our
         # SHA1 at "(page 99)" vs intended "(page 4)"), so correctness for
         # that case is preserved without the shortcut.
-        first = first_uploader(self.site, existing_file)
+        first = first_uploader(existing_file)
         first_is_dpla_bot = (
             first is not None and _normalize_account(first) in _NORMALIZED_DPLA_BOTS
         )

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -943,6 +943,29 @@ class Uploader:
                             # as UPLOAD_AND_TAG — this ends up in the same
                             # category and shouldn't add to it if the category
                             # is already saturated.
+                            # Idempotency: if an await-target-free entry for
+                            # this (dpla_id, ordinal) already exists, we've
+                            # already emitted the tag on a prior run and are
+                            # waiting for the admin. Don't re-upload, re-tag,
+                            # or consume a throttle grant for a tag that's
+                            # already in Category:Duplicate; short-circuit
+                            # AHEAD of the throttle gate so re-runs don't
+                            # over-consume headroom.
+                            if await_target_free_sidecar.has_entry(
+                                partner, dpla_id, ordinal
+                            ):
+                                logging.info(
+                                    f"Skipping {dpla_id} {ordinal}: "
+                                    f"await-target-free entry already pending "
+                                    f"for [[File:{page_title}]] (drain-deferred "
+                                    f"owns the next transition)."
+                                )
+                                self.tracker.increment(Result.SKIPPED)
+                                return {
+                                    "status": ORDINAL_SKIPPED,
+                                    "title": page_title,
+                                    "pageid": None,
+                                }
                             if (
                                 self.dup_throttle is not None
                                 and not self.dup_throttle.try_acquire()
@@ -957,26 +980,6 @@ class Uploader:
                                 )
                                 return {
                                     "status": ORDINAL_DEFERRED,
-                                    "title": page_title,
-                                    "pageid": None,
-                                }
-                            # Idempotency: if an await-target-free entry for
-                            # this (dpla_id, ordinal) already exists, we've
-                            # already emitted the tag on a prior run and are
-                            # waiting for the admin. Don't re-upload or
-                            # re-tag; short-circuit to SKIPPED.
-                            if await_target_free_sidecar.has_entry(
-                                partner, dpla_id, ordinal
-                            ):
-                                logging.info(
-                                    f"Skipping {dpla_id} {ordinal}: "
-                                    f"await-target-free entry already pending "
-                                    f"for [[File:{page_title}]] (drain-deferred "
-                                    f"owns the next transition)."
-                                )
-                                self.tracker.increment(Result.SKIPPED)
-                                return {
-                                    "status": ORDINAL_SKIPPED,
                                     "title": page_title,
                                     "pageid": None,
                                 }

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -795,6 +795,26 @@ class Uploader:
             )
             if existing_file is not None:
                 if existing_file.title(with_ns=False) == page_title:
+                    # Resume guard for a partially-completed Case-2
+                    # self-tag-defer. If a prior run uploaded these bytes
+                    # to the canonical title and then died before writing
+                    # the {{Duplicate}} tag, the await-target-free entry is
+                    # still ``tag_emitted=False`` and drain-deferred will
+                    # sit on it forever (it treats un-emitted entries as
+                    # PENDING, not advanceable). ``find_file_by_hash`` with
+                    # ``preferred_title=page_title`` returns THIS canonical
+                    # file, so control would otherwise skip straight past
+                    # the self-tag-defer branch below and never retry the
+                    # tag. Finish the tag here before returning SKIPPED —
+                    # the upload itself is genuinely already done, only the
+                    # tag needs completing.
+                    if not dry_run:
+                        self._resume_self_tag_if_pending(
+                            partner=partner,
+                            page_title=page_title,
+                            dpla_id=dpla_id,
+                            ordinal=ordinal,
+                        )
                     logging.info(
                         f"Skipping {dpla_id} {ordinal}: Already exists on commons."
                     )
@@ -2202,6 +2222,50 @@ class Uploader:
             raise
         except Exception as ex:
             logging.warning(f"Failed to tag [[File:{old_filename}]] as duplicate: {ex}")
+
+    def _resume_self_tag_if_pending(
+        self, *, partner: str, page_title: str, dpla_id: str, ordinal: int
+    ) -> None:
+        """Finish a Case-2 self-tag-defer that a prior run left mid-flight.
+
+        Called from the "already exists on Commons" skip path: if an
+        await-target-free entry for ``(dpla_id, ordinal)`` exists with
+        ``tag_emitted=False``, the prior run uploaded the canonical bytes
+        but died before writing the {{Duplicate}} tag. Re-drive the tag
+        via :meth:`_tag_self_and_defer` (whose steps are all idempotent:
+        ``add_entry`` dedupes, ``tag_as_duplicate`` skips an already-
+        tagged page, ``mark_tag_emitted`` is a no-op if already True).
+
+        No pending entry, or one already ``tag_emitted=True`` → nothing
+        to do. Respects the Category:Duplicate throttle exactly like the
+        first-time path: if the category is at capacity, leave the entry
+        ``tag_emitted=False`` and let a later uploader run (or the drain
+        pass, which re-invokes the uploader) retry — never emit a tag
+        that overflows the admins' queue.
+        """
+        pending = await_target_free_sidecar.get_entry(partner, dpla_id, ordinal)
+        if pending is None or pending.get("tag_emitted", True):
+            return
+        if self.dup_throttle is not None and not self.dup_throttle.try_acquire():
+            logging.info(
+                f"Deferring self-tag retry for {dpla_id} {ordinal}: "
+                f"Category:Duplicate at capacity; entry stays tag_emitted="
+                f"False for a later run to finish."
+            )
+            return
+        logging.info(
+            f"Resuming self-tag for {dpla_id} {ordinal}: canonical file "
+            f"[[File:{page_title}]] already uploaded on a prior run but the "
+            f"{{{{Duplicate}}}} tag was never emitted; retrying the tag."
+        )
+        self._tag_self_and_defer(
+            partner=partner,
+            dpla_canonical_title=page_title,
+            community_title=pending["community_title"],
+            dpla_id=dpla_id,
+            ordinal=ordinal,
+            expected_sha1=pending["expected_sha1"],
+        )
 
     def _tag_self_and_defer(
         self,

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -1999,30 +1999,19 @@ class Uploader:
         # title-drift-move machinery.
         # Decide whether the sha1-sibling is stranded-DPLA-bot (safe to
         # tag for admin deletion) or community-authored (must NOT be
-        # tagged; instead defer to drain-deferred stage 2). Two signals:
+        # tagged; instead defer). Provenance is decided ONLY by
+        # ``first_uploader``: the file's oldest revision's uploader.
         #
-        #   1. A DPLA-canonical title suffix (``... - DPLA - <id>``) is
-        #      a definitive fingerprint of a bot upload — no community
-        #      editor uses that naming — so we short-circuit to
-        #      UPLOAD_AND_TAG without any API call. Covers the orphan-
-        #      within-item case (our SHA1 lives at "(page 99)" while
-        #      the intended title is "(page 4)").
-        #   2. Otherwise, query ``first_uploader``. If it resolves to a
-        #      known DPLA-adjacent bot, still UPLOAD_AND_TAG. Every
-        #      other outcome — community editor, empty history, or an
-        #      API failure — routes through the non-destructive
-        #      UPLOAD_AND_SELF_TAG_DEFER path. Unknown provenance does
-        #      NOT prove bot-authorship, so defaulting to community-tag
-        #      would be aggressive on ambiguous input.
-        actual_dpla_id = extract_dpla_id_from_commons_title(actual_filename)
-        if actual_dpla_id is not None:
-            logging.info(
-                f"Title drift (Case 2): [[File:{intended_page.title(with_ns=False)}]] "
-                f"has a different hash; will upload correct hash and tag "
-                f"stranded DPLA-bot file [[File:{actual_filename}]] as duplicate."
-            )
-            return DriftResolution.UPLOAD_AND_TAG
-
+        # We deliberately do NOT treat a DPLA-canonical-shaped title
+        # (``... - DPLA - <id>``) as proof of bot authorship. A community
+        # editor can rename a file into that form, and routing on the
+        # filename alone would send a community upload down the
+        # destructive tag-for-deletion path — the exact Bartlett harm
+        # this whole flow exists to prevent. The provenance lookup is one
+        # cheap API call on an already-rare path, and it returns a
+        # DPLA-adjacent bot for our own stranded orphans anyway (e.g. our
+        # SHA1 at "(page 99)" vs intended "(page 4)"), so correctness for
+        # that case is preserved without the shortcut.
         first = first_uploader(self.site, existing_file)
         first_is_dpla_bot = (
             first is not None and _normalize_account(first) in _NORMALIZED_DPLA_BOTS


### PR DESCRIPTION
## Summary

The uploader's Case-2 hash-drift path used to tag the drift-target file for admin deletion regardless of who authored it. For **community-authored** files that predate DPLA involvement (Bartlett incident: `File:Angus F. Bartlett, Captain … .jpg`, uploaded by [Fæ](https://commons.wikimedia.org/wiki/User:F%C3%A6) in 2017, tagged for deletion by DPLA bot in 2026 because our S3 SHA1 now matched their bytes), this was a destructive imposition — a decade-old community upload with real curation, external references, and an explicit ``other versions = DPLA:`` link would land in F8.

Instead, when the drift target's **first revision** was made by a real editor (not a DPLA-adjacent bot per `DPLA_BOT_ACCOUNTS`), we now:

1. Upload S3 bytes to the DPLA-canonical title (invariant satisfied there).
2. Tag **our own** freshly uploaded file with `{{Duplicate|<community title>}}` (single-arg form — the Duplicate template's default text is more informative than any caller-supplied reason).
3. Enqueue an entry in a new per-partner sidecar `await-target-free.json` recording the tagged (DPLA-canonical) title, the community title, and the expected community SHA1.

`drain-deferred` gains a stage-2 processor that polls each entry's tagged title:

- **Doesn't exist** (admin ran F8) → advance: move community file into freed canonical title + `CommonsDelinker` relink.
- **Redirect** (admin merged rather than deleted) → advance identically (per user feedback: not an edge case, standard title-drift-move handles moving onto a redirect).
- **Exists with `{{Duplicate}}` still present** → still waiting; entry stays queued.
- **Exists but tag removed** (editor decline) → drop entry, log FAIL.

Post-move, sdc-sync's next visit picks up the community file's pageid under the DPLA-canonical title and runs its normal migration + DPLA-attributed SDC write — so community history and curation survive under the canonical title. **No wikitext or SDC rescue at self-tag time**; the community file's metadata stays with the community file until the standard title-drift flow after the move.

## Invariant analysis

At every step, does each DPLA-canonical title hold its S3 source's SHA1?

| Moment | DPLA-canonical title state | Invariant |
|---|---|---|
| After upload (step 1) | S3 bytes | ✓ |
| After self-tag (step 2) | S3 bytes + `{{Duplicate}}` in wikitext | ✓ (tag is wikitext, not bytes) |
| Deferral wait window | S3 bytes, unchanged | ✓ |
| Post-admin-deletion, pre-move | title empty / deleted | transient (≤ one poll interval; both patient + opportunistic drains close it) |
| Post-move | community file's bytes (= S3 SHA1) | ✓ |

The one transient window is ≤ one poll cycle — the opportunistic drain runs on every partner target's chain, so any active partner closes it fast.

## Test plan

- [x] `pytest` — 1346 pass (29 new tests: 14 sidecar, 3 wikimedia, 3 uploader, 9 drain-deferred).
- [x] `ruff check --fix` + `ruff format` — clean.
- [x] Full suite covers: sidecar (empty / roundtrip / dedupe / malformed / has/add/remove / partner-scope / si→smithsonian); `tag_as_duplicate` single-arg form + `first_uploader` oldest-history semantics; `_resolve_hash_drift` sub-classification (community/bot/unknown); stage-2 state machine (pending / editor-decline / deletion / redirect / missing community file / SHA1 drift); `_process_await_target_free` end-to-end.

## Rollout notes

- The sidecar is per-partner and additive — no schema evolution on the existing `deferred-drain.json`. Zero backward-compat risk for the existing category-capacity gate.
- `_resolve_hash_drift`'s existing UPLOAD_AND_TAG path is preserved for stranded-DPLA-bot targets; the new branch fires only when `first_uploader` positively identifies a non-bot editor.
- If Commons admins never action the tag, the entry stays queued indefinitely — the invariant remains satisfied (our uploaded bytes are the ones on the DPLA-canonical title), and operator visibility comes for free via the drain-deferred logging (queue depth reported every run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updates Case-2 hash-drift handling for community-authored Wikimedia files by routing conflicted content through a “self-tag now, wait later” workflow.

- **Uploader (Case-2)**: uploads the S3 bytes to the **DPLA-canonical** Commons title, then applies `{{Duplicate|<community title>}}` to the canonical file.
- **Persistent await tracking (per partner)**: records `(dpla_id, ordinal)` in a new sidecar file `await-target-free.json` (`ingest_wikimedia/await_target_free_sidecar.py`). The sidecar is updated **atomically** and **concurrency-safe** via an `fcntl.flock` lock on a companion `<sidecar>.lock`.
- **Deferred reconciliation via reruns (`drain-deferred`)**: extends `tools/drain_deferred.py` to drain **two independent per-partner queues**:
  - the existing category-capacity queue, and
  - the new await-target-free set,
  by repeatedly re-invoking the idempotent uploader (and `sdc-sync`) for queued DPLA IDs until the relevant queue is empty. In await-target-free mode, queued entries are kept until the canonical page’s `{{Duplicate}}` tag disappears, then the corresponding await entry is dropped.
- **Provenance classification**: adds `first_uploader(file_page)` to read the oldest file-history uploader and uses it to decide whether to take the defer path vs. legacy behavior (`ingest_wikimedia/wikimedia.py`, `tools/uploader.py`).
- **Duplicate template rendering + safety**: makes the `reason` argument optional for `tag_as_duplicate()`, conditionally emitting `{{Duplicate|<filename>}}` vs `{{Duplicate|<filename>|<escaped reason>}}` to avoid empty-parameter templates and reduce template-param injection risk.
- **Defer workflow details**:
  - On skip of a canonical title that already exists, reconciles/removes await entries only once the canonical `{{Duplicate}}` tag is gone (`_reconcile_awaiting_skip`).
  - After successful upload in the new branch, writes the await-marker key first, then emits the `{{Duplicate|<community title>}}` self-tag (`_tag_self_and_defer`).

## Tests

- Adds a dedicated unit test suite for the sidecar key API, including persistence, ordering/deduplication, corruption tolerance, partner scoping, and concurrency (`tests/test_await_target_free_sidecar.py`).
- Extends `drain-deferred` tests for both patient and `--no-wait` behavior, host-lock semantics, and await-target-free draining (`tests/test_drain_deferred.py`).
- Adds/extends uploader tests for Case-2 drift routing, await-key write ordering, exception handling during tagging, and reconciliation when `{{Duplicate}}` is added/removed (`tests/test_uploader.py`).
- Extends wikimedia unit tests for `tag_as_duplicate()` rendering and `first_uploader()` behavior (`tests/test_wikimedia.py`).

## Deployment and infrastructure / compatibility / security

- **Manual pipeline trigger / ECS redeployment required**: Not indicated. The behavior takes effect on subsequent runs of the existing uploader and `drain-deferred` jobs after deployment.
- **Environment variables / AWS Secrets Manager keys**: None added, removed, or renamed.
- **Database migration**: None.
- **Shared infrastructure configuration (CodePipeline, CodeBuild, ECS task definitions, IAM policies)**: None indicated.
- **Public-facing API response shape or endpoints**: None.
- **Security implications**:
  - Adds a MediaWiki file-history “oldest revision uploader” lookup (`first_uploader`) to classify provenance.
  - Escapes template parameters when rendering `{{Duplicate}}` with a non-empty reason.
  - Hardens sidecar persistence against concurrent update races and lost writes via atomic temp-file replacement and `fcntl.flock` locking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->