### PR TITLE
Fix SDC-sync status readout for maintain --cat/--file mode

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -599,10 +599,10 @@ def get_phase_and_progress(
         if total_ordinals > 0 and ordinal_count > 0:
             files_pct = f"{ordinal_count / total_ordinals * 100:.1f}"
             progress = f"{ordinal_count:,} / {total_ordinals:,} files, ~{files_pct}%"
-        elif 0 < dpla_id_count <= total:
+        elif dpla_id_count <= total:
             # Legacy partner-mode SDC with no download log: the per-partner ids
             # CSV is a valid item denominator and each "DPLA ID:" marker is one
-            # item.
+            # item. (dpla_id_count > 0 here — the == 0 case returned above.)
             progress = f"{dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%"
         else:
             # Maintain --cat/--file ("lite") mode: the scope is a Commons

--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -582,10 +582,12 @@ def get_phase_and_progress(
         # `total_ordinals` denominator from the download log) when both
         # are available — same rationale as the Upload branch, since
         # multi-page items take proportionally more SDC-write work than
-        # 1-image items. Falls back to item-level when no download log
-        # has been found (legacy sessions). Terminal completion still
-        # reports items, since the tracker's SDC_ITEMS_SYNCED is per
-        # item.
+        # 1-image items. Falls back to item-level against the per-partner
+        # ids CSV for legacy no-download-log partner sessions, and to a
+        # bare file count for maintain --cat/--file runs (whose scope is a
+        # Commons category / file list, so the CSV is not a valid
+        # denominator). Terminal completion still reports items, since the
+        # tracker's SDC_ITEMS_SYNCED is per item.
         if dpla_id_count == 0:
             start_state = "queued" if waiting_on_slots else "starting..."
             return f"SDC syncing ({start_state}){slot_suffix}", log_mtime
@@ -597,8 +599,21 @@ def get_phase_and_progress(
         if total_ordinals > 0 and ordinal_count > 0:
             files_pct = f"{ordinal_count / total_ordinals * 100:.1f}"
             progress = f"{ordinal_count:,} / {total_ordinals:,} files, ~{files_pct}%"
-        else:
+        elif 0 < dpla_id_count <= total:
+            # Legacy partner-mode SDC with no download log: the per-partner ids
+            # CSV is a valid item denominator and each "DPLA ID:" marker is one
+            # item.
             progress = f"{dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%"
+        else:
+            # Maintain --cat/--file ("lite") mode: the scope is a Commons
+            # category or file list, not the per-partner ids CSV, so `total`
+            # (the {label}.csv wc -l) is a stale/unrelated count — or 0 — and
+            # there's no download log for ordinals. sdc_sync logs one
+            # "DPLA ID:" marker per category-member FILE on this path
+            # (tools/sdc_sync.py), so report that file count alone rather than a
+            # ratio against a denominator that doesn't describe the scope (the
+            # mismatch is what produced the ">100%" readout).
+            progress = f"{dpla_id_count:,} files processed"
         return (
             f"SDC syncing ({progress}){slot_suffix}{stale_suffix}",
             log_mtime,

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -301,6 +301,33 @@ def test_get_phase_and_progress_reports_sdc_syncing_in_progress():
     assert log_mtime > 0
 
 
+def test_get_phase_and_progress_sdc_maintain_cat_reports_bare_file_count():
+    """maintain --cat/--file ("lite") runs sync a Commons category, not the
+    per-partner ids CSV, so the {label}.csv wc -l is a stale/unrelated total
+    (here georgia.csv = 63) and the per-file "DPLA ID:" count exceeds it. With
+    no download log for ordinals, the phase must report a bare file count, not a
+    ratio against the wrong denominator — regression against the observed
+    "1,911 / 63 items, ~3033.3%".
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_phase(
+        log_filename="20260714-010640-georgia-sdc.log",
+        awk_counts=[1911, 0, 0, 0, 0],  # 1,911 files processed; no ordinals
+        csv_total=63,  # stale georgia.csv, unrelated to the --cat scope
+        total_ordinals=0,  # maintain --cat has no download log
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _ = get_phase_and_progress(
+            client=None, session="wikimedia-georgia", hub="georgia", label="georgia"
+        )
+    assert phase.startswith("SDC syncing (1,911 files processed)"), phase
+    # No bogus denominator, percentage, or "items" unit.
+    assert "63" not in phase and "%" not in phase and "items" not in phase
+
+
 def test_get_phase_and_progress_flags_waiting_on_slots():
     """When the sdc-log tail's last line is the slot-budget wait message,
     the phase is annotated 'waiting on slots' — and the idle/stale warning


### PR DESCRIPTION
## Bug

A status update printed:

```
georgia SDC syncing (1,911 / 63 items, ~3033.3%) [Slots: 18]
```

Three problems: the percentage is impossible (>100%), the denominator (63) is far too small, and an SDC-sync phase should report **files**, not items.

## Cause

`get_phase_and_progress` builds the SDC line from a per-file numerator and a per-partner-CSV denominator:
- **numerator** = count of `DPLA ID:` markers in the `-sdc.log`;
- **denominator** = `wc -l` of `{base}/{label}.csv`.

That pairing holds for the standard partner pipeline, but **maintain `--cat`/`--file` ("lite") mode** breaks both assumptions:
- Its scope is a **Commons category / file list**, not the per-partner ids CSV — so `{label}.csv` (here `georgia.csv` = **63 lines**, a stale leftover; the real scope is a category of thousands) is not a valid denominator. The growing per-file count blows straight past it → >100%.
- It re-links whole files and emits **no download log** (no ordinal data), so the file-level branch (`ordinal_count / total_ordinals`) can't fire and it falls into the item-CSV branch.
- On this path `sdc_sync` logs one `DPLA ID:` marker **per category-member file** (`tools/sdc_sync.py`), so the count is file-level — hence "items" is also the wrong unit.

Not introduced by #404 (its diff was `worker_slots.py` / `wikimedia_launch.py` / docs — not this script). Latent since maintain-lite's per-file marker was wired into the poller without adjusting the denominator.

## Fix

In the SDC branch, when there's no ordinal file-data **and** the CSV isn't a plausible denominator (numerator exceeds it, or it's 0 — i.e. maintain `--cat`/`--file`), report the **bare file count** instead of a ratio against the wrong total:

```
SDC syncing (2,791 files processed)
```

The standard file-level branch (`ordinal_count / total_ordinals files`) and the legacy no-download-log item-CSV fallback are unchanged.

## Verification

- Unit test `test_get_phase_and_progress_sdc_maintain_cat_reports_bare_file_count` mocks the exact georgia inputs (per-file count 1,911, stale CSV 63, no ordinals / no download log) and asserts a bare file count with no `%`, no `63`, no "items". 76 tests pass; ruff clean.
- **Driven live** against the running `wikimedia-georgia` maintain `--cat` session: `SDC syncing (2,791 files processed)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes SDC-sync progress reporting for `maintain --cat/--file` mode by detecting invalid CSV denominators and reporting a bare processed-file count instead of a misleading percentage or item count.

- Preserves standard ordinal-based progress and legacy partner-mode behavior.
- Adds regression coverage for stale CSV denominators (Georgia inputs).
- No manual pipeline trigger or ECS redeployment required.
- No environment variables, secrets, database migrations, infrastructure configuration (CodePipeline/CodeBuild/ECS/IAM), public-facing API response shape/endpoints, or security-sensitive behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->