### PR TITLE
Add SDC-merge foundation for the duplicate-SHA1 redesign (PR A)

### DIFF
--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -3056,7 +3056,7 @@ def test_amend_p760_page_qualifier_noop_when_page_number_is_none_and_no_existing
             "M999",
             "abcdef",
             {"claims": [], "ingest_date": "2026-06-23"},
-            page_number=None,
+            page_numbers=None,
         )
     assert submit_calls == []
     # No writes happened → no terminal invalidate.
@@ -3101,7 +3101,7 @@ def test_amend_p760_page_qualifier_removes_stale_p304_when_page_number_is_none()
             "M999",
             "abcdef",
             {"claims": [], "ingest_date": "2026-06-23"},
-            page_number=None,
+            page_numbers=None,
         )
 
     assert sdc_sync.qualifier_removals == [("M999$p760id", "obsolete-hash")]
@@ -3130,7 +3130,10 @@ def test_amend_p760_page_qualifier_stamps_missing_p304_via_accumulator():
     sdc_sync._reset_per_file_accumulators()
     with patch.object(sdc_sync, "get_entity", return_value=entity):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=2
+            "M999",
+            "abcdef",
+            {"claims": [], "ingest_date": "2026-06-23"},
+            page_numbers={2},
         )
 
     assert len(sdc_sync.qualifier_amends) == 1
@@ -3167,7 +3170,10 @@ def test_amend_p760_page_qualifier_idempotent_when_p304_already_matches():
         patch.object(sdc_sync, "invalidate_entity"),
     ):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=2
+            "M999",
+            "abcdef",
+            {"claims": [], "ingest_date": "2026-06-23"},
+            page_numbers={2},
         )
 
 
@@ -3193,7 +3199,10 @@ def test_amend_p760_page_qualifier_skips_when_no_dpla_authored_p760():
         patch.object(sdc_sync, "invalidate_entity"),
     ):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=1
+            "M999",
+            "abcdef",
+            {"claims": [], "ingest_date": "2026-06-23"},
+            page_numbers={1},
         )
 
 
@@ -3232,7 +3241,10 @@ def test_amend_p760_page_qualifier_removes_stale_value_when_page_changes():
     sdc_sync._reset_per_file_accumulators()
     with patch.object(sdc_sync, "get_entity", return_value=entity):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=2
+            "M999",
+            "abcdef",
+            {"claims": [], "ingest_date": "2026-06-23"},
+            page_numbers={2},
         )
 
     assert sdc_sync.qualifier_removals == [("M999$p760id", "stale-snak-hash-3")]
@@ -3282,7 +3294,10 @@ def test_amend_p760_page_qualifier_removes_stale_when_expected_also_present():
     sdc_sync._reset_per_file_accumulators()
     with patch.object(sdc_sync, "get_entity", return_value=entity):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=2
+            "M999",
+            "abcdef",
+            {"claims": [], "ingest_date": "2026-06-23"},
+            page_numbers={2},
         )
 
     # Only the stale snak got queued for removal; the expected value
@@ -3571,10 +3586,256 @@ def test_amend_p760_page_qualifier_does_not_re_invalidate_when_p304_matches():
         ),
     ):
         sdc_sync._amend_p760_page_qualifier(
-            "M999", "abcdef", {"claims": [], "ingest_date": "2026-06-23"}, page_number=2
+            "M999",
+            "abcdef",
+            {"claims": [], "ingest_date": "2026-06-23"},
+            page_numbers={2},
         )
 
     assert invalidate_calls == []
