### PR TITLE
Preserve other_fields on rescue node-swap; count no-op merges as SKIP

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -680,6 +680,9 @@ _INFI_CREATOR_LABEL_RE = re.compile(r"^\s*creator\s*$", re.IGNORECASE)
 
 # ``Other fields 1``, ``Other fields 2``, ..., or the bare ``Other fields``.
 # Case-folded param names since ``_normalize_param_name`` already lower-cases.
+# NB: distinct from ``_NUMBERED_OTHER_FIELDS_RE`` (used by the rescue display-row
+# carry) — that one excludes the bare form and adds the modern ``other_fields``;
+# don't unify them (see the comment there). This one drives creator extraction.
 _OTHER_FIELDS_PARAM_RE = re.compile(r"^other fields(?: \d+)?$")
 
 # ``{{creator|Wikidata=Q56159174}}`` — Commons Creator template with a
@@ -2396,6 +2399,19 @@ def entity_was_already_migrated(entity: dict) -> bool:
     return False
 
 
+def _find_dpla_metadata_node(wikicode):
+    """Return the first ``{{DPLA metadata}}`` template node in ``wikicode``,
+    or ``None``. (Node form of :func:`_extract_dpla_metadata_template`.)"""
+    return next(
+        (
+            t
+            for t in wikicode.filter_templates()
+            if _template_name(t) == "dpla metadata"
+        ),
+        None,
+    )
+
+
 def _extract_dpla_metadata_template(block: str) -> str:
     """Pull just the ``{{DPLA metadata ...}}`` template out of
     ``block``. ``block`` is typically the full upload-form output of
@@ -2411,11 +2427,8 @@ def _extract_dpla_metadata_template(block: str) -> str:
     ``{{DPLA metadata}}`` template is found in it — a defensive
     no-op for callers that already pass just the template.
     """
