### PR TITLE
Guard migrate_legacy_file strip against missing canonical SDC

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -135,6 +135,32 @@ LEGACY_IMPORT_PROPERTY: dict[str, tuple[str, str]] = {
     "creator": ("P2093", "string"),
 }
 
+# Render-critical {{DPLA metadata}} params and the SDC property that must
+# already be present before it is safe to strip the param from the wikitext.
+# ``migrate_legacy_file`` posts only community imports (never the canonical
+# scalars), so its strip relies on the sdc-sync's prior canonical-SDC write
+# having landed; stripping a param whose value has no SDC counterpart blanks
+# the field in both representations. ``creator`` renders from P170 (P2093 is
+# only its qualifier); ``permission`` (rights) from P6216.
+#
+# The guard is deliberately PRESENCE-based (is there a statement for this
+# property at all?), a backstop for the dominant failure: the canonical write
+# not firing, leaving the property entirely absent. It is intentionally looser
+# than ``tools/sdc_sync.py``'s provenance-based ``_entity_has_dpla_attributed_claims``
+# (which matches the P123=Q_DPLA publisher reference) — presence cannot
+# over-preserve the normal flow (canonical SDC present ⟹ property present ⟹
+# strip proceeds), whereas a provenance check would entangle with the codebase's
+# two distinct DPLA-attribution markers (P123 reference vs P459 heuristic
+# qualifier) and risk keeping params whose canonical claims are shaped
+# differently. Not accidental inconsistency; a deliberately conservative check.
+STRIP_GUARD_SDC_PROPERTY: dict[str, str] = {
+    "title": "P1476",
+    "creator": "P170",
+    "description": "P10358",
+    "date": "P571",
+    "permission": "P6216",
+}
+
 # Canonical mapping from legacy template param names (case-folded) to
 # the canonical-params keys both the writer and comparator use. Covers
 # the param sets the legacy DPLA-bot ``{{Artwork}}`` form emitted plus
@@ -2707,7 +2733,25 @@ def migrate_legacy_file(
     # ``get_wiki_text`` emits for fresh uploads.
     from .wikitext_normalize import canonicalize, normalize
 
-    rewritten, _stripped = normalize(rewritten, canonical_params)
+    # Guard: never strip a render-critical param into a void. This migration
+    # posts only community imports (not the canonical scalars), so the strip
+    # below relies on the sdc-sync's prior canonical-SDC write having landed.
+    # If that write silently failed for this file, ``entity`` (fetched above,
+    # before our own import) won't carry the param's SDC property, and
+    # stripping it would leave the value in NEITHER the wikitext nor SDC — the
+    # same blanking that ``normalize_page``'s cleanup guard prevents on the
+    # sibling path. Restrict the strip to params whose SDC property is actually
+    # present so an unbacked param stays on the template and still renders.
+    # ``entity`` predates our community import, so this is not fooled by the
+    # claims we just posted (unlike a bare "has any DPLA SDC" entity check).
+    entity_statements = entity.get("statements") or entity.get("claims") or {}
+    strippable_params = {
+        key: value
+        for key, value in canonical_params.items()
+        if key not in STRIP_GUARD_SDC_PROPERTY
+        or STRIP_GUARD_SDC_PROPERTY[key] in entity_statements
+    }
+    rewritten, _stripped = normalize(rewritten, strippable_params)
     rewritten = canonicalize(rewritten)
     # Re-inject wikitext-preserved extension remainders (galleries,
     # HRs, wikitables, etc. the user appended past the DPLA-authored

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1601,18 +1601,19 @@ def _site_with_empty_entity():
     return site
 
 
-def _site_with_canonical_sdc_entity():
-    """Site whose MediaInfo entity already carries the canonical render SDC
-    (title/creator/description/date/rights) the sdc-sync writes before the
-    wikitext cleanup — the real precondition for migrate's strip. Carries no
-    inferred-from-Wikitext reference, so ``entity_was_already_migrated`` does
-    not trip and the migration proceeds normally."""
+def _site_with_canonical_sdc_entity(props=("P1476", "P170", "P10358", "P571", "P6216")):
+    """Site whose MediaInfo entity already carries canonical render SDC for
+    ``props`` (default: all five render-critical properties) — the precondition
+    the sdc-sync satisfies before the wikitext cleanup, and what the migrate
+    strip guard checks per param. Pass a subset to model a partial canonical
+    write. Carries no inferred-from-Wikitext reference, so
+    ``entity_was_already_migrated`` does not trip and the migration proceeds."""
     site = MagicMock()
     site.tokens = {"csrf": "CSRFTOKEN"}
     entity = {
         "statements": {
             prop: [{"mainsnak": {"snaktype": "value", "property": prop}}]
-            for prop in ("P1476", "P170", "P10358", "P571", "P6216")
+            for prop in props
         }
     }
     site.simple_request.return_value.submit.return_value = {"entities": {"M42": entity}}
@@ -2372,6 +2373,54 @@ def test_migrate_legacy_file_keeps_render_params_when_canonical_sdc_absent():
         )
     # And their values are still on the page — nothing was blanked.
     assert "A Title" in saved and "A description" in saved