+
+
+def test_amend_p760_page_qualifier_stamps_multiple_pages_for_merged_file():
+    """A merged within-item duplicate (rule #3) carries SEVERAL page numbers
+    on one P760 statement — ``page_numbers`` is a multi-element set and every
+    missing value is queued as its own P304 snak."""
+    from tools import sdc_sync
+
+    existing_p760 = {
+        "id": "M999$p760id",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abcdef"},
+        },
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P760": [existing_p760]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._amend_p760_page_qualifier(
+            "M999",
+            "abcdef",
+            {"claims": [], "ingest_date": "2026-06-23"},
+            page_numbers={3, 1},
+        )
+
+    stamped = sorted(
+        snak["datavalue"]["value"]
+        for (_cid, prop, snak) in sdc_sync.qualifier_amends
+        if prop == "P304"
+    )
+    assert stamped == ["1", "3"]
+    assert sdc_sync.qualifier_removals == []
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_amend_p760_page_qualifier_keeps_present_adds_missing_removes_stale():
+    """Merged file: expected pages {1,2}; existing P304 has "1" (keep) and a
+    stale "9" (remove). Only the missing "2" is added; "1" is untouched."""
+    from tools import sdc_sync
+
+    existing_p760 = {
+        "id": "M999$p760id",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abcdef"},
+        },
+        "qualifiers": {
+            "P459": _dpla_p459(),
+            "P304": [
+                {
+                    "snaktype": "value",
+                    "property": "P304",
+                    "datavalue": {"type": "string", "value": "1"},
+                    "hash": "h1",
+                },
+                {
+                    "snaktype": "value",
+                    "property": "P304",
+                    "datavalue": {"type": "string", "value": "9"},
+                    "hash": "h9",
+                },
+            ],
+        },
+        "references": [_dpla_reference("abcdef")],
+    }
+    entity = {"pageid": 999, "statements": {"P760": [existing_p760]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        sdc_sync._amend_p760_page_qualifier(
+            "M999",
+            "abcdef",
+            {"claims": [], "ingest_date": "2026-06-23"},
+            page_numbers={1, 2},
+        )
+
+    added = [
+        snak["datavalue"]["value"]
+        for (_c, p, snak) in sdc_sync.qualifier_amends
+        if p == "P304"
+    ]
+    assert added == ["2"]  # only the missing page is added
+    assert sdc_sync.qualifier_removals == [("M999$p760id", "h9")]  # stale removed
+    sdc_sync._reset_per_file_accumulators()
+
+
+def test_build_qualifier_fragments_unions_multiple_p304_snaks():
+    """Two P304 amends queued for one P760 statement (a merged within-item
+    duplicate) fold into a SINGLE fragment carrying BOTH page snaks — the
+    wholesale-replace qualifier set is the union, not last-writer-wins — and
+    the fragment carries ``type: statement`` so the atomic bundle isn't
+    rejected."""
+    from tools import sdc_sync
+
+    stmt = {
+        "id": "M7$p760",
+        "mainsnak": {
+            "property": "P760",
+            "snaktype": "value",
+            "datavalue": {"type": "string", "value": "abc"},
+        },
+        "rank": "normal",
+        "qualifiers": {"P459": _dpla_p459()},
+        "references": [_dpla_reference("abc")],
+    }
+    entity = {"pageid": 7, "statements": {"P760": [stmt]}}
+
+    sdc_sync._reset_per_file_accumulators()
+    sdc_sync.qualifier_amends.append(
+        ("M7$p760", "P304", sdc_sync._string_snak("P304", "1"))
+    )
+    sdc_sync.qualifier_amends.append(
+        ("M7$p760", "P304", sdc_sync._string_snak("P304", "3"))
+    )
+    with patch.object(sdc_sync, "get_entity", return_value=entity):
+        frags = sdc_sync._build_qualifier_update_fragments("M7")
+    sdc_sync._reset_per_file_accumulators()
+
+    assert len(frags) == 1
+    values = sorted(s["datavalue"]["value"] for s in frags[0]["qualifiers"]["P304"])
+    assert values == ["1", "3"]
+    assert frags[0]["type"] == "statement"
+    assert frags[0]["mainsnak"]["property"] == "P760"
+
+
+def test_normalize_pages_accepts_int_iterable_or_none():
+    from tools import sdc_sync
+
+    assert sdc_sync._normalize_pages(None) == set()
+    assert sdc_sync._normalize_pages(2) == {"2"}
+    assert sdc_sync._normalize_pages("3") == {"3"}
+    assert sdc_sync._normalize_pages({1, 3}) == {"1", "3"}
+    assert sdc_sync._normalize_pages([1, 2, 2]) == {"1", "2"}
+
+
+def test_contributing_dpla_ids_reads_p760_values():
+    from tools import sdc_sync
+
+    def _p760(val):
+        return {
+            "id": f"M1${val}",
+            "mainsnak": {
+                "property": "P760",
+                "snaktype": "value",
+                "datavalue": {"type": "string", "value": val},
+            },
+        }
+
+    assert sdc_sync._contributing_dpla_ids(
+        {"statements": {"P760": [_p760("aaa")]}}
+    ) == {"aaa"}
+    assert sdc_sync._contributing_dpla_ids(
+        {"statements": {"P760": [_p760("aaa"), _p760("bbb")]}}
+    ) == {"aaa", "bbb"}
+    assert sdc_sync._contributing_dpla_ids({}) == set()
+    # somevalue/novalue P760 snaks carry no id and are ignored
+    assert (
+        sdc_sync._contributing_dpla_ids(
+            {
+                "statements": {
+                    "P760": [
+                        {"mainsnak": {"property": "P760", "snaktype": "somevalue"}}
+                    ]
+                }
+            }
+        )
+        == set()
+    )
+
+
+def test_merge_item_onto_canonical_delegates_add_only():
+    """Rule #3 merge entry point is a thin, add-only wrapper: it calls
+    process_one_from_sdc against the canonical mediaid with reconcile=False so
+    no other contributor's statements are removed, forwarding page numbers."""
+    from tools import sdc_sync
+
+    calls = []
+    with patch.object(
+        sdc_sync,
+        "process_one_from_sdc",
+        side_effect=lambda *a, **kw: calls.append((a, kw)),
+    ):
+        sdc_sync.merge_item_onto_canonical(
+            "M42",
+            "dupid",
+            {"claims": [], "ingest_date": "2026-06-23"},
+            page_numbers={5},
+            download_url="http://x/y.jpg",
+        )
+    assert len(calls) == 1
+    args, kw = calls[0]
+    assert args == ("M42", "dupid", {"claims": [], "ingest_date": "2026-06-23"})
+    assert kw["reconcile"] is False
+    assert kw["page_number"] == {5}
+    assert kw["download_url"] == "http://x/y.jpg"
+
+
+def test_process_one_from_sdc_skips_reconcile_on_merged_file():
+    """A merged (multi-contributor, >1 P760) file must NOT be reconciled by a
+    single item's sync — otherwise item A's sync would strip item B's merged
+    statements. Single-contributor files reconcile exactly as before."""
+    from tools import sdc_sync
+
+    def _p760(val):
+        return {
+            "id": f"M1${val}",
+            "mainsnak": {
+                "property": "P760",
+                "snaktype": "value",
+                "datavalue": {"type": "string", "value": val},
+            },
+        }
+
+    payload = {"claims": [], "ingest_date": "2026-06-23"}
+
+    def run(entity):
+        recon = []
+        with (
+            patch.object(sdc_sync, "get_entity", return_value=entity),
+            patch.object(sdc_sync, "_amend_p7482_url_qualifiers"),
+            patch.object(sdc_sync, "_amend_p760_page_qualifier"),
+            patch.object(sdc_sync, "_reconcile_inferred_from_wikitext_dupes"),
+            patch.object(sdc_sync, "_flush_per_file_edits"),
+            patch.object(
+                sdc_sync,
+                "_reconcile_existing_claims",
+                side_effect=lambda *a, **kw: recon.append(a),
+            ),
+        ):
+            sdc_sync.process_one_from_sdc("M999", "aaa", payload)
+        return recon
+
+    # single contributor -> reconciliation runs
+    assert run({"pageid": 999, "statements": {"P760": [_p760("aaa")]}})
+    # merged (two distinct P760) -> reconciliation skipped
+    assert (
+        run({"pageid": 999, "statements": {"P760": [_p760("aaa"), _p760("bbb")]}}) == []
+    )
 
 
 def test_qualifier_values_returns_empty_when_no_qualifiers():

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -2111,7 +2111,7 @@ def _compute_page_numbers(ordinal_items):
     return page_numbers
 
 
-def _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_number):
+def _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_numbers):
     """Stamp a missing ``P304`` (page-number) qualifier onto an existing
     DPLA-authored ``P760`` (DPLA ID) statement on Commons.
 
@@ -2132,13 +2132,14 @@ def _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_number):
     cleanup pass a file would keep incorrect page metadata after its
     sibling ordinals were deleted.
     """
