### PR TITLE
Fix within-item duplicate P304 page-qualifier stripping

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -309,46 +309,121 @@ def compute_ordinal_exts_and_page_labels(
     return ordinal_exts, page_labels
 
 
-def collect_duplicate_source_sha1s(
+def read_sha1_by_ordinal(
     s3_client: S3Client,
     dpla_id: str,
     partner: str,
     num_files: int,
-) -> set[str]:
-    """Return SHA1s that appear at TWO OR MORE positions in this item's S3
-    asset list.
+) -> dict[int, str]:
+    """Read each ordinal's stored SHA1 (the ``CHECKSUM`` S3 user-metadata) in a
+    SINGLE pass over the item's asset list.
 
-    A SHA1 in this set means the source data has the same file content
-    listed at multiple ordinals — both/all positions are legitimate per
-    the source and should land at their own Commons titles.  Without
-    this knowledge, _resolve_hash_drift would see SHA1 X already at
-    (page A), be asked to upload it to (page B), and conclude that
-    (page A) is drift to be moved over (page B).  That's wrong: both
-    positions should exist as separate Commons pages.
+    This snapshot is the item's authoritative content fingerprint, and BOTH
+    duplicate detection (:func:`collect_duplicate_source_sha1s`) and P304 page
+    numbering (:func:`compute_sha1_page_numbers`) derive from it. Reading once
+    and sharing the result is deliberate, not incidental: two independent S3
+    passes can DISAGREE (one reads an ordinal's hash, the other transiently
+    fails), and a within-item duplicate that is *detected* but whose page is not
+    *unioned* onto the canonical is exactly how P304 silently drops. One snapshot
+    makes detection and numbering provably consistent — the same producer/
+    consumer-share rule :func:`compute_ordinal_exts_and_page_labels` documents.
 
-    SHA1 metadata read failures (transient S3 errors, stub ordinals)
-    are tolerated — those ordinals are simply absent from the count,
-    which conservatively keeps the SHA1 out of the duplicate set.  We
-    DO log the skipped ordinal: under-counting silently would cause
-    _resolve_hash_drift to incorrectly treat a legitimate sibling as
-    drift and move/redirect it, so visibility matters for diagnosis.
+    Error contract mirrors that sibling: a genuinely-absent object
+    (404 / NoSuchKey) is skipped; any other S3 error is re-raised so a transient
+    failure fails the item LOUDLY rather than silently under-populating the
+    fingerprint. An object present with empty/absent CHECKSUM metadata is also
+    skipped (ordinal absent from the map) — the caller treats an ordinal with no
+    known SHA1 as its own singleton group, so it still keeps its own
+    title-derived page number and is never mistaken for a page-less file whose
+    P304 should be stripped.
+
+    Single-file items short-circuit to ``{}`` (like the sibling's ``num_files >
+    1`` guard): one file cannot be a WITHIN-item duplicate of itself and has no
+    page number, so the read is pure overhead — and, because it can re-raise,
+    the read would otherwise turn a transient S3 blip into a whole-item failure
+    on the dominant single-file shape. (Cross-item duplication of a lone file is
+    detected separately by process_file's own hash probe, not here.)
+
+    KNOWN RESIDUAL (not a regression; documented, not silently accepted): the
+    SHA1 fingerprint lives only in droppable S3 user-metadata. If a within-item
+    duplicate sibling's CHECKSUM is stripped externally (e.g. a copy_object with
+    MetadataDirective=REPLACE that omits it) BETWEEN a correct run and a re-run,
+    that sibling drops out of the snapshot, the canonical is recomputed without
+    the sibling's page, and the authoritative P304 amend shrinks a
+    previously-correct set. Fixing this needs a fingerprint that survives
+    metadata drift (recompute from bytes, or persist the per-ordinal grouping)
+    — deferred; the add-only "don't shrink" shortcut is rejected because it
+    would also block the legitimate removal of a genuinely-stale P304.
     """
-    counts: Counter[str] = Counter()
+    if num_files <= 1:
+        return {}
+    sha1_by_ordinal: dict[int, str] = {}
     for i in range(1, num_files + 1):
         s3_path = s3_client.get_media_s3_path(dpla_id, i, partner)
         try:
             s3_obj = s3_client.get_s3().Object(S3_BUCKET, s3_path)
             sha1 = (s3_obj.metadata or {}).get(CHECKSUM)
-        except Exception as ex:
-            logging.warning(
-                f"collect_duplicate_source_sha1s: skipped ordinal {i} for "
-                f"{dpla_id} (path={s3_path}): {ex}; duplicate detection may "
-                f"under-count this item"
-            )
-            continue
+        except ClientError as e:
+            # 404/NoSuchKey → tolerated skip; anything else re-raises (see the
+            # error-contract paragraph in the docstring for why loud-fail here).
+            if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
+                continue
+            raise
         if sha1:
-            counts[sha1] += 1
+            sha1_by_ordinal[i] = sha1
+    return sha1_by_ordinal
+
+
+def collect_duplicate_source_sha1s(sha1_by_ordinal: dict[int, str]) -> set[str]:
+    """Return SHA1s that appear at TWO OR MORE ordinals in this item's asset
+    list, given a :func:`read_sha1_by_ordinal` snapshot.
+
+    A SHA1 in this set means the source lists the same content at multiple
+    ordinals — legitimate within-item / cross-item duplication that must
+    centralize onto ONE canonical Commons file rather than upload byte-identical
+    copies. Without this knowledge, _resolve_hash_drift would see SHA1 X already
+    at (page A), be asked to upload it to (page B), and wrongly conclude
+    (page A) is drift to move over (page B). Ordinals whose SHA1 couldn't be read
+    are simply absent from the snapshot, so they neither count toward nor mask a
+    duplicate.
+    """
+    counts: Counter[str] = Counter(sha1_by_ordinal.values())
     return {sha1 for sha1, n in counts.items() if n > 1}
+
+
+def compute_sha1_page_numbers(
+    sha1_by_ordinal: dict[int, str],
+    page_labels: dict[int, str],
+) -> dict[int, list[int]]:
+    """Map each ordinal to the COMPLETE sorted set of P304 page numbers its
+    content occupies in this item, from a :func:`read_sha1_by_ordinal` snapshot.
+
+    Page numbers come from the title-derived ``page_labels`` — an ordinal's own
+    position in its extension series. SHA1 grouping only adds the UNION: a
+    within-item duplicate and its canonical share a SHA1, so the canonical must
+    carry EVERY page position of that SHA1. Detection
+    (:func:`collect_duplicate_source_sha1s`) and numbering derive from the SAME
+    snapshot, so a file detected as a duplicate always has its page unioned onto
+    the canonical — they cannot disagree.
+
+    Every ordinal gets AT LEAST its own page label. An ordinal with no known
+    SHA1 (metadata missing) is its own group of one, so it keeps its own page and
+    is never dropped to ``[]`` — which the authoritative P304 amend would read as
+    "strip all pages". An ordinal that is genuinely a singleton in its extension
+    series (empty label) maps to ``[]``: correct, it has no page number.
+    """
+    pages_by_sha1: dict[str, set[int]] = {}
+    for i, sha1 in sha1_by_ordinal.items():
+        label = page_labels.get(i)
+        if label:  # "" = singleton in its extension group (no page number)
+            pages_by_sha1.setdefault(sha1, set()).add(int(label))
+    result: dict[int, list[int]] = {}
+    for i, label in page_labels.items():
+        own = {int(label)} if label else set()
+        sha1 = sha1_by_ordinal.get(i)
+        group = pages_by_sha1.get(sha1, set()) if sha1 else set()
+        result[i] = sorted(own | group)
+    return result
 
 
 def license_to_markup_code(rights_uri: str) -> str:

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -6933,3 +6933,122 @@ def test_assert_build_sdc_on_miss_allowed_permits_safe_combos():
     sdc_sync._assert_build_sdc_on_miss_allowed(True, "georgia")
     sdc_sync._assert_build_sdc_on_miss_allowed(False, "nara")
     sdc_sync._assert_build_sdc_on_miss_allowed(False, None)
+
+
+# ---------------------------------------------------------------------------
+# _process_one_partner_item — P304 page-number source of truth + MERGED
+# exclusion. Regression coverage for the within-item P304-stripping bug
+# (PR #408 follow-up, fix/within-item-p304-stripping). The sync must (a)
+# stamp the COMPLETE page set the uploader recorded per ordinal, and (b)
+# skip MERGED (redirect) ordinals entirely rather than discovery-rescue and
+# re-derive them.
+# ---------------------------------------------------------------------------
+
+
+def _drive_partner_item(monkeypatch, *, ordinals, file_list=None):
+    """Drive ``_process_one_partner_item`` with a stubbed S3 + Commons surface.
+
+    Returns the ``[(mediaid, page_number), ...]`` list capturing every
+    ``process_one_from_sdc`` call in order, so a test can assert which ordinals
+    synced and with what P304 page value.
+    """
+    from tools import sdc_sync
+
+    s3 = MagicMock()
+    s3.get_sdc_json.return_value = '{"claims": [{"P": 1}], "ingest_date": "2026-01-01"}'
+    s3.get_upload_result.return_value = json.dumps({"ordinals": ordinals})
+    s3.get_file_list.return_value = file_list or []
+
+    calls = []
+
+    def fake_process_one(
+        mediaid, dpla_id, payload, download_url=None, page_number=None
+    ):
+        calls.append((mediaid, page_number))
+
+    monkeypatch.setattr(sdc_sync, "process_one_from_sdc", fake_process_one)
+    monkeypatch.setattr(sdc_sync, "tracker", MagicMock(), raising=False)
+    monkeypatch.setattr(sdc_sync, "site", MagicMock(), raising=False)
+    # Constant write counter → no null-edit touch → the Commons site is never
+    # actually hit; keeps the test offline.
+    monkeypatch.setattr(sdc_sync, "_sdc_writes_total", lambda: 0)
+    # Skip the post-SDC cleanup pass entirely.
+    monkeypatch.setattr(sdc_sync, "_normalize_wikitext_enabled", False, raising=False)
+    # Discovery must NOT run when every ordinal is already resolved (eligible or
+    # terminally MERGED). Make it loud so a regression that routes MERGED back
+    # into discovery fails here.
+    monkeypatch.setattr(
+        sdc_sync,
+        "_find_existing_commons_files_by_dpla_id",
+        lambda d: pytest.fail("discovery must not run for resolved ordinals"),
+    )
+
+    sdc_sync._process_one_partner_item(s3, "ohio", "a" * 32, 1, 1)
+    return calls
+
+
+def test_partner_item_within_item_stamps_complete_recorded_page_set(monkeypatch):
+    # The bug repro at the sync layer: two byte-identical JPGs at pages 1 and 2.
+    # Ordinal 1 is the canonical (UPLOADED); ordinal 2 MERGED (redirect) onto it.
+    # Only the canonical syncs, and it stamps the COMPLETE set [1, 2] — never a
+    # single page that the authoritative amend would use to STRIP the other.
+    ordinals = {
+        "1": {
+            "status": "UPLOADED",
+            "pageid": 100,
+            "title": "X (page 1).jpg",
+            "page_numbers": [1, 2],
+        },
+        "2": {
+            "status": "MERGED",
+            "pageid": 101,
+            "title": "X (page 2).jpg",
+            "page_numbers": [1, 2],
+        },
+    }
+    calls = _drive_partner_item(monkeypatch, ordinals=ordinals, file_list=["u1", "u2"])
+    assert calls == [("M100", [1, 2])]
+
+
+def test_partner_item_singleton_recorded_empty_list_yields_none(monkeypatch):
+    # A singleton records page_numbers=[]; the sync must pass None (no P304),
+    # NOT an empty set (which the authoritative amend would read as "strip all").
+    ordinals = {
+        "1": {
+            "status": "UPLOADED",
+            "pageid": 100,
+            "title": "X.jpg",
+            "page_numbers": [],
+        },
+    }
+    calls = _drive_partner_item(monkeypatch, ordinals=ordinals)
+    assert calls == [("M100", None)]
+
+
+def test_partner_item_missing_page_numbers_field_falls_back_to_positional(monkeypatch):
+    # An OLD upload-result.json written before the uploader recorded
+    # page_numbers: the field is absent, so the sync falls back to the
+    # positional per-extension computation (two JPGs → pages 1 and 2).
+    ordinals = {
+        "1": {"status": "UPLOADED", "pageid": 100, "title": "X - a.jpg"},
+        "2": {"status": "UPLOADED", "pageid": 200, "title": "X - b.jpg"},
+    }
+    calls = _drive_partner_item(monkeypatch, ordinals=ordinals, file_list=["u1", "u2"])
+    assert calls == [("M100", 1), ("M200", 2)]
+
+
+def test_partner_item_cross_item_merged_only_does_not_sync_or_discover(monkeypatch):
+    # A cross-item duplicate whose only ordinal MERGED onto another item's
+    # canonical. Its own title is a redirect with no MediaInfo — it must NOT be
+    # synced here, and (the fix) must NOT be discovery-rescued as a standalone
+    # file. No eligible ordinals → the item is skipped with zero sync calls.
+    ordinals = {
+        "1": {
+            "status": "MERGED",
+            "pageid": 100,
+            "title": "X.jpg",
+            "page_numbers": [],
+        },
+    }
+    calls = _drive_partner_item(monkeypatch, ordinals=ordinals)
+    assert calls == []

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -7052,3 +7052,36 @@ def test_partner_item_cross_item_merged_only_does_not_sync_or_discover(monkeypat
     }
     calls = _drive_partner_item(monkeypatch, ordinals=ordinals)
     assert calls == []
+
+
+def test_partner_item_malformed_page_numbers_skips_ordinal(monkeypatch):
+    # A present-but-malformed page_numbers (corrupt/hand-edited sidecar) must NOT
+    # drive the authoritative P304 reconcile — the ordinal is skipped, not synced
+    # with garbage that could strip real pages.
+    for bad in ("notalist", [-1], [0], [1, "x"], {"1": 1}):
+        ordinals = {
+            "1": {
+                "status": "UPLOADED",
+                "pageid": 100,
+                "title": "X.jpg",
+                "page_numbers": bad,
+            },
+        }
+        calls = _drive_partner_item(monkeypatch, ordinals=ordinals)
+        assert calls == [], f"expected skip for malformed page_numbers={bad!r}"
+
+
+def test_partner_item_explicit_null_page_numbers_skips_ordinal(monkeypatch):
+    # Explicit null is distinct from an absent key: the fixed writer never emits
+    # null (it writes [] for "no pages"), so a present null is untrusted → skip,
+    # NOT the legacy positional fallback (which an absent key would take).
+    ordinals = {
+        "1": {
+            "status": "UPLOADED",
+            "pageid": 100,
+            "title": "X.jpg",
+            "page_numbers": None,
+        },
+    }
+    calls = _drive_partner_item(monkeypatch, ordinals=ordinals)
+    assert calls == []

--- a/tests/test_upload_invariant.py
+++ b/tests/test_upload_invariant.py
@@ -319,7 +319,10 @@ def test_merge_and_redirect_within_item_stamps_page_number():
         )
 
     _, kwargs = merge.call_args
-    assert kwargs["page_numbers"] == {"2"}
+    # Fallback path: no canonical_page_numbers passed, so the merge stamps just
+    # this ordinal's own page as a single-element list (the primary path passes
+    # the complete list[int]; see test_merge_sdc_onto_canonical_* in test_uploader).
+    assert kwargs["page_numbers"] == ["2"]
 
 
 def test_create_redirect_refuses_to_clobber_real_file():

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -3140,10 +3140,15 @@ def test_merge_and_redirect_fails_when_sdc_merge_fails():
     assert tracker.count(Result.FAILED) == 1
 
 
-def test_merge_sdc_onto_canonical_within_item_passes_page_numbers():
+def test_merge_sdc_onto_canonical_within_item_passes_complete_page_set():
     """Reads the item's staged sdc.json, json-parses it, points sdc_sync at
-    our site, and calls merge_item_onto_canonical with the within-item page
-    number as a P304 qualifier set."""
+    our site, and calls merge_item_onto_canonical with the CANONICAL'S COMPLETE
+    page set (every position its SHA1 occupies in the item) as P304 qualifiers.
+
+    This is the within-item P304-stripping fix: a within-item duplicate at page
+    2 must not stamp only {2} onto the canonical — the authoritative amend would
+    read that as the full set and STRIP the canonical's page 1. Passing the
+    complete [1, 2] set (computed up front) stamps every page in one edit."""
     uploader = _build_uploader_with_dpla()
     uploader.s3_client.get_sdc_json.return_value = '{"claims": {"P170": []}}'
 
@@ -3154,8 +3159,9 @@ def test_merge_sdc_onto_canonical_within_item_passes_page_numbers():
             canonical_mediaid="M42",
             dpla_id="yyyy",
             partner="nara",
-            page_label="3",
+            page_label="2",  # this dup ordinal's own page …
             within_item=True,
+            canonical_page_numbers=[1, 2],  # … but the COMPLETE set wins
         )
         assert sdc_sync.site is uploader.site
 
@@ -3165,7 +3171,27 @@ def test_merge_sdc_onto_canonical_within_item_passes_page_numbers():
     assert args[0] == "M42"
     assert args[1] == "yyyy"
     assert args[2] == {"claims": {"P170": []}}
-    assert merge_mock.call_args.kwargs["page_numbers"] == {"3"}
+    assert merge_mock.call_args.kwargs["page_numbers"] == [1, 2]
+
+
+def test_merge_sdc_onto_canonical_within_item_falls_back_to_own_page():
+    """When the complete set wasn't supplied (defensive fallback), a within-item
+    merge stamps just this ordinal's own page. The SDC-sync phase re-stamps the
+    full recorded set regardless, so this transient partial is corrected."""
+    uploader = _build_uploader_with_dpla()
+    uploader.s3_client.get_sdc_json.return_value = '{"claims": {"P170": []}}'
+
+    with patch("tools.sdc_sync.merge_item_onto_canonical") as merge_mock:
+        uploader._merge_sdc_onto_canonical(
+            canonical_mediaid="M42",
+            dpla_id="yyyy",
+            partner="nara",
+            page_label="3",
+            within_item=True,
+            canonical_page_numbers=None,
+        )
+
+    assert merge_mock.call_args.kwargs["page_numbers"] == ["3"]
 
 
 def test_merge_sdc_onto_canonical_cross_item_passes_no_page_numbers():

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -14,6 +14,8 @@ from ingest_wikimedia.wikimedia import (
     join,
     collect_duplicate_source_sha1s,
     compute_ordinal_exts_and_page_labels,
+    compute_sha1_page_numbers,
+    read_sha1_by_ordinal,
     extract_page_ordinal_from_commons_title,
     extract_strings,
     extract_strings_dict,
@@ -1114,19 +1116,22 @@ def test_page_labels_clienterror_treated_as_stub_placeholder():
     assert labels == {1: "1", 2: "", 3: "2"}
 
 
-# collect_duplicate_source_sha1s — drift logic must recognize legit duplicates
-def _fake_s3_client_with_sha1s(sha1_by_ord: dict[int, str | None]):
-    """Mock S3Client whose Object().metadata['sha1'] returns the configured sha1
-    per ordinal. None means the ordinal raises (treated as missing)."""
+# read_sha1_by_ordinal — the SINGLE S3 pass both duplicate detection and P304
+# page numbering derive from (so they can never diverge and drop a page).
+def _fake_s3_client_with_sha1s(sha1_by_ord: dict[int, object]):
+    """Mock S3Client whose Object().metadata[CHECKSUM] returns the configured
+    value per ordinal. A str value is the stored sha1 ("" = present but empty);
+    an Exception value is raised when that ordinal's object is accessed; an
+    absent ordinal returns an object with no CHECKSUM metadata."""
     s3_client = MagicMock()
 
     def get_obj(bucket, path):
         ord_num = int(path.rsplit("/", 1)[-1].split("_", 1)[0])
-        sha1 = sha1_by_ord.get(ord_num)
-        if sha1 is None:
-            raise RuntimeError("missing")
+        val = sha1_by_ord.get(ord_num)
+        if isinstance(val, Exception):
+            raise val
         obj = MagicMock()
-        obj.metadata = {"sha1": sha1}
+        obj.metadata = {} if val is None else {"sha1": val}
         return obj
 
     boto3_resource = MagicMock()
@@ -1138,61 +1143,162 @@ def _fake_s3_client_with_sha1s(sha1_by_ord: dict[int, str | None]):
     return s3_client
 
 
+def _client_error(code: str):
+    from botocore.exceptions import ClientError
+
+    return ClientError({"Error": {"Code": code, "Message": "x"}}, "HeadObject")
+
+
+def test_read_sha1_by_ordinal_reads_all():
+    s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: "bbb", 3: "aaa"})
+    assert read_sha1_by_ordinal(s3, "abc" * 11, "pa", 3) == {
+        1: "aaa",
+        2: "bbb",
+        3: "aaa",
+    }
+
+
+def test_read_sha1_by_ordinal_skips_empty_and_absent_metadata():
+    # Present object with empty/absent CHECKSUM → ordinal simply absent from the
+    # snapshot (the caller treats it as its own singleton group — never a strip).
+    s3 = _fake_s3_client_with_sha1s({1: "", 2: None, 3: "ccc"})
+    assert read_sha1_by_ordinal(s3, "abc" * 11, "pa", 3) == {3: "ccc"}
+
+
+def test_read_sha1_by_ordinal_skips_genuinely_absent_object():
+    # A 404 / NoSuchKey means the object isn't there (stub) — tolerated skip.
+    s3 = _fake_s3_client_with_sha1s({1: _client_error("404"), 2: "bbb"})
+    assert read_sha1_by_ordinal(s3, "abc" * 11, "pa", 2) == {2: "bbb"}
+    s3 = _fake_s3_client_with_sha1s({1: _client_error("NoSuchKey"), 2: "bbb"})
+    assert read_sha1_by_ordinal(s3, "abc" * 11, "pa", 2) == {2: "bbb"}
+
+
+def test_read_sha1_by_ordinal_single_file_short_circuits_without_s3():
+    # A single-file item can't be a within-item duplicate and has no page
+    # number, so we skip the read entirely — matching the sibling's num_files>1
+    # guard. Critically, this avoids turning a transient S3 blip into a
+    # whole-item failure on the dominant single-file shape (the read re-raises).
+    s3 = _fake_s3_client_with_sha1s({1: _client_error("SlowDown")})
+    assert read_sha1_by_ordinal(s3, "abc" * 11, "pa", 1) == {}
+    # No S3 object access attempted at all.
+    assert s3.get_s3.return_value.Object.call_count == 0
+
+
+def test_read_sha1_by_ordinal_reraises_transient_s3_error():
+    # A transient/permission S3 error must FAIL LOUDLY, not silently drop the
+    # ordinal — a dropped ordinal is exactly how a detected duplicate's page goes
+    # un-unioned and P304 gets stripped. Mirrors compute_ordinal_exts_and_page_labels.
+    import pytest
+    from botocore.exceptions import ClientError
+
+    s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: _client_error("AccessDenied")})
+    with pytest.raises(ClientError):
+        read_sha1_by_ordinal(s3, "abc" * 11, "pa", 2)
+
+
+# collect_duplicate_source_sha1s — pure over a read_sha1_by_ordinal snapshot.
 def test_collect_duplicate_source_sha1s_all_unique():
