### PR TITLE
Deferred cleanups: CI format gate, helper relocation, site param (#396, #398, #408a)

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,3 +15,10 @@ jobs:
           # Don't leave a writable GITHUB_TOKEN in the runner for later steps.
           persist-credentials: false
       - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+      # Also enforce formatting — `ruff check` (above) does not check format, so
+      # style drift slipped through until a later commit reformatted it. This
+      # step fails the build on any unformatted file (matches the pre-commit
+      # `ruff format` contributors run locally).
+      - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          args: format --check

--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -146,7 +146,7 @@ LEGACY_IMPORT_PROPERTY: dict[str, tuple[str, str]] = {
 # The guard is deliberately PRESENCE-based (is there a statement for this
 # property at all?), a backstop for the dominant failure: the canonical write
 # not firing, leaving the property entirely absent. It is intentionally looser
-# than ``tools/sdc_sync.py``'s provenance-based ``_entity_has_dpla_attributed_claims``
+# than ``ingest_wikimedia/sdc.py``'s provenance-based ``_entity_has_dpla_attributed_claims``
 # (which matches the P123=Q_DPLA publisher reference) — presence cannot
 # over-preserve the normal flow (canonical SDC present ⟹ property present ⟹
 # strip proceeds), whereas a provenance check would entangle with the codebase's

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -2008,7 +2008,11 @@ def _is_dpla_reference(reference) -> bool:
     America"). DPLA stamps that snak on every reference it writes via
     formattedclaim, so it's a sufficient marker for "we authored this".
     """
-    snaks = (reference or {}).get("snaks") or {}
+    if not isinstance(reference, dict):
+        return False
+    snaks = reference.get("snaks") or {}
+    if not isinstance(snaks, dict):
+        return False
     for snak in snaks.get("P123") or []:
         try:
             if snak["datavalue"]["value"]["id"] == Q_DPLA:
@@ -2042,7 +2046,10 @@ def _entity_has_dpla_attributed_claims(entity: dict) -> bool:
         for stmt in stmt_list:
             if not isinstance(stmt, dict):
                 continue
-            for reference in stmt.get("references") or []:
+            references = stmt.get("references") or []
+            if not isinstance(references, list):
+                continue
+            for reference in references:
                 if _is_dpla_reference(reference):
                     return True
     return False

--- a/ingest_wikimedia/sdc.py
+++ b/ingest_wikimedia/sdc.py
@@ -2000,3 +2000,49 @@ def build_claims_for_doc(
         )
 
     return {"claims": claims, "ingest_date": retrieval_date.isoformat()}
+
+
+def _is_dpla_reference(reference) -> bool:
+    """Return True iff `reference` is a DPLA-authored reference, identified
+    by a `P123 = Q2944483` snak (publisher = "Digital Public Library of
+    America"). DPLA stamps that snak on every reference it writes via
+    formattedclaim, so it's a sufficient marker for "we authored this".
+    """
+    snaks = (reference or {}).get("snaks") or {}
+    for snak in snaks.get("P123") or []:
+        try:
+            if snak["datavalue"]["value"]["id"] == Q_DPLA:
+                return True
+        except (KeyError, TypeError):
+            continue
+    return False
+
+
+def _entity_has_dpla_attributed_claims(entity: dict) -> bool:
+    """True iff ``entity`` carries at least one DPLA-attributed statement.
+
+    Mirrors :func:`Module:DPLA`'s ``isDplaDetermined`` filter on Commons:
+    the canonical DPLA-provenance marker is the ``P123 = Q2944483``
+    (publisher = DPLA) snak in any statement reference, stamped by
+    ``formattedclaim`` on every claim DPLA writes. The prior implementation
+    checked the ``P459 = Q61848113`` qualifier instead — a display-side
+    co-stamp that isn't a reference-independent marker — despite the
+    docstring already claiming alignment with Module:DPLA. Detecting
+    provenance via the reference closes that drift and keeps this guard
+    aligned with the template renderer's notion of "has DPLA SDC".
+    """
+    if not entity:
+        return False
+    statements = entity.get("statements") or entity.get("claims") or {}
+    if not isinstance(statements, dict):
+        return False
+    for stmt_list in statements.values():
+        if not isinstance(stmt_list, list):
+            continue
+        for stmt in stmt_list:
+            if not isinstance(stmt, dict):
+                continue
+            for reference in stmt.get("references") or []:
+                if _is_dpla_reference(reference):
+                    return True
+    return False

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -3264,8 +3264,6 @@ def test_merge_sdc_onto_canonical_within_item_passes_complete_page_set():
     uploader.s3_client.get_sdc_json.return_value = '{"claims": {"P170": []}}'
 
     with patch("tools.sdc_sync.merge_item_onto_canonical") as merge_mock:
-        import tools.sdc_sync as sdc_sync
-
         uploader._merge_sdc_onto_canonical(
             canonical_mediaid="M42",
             dpla_id="yyyy",
@@ -3274,7 +3272,6 @@ def test_merge_sdc_onto_canonical_within_item_passes_complete_page_set():
             within_item=True,
             canonical_page_numbers=[1, 2],  # … but the COMPLETE set wins
         )
-        assert sdc_sync.site is uploader.site
 
     uploader.s3_client.get_sdc_json.assert_called_once_with("nara", "yyyy")
     merge_mock.assert_called_once()
@@ -3283,6 +3280,9 @@ def test_merge_sdc_onto_canonical_within_item_passes_complete_page_set():
     assert args[1] == "yyyy"
     assert args[2] == {"claims": {"P170": []}}
     assert merge_mock.call_args.kwargs["page_numbers"] == [1, 2]
+    # The uploader hands its authenticated site through the call (no direct
+    # mutation of sdc_sync.site); merge_item_onto_canonical installs it.
+    assert merge_mock.call_args.kwargs["commons_site"] is uploader.site
 
 
 def test_merge_sdc_onto_canonical_within_item_falls_back_to_own_page():

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -19,6 +19,8 @@ from ingest_wikimedia.logs import setup_logging
 from ingest_wikimedia.sdc import (
     CHUNKABLE_PROPS,
     NARA_PROVIDER_NAME,
+    _entity_has_dpla_attributed_claims,
+    _is_dpla_reference,
     build_claims_for_doc,
     casefold_for_compare,
     fetch_institutions_v2,
@@ -370,36 +372,6 @@ def _fetch_entity_for_cleanup_guard(mediaid: str) -> dict:
     if not isinstance(ent, dict):
         return {}
     return ent
-
-
-def _entity_has_dpla_attributed_claims(entity: dict) -> bool:
-    """True iff ``entity`` carries at least one DPLA-attributed statement.
-
-    Mirrors :func:`Module:DPLA`'s ``isDplaDetermined`` filter on Commons:
-    the canonical DPLA-provenance marker is the ``P123 = Q2944483``
-    (publisher = DPLA) snak in any statement reference, stamped by
-    ``formattedclaim`` on every claim DPLA writes. The prior implementation
-    checked the ``P459 = Q61848113`` qualifier instead — a display-side
-    co-stamp that isn't a reference-independent marker — despite the
-    docstring already claiming alignment with Module:DPLA. Detecting
-    provenance via the reference closes that drift and keeps this guard
-    aligned with the template renderer's notion of "has DPLA SDC".
-    """
-    if not entity:
-        return False
-    statements = entity.get("statements") or entity.get("claims") or {}
-    if not isinstance(statements, dict):
-        return False
-    for stmt_list in statements.values():
-        if not isinstance(stmt_list, list):
-            continue
-        for stmt in stmt_list:
-            if not isinstance(stmt, dict):
-                continue
-            for reference in stmt.get("references") or []:
-                if _is_dpla_reference(reference):
-                    return True
-    return False
 
 
 def _classify_item_outcome(synced_this_item: bool, had_ordinal_error: bool) -> Result:
@@ -1005,22 +977,6 @@ def _allowed_qualifier_props(prop):
     statement property. Always includes P459 (the determination-method
     marker stamped by formattedclaim)."""
     return {"P459"} | _DPLA_EXTRA_QUALIFIER_PROPS.get(prop, set())
-
-
-def _is_dpla_reference(reference):
-    """Return True iff `reference` is a DPLA-authored reference, identified
-    by a `P123 = Q2944483` snak (publisher = "Digital Public Library of
-    America"). DPLA stamps that snak on every reference it writes via
-    formattedclaim, so it's a sufficient marker for "we authored this".
-    """
-    snaks = (reference or {}).get("snaks") or {}
-    for snak in snaks.get("P123") or []:
-        try:
-            if snak["datavalue"]["value"]["id"] == "Q2944483":
-                return True
-        except (KeyError, TypeError):
-            continue
-    return False
 
 
 def _is_safe_to_amend_in_place(statement, prop):
@@ -4632,7 +4588,12 @@ def process_one_from_sdc(
 
 
 def merge_item_onto_canonical(
-    canonical_mediaid, dpla_id, sdc_payload, page_numbers=None, download_url=None
+    canonical_mediaid,
+    dpla_id,
+    sdc_payload,
+    page_numbers=None,
+    download_url=None,
+    commons_site=None,
 ):
     """Rule #3: merge a duplicate DPLA item's SDC onto the already-existing
     canonical Commons file instead of uploading a second byte-identical file.
@@ -4648,7 +4609,15 @@ def merge_item_onto_canonical(
     ``page_numbers`` is the set of within-item page numbers this DPLA ID
     occupies on the canonical file (the within-item duplicate case); ``None``
     when the duplication is cross-item / cross-institution.
+
+    ``commons_site``, when provided, is installed as the module-level pywikibot
+    ``site`` the merge writes through — so out-of-module callers (the uploader's
+    dedup path) hand their authenticated site in via this parameter instead of
+    reaching into and mutating ``sdc_sync.site`` directly.
     """
+    if commons_site is not None:
+        global site
+        site = commons_site
     process_one_from_sdc(
         canonical_mediaid,
         dpla_id,

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -2214,8 +2214,6 @@ class Uploader:
             )
         else:
             page_numbers = None
-        # The merge writes through sdc_sync's module-level ``site`` handle.
-        sdc_sync.site = self.site
         # Snapshot the SDC write counter around the merge so we can tell a real
         # merge (something was written) from an idempotent no-op re-encounter
         # (everything already present → merge_item_onto_canonical writes
@@ -2224,11 +2222,15 @@ class Uploader:
         # means the merge changed nothing on Commons this run.
         writes_before = sdc_sync._sdc_writes_total()
         try:
+            # Pass our authenticated site through the call (merge_item_onto_canonical
+            # installs it as sdc_sync's module ``site``) rather than mutating
+            # sdc_sync.site from here.
             sdc_sync.merge_item_onto_canonical(
                 canonical_mediaid,
                 dpla_id,
                 sdc_payload,
                 page_numbers=page_numbers,
+                commons_site=self.site,
             )
             changed = sdc_sync._sdc_writes_total() > writes_before
             logging.info(


### PR DESCRIPTION
Three small deferred-work items surfaced by a review of the last 50 PRs. All mechanical — no behavior change intended.

### #396 — enforce formatting in CI
The Ruff workflow only ran `ruff check`, which does **not** verify formatting, so style drift slipped through until a later commit reformatted it. Adds a second `astral-sh/ruff-action` step running `format --check`, which fails the build on any unformatted file (matching the `ruff format` contributors run locally as a pre-commit step). A separate step is intentional: `check` and `format --check` are distinct ruff subcommands and give independently-named CI annotations (lint failure vs. format drift).

### #398 — relocate DPLA-provenance helpers to the shared library
Moves the pure functions `_is_dpla_reference` and `_entity_has_dpla_attributed_claims` from `tools/sdc_sync.py` into `ingest_wikimedia/sdc.py` (re-imported into `sdc_sync` so all call sites keep working). These are library-layer helpers keyed on the DPLA publisher marker (`P123 = Q2944483`); they belong with the rest of the SDC logic. Now colocated with the `Q_DPLA` constant, `_is_dpla_reference` uses it instead of the bare `"Q2944483"` literal. A stale comment in `legacy_artwork.py` that attributed the helper to `tools/sdc_sync.py` is corrected.

### #408a — pass `commons_site` as a parameter instead of mutating a module global from the uploader
Previously the uploader reached across the module boundary and mutated `sdc_sync.site` directly (`sdc_sync.site = self.site`). This adds a `commons_site=` parameter to `merge_item_onto_canonical`; the caller passes the site as data and `sdc_sync` installs its own module global internally. `sdc_sync` remains script-style/global-stateful by design — fully threading `site` through `process_one_from_sdc` and its POST helpers is a larger refactor left out of scope; this is the right-sized bridge that moves responsibility for the mutation inside the module. The affected test now asserts the parameter contract (`call_args.kwargs["commons_site"]`) rather than the post-mutation global.

`#408b` (folding the community-file gate into `_resolve_hash_drift`) turned out to be a restructure of the invariant-critical collision path rather than a mechanical move, so it is deliberately **not** in this PR and will come separately with dedicated tests.

### Verification
- Full `pytest tests/` — **1301 passed**
- `ruff check` clean; `ruff format --check` clean
- simplify skill run (reuse/simplification/efficiency/altitude); findings applied: `Q_DPLA` constant reuse + stale-comment fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Enforces Ruff formatting in CI with `ruff format --check` alongside the existing `ruff check`.
- Centralizes DPLA-provenance helper logic in `ingest_wikimedia.sdc` (reusing `Q_DPLA`) and updates `tools/sdc_sync.py`/legacy comment to use the shared implementation.
- Adds defensive type guards in the DPLA-provenance helpers so malformed reference containers return `False` instead of raising.
- Updates SDC merge wiring by adding a `commons_site` parameter to `merge_item_onto_canonical` (and updating callers/tests accordingly), removing prior reliance on mutating `tools.sdc_sync`’s module-level `site`.
- Corrects a stale helper-location comment.
- Verification: 1,301 tests passed; Ruff checks are clean.

## Operational Impact

- No manual pipeline trigger or ECS redeployment required.
- No environment variables, AWS Secrets Manager keys, database migrations, shared infrastructure configuration, or public API response/endpoint changes.
- No security-impacting changes; session/site handling is made more explicit without changing authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->