-    # ``page_number=None`` means "no P304 is expected for this file" —
-    # typically a file that was once part of a multi-file extension
-    # group (with a P304 stamped) but is now a singleton in its group
-    # (e.g. siblings were deleted by a Commons curator). We must still
-    # walk the existing qualifiers and queue any stale P304 removal;
-    # otherwise the file keeps incorrect page metadata indefinitely.
-    expected_value = None if page_number is None else str(page_number)
+    # An empty ``page_numbers`` means "no P304 is expected for this file" —
+    # e.g. a file once part of a multi-file extension group (with a P304
+    # stamped) that is now a singleton in its group (siblings deleted by a
+    # Commons curator). We still walk the existing qualifiers and queue any
+    # stale P304 removal so the file doesn't keep incorrect page metadata.
+    # A multi-element set is a merged file (rule #3 within-item duplicate)
+    # that legitimately carries several page numbers on one P760 statement.
+    expected_values = {str(p) for p in (page_numbers or [])}
 
     entity = get_entity(mediaid)
     existing_p760 = (entity.get("statements") or {}).get("P760") or []
@@ -2161,21 +2162,21 @@ def _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_number):
     # for removal). The dispatcher will assemble the wholesale-replace
     # qualifier set from the combined adds and removes across all
     # accumulators when it builds the final wbeditentity payload.
-    expected_already_present = False
+    present = set()
     for q in target_stmt.get("qualifiers", {}).get("P304", []) or []:
         if q.get("snaktype") != "value":
             continue
         dv = q.get("datavalue")
         if not (isinstance(dv, dict) and "value" in dv):
             continue
-        if expected_value is not None and dv["value"] == expected_value:
-            expected_already_present = True
+        if dv["value"] in expected_values:
+            present.add(dv["value"])
         elif q.get("hash"):
             qualifier_removals.append((target_stmt["id"], q["hash"]))
 
-    if expected_value is not None and not expected_already_present:
+    for value in sorted(expected_values - present):
         qualifier_amends.append(
-            (target_stmt["id"], "P304", _string_snak("P304", expected_value))
+            (target_stmt["id"], "P304", _string_snak("P304", value))
         )
 
 
@@ -4425,8 +4426,56 @@ def process_one(mediaid, dpla_id):
         return
 
 
+def _normalize_pages(page_number) -> set[str]:
+    """Normalize the ``page_number`` argument to a set of string P304 values.
+
+    Accepts a single int (the per-ordinal case), an iterable of ints/strs (a
+    merged within-item duplicate carrying several page numbers on one P760),
+    or ``None`` (no page number). A single int reproduces the historical
+    one-page behavior exactly.
+    """
+    if isinstance(page_number, (str, int)):
+        return {str(page_number)}
+    return {str(p) for p in (page_number or [])}
+
+
+def _contributing_dpla_ids(entity) -> set[str]:
+    """DPLA IDs currently represented on a MediaInfo entity, read from its
+    P760 (DPLA ID) statements.
+
+    A file carrying more than one is a MERGED (multi-contributor) file per
+    rule #3 (SDC-merge instead of uploading a duplicate SHA1). Because each
+    contributing DPLA ID has its own P760 statement, the contributor set is
+    self-describing on the entity — no separate manifest sidecar is needed.
+    Used to gate reconciliation so one item's sync can't strip another's
+    merged statements.
+    """
+    ids = set()
+    for stmt in (entity.get("statements") or {}).get("P760", []) or []:
+        try:
+            if stmt["mainsnak"]["snaktype"] == "value":
+                ids.add(stmt["mainsnak"]["datavalue"]["value"])
+        except (KeyError, TypeError):
+            continue
+    return ids
+
+
+def _is_merged_file(entity) -> bool:
+    """True when a MediaInfo entity carries more than one DPLA ID (P760) — a
+    merged, multi-contributor file (rule #3). Such files must not be
+    reconciled by a single item's sync, which only knows its own item's
+    expected statement set.
+    """
+    return len(_contributing_dpla_ids(entity)) > 1
+
+
 def process_one_from_sdc(
-    mediaid, dpla_id, sdc_payload, download_url=None, page_number=None
+    mediaid,
+    dpla_id,
+    sdc_payload,
+    download_url=None,
+    page_number=None,
+    reconcile=True,
 ):
     """Sync SDC for a single Commons file against a precomputed claim list.
 
@@ -4484,6 +4533,11 @@ def process_one_from_sdc(
         )
     _current_ingest_date = datetime.date.fromisoformat(raw_ingest_date)
 
+    # Normalize page_number (a single int for the per-ordinal case, an
+    # iterable for a merged within-item duplicate, or None) to a set of
+    # string P304 values; one qualifier snak is stamped per value.
+    pages = _normalize_pages(page_number)
+
     sdc_claims = sdc_payload.get("claims", [])
     first_check = True
     for source_claim in sdc_claims:
@@ -4512,13 +4566,14 @@ def process_one_from_sdc(
         # claim — same per-ordinal rationale as P2699 above. Only stamped
         # for files that are part of a multi-file extension group on a
         # multipage item; ``page_number`` is ``None`` otherwise.
-        if prop == "P760" and page_number is not None:
+        if prop == "P760" and pages:
             claim.setdefault("qualifiers", {})["P304"] = [
                 {
                     "snaktype": "value",
                     "property": "P304",
-                    "datavalue": {"value": str(page_number), "type": "string"},
+                    "datavalue": {"value": p, "type": "string"},
                 }
+                for p in sorted(pages)
             ]
 
         kind = _check_kind_for_claim(claim)
@@ -4552,11 +4607,55 @@ def process_one_from_sdc(
     # the new-claims / new-refs lists populated by the check() walk
     # above) are then flushed in one atomic wbeditentity per file.
     _amend_p7482_url_qualifiers(mediaid, dpla_id, sdc_payload, download_url)
-    _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, page_number)
-    expected = _build_expected_from_sdc(sdc_payload)
-    _reconcile_existing_claims(mediaid, dpla_id, expected)
-    _reconcile_inferred_from_wikitext_dupes(mediaid)
+    _amend_p760_page_qualifier(mediaid, dpla_id, sdc_payload, pages)
+    # Reconciliation removes DPLA-authored statements not warranted by this
+    # item's sdc.json. On a MERGED file (rule #3 — more than one DPLA ID
+    # present), each per-item sync only knows its own expected set, so
+    # reconciling here would strip the other contributors' statements. Skip
+    # removal for merged files (add-only) and when the caller opts out
+    # (merge_item_onto_canonical). Single-contributor files — every file
+    # today — reconcile exactly as before, so this is a no-op until PR C
+    # starts merging.
+    if reconcile:
+        if _is_merged_file(get_entity(mediaid)):
+            logging.info(
+                " -- %s carries multiple DPLA IDs (merged); skipping "
+                "reconciliation to preserve other contributors' statements.",
+                mediaid,
+            )
+        else:
+            expected = _build_expected_from_sdc(sdc_payload)
+            _reconcile_existing_claims(mediaid, dpla_id, expected)
+            _reconcile_inferred_from_wikitext_dupes(mediaid)
     _flush_per_file_edits(mediaid, dpla_id)
+
+
+def merge_item_onto_canonical(
+    canonical_mediaid, dpla_id, sdc_payload, page_numbers=None, download_url=None
+):
+    """Rule #3: merge a duplicate DPLA item's SDC onto the already-existing
+    canonical Commons file instead of uploading a second byte-identical file.
+
+    Adds this item's P760 (DPLA ID) and any non-duplicative statements as
+    ADDITIONAL values, and stamps its page number(s) as P304 qualifiers, via
+    the same ``check()`` / accumulator machinery ``process_one_from_sdc`` uses
+    — ``check()`` already adds a not-present value alongside and skips one
+    already present, so the merge is additive and idempotent. Reconciliation
+    is disabled (``reconcile=False``) so the canonical owner's (and any other
+    contributor's) statements are never removed.
+
+    ``page_numbers`` is the set of within-item page numbers this DPLA ID
+    occupies on the canonical file (the within-item duplicate case); ``None``
+    when the duplication is cross-item / cross-institution.
+    """
+    process_one_from_sdc(
+        canonical_mediaid,
+        dpla_id,
+        sdc_payload,
+        download_url=download_url,
+        page_number=page_numbers,
+        reconcile=False,
+    )
 
 
 _NORMALIZE_EDIT_SUMMARY = (


### PR DESCRIPTION
## What & why

First PR of the collision-mechanism redesign. New framework: **no two Commons files may share a SHA1.** The invariant's *goal* is unchanged — every DPLA item's content is represented and discoverable at its expected title — but we now satisfy it by **centralizing** each SHA1 to one file that carries all contributing items' data in its SDC (and, in PR C, redirecting the other expected titles to it) rather than uploading byte-identical copies.

This PR is the **SDC-merge foundation** for rule #3 (source duplication → merge onto the canonical file instead of uploading a duplicate). It is entirely additive and gated — **no behavior change** until the uploader flip (PR C) starts calling the merge path.

## Changes (`tools/sdc_sync.py`)

- **`merge_item_onto_canonical()`** — add-only merge of a duplicate DPLA item's SDC onto an existing canonical file, via the same `check()`/accumulator machinery `process_one_from_sdc` already uses. `check()` adds a not-present value alongside and skips one already present, so the merge is additive and idempotent. `reconcile=False`, so the canonical owner's (and any other contributor's) statements are never removed. *(No callers yet — PR C wires it in.)*
- **`process_one_from_sdc(..., reconcile=True)`** — skips reconciliation on a **merged** (multi-contributor, >1 P760) file; otherwise one item's per-item sync would strip another item's merged statements. The contributor set is read self-describingly off the entity's P760 statements — no sidecar manifest.
- **`_amend_p760_page_qualifier(..., page_numbers)`** — accepts a *set* of page numbers so a merged within-item duplicate carries multiple P304 qualifiers on one P760 statement; single-page callers pass a one-element set (identical behavior). The multiple P304 snaks union correctly through the existing `_merge_qualifier_snaks` fold, and the fragment carries `type: statement`.

## Why it's safe to land now

Every file on Commons today carries exactly one P760, so `_is_merged_file` is always false and reconciliation runs exactly as before; `merge_item_onto_canonical` has no callers. **Net behavior change on current data: none.**

## Testing

- `pytest tests/test_sdc_sync.py` → **221 passed** (7 new).
- New tests: multi-P304 amend, end-to-end fragment union (two P304 snaks on one statement + `type: statement`), `_normalize_pages`, `_contributing_dpla_ids`, merge delegation (`reconcile=False`), and the reconcile gate (single- vs multi-contributor).
- `simplify` (4-agent pass) + `ruff` clean.
- **A live test on a real merged record will run before merge**, per practice for transforms over the corpus.

## Sequence

PR A (this) → **Module:DPLA** render change on Commons (render multiple P760 values + a "Pages" row; validated via a hand-crafted-SDC test file, during this review) → **PR C+D** (uploader flip: never upload a duplicate SHA1, redirect other expected titles to the canonical file, retire the `{{Duplicate}}`/drain/throttle/await apparatus, rewrite `upload-invariant.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added gated SDC merge groundwork for duplicate-SHA1 handling through additive `merge_item_onto_canonical()` behavior.
- Prevented reconciliation from removing other contributors’ statements on merged files.
- Added support for multiple P304 page qualifiers per P760 statement, including normalization and correct qualifier union/removal.
- Added seven tests covering page qualifiers, contributor detection, merge delegation, normalization, and reconciliation safeguards.
- Test suite passes with 221 tests; `simplify` and `ruff` are clean.

## Operational impact

- No manual pipeline trigger or ECS redeployment is required; the merge path has no callers yet, so current behavior is unchanged.
- No environment variables or AWS Secrets Manager keys were added, removed, or renamed.
- No database migration is included.
- No shared infrastructure configuration, public-facing API response shape, or endpoints were changed.
- No security-related changes are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->