-    s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: "bbb", 3: "ccc"})
-    assert collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 3) == set()
+    assert collect_duplicate_source_sha1s({1: "aaa", 2: "bbb", 3: "ccc"}) == set()
 
 
 def test_collect_duplicate_source_sha1s_one_pair_repeats():
     # Sherman pattern: same content at positions 1 and 12.
-    s3 = _fake_s3_client_with_sha1s(
-        {
-            1: "aaa",
-            2: "bbb",
-            3: "ccc",
-            4: "ddd",
-            5: "eee",
-            6: "fff",
-            7: "ggg",
-            8: "hhh",
-            9: "iii",
-            10: "jjj",
-            11: "kkk",
-            12: "aaa",
-            13: "bbb",
-        }
-    )
-    assert collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 13) == {"aaa", "bbb"}
+    snapshot = {
+        1: "aaa",
+        2: "bbb",
+        3: "ccc",
+        4: "ddd",
+        5: "eee",
+        6: "fff",
+        7: "ggg",
+        8: "hhh",
+        9: "iii",
+        10: "jjj",
+        11: "kkk",
+        12: "aaa",
+        13: "bbb",
+    }
+    assert collect_duplicate_source_sha1s(snapshot) == {"aaa", "bbb"}
 
 
 def test_collect_duplicate_source_sha1s_same_sha1_three_times():