-    wikicode = mwparserfromhell.parse(block)
-    for tpl in wikicode.filter_templates():
-        if _template_name(tpl) == "dpla metadata":
-            return str(tpl)
-    return block
+    node = _find_dpla_metadata_node(mwparserfromhell.parse(block))
+    return str(node) if node is not None else block
 
 
 def render_migrated_wikitext(
@@ -2451,6 +2464,52 @@ def render_migrated_wikitext(
     return text
 
 
+# Community-added display params on a ``{{DPLA metadata}}`` invocation that the
+# fresh ``get_wiki_text`` block never emits (it is built from the fixed
+# ``dpla_metadata_params`` set): the modern single ``other_fields`` and the
+# legacy numbered ``Other fields N``. Names match exactly what ``Module:DPLA``
+# reads — ``args.other_fields`` (underscore) and ``args['other fields ' .. i]``
+# / ``['Other fields ' .. i]`` (space) — so casefold but do NOT collapse
+# underscores to spaces (the two forms are distinct params to the renderer).
+# NB: distinct from ``_OTHER_FIELDS_PARAM_RE`` (creator-extraction, matches the
+# bare ``other fields`` too); intentionally not unified.
+_NUMBERED_OTHER_FIELDS_RE = re.compile(r"other fields \d+")
+
+
+def _is_user_extension_param(param) -> bool:
+    name = _normalize_param_name(param)
+    return (
+        name == "other_fields" or _NUMBERED_OTHER_FIELDS_RE.fullmatch(name) is not None
+    )
+
+
+def _carry_user_extension_params(old_template, new_block: str) -> str:
+    """Return ``new_block`` with any user-extension params (see
+    :func:`_is_user_extension_param`) copied from ``old_template`` when the
+    fresh block's ``{{DPLA metadata}}`` lacks them.
+
+    Used only when the node being swapped is itself a ``{{DPLA metadata}}``
+    template — the cross-page drift rescue over a source already on the new
+    form. Without this, a rescue replaces the whole node with the fresh block
+    and drops these community-added display rows. Only these extension params
+    are carried: every other param is canonical and is intentionally refreshed
+    by the rescue, so a fresh-block value always wins.
+    """
+    to_carry = [p for p in old_template.params if _is_user_extension_param(p)]
+    if not to_carry:
+        return new_block
+    fresh = mwparserfromhell.parse(new_block)
+    target = _find_dpla_metadata_node(fresh)
+    if target is None:
+        return new_block
+    existing = {_normalize_param_name(p) for p in target.params}
+    for p in to_carry:
+        if _normalize_param_name(p) in existing:
+            continue  # fresh block already sets it — canonical value wins
+        target.add(str(p.name).strip(), str(p.value).strip())
+    return str(fresh)
+
+
 def _swap_wrapper_node(
     original_text: str,
     new_template_block: str,
@@ -2465,11 +2524,20 @@ def _swap_wrapper_node(
     so callers can distinguish "swapped the wrapper" from "nothing to do"
     (the shared preserve-by-default primitive behind both the regular
     migration and the cross-page drift rescue).
+
+    When the matched wrapper is itself a ``{{DPLA metadata}}`` template (the
+    rescue path — ``render_migrated_wikitext`` passes only legacy names, so it
+    never hits this), community-added display rows (``other_fields`` / numbered
+    ``Other fields N``) are carried from the old node into the fresh block,
+    which is built from canonical params only and would otherwise drop them.
     """
     wikicode = mwparserfromhell.parse(original_text)
     for tpl in wikicode.filter_templates():
         if _template_name(tpl) in wrapper_names:
-            wikicode.replace(tpl, _extract_dpla_metadata_template(new_template_block))
+            replacement = _extract_dpla_metadata_template(new_template_block)
+            if _template_name(tpl) == "dpla metadata":
+                replacement = _carry_user_extension_params(tpl, replacement)
+            wikicode.replace(tpl, replacement)
             return str(wikicode), True
     return original_text, False
 

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -1553,6 +1553,73 @@ def test_rescue_wikitext_recognizes_all_wrappers(wrapper):
     assert "title=Old" not in result  # old wrapper replaced, not appended
 
 
+def test_rescue_wikitext_carries_other_fields_from_dpla_metadata_source():
+    """When the source is already on {{DPLA metadata}}, a rescue node-swaps it
+    for the fresh block — which is built from canonical params only. Community
+    display rows added via ``other_fields`` (mirrors {{Information}}) must be
+    carried across, or the rescue silently drops user-contributed content."""
+    source = (
+        "== {{int:filedesc}} ==\n"
+        "{{DPLA metadata\n"
+        "| title = Old Title\n"
+        "| other_fields = {{information field|Text|MOTE, MR.; Calhoun Times}}\n"
+        "}}\n"
+        "[[Category:Keep]]"
+    )
+    result = rescue_wikitext(source, "{{DPLA metadata\n| title = New Title\n}}")
+    assert "other_fields" in result and "MOTE, MR." in result  # carried
+    assert "New Title" in result and "Old Title" not in result  # canonical refreshed
+    assert "[[Category:Keep]]" in result
+
+
+def test_rescue_wikitext_carries_numbered_other_fields():
+    """The legacy numbered ``Other fields N`` shape is carried too."""
+    source = (
+        "{{DPLA metadata\n"
+        "| title = Old\n"
+        "| Other fields 2 = {{InFi|Notes|A community note}}\n"
+        "}}"
+    )
+    result = rescue_wikitext(source, "{{DPLA metadata\n| title = New\n}}")
+    assert "Other fields 2" in result and "A community note" in result
+
+
+def test_rescue_wikitext_does_not_carry_canonical_params():
+    """Only the user-extension params are carried — a canonical param present on
+    the old node (but not the fresh block) is NOT resurrected, so the rescue
+    still refreshes/clears stale canonical metadata as intended."""
+    source = (
+        "{{DPLA metadata\n"
+        "| title = Old\n"
+        "| date = 1899\n"  # stale canonical param, absent from fresh block
+        "| other_fields = {{InFi|Text|keep me}}\n"
+        "}}"
+    )
+    result = rescue_wikitext(source, "{{DPLA metadata\n| title = New\n}}")
+    assert "keep me" in result  # extension carried
+    assert "1899" not in result  # stale canonical param dropped, not carried
+
+
+def test_rescue_wikitext_carries_other_fields_with_full_form_new_block():
+    """The real caller passes get_wiki_text()'s FULL upload form (heading +
+    blank line + template), not a bare template. The node-swap must still
+    extract template-only (no duplicated heading) AND carry other_fields."""
+    source = (
+        "== {{int:filedesc}} ==\n"
+        "{{DPLA metadata\n"
+        "| title = Old\n"
+        "| other_fields = {{InFi|Text|keep me}}\n"
+        "}}\n"
+        "[[Category:Keep]]"
+    )
+    full_form_new = "== {{int:filedesc}} ==\n\n{{DPLA metadata\n| title = New\n}}"
+    result = rescue_wikitext(source, full_form_new)
+    assert "keep me" in result  # other_fields carried
+    assert "title = New" in result and "title = Old" not in result
+    assert result.count("{{int:filedesc}}") == 1  # heading NOT duplicated
+    assert "[[Category:Keep]]" in result
+
+
 def test_rescue_wikitext_falls_back_to_allowlist_when_no_wrapper():
     """A source with no recognised metadata wrapper can't be node-swapped, so
     rescue_wikitext falls back to the narrow merge_preserved_wikitext allowlist

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -3037,7 +3037,9 @@ def test_merge_and_redirect_merges_sdc_and_creates_redirect():
     canonical = _canonical_file("Canonical - DPLA - xxxx (page 1).jpg", 777)
 
     with (
-        patch.object(uploader, "_merge_sdc_onto_canonical") as merge_mock,
+        patch.object(
+            uploader, "_merge_sdc_onto_canonical", return_value=(True, True)
+        ) as merge_mock,
         patch.object(
             uploader, "_create_redirect_to_canonical", return_value="created"
         ) as redirect_mock,
@@ -3117,7 +3119,7 @@ def test_merge_and_redirect_fails_when_sdc_merge_fails():
 
     with (
         patch.object(
-            uploader, "_merge_sdc_onto_canonical", return_value=False
+            uploader, "_merge_sdc_onto_canonical", return_value=(False, False)
         ) as merge_mock,
         patch.object(uploader, "_create_redirect_to_canonical") as redirect_mock,
     ):
@@ -3138,6 +3140,115 @@ def test_merge_and_redirect_fails_when_sdc_merge_fails():
     assert tracker.count(Result.UPLOAD_MERGED_TO_CANONICAL) == 0
     # Returned normally, so this branch must count the failure itself.
     assert tracker.count(Result.FAILED) == 1
+
+
+def test_merge_and_redirect_noop_counts_skipped_keeps_merged_status():
+    """Full no-op re-encounter — redirect already existed AND the SDC merge
+    wrote nothing — is tallied as SKIPPED (already-correct), NOT MERGED. But the
+    returned ordinal STATUS stays ORDINAL_MERGED: it is a redirect and must stay
+    excluded from sdc-sync eligibility (PR #410 / within-item P304 fix). Only the
+    COUNTS bucket moves — asserting the status here guards that coupling."""
+    tracker = Tracker()
+    uploader = _build_uploader_with_dpla()
+    uploader.tracker = tracker
+    canonical = _canonical_file("Canonical - DPLA - xxxx (page 1).jpg", 777)
+    with (
+        patch.object(uploader, "_merge_sdc_onto_canonical", return_value=(True, False)),
+        patch.object(uploader, "_create_redirect_to_canonical", return_value="already"),
+    ):
+        result = uploader._merge_and_redirect(
+            canonical_file=canonical,
+            intended_title="Ours - DPLA - yyyy (page 1).jpg",
+            dpla_id="yyyy",
+            ordinal=1,
+            partner="nara",
+            page_label="1",
+            within_item=True,
+            sha1="a" * 40,
+        )
+    assert result["status"] == "MERGED"  # eligibility exclusion preserved
+    assert tracker.count(Result.SKIPPED) == 1
+    assert tracker.count(Result.UPLOAD_MERGED_TO_CANONICAL) == 0
+
+
+def test_merge_and_redirect_sdc_change_counts_merged():
+    """Redirect already existed but the SDC merge actually wrote → real MERGE."""
+    tracker = Tracker()
+    uploader = _build_uploader_with_dpla()
+    uploader.tracker = tracker
+    canonical = _canonical_file("Canonical - DPLA - xxxx (page 1).jpg", 777)
+    with (
+        patch.object(uploader, "_merge_sdc_onto_canonical", return_value=(True, True)),
+        patch.object(uploader, "_create_redirect_to_canonical", return_value="already"),
+    ):
+        result = uploader._merge_and_redirect(
+            canonical_file=canonical,
+            intended_title="Ours - DPLA - yyyy (page 1).jpg",
+            dpla_id="yyyy",
+            ordinal=1,
+            partner="nara",
+            page_label="1",
+            within_item=True,
+            sha1="a" * 40,
+        )
+    assert result["status"] == "MERGED"
+    assert tracker.count(Result.UPLOAD_MERGED_TO_CANONICAL) == 1
+    assert tracker.count(Result.SKIPPED) == 0
+
+
+def test_merge_and_redirect_new_redirect_counts_merged_even_if_sdc_noop():
+    """A newly-created redirect is itself a real action this run → MERGE, even
+    when the SDC merge wrote nothing."""
+    tracker = Tracker()
+    uploader = _build_uploader_with_dpla()
+    uploader.tracker = tracker
+    canonical = _canonical_file("Canonical - DPLA - xxxx (page 1).jpg", 777)
+    with (
+        patch.object(uploader, "_merge_sdc_onto_canonical", return_value=(True, False)),
+        patch.object(uploader, "_create_redirect_to_canonical", return_value="created"),
+    ):
+        result = uploader._merge_and_redirect(
+            canonical_file=canonical,
+            intended_title="Ours - DPLA - yyyy (page 1).jpg",
+            dpla_id="yyyy",
+            ordinal=1,
+            partner="nara",
+            page_label="1",
+            within_item=True,
+            sha1="a" * 40,
+        )
+    assert result["status"] == "MERGED"
+    assert tracker.count(Result.UPLOAD_MERGED_TO_CANONICAL) == 1
+    assert tracker.count(Result.SKIPPED) == 0
+
+
+def test_merge_sdc_onto_canonical_reports_changed_via_write_delta():
+    """``changed`` is True only when the SDC write counter advanced across the
+    merge (a real write), False on an idempotent no-op."""
+    uploader = _build_uploader_with_dpla()
+    uploader.s3_client.get_sdc_json.return_value = '{"claims": {"P170": []}}'
+    with (
+        patch("tools.sdc_sync.merge_item_onto_canonical"),
+        patch("tools.sdc_sync._sdc_writes_total", side_effect=[0, 1]),
+    ):
+        assert uploader._merge_sdc_onto_canonical(
+            canonical_mediaid="M42",
+            dpla_id="yyyy",
+            partner="nara",
+            page_label="1",
+            within_item=True,
+        ) == (True, True)
+    with (
+        patch("tools.sdc_sync.merge_item_onto_canonical"),
+        patch("tools.sdc_sync._sdc_writes_total", side_effect=[5, 5]),
+    ):
+        assert uploader._merge_sdc_onto_canonical(
+            canonical_mediaid="M42",
+            dpla_id="yyyy",
+            partner="nara",
+            page_label="1",
+            within_item=True,
+        ) == (True, False)
 
 
 def test_merge_sdc_onto_canonical_within_item_passes_complete_page_set():
@@ -3226,10 +3337,11 @@ def test_merge_sdc_onto_canonical_skips_when_no_staged_sdc():
         )
 
     # A genuinely-absent sdc.json (item contributes no claims) is "nothing to
-    # merge" = success, NOT a failure — the caller treats a falsy return as a
-    # retryable merge failure, so pin the True so a regression to None/False
-    # (which would strand the DEDUP outcome in permanent retry) is caught.
-    assert result is True
+    # merge" = success (ok=True), NOT a failure — the caller treats a falsy
+    # ``ok`` as a retryable merge failure, so pin ok=True so a regression to
+    # None/False (which would strand the DEDUP outcome in permanent retry) is
+    # caught. ``changed`` is False: nothing was written.
+    assert result == (True, False)
     merge_mock.assert_not_called()
 
 
@@ -3400,7 +3512,9 @@ def test_merge_and_redirect_hand_fix_when_intended_title_holds_real_file():
     occupant.latest_file_info.sha1 = "ffff" * 10
 
     with (
-        patch.object(uploader, "_merge_sdc_onto_canonical") as merge_mock,
+        patch.object(
+            uploader, "_merge_sdc_onto_canonical", return_value=(True, True)
+        ) as merge_mock,
         patch("tools.uploader.get_page", return_value=occupant),
         patch("tools.uploader.hand_fix_sidecar.record_hand_fix") as record_mock,
     ):
@@ -3438,7 +3552,9 @@ def test_merge_and_redirect_fenced_in_maintain_mode_is_not_merged():
     page = _redirect_intended_page(exists=False)
 
     with (
-        patch.object(uploader, "_merge_sdc_onto_canonical") as merge_mock,
+        patch.object(
+            uploader, "_merge_sdc_onto_canonical", return_value=(True, True)
+        ) as merge_mock,
         patch("tools.uploader.get_page", return_value=page),
     ):
         result = uploader._merge_and_redirect(

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -2024,11 +2024,15 @@ class Uploader:
         Once the SDC has merged, the outcome is gated on whether the redirect
         was established (``_create_redirect_to_canonical``'s return value):
 
-        - ``created`` / ``already`` → report ``ORDINAL_MERGED`` and bump
-          ``UPLOAD_MERGED_TO_CANONICAL``. Our intended title now resolves to
-          the canonical file. ``ORDINAL_MERGED`` is deliberately NOT in the
-          SDC-sync UPLOADED/SKIPPED eligibility set — the SDC was merged inline
-          onto the canonical file.
+        - ``created`` / ``already`` → report ``ORDINAL_MERGED``. Our intended
+          title now resolves to the canonical file. ``ORDINAL_MERGED`` is
+          deliberately NOT in the SDC-sync UPLOADED/SKIPPED eligibility set — the
+          SDC was merged inline onto the canonical file. The COUNTS tally is
+          separate from that status: a real merge (redirect newly ``created`` OR
+          the SDC merge wrote something) bumps ``UPLOAD_MERGED_TO_CANONICAL``; a
+          pure no-op re-encounter (redirect ``already`` there AND idempotent SDC
+          merge) bumps ``SKIPPED`` instead, matching the UPLOADED-vs-SKIPPED
+          convention. The recorded status stays ``ORDINAL_MERGED`` either way.
         - ``blocked_real_file`` → the intended title holds a DIFFERENT real
           file, so the redirect could not be established and our SHA1 is NOT
           discoverable at the intended title. Do NOT report MERGED; record a
@@ -2069,14 +2073,15 @@ class Uploader:
                     f"pageid; SDC merge could not run"
                 ),
             }
-        if not self._merge_sdc_onto_canonical(
+        merge_ok, sdc_changed = self._merge_sdc_onto_canonical(
             canonical_mediaid=f"M{canonical_pageid}",
             dpla_id=dpla_id,
             partner=partner,
             page_label=page_label,
             within_item=within_item,
             canonical_page_numbers=canonical_page_numbers,
-        ):
+        )
+        if not merge_ok:
             logging.warning(
                 f"Merge for {dpla_id} {ordinal}: SDC merge onto "
                 f"[[File:{canonical_title}]] failed; leaving the ordinal for "
@@ -2122,9 +2127,15 @@ class Uploader:
                 "pageid": None,
                 "error": "would create a redirect page (blocked in maintain mode)",
             }
-        # redirect_outcome in ("created", "already"): the redirect is
-        # established and the intended title resolves to the canonical file.
-        self.tracker.increment(Result.UPLOAD_MERGED_TO_CANONICAL)
+        # redirect_outcome in ("created", "already"): the redirect is established
+        # and the intended title resolves to the canonical file. Tally a real
+        # MERGE vs a no-op SKIP (see docstring); the recorded status stays
+        # ORDINAL_MERGED in BOTH cases — it is a redirect and MUST stay excluded
+        # from sdc-sync eligibility (PR #410 / within-item P304 fix).
+        if redirect_outcome == "created" or sdc_changed:
+            self.tracker.increment(Result.UPLOAD_MERGED_TO_CANONICAL)
+        else:
+            self.tracker.increment(Result.SKIPPED)
         return {
             "status": ORDINAL_MERGED,
             "title": canonical_title,
@@ -2140,7 +2151,7 @@ class Uploader:
         page_label: str,
         within_item: bool,
         canonical_page_numbers: list[int] | None = None,
-    ) -> bool:
+    ) -> tuple[bool, bool]:
         """Read this item's staged ``sdc.json`` and merge it onto the canonical
         file's MediaInfo entity via ``sdc_sync.merge_item_onto_canonical``
         (already on ``main`` from PR A).
@@ -2150,12 +2161,15 @@ class Uploader:
         this rare path. We point its module ``site`` at our authenticated
         Commons site for the duration of the call.
 
-        Returns ``True`` when the item's SDC was merged onto the canonical
-        file, or when there is genuinely nothing to merge (no staged
-        ``sdc.json`` — the item contributes no structured data). Returns
-        ``False`` on a hard failure (import / S3 read / JSON parse / merge
-        error) so the caller can avoid reporting a terminal ``MERGED`` for an
-        ordinal whose data never landed, and retry it on a later run instead.
+        Returns ``(ok, changed)``. ``ok`` is ``True`` when the item's SDC was
+        merged onto the canonical file, or when there is genuinely nothing to
+        merge (no staged ``sdc.json`` — the item contributes no structured
+        data); ``False`` on a hard failure (import / S3 read / JSON parse /
+        merge error) so the caller can avoid reporting a terminal ``MERGED``
+        for an ordinal whose data never landed, and retry it on a later run
+        instead. ``changed`` is ``True`` only when the merge actually wrote to
+        Commons (detected via the SDC write-counter delta), so the caller can
+        distinguish a real merge from an idempotent no-op re-encounter.
         """
         try:
             from tools import sdc_sync
@@ -2164,7 +2178,7 @@ class Uploader:
                 f"Merge for {dpla_id}: could not import sdc_sync ({ex!r}); "
                 f"SDC not merged."
             )
-            return False
+            return False, False
         try:
             sdc_raw = self.s3_client.get_sdc_json(partner, dpla_id)
         except Exception as ex:
@@ -2172,17 +2186,17 @@ class Uploader:
                 f"Merge for {dpla_id}: S3 read of sdc.json failed ({ex!r}); "
                 f"SDC not merged."
             )
-            return False
+            return False, False
         if not sdc_raw:
             logging.info(f"Merge for {dpla_id}: no staged sdc.json; nothing to merge.")
-            return True
+            return True, False
         try:
             sdc_payload = json.loads(sdc_raw)
         except json.JSONDecodeError as ex:
             logging.warning(
                 f"Merge for {dpla_id}: sdc.json failed to parse ({ex}); SDC not merged."
             )
-            return False
+            return False, False
         # Within-item duplication: stamp the canonical's COMPLETE page set —
         # every position this SHA1 occupies in the item, computed up front from
         # the source asset list — as P304 qualifiers, authoritatively and in one
@@ -2202,6 +2216,13 @@ class Uploader:
             page_numbers = None
         # The merge writes through sdc_sync's module-level ``site`` handle.
         sdc_sync.site = self.site
+        # Snapshot the SDC write counter around the merge so we can tell a real
+        # merge (something was written) from an idempotent no-op re-encounter
+        # (everything already present → merge_item_onto_canonical writes
+        # nothing). merge_item_onto_canonical → process_one_from_sdc bumps
+        # these counters on every commit, so a post-minus-pre delta of zero
+        # means the merge changed nothing on Commons this run.
+        writes_before = sdc_sync._sdc_writes_total()
         try:
             sdc_sync.merge_item_onto_canonical(
                 canonical_mediaid,
@@ -2209,11 +2230,13 @@ class Uploader:
                 sdc_payload,
                 page_numbers=page_numbers,
             )
+            changed = sdc_sync._sdc_writes_total() > writes_before
             logging.info(
                 f"Merged SDC for {dpla_id} onto canonical {canonical_mediaid}"
                 + (f" (pages {sorted(page_numbers)})" if page_numbers else "")
+                + ("" if changed else " (no change)")
             )
-            return True
+            return True, changed
         except CsrfRecoveryFailed:
             raise
         except Exception as ex:
@@ -2221,7 +2244,7 @@ class Uploader:
                 f"Merge for {dpla_id}: merge_item_onto_canonical failed "
                 f"({ex!r}); SDC not merged, ordinal left for retry next run."
             )
-            return False
+            return False, False
 
     def _create_redirect_to_canonical(
         self,


### PR DESCRIPTION
Two reporting/preservation refinements in `dpla/ingest-wikimedia`, bundled per request. Both are safe now (bot idle) and matter before the bot / drift-remediation sweep is re-run.

## A — Preserve `other_fields` through a `{{DPLA metadata}}` rescue node-swap

`{{DPLA metadata|other_fields=…}}` now renders on live Commons (Module:DPLA updated separately). But the cross-page drift **rescue** (`rescue_wikitext` / `render_migrated_wikitext`) node-swaps an existing `{{DPLA metadata}}` wrapper for a fresh `get_wiki_text` block — built from the fixed `dpla_metadata_params` set — which **silently dropped** community-added display rows (`other_fields` and the legacy numbered `Other fields N`, mirroring `{{Information}}`).

`_swap_wrapper_node` now carries those **user-extension params only** from the old node into the fresh block when the swapped wrapper is itself `{{DPLA metadata}}`. Canonical params (title/date/…) are still refreshed by the rescue — a blanket carry would resurrect stale values (guarded by a test). Scoped to the rescue path: `render_migrated_wikitext` passes only legacy template names, so the regular migration is untouched. Extracted `_find_dpla_metadata_node` rather than add a third inline copy of that node-find loop.

## B — Count a no-op duplicate merge as SKIP, not MERGED

The duplicate path counted **every** successful re-encounter as `MERGED`, including a pure no-op re-run where the redirect already existed **and** the SDC merge wrote nothing — inflating the run's `MERGED` count with already-correct duplicates.

- `_merge_sdc_onto_canonical` now returns `(ok, changed)`, where `changed` comes from an `sdc_sync._sdc_writes_total()` before/after delta (the established write-detection idiom).
- `_merge_and_redirect` tallies `UPLOAD_MERGED_TO_CANONICAL` only for a real merge (redirect newly `created` OR the SDC merge wrote something); a full no-op bumps `SKIPPED`, matching the existing UPLOADED-vs-SKIPPED convention.

🛑 **The recorded ordinal status stays `ORDINAL_MERGED` in both cases** — a redirect must remain excluded from sdc-sync eligibility or the within-item P304 hole (#410) re-opens. Only the COUNTS bucket differs; recorded status and the tally are independent axes. A regression test asserts the no-op still returns `ORDINAL_MERGED`.

## Tests / checks

- New regression tests for both paths in `tests/test_legacy_artwork.py` and `tests/test_uploader.py` — including the rescue with `get_wiki_text`'s **full-form** payload (no heading duplication + `other_fields` carried), and the no-op-stays-MERGED-status guard. Updated existing merge tests for the `(ok, changed)` tuple return.
- **Full `pytest tests/` green (1,301 passed)** — not a subset (a within-item test lives in a separate file). ruff check/format clean; `simplify` skill run (4 agents) with fixes applied; lessons.md reviewed (node-swap kept template-only per the mwparserfromhell-replace lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserve user-added `other_fields` and legacy numbered fields during `{{DPLA metadata}}` rescue node-swaps while refreshing canonical metadata.
- Count idempotent duplicate merges as `SKIPPED` when the redirect exists and SDC writes nothing, while retaining `ORDINAL_MERGED` status.
- Added regression coverage for both behaviors; all 1,301 tests pass, with clean Ruff checks and formatting.

## Operational Impact

- No manual pipeline trigger or ECS redeployment required.
- No environment variables or AWS Secrets Manager keys changed.
- No database migration.
- No shared infrastructure configuration changes.
- No public API response or endpoint changes.
- No security-impacting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->