+
+
+def test_migrate_legacy_file_strips_only_params_with_backing_sdc():
+    """Per-param independence: with canonical SDC present for only SOME render
+    properties (here title P1476 + date P571), migrate strips exactly those
+    params and keeps the rest (creator/description/permission) with their
+    values. A guard that gated all params on a single property would wrongly
+    strip — or keep — all five together, so this partial case is what
+    distinguishes the per-param filter from an entity-level bail."""
+
+    class _Rev1:
+        revid, user = 1, "DPLA_bot"
+        text = (
+            "== {{int:filedesc}} ==\n"
+            "     {{ Artwork\n"
+            "        | Other fields 1 = {{ InFi | Creator |"
+            " A Creator | id=fileinfotpl_aut}}\n"
+            "        | title = A Title\n"
+            "        | description = A description\n"
+            "        | date = 1900\n"
+            "        | permission = {{NoC-US | Q1}}\n"
+            "     }}\n"
+        )
+
+    page = _mock_file_page("File:Foo.jpg", _Rev1.text, [_Rev1()])
+    item, provider, dp = _item_md()
+    # Only title (P1476) and date (P571) are backed by canonical SDC.
+    site = _site_with_canonical_sdc_entity(props=("P1476", "P571"))
+    migrate_legacy_file(
+        file_page=page,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    saved = page.text
+    # SDC-backed params are stripped (the renderer supplies them).
+    for key in ("title", "date"):
+        assert f"| {key}" not in saved, (
+            f"backed param {key!r} should have been stripped; full text:\n{saved}"
+        )
+    # Unbacked params — and their values — stay on the template.
+    for key in ("creator", "description", "permission"):
+        assert f"| {key}" in saved, (
+            f"unbacked param {key!r} should have been kept; full text:\n{saved}"
+        )
+    assert "A description" in saved
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1601,6 +1601,24 @@ def _site_with_empty_entity():
     return site
 
 
+def _site_with_canonical_sdc_entity():
+    """Site whose MediaInfo entity already carries the canonical render SDC
+    (title/creator/description/date/rights) the sdc-sync writes before the
+    wikitext cleanup — the real precondition for migrate's strip. Carries no
+    inferred-from-Wikitext reference, so ``entity_was_already_migrated`` does
+    not trip and the migration proceeds normally."""
+    site = MagicMock()
+    site.tokens = {"csrf": "CSRFTOKEN"}
+    entity = {
+        "statements": {
+            prop: [{"mainsnak": {"snaktype": "value", "property": prop}}]
+            for prop in ("P1476", "P170", "P10358", "P571", "P6216")
+        }
+    }
+    site.simple_request.return_value.submit.return_value = {"entities": {"M42": entity}}
+    return site
+
+
 def _item_md(title="A Title"):
     return (
         {
@@ -2275,7 +2293,10 @@ def test_migrate_legacy_file_strips_params_matching_sdc_in_one_edit():
 
     page = _mock_file_page("File:Foo.jpg", _Rev1.text, [_Rev1()])
     item, provider, dp = _item_md()
-    site = _site_with_empty_entity()
+    # The canonical SDC is already present (the sdc-sync writes it before the
+    # wikitext cleanup) — the real precondition for a migrate strip, and what
+    # STRIP_GUARD_SDC_PROPERTY checks before removing a render-critical param.
+    site = _site_with_canonical_sdc_entity()
     migrate_legacy_file(
         file_page=page,
         item_metadata=item,
@@ -2307,6 +2328,50 @@ def test_migrate_legacy_file_strips_params_matching_sdc_in_one_edit():
     assert "{{DPLA metadata}}" in saved
     # And only one save was issued.
     assert page.save.call_count == 1
+
+
+def test_migrate_legacy_file_keeps_render_params_when_canonical_sdc_absent():
+    """Guard: when the sdc-sync's canonical-SDC write never landed (the entity
+    carries no title/creator/description/date/rights statements), migrate must
+    NOT strip those render-critical params — the strip relies on that SDC being
+    present, and removing the params without it would blank the field in BOTH
+    the wikitext and SDC. They must stay on the template so the page still
+    renders. Structural params (source/institution) may still be stripped; the
+    guard only protects STRIP_GUARD_SDC_PROPERTY keys."""
+
+    class _Rev1:
+        revid, user = 1, "DPLA_bot"
+        text = (
+            "== {{int:filedesc}} ==\n"
+            "     {{ Artwork\n"
+            "        | Other fields 1 = {{ InFi | Creator |"
+            " A Creator | id=fileinfotpl_aut}}\n"
+            "        | title = A Title\n"
+            "        | description = A description\n"
+            "        | date = 1900\n"
+            "        | permission = {{NoC-US | Q1}}\n"
+            "     }}\n"
+        )
+
+    page = _mock_file_page("File:Foo.jpg", _Rev1.text, [_Rev1()])
+    item, provider, dp = _item_md()
+    site = _site_with_empty_entity()  # canonical-SDC write never landed
+    migrate_legacy_file(
+        file_page=page,
+        item_metadata=item,
+        provider=provider,
+        data_provider=dp,
+        dpla_id="abc",
+        site=site,
+    )
+    saved = page.text
+    # Render-critical params survive (no SDC counterpart to render them).
+    for key in ("title", "description", "creator", "date", "permission"):
+        assert f"| {key}" in saved, (
+            f"guard should have kept unbacked param {key!r}; full text:\n{saved}"
+        )
+    # And their values are still on the page — nothing was blanked.
+    assert "A Title" in saved and "A description" in saved
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`migrate_legacy_file` strips `{{DPLA metadata}}` params that match the canonical values via `normalize(rewritten, canonical_params)`. But it posts **only community imports** (never the canonical scalars), so that strip relies entirely on the sdc-sync's *prior* canonical-SDC write having landed. If that write silently failed for a file, the strip removed render-critical params — title / creator / description / date / permission — with **no SDC counterpart**, blanking the field in both the wikitext and SDC.

This is the same failure mode the sibling cleanup path already guards against: `_post_sdc_cleanup_for_page` refuses to run `normalize_page` when the entity has no DPLA-attributed SDC. `migrate_legacy_file` had **no equivalent guard**.

## Fix

Gate the strip **per-param** on the entity fetched earlier in the function. Crucially, that entity snapshot predates the function's own community-import POST, so it is not fooled by the claims we just wrote (a bare "has any DPLA SDC" check would be). Any render-critical param whose SDC property is absent stays on the template and keeps rendering.

The gate is **deliberately presence-based** (documented at `STRIP_GUARD_SDC_PROPERTY`): it can't over-preserve the normal flow (canonical SDC present ⟹ property present ⟹ strip proceeds), and it sidesteps the codebase's two distinct DPLA-attribution markers (P123 reference vs P459 heuristic qualifier). A provenance-aware version keyed on the P123 publisher reference is a reasonable future hardening, but presence is the safe, no-regression backstop for the dominant failure (canonical write never fired → property entirely absent).

## Tests

- Update `test_migrate_legacy_file_strips_params_matching_sdc_in_one_edit` to mock the **real precondition** (canonical SDC present) via a new `_site_with_canonical_sdc_entity()` helper. It previously used an *empty* entity yet asserted a full strip — i.e. it encoded the unguarded behavior under an unrealistic mock.
- Add `test_migrate_legacy_file_keeps_render_params_when_canonical_sdc_absent`: with no canonical SDC, the render-critical params must survive.

442 tests pass (`test_legacy_artwork` + `test_sdc_sync` + `test_wikitext_normalize`); ruff clean.

## Context / priority

Found while auditing the drift-remediation strip-blanking incident. The forward migrate path is actively used (e.g. Portal-to-Texas newspapers) but is normally protected because the sdc-sync writes canonical SDC before the strip — a spot check found **no actual blanks** from this path. So this is **low-priority defense-in-depth** closing an SDC-write-failure edge case, not a live fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated `migrate_legacy_file` to apply per-`{{DPLA metadata}}` template-parameter guards (via new `STRIP_GUARD_SDC_PROPERTY`) so render-critical parameter values are only stripped when the corresponding canonical SDC property exists on the destination MediaInfo entity.
- Prevents blanking of render-critical fields (title, creator, description, date, permission) when a canonical SDC write is missing/absent, while still allowing safe removal of structural/unguarded parameters.
- Added/updated tests to cover:
  - canonical-SDC-present behavior (guarded params stripped in the correct cases)
  - canonical-SDC-absent behavior (render-critical params retained)
  - independence when only a subset of canonical properties is present.

## Operational impact

- No manual pipeline trigger or ECS redeployment is required.
- No environment variables/secrets manager keys added, removed, or renamed.
- No database migrations included.
- No shared infrastructure configuration changes (e.g., CodePipeline/CodeBuild/ECS/IAM).
- No public-facing API response shape changes or endpoints added/removed.
- No security-sensitive behavior changes.

## Quality

- 442 tests pass; Ruff reports no issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->