-    s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: "bbb", 3: "aaa", 4: "aaa"})
-    assert collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 4) == {"aaa"}
+    assert collect_duplicate_source_sha1s({1: "aaa", 2: "bbb", 3: "aaa", 4: "aaa"}) == {
+        "aaa"
+    }
 
 
-def test_collect_duplicate_source_sha1s_handles_missing_metadata():
-    # Read failures are tolerated; affected ordinals are absent from the count.
-    s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: None, 3: "aaa"})
-    assert collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 3) == {"aaa"}
+def test_collect_duplicate_source_sha1s_ordinal_absent_from_snapshot():
+    # An ordinal whose SHA1 couldn't be read is absent from the snapshot, so it
+    # neither counts toward nor masks a duplicate.
+    assert collect_duplicate_source_sha1s({1: "aaa", 3: "aaa"}) == {"aaa"}
 
 
-def test_collect_duplicate_source_sha1s_logs_skipped_ordinals(caplog):
-    """Silent skips would hide drift miscorrection; ensure each failed read
-    produces a WARNING line so an operator can see why the count is low."""
-    import logging as _logging
-
-    s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: None, 3: "aaa"})
-    with caplog.at_level(_logging.WARNING):
-        collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 3)
-    messages = " | ".join(r.message for r in caplog.records)
-    assert "skipped ordinal 2" in messages
-    assert "under-count" in messages
+def test_collect_duplicate_source_sha1s_empty_snapshot():
+    assert collect_duplicate_source_sha1s({}) == set()
 
 
-def test_collect_duplicate_source_sha1s_skips_empty_sha1():
-    # Empty sha1 metadata (e.g. truncated) is not counted as duplicate-of-itself.
-    s3 = _fake_s3_client_with_sha1s({1: "", 2: "", 3: "aaa"})
-    assert collect_duplicate_source_sha1s(s3, "abc" * 11, "pa", 3) == set()
+# compute_sha1_page_numbers — pure over the snapshot; every ordinal keeps at
+# least its own title-derived page, plus the SHA1-group union for duplicates.
+def test_compute_sha1_page_numbers_within_item_duplicate_gets_complete_set():
+    # The bug repro (DPLA ID 2332631a…): two byte-identical JPGs at pages 1 and
+    # 2 of one item. BOTH ordinals map to the COMPLETE set [1, 2], so whichever
+    # lands the canonical stamps every page it occupies — never a single page
+    # that the authoritative amend would use to strip the other.
+    result = compute_sha1_page_numbers({1: "aaa", 2: "aaa"}, {1: "1", 2: "2"})
+    assert result == {1: [1, 2], 2: [1, 2]}
+
+
+def test_compute_sha1_page_numbers_within_item_triplicate():
+    # Same content at three positions → the complete set is all three pages.
+    result = compute_sha1_page_numbers(
+        {1: "aaa", 2: "aaa", 3: "aaa"}, {1: "1", 2: "2", 3: "3"}
+    )
+    assert result == {1: [1, 2, 3], 2: [1, 2, 3], 3: [1, 2, 3]}
+
+
+def test_compute_sha1_page_numbers_normal_multipage_each_its_own_page():
+    # Parity: a normal multipage item (distinct content per page) keeps the
+    # per-ordinal single-page behavior — no accidental unioning.
+    result = compute_sha1_page_numbers(
+        {1: "aaa", 2: "bbb", 3: "ccc"}, {1: "1", 2: "2", 3: "3"}
+    )
+    assert result == {1: [1], 2: [2], 3: [3]}
+
+
+def test_compute_sha1_page_numbers_singleton_maps_to_empty():
+    # A single-file item has no page series ("" label) → empty list, so the sync
+    # stamps no P304 qualifier (and correctly strips any stale one).
+    assert compute_sha1_page_numbers({1: "aaa"}, {1: ""}) == {1: []}
+
+
+def test_compute_sha1_page_numbers_dup_pair_plus_standalone_other_ext():
+    # A JPG pair (within-item dup, pages 1 & 2) alongside a standalone PDF
+    # (its own extension series, singleton → no page). The dup pair each get
+    # [1, 2]; the PDF gets [].
+    result = compute_sha1_page_numbers(
+        {1: "aaa", 2: "aaa", 3: "ppp"}, {1: "1", 2: "2", 3: ""}
+    )
+    assert result == {1: [1, 2], 2: [1, 2], 3: []}
+
+
+def test_compute_sha1_page_numbers_missing_sha1_keeps_own_page_no_strip():
+    # REGRESSION (the fix's own bug): ordinal 1's CHECKSUM metadata is missing
+    # (a documented real bucket state after copy_object drops user metadata), so
+    # it is ABSENT from the snapshot — but it is a normal page-1 file, not a
+    # duplicate. It must keep its own title-derived page [1], NOT be dropped to
+    # [] (which the authoritative P304 amend would read as "strip page 1").
+    result = compute_sha1_page_numbers({2: "bbb"}, {1: "1", 2: "2"})
+    assert result == {1: [1], 2: [2]}
+
+
+def test_compute_sha1_page_numbers_duplicate_with_missing_sibling_sha1():
+    # A within-item duplicate where the SECOND sibling's SHA1 is missing from
+    # the snapshot: because detection and numbering share this snapshot, ordinal
+    # 2 is NOT seen as a duplicate of 1, so they are treated as two separate
+    # single-page files — no false union, and critically no strip. Page 2 is
+    # preserved on ordinal 2's own file rather than lost.
+    result = compute_sha1_page_numbers({1: "aaa"}, {1: "1", 2: "2"})
+    assert result == {1: [1], 2: [2]}
 
 
 def test_page_labels_non_404_clienterror_propagates():

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -4501,14 +4501,15 @@ def process_one_from_sdc(
     statements on Commons that lack P2699, ``_amend_p7482_url_qualifiers``
     POSTs the missing qualifier via wbsetqualifier (idempotent).
 
-    ``page_number`` is the per-ordinal P304 (page-number) value computed
-    by :func:`_compute_page_numbers` from upload-result.json's per-file
-    extension grouping. Supplied only for files that are part of a
-    multi-file extension group on a multipage item; ``None`` for
-    single-file ordinals. When supplied, the P760 (DPLA ID) claim
-    receives a P304 qualifier with the page number; the legacy-state
-    backfill ``_amend_p760_page_qualifier`` handles existing P760
-    statements that lack it.
+    ``page_number`` is the P304 (page-number) value(s) for this file: a
+    single int, an iterable of ints (a within-item canonical that absorbed
+    a duplicate carries EVERY page its SHA1 occupies — the complete set the
+    uploader recorded in upload-result.json), or ``None`` for a single-file
+    ordinal with no page series. Treated AUTHORITATIVELY: the P760 (DPLA ID)
+    claim's P304 qualifiers are reconciled to exactly this set via
+    :func:`_amend_p760_page_qualifier` (missing added, stale removed), so the
+    complete set must be passed — a partial set would strip the file's other
+    pages.
     """
     # Drop every prior file's cached entity at the file boundary so the
     # cache doesn't leak entities across files (see _entity_cache
@@ -5499,6 +5500,14 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
             continue
         if data.get("status") in ("UPLOADED", "SKIPPED"):
             eligible[ord_str] = data
+        elif data.get("status") == "MERGED":
+            # Terminal within-item/cross-item duplicate: its own title is a
+            # redirect to the canonical (no MediaInfo of its own), and its page
+            # is already carried on the canonical's P304. It must NOT be
+            # discovery-rescued and synced as if it were a standalone file —
+            # doing so re-derives page numbers against the redirect and can
+            # double-count. Skip it entirely.
+            continue
         else:
             # NOT_PRESENT / INELIGIBLE / FAILED — the upload phase
             # couldn't confirm this ordinal in *this* run, but the
@@ -5599,13 +5608,24 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
         tracker.increment(Result.SDC_ITEMS_SKIPPED_MAPPING)
         return
 
-    # Compute per-ordinal P304 (page-number) values for any
-    # multi-file extension group. Single-file groups (one JPG,
-    # one PDF, etc.) are absent from the map — `page_numbers.get(
-    # ord_str)` returns None for them and process_one_from_sdc
-    # skips the qualifier. JPGs and PDFs are numbered as
-    # independent series per the user-confirmed rule.
-    page_numbers = _compute_page_numbers(ordinal_items)
+    # Per-ordinal P304 page numbers. The authoritative source is the COMPLETE
+    # page set the uploader recorded per ordinal in upload-result.json
+    # (``data["page_numbers"]`` — every page position that file's SHA1 occupies
+    # in the item, so a within-item canonical carries ALL its pages). This is
+    # read below per ordinal. ``_compute_page_numbers`` is retained only as a
+    # fallback for OLD upload-result.json files written before the uploader
+    # recorded page_numbers; it numbers eligible ordinals positionally and does
+    # NOT see within-item duplicates (the stripping bug), so it is used only
+    # when the recorded field is absent.
+    #
+    # KNOWN LEGACY LIMITATION: because the fallback can't see within-item dups
+    # and its result still drives the AUTHORITATIVE amend below, re-syncing a
+    # #408-era within-item item from its old (field-less) sidecar re-strips the
+    # canonical's extra pages. This is not a regression (those items are already
+    # stripped by the original bug), but the operational fix is to RE-RUN THE
+    # UPLOAD PHASE (which regenerates the sidecar WITH page_numbers), not to run
+    # sdc-sync alone against the stale sidecar.
+    page_numbers_fallback = _compute_page_numbers(ordinal_items)
 
     for ord_str, data in ordinal_items:
         pageid = data.get("pageid")
@@ -5685,13 +5705,24 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
                 download_url = file_list[ord_num - 1] or None
             else:
                 download_url = None
+        # Prefer the COMPLETE page set the uploader recorded for this ordinal
+        # (every position its SHA1 occupies in the item — so a within-item
+        # canonical that absorbed a duplicate carries ALL its pages). An empty
+        # list means a singleton with no page qualifier. Only when the field is
+        # entirely absent (an upload-result.json written before the uploader
+        # recorded page_numbers) do we fall back to the positional computation.
+        recorded_pages = data.get("page_numbers")
+        if recorded_pages is None:
+            page_number = page_numbers_fallback.get(ord_str)
+        else:
+            page_number = recorded_pages or None
         try:
             process_one_from_sdc(
                 mediaid,
                 dpla_id,
                 sdc_payload,
                 download_url=download_url,
-                page_number=page_numbers.get(ord_str),
+                page_number=page_number,
             )
         except _MissingEntityError:
             # Commons says the MediaInfo entity at this M-id doesn't

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -5708,13 +5708,32 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
         # Prefer the COMPLETE page set the uploader recorded for this ordinal
         # (every position its SHA1 occupies in the item — so a within-item
         # canonical that absorbed a duplicate carries ALL its pages). An empty
-        # list means a singleton with no page qualifier. Only when the field is
-        # entirely absent (an upload-result.json written before the uploader
-        # recorded page_numbers) do we fall back to the positional computation.
-        recorded_pages = data.get("page_numbers")
-        if recorded_pages is None:
+        # list means a singleton with no page qualifier. Key ABSENCE (not a
+        # null/empty value) is the legacy signal: only an upload-result.json
+        # written before the uploader recorded page_numbers lacks the key, and
+        # only then do we fall back to the positional computation.
+        if "page_numbers" not in data:
             page_number = page_numbers_fallback.get(ord_str)
         else:
+            recorded_pages = data["page_numbers"]
+            # The recorded value drives an AUTHORITATIVE P304 reconcile (adds
+            # missing, strips stale), so a corrupt/hand-edited value must never
+            # reach it. The writer only ever emits a list of positive ints (or
+            # []). Anything else (null, string, negatives, non-list) is treated
+            # as untrustworthy: skip the ordinal loudly rather than strip P304
+            # from garbage.
+            if not (
+                isinstance(recorded_pages, list)
+                and all(isinstance(p, int) and p > 0 for p in recorded_pages)
+            ):
+                logging.warning(
+                    f" -- Ordinal {ord_str}: malformed page_numbers"
+                    f" {recorded_pages!r} in upload-result.json; skipping ordinal"
+                    " (refusing to reconcile P304 from untrusted data)."
+                )
+                tracker.increment(Result.SDC_ORDINALS_SKIPPED_ERROR)
+                had_ordinal_error = True
+                continue
             page_number = recorded_pages or None
         try:
             process_one_from_sdc(

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -2668,6 +2668,11 @@ class Uploader:
                     ordinal_results[str(ordinal)] = {
                         "status": ORDINAL_FAILED,
                         "error": str(ex),
+                        # Record on failure paths too so the SDC-sync reader's
+                        # "field absent = legacy sidecar" signal stays reliable:
+                        # a discovery-rescued failed ordinal then uses this
+                        # recorded set instead of the positional fallback.
+                        "page_numbers": ordinal_pages,
                     }
                     self.handle_upload_exception(ex)
                     break
@@ -2688,6 +2693,10 @@ class Uploader:
                         "title": None,
                         "pageid": None,
                         "error": "would create a new File page (blocked in maintain mode)",
+                        # See the UploadTimeoutError handler: record here too so a
+                        # later discovery-rescue of this ordinal reads the complete
+                        # set rather than the positional fallback.
+                        "page_numbers": ordinal_pages,
                     }
                     continue
 

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -118,6 +118,8 @@ from ingest_wikimedia.wikimedia import (
     build_title_drift_move_reason,
     collect_duplicate_source_sha1s,
     compute_ordinal_exts_and_page_labels,
+    compute_sha1_page_numbers,
+    read_sha1_by_ordinal,
     get_page_title,
     get_wiki_text,
     wikimedia_url,
@@ -700,6 +702,7 @@ class Uploader:
         dry_run: bool,
         duplicate_source_sha1s: set[str] | None = None,
         expected_item_titles: set[str] | None = None,
+        canonical_page_numbers: list[int] | None = None,
     ) -> dict:
         """Process one ordinal's source asset and return a per-ordinal result dict.
 
@@ -988,6 +991,7 @@ class Uploader:
                             page_label=page_label,
                             within_item=True,
                             sha1=sha1,
+                            canonical_page_numbers=canonical_page_numbers,
                         )
 
                     drift_action = self._resolve_hash_drift(
@@ -1043,6 +1047,7 @@ class Uploader:
                             within_item=bool(expected_item_titles)
                             and existing_title in expected_item_titles,
                             sha1=sha1,
+                            canonical_page_numbers=canonical_page_numbers,
                         )
                     # DriftResolution.HAND_FIX (and any unforeseen sentinel):
                     # our SHA1 is at a wrong title and the intended title is
@@ -1992,6 +1997,7 @@ class Uploader:
         page_label: str,
         within_item: bool,
         sha1: str,
+        canonical_page_numbers: list[int] | None = None,
     ) -> dict:
         """Rule #3 (source duplication): centralize our SHA1 onto the earliest
         existing (canonical) Commons file instead of uploading a second
@@ -1999,8 +2005,10 @@ class Uploader:
 
         (a) Merge THIS item's structured data onto the canonical file's
             MediaInfo entity (add-only; other contributors' statements are
-            preserved). Within-item duplication stamps the page number this
-            ordinal occupies as a P304 qualifier; cross-item passes none.
+            preserved). Within-item duplication stamps the canonical's COMPLETE
+            page set (``canonical_page_numbers`` — every page position this
+            SHA1 occupies in the item, computed up front) as P304 qualifiers,
+            authoritatively and in one edit; cross-item passes none.
         (b) Leave a ``#REDIRECT`` at our intended title. A redirect carries no
             media, so the one-SHA1-one-file constraint holds.
 
@@ -2067,6 +2075,7 @@ class Uploader:
             partner=partner,
             page_label=page_label,
             within_item=within_item,
+            canonical_page_numbers=canonical_page_numbers,
         ):
             logging.warning(
                 f"Merge for {dpla_id} {ordinal}: SDC merge onto "
@@ -2130,6 +2139,7 @@ class Uploader:
         partner: str,
         page_label: str,
         within_item: bool,
+        canonical_page_numbers: list[int] | None = None,
     ) -> bool:
         """Read this item's staged ``sdc.json`` and merge it onto the canonical
         file's MediaInfo entity via ``sdc_sync.merge_item_onto_canonical``
@@ -2173,9 +2183,23 @@ class Uploader:
                 f"Merge for {dpla_id}: sdc.json failed to parse ({ex}); SDC not merged."
             )
             return False
-        # Within-item duplication: stamp the page number this ordinal occupies
-        # as a P304 qualifier. Cross-item / cross-institution: no page number.
-        page_numbers = {page_label} if within_item and page_label else None
+        # Within-item duplication: stamp the canonical's COMPLETE page set —
+        # every position this SHA1 occupies in the item, computed up front from
+        # the source asset list — as P304 qualifiers, authoritatively and in one
+        # edit. Passing only this ordinal's page would make the authoritative
+        # amend STRIP the canonical's other pages (the bug this fixes). Fall
+        # back to this ordinal's page only if the complete set wasn't supplied;
+        # the SDC-sync phase re-stamps the full set from the recorded numbers
+        # regardless. Cross-item / cross-institution: no page number.
+        if within_item:
+            # ``page_label`` is already a page-number string ("" for none); keep
+            # it as-is (no int() — _normalize_pages/P304 store strings anyway, so
+            # a non-numeric label can never raise here).
+            page_numbers = canonical_page_numbers or (
+                [page_label] if page_label else None
+            )
+        else:
+            page_numbers = None
         # The merge writes through sdc_sync's module-level ``site`` handle.
         sdc_sync.site = self.site
         try:
@@ -2551,14 +2575,31 @@ class Uploader:
                 self.s3_client, dpla_id, partner, len(files)
             )
 
-            # Identify SHA1s that legitimately appear at MORE THAN ONE
-            # position in the source asset list.  process_file uses this to
-            # short-circuit drift correction when its SHA1 is in the set —
-            # the existing Commons file at another title is a valid sibling,
-            # not a drift artefact, and both positions should remain as
-            # separate Commons pages.
-            duplicate_source_sha1s = collect_duplicate_source_sha1s(
+            # Read every ordinal's SHA1 ONCE. Both duplicate detection and the
+            # P304 page-number map derive from this single snapshot, so they can
+            # never disagree — a within-item duplicate that is detected always
+            # has its page unioned onto the canonical (two separate S3 passes
+            # could diverge and drop a page; see read_sha1_by_ordinal).
+            sha1_by_ordinal = read_sha1_by_ordinal(
                 self.s3_client, dpla_id, partner, len(files)
+            )
+
+            # SHA1s that legitimately appear at MORE THAN ONE position in the
+            # source asset list. process_file uses this to short-circuit drift
+            # correction when its SHA1 is in the set — the existing Commons file
+            # at another title is a valid sibling, not a drift artefact, and both
+            # positions should remain as separate Commons pages.
+            duplicate_source_sha1s = collect_duplicate_source_sha1s(sha1_by_ordinal)
+
+            # The COMPLETE P304 page set for each ordinal's file, from the item's
+            # own SHA1 grouping. A within-item duplicate and its canonical share
+            # the same SHA1 and therefore the same full page list, so whichever
+            # ordinal lands the canonical stamps EVERY page position
+            # authoritatively — and each ordinal's list is recorded in
+            # upload-result.json so the SDC-sync phase re-stamps from the same
+            # source of truth rather than re-deriving it per-ordinal.
+            page_numbers_by_ordinal = compute_sha1_page_numbers(
+                sha1_by_ordinal, page_labels
             )
 
             # Build the set of Commons titles this item's current asset list
@@ -2596,6 +2637,12 @@ class Uploader:
             ):
                 logging.info(f"Page {ordinal}")
                 page_label = page_labels.get(ordinal, "")
+                # This ordinal's COMPLETE P304 page set (every page its SHA1
+                # occupies in the item). Passed to the merge path AND recorded so
+                # the SDC-sync phase stamps it authoritatively from this single
+                # source of truth (within-item canonical → all its pages; normal
+                # file → its one page; singleton → []).
+                ordinal_pages = page_numbers_by_ordinal.get(ordinal, [])
                 try:
                     result = self.process_file(
                         dpla_id,
@@ -2610,7 +2657,12 @@ class Uploader:
                         dry_run,
                         duplicate_source_sha1s=duplicate_source_sha1s,
                         expected_item_titles=expected_item_titles,
+                        canonical_page_numbers=ordinal_pages,
                     )
+                    # process_file always returns a dict, but guard defensively:
+                    # a NoneType here would crash the whole item's upload loop.
+                    if isinstance(result, dict):
+                        result["page_numbers"] = ordinal_pages
                     ordinal_results[str(ordinal)] = result
                 except UploadTimeoutError as ex:
                     ordinal_results[str(ordinal)] = {


### PR DESCRIPTION
## Problem

The SHA1-uniqueness redesign (#408) **erased** a within-item duplicate's canonical Commons file P304 (page-number) qualifiers instead of accumulating them — the exact opposite of the intended behavior. Reproduced live on DPLA ID `2332631a4f7e2c6c5678bda6748c2345` (canonical `M195649834`): two `wbsetclaim-update-qualifiers` edits, first `P304 1 → 2`, then `P304` cleared.

Two compounding bugs, both flowing into the **authoritative** `_amend_p760_page_qualifier` (which reconciles P304 to exactly the set it's handed — adding missing, **removing stale**):

1. **Merge phase** stamped only the current dup ordinal's *single* page (`{page_label}`) → the amend removed the canonical's own page and added the dup's.
2. **SDC-sync phase** excluded the `MERGED` ordinal from its positional page count, so the canonical looked like a lone file → `page_number=None` → the amend stripped **all** remaining P304.

## Fix — one snapshot, one source of truth

Compute each ordinal's **complete** page set once, from a single S3 SHA1 snapshot, and stamp it authoritatively:

- **`read_sha1_by_ordinal`** (new) — one S3 pass reading every ordinal's `CHECKSUM`. Both duplicate detection (`collect_duplicate_source_sha1s`) and page numbering (`compute_sha1_page_numbers`) are now **pure functions of that one snapshot**, so a detected duplicate's page is *always* unioned onto the canonical — they cannot diverge.
- The uploader records each ordinal's complete page set in `upload-result.json`; the SDC-sync phase stamps that **recorded** set authoritatively and **excludes `MERGED` (redirect) ordinals** entirely (a redirect has no MediaInfo of its own).
- `read_sha1_by_ordinal` **fails loudly** on transient (non-404) S3 errors rather than silently under-populating the fingerprint, and **short-circuits single-file items** (no within-item dup possible, no page number).
- Every ordinal keeps **at least its own title-derived page**, so a file whose `CHECKSUM` metadata is missing is never coerced to `[]` → stripped.

## Verification

- **447 tests pass**; `ruff check`/`format` clean. New coverage: the exact bug repro (canonical → `P304=[1,2]`), normal-multipage/singleton parity, the missing-`CHECKSUM`-keeps-own-page regression, single-file short-circuit, and full-loop `_process_one_partner_item` tests (recorded set used, `MERGED` excluded, `[]`→`None`, legacy fallback).
- **Two adversarial-review rounds.** Round 1 caught a real regression in the first attempt (silent strip when `CHECKSUM` was missing) — fixed by the single-snapshot rework. Round 2 verdict `SAFE_TO_PROCEED`, both prior manifestations confirmed closed; it surfaced one genuine single-file regression (fixed: the `num_files<=1` short-circuit) and one non-regressive residual (below).
- A **4-agent `simplify` pass** was applied (lookup dedup, comment tightening) with two structural cleanups deferred (below).

## Known residuals (documented in-code, not regressions)

1. **CHECKSUM-drop between runs.** The SHA1 fingerprint lives only in droppable S3 user-metadata. If a within-item sibling's `CHECKSUM` is stripped externally (e.g. `copy_object` with `MetadataDirective=REPLACE`) *between* a correct run and a re-run, the canonical can lose that page. A durable fingerprint (recompute from bytes, or persist the grouping) is the real fix — deferred.
2. **#408-era legacy sidecars.** An `upload-result.json` written by #408 (before this fix) lacks the `page_numbers` field, so the sync uses the positional fallback, which can't see within-item dups. Operational fix: **re-run the upload phase** (regenerates the sidecar), not sync-only. Not a new regression — those items are already stripped by the original bug.

## Deferred altitude follow-ups (out of scope here)

- **Single-pass S3 read.** `read_sha1_by_ordinal` and `compute_ordinal_exts_and_page_labels` read two attributes of the same object in two passes (2N HEADs). Merging into one pass needs a signature change to the shared helper (`verify_item.py` also uses it) — a separate, reviewable refactor.
- **Merge add-only / sync authoritative.** The P304 amend strips authoritatively even on the add-only merge path, compensated by threading the complete set to the merge call site. A cleaner split (merge add-only, sync sole authority) would drop that plumbing — but the current up-front stamp keeps the canonical correct *even if the sync phase never runs*, a robustness trade-off worth a deliberate design decision.

## Before merge

Per the "live-test before merge" rule for corpus-wide SDC transforms, this will be **dry-run on a real within-item record** (and the damaged `M195649834` repaired) before merge is requested. **Do not merge without that dry-run and explicit go-ahead.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes within-item duplicate P304 page-qualifier stripping by using a single per-item S3 `CHECKSUM` (SHA1) snapshot to drive both duplicate detection and authoritative per-ordinal “complete page sets”.
- `uploader` now computes `page_numbers` per ordinal (from the SHA1 snapshot + ordinal page labels), writes authoritative `page_numbers` into `upload-result.json` even for certain failure/skip outcomes (e.g., upload timeout / blocked uploads), and passes `canonical_page_numbers` into the within-item merge path so `_merge_sdc_onto_canonical` stamps the full set (not just the current ordinal’s label). Cross-item merges continue to pass no page numbers.
- `sdc-sync` partner-mode treats the recorded `upload-result.json.page_numbers` as authoritative for P304 reconciliation, explicitly skips `MERGED` ordinals, validates `page_numbers` is a list of positive ints, skips ordinals with malformed/`null`/untrusted values, and falls back to positional `_compute_page_numbers` only when the `page_numbers` field is absent (older sidecars).
- Reworks wikimedia-side duplicate SHA1 collection to avoid per-ordinal S3 iteration: reads stored SHA1 from S3 object user-metadata once per ordinal (skipping missing/empty metadata and re-raising transient/unexpected S3 errors). Preserves singleton/title-derived pages when `CHECKSUM` metadata is missing.
- Adds regression coverage for within-item duplicates, singleton/empty semantics (`page_numbers=[]` → `page_number=None`), missing `page_numbers` fallback, defensive skipping on malformed/`None` values, and `MERGED` redirect behavior.

## Operational impact

- A real-record dry run and repair of `M195649834` are required before merge.

## Release / deployment / infra / security checks

- No manual pipeline trigger or ECS redeployment is indicated by this change set.
- No environment variables or Secrets Manager keys are added, renamed, or changed.
- No database migrations are included.
- No shared infrastructure configuration (CodePipeline, CodeBuild, ECS task definitions, IAM policies) is changed.
- No public API endpoints or response shapes are modified.
- No new security implications beyond continued existing S3 metadata reads; no new credential-handling is introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->