### PR TITLE
Fuse per-ordinal S3 reads into a single prescan_ordinals pass (#410 follow-up)

### DIFF
--- a/ingest_wikimedia/wikimedia.py
+++ b/ingest_wikimedia/wikimedia.py
@@ -243,50 +243,90 @@ def get_page_title(
         return f"{escaped_visible_title} - DPLA - {dpla_identifier}{suffix}"
 
 
-def compute_ordinal_exts_and_page_labels(
+def prescan_ordinals(
     s3_client: S3Client,
     dpla_id: str,
     partner: str,
     num_files: int,
-) -> tuple[dict[int, str], dict[int, str]]:
-    """Compute per-ordinal extension and page-label for a multi-file DPLA item.
+) -> tuple[dict[int, str], dict[int, str], dict[int, str]]:
+    """Read every ordinal's S3 object ONCE and return the three per-ordinal facts
+    the uploader derives from a multi-file DPLA item's asset list.
 
-    Mirrors the uploader's pre-scan + per-extension counter logic so any code
-    that needs to predict the Commons title an S3 ordinal will land at can
-    reconstruct it without duplicating the (subtle) accounting. Producer
-    (uploader) and consumer (verifier) MUST share this helper so they never
-    diverge — see lessons.md "Don't normalize platform-dependent values on
-    one side of a producer/consumer pair".
+    A boto3 ``Object`` load is a single HEAD that caches every attribute, so the
+    ``content_type`` (drives the extension / page-label accounting) and the
+    ``CHECKSUM`` user-metadata (the content fingerprint) are read off the SAME
+    object for one request per ordinal, not two passes of ``num_files`` HEADs
+    each. Beyond halving the requests, reading both off one HEAD makes the
+    extension accounting and the SHA1 snapshot provably consistent — the exact
+    divergence the P304 machinery must avoid (see :func:`compute_sha1_page_numbers`).
+
+    Any code that needs to predict the Commons title an ordinal lands at MUST
+    share this helper so producer (uploader) and consumer (verifier) never
+    diverge — see lessons.md "Don't normalize platform-dependent values on one
+    side of a producer/consumer pair".
 
     Returns:
-        ordinal_exts: {ordinal: extension} for ordinals the uploader has
-            classified during pre-scan.
+        ordinal_exts: {ordinal: extension} for ordinals classified during the
+            pre-scan.
               - real ext (e.g. ".jpg") means a normal uploadable file.
-              - "" means a stub or octet-stream placeholder; process_file
-                may still upload it after content-type re-detection but
-                without a (page N) suffix.
-              - ordinals absent from the dict are download-only files
-                (e.g. videos) — staged to S3 but never uploaded.
+              - "" means a stub or octet-stream placeholder; process_file may
+                still upload it after content-type re-detection but without a
+                (page N) suffix.
+              - ordinals absent from the dict are download-only files (e.g.
+                videos) — staged to S3 but never uploaded.
         page_labels: {ordinal: page_label_string} for every ordinal in
-            1..num_files. Pass to get_page_title(page=...). Empty string
-            means no (page N) suffix on the Commons title.
+            1..num_files. Pass to get_page_title(page=...). Empty string means no
+            (page N) suffix on the Commons title.
+        sha1_by_ordinal: {ordinal: stored CHECKSUM sha1}, the item's content
+            fingerprint. Consumed by :func:`collect_duplicate_source_sha1s`
+            (duplicate detection) and :func:`compute_sha1_page_numbers` (P304
+            page numbering). An ordinal with empty/absent CHECKSUM metadata is
+            absent from the map; the caller treats it as its own singleton group,
+            so it keeps its own title-derived page and is never mistaken for a
+            page-less file whose P304 should be stripped. (The error contract and
+            the read-before-classification ordering are documented inline below.)
+
+    Single-file / empty items skip the S3 pass entirely (``num_files <= 1``): one
+    file cannot be a WITHIN-item duplicate of itself and has no page number, so
+    the read is pure overhead — and, because it can re-raise, it would otherwise
+    turn a transient S3 blip into a whole-item failure on the dominant single-
+    file shape. (Cross-item duplication of a lone file is detected separately by
+    process_file's own hash probe, not here.)
+
+    KNOWN RESIDUAL (not a regression; documented, not silently accepted): the
+    SHA1 fingerprint lives only in droppable S3 user-metadata. If a within-item
+    duplicate sibling's CHECKSUM is stripped externally (e.g. a copy_object with
+    MetadataDirective=REPLACE that omits it) BETWEEN a correct run and a re-run,
+    that sibling drops out of the snapshot, the canonical is recomputed without
+    the sibling's page, and the authoritative P304 amend shrinks a
+    previously-correct set. Fixing this needs a fingerprint that survives
+    metadata drift (recompute from bytes, or persist the per-ordinal grouping)
+    — deferred; the add-only "don't shrink" shortcut is rejected because it
+    would also block the legitimate removal of a genuinely-stale P304.
     """
     ordinal_exts: dict[int, str] = {}
+    sha1_by_ordinal: dict[int, str] = {}
     if num_files > 1:
         for i in range(1, num_files + 1):
             s3_path = s3_client.get_media_s3_path(dpla_id, i, partner)
             try:
                 s3_obj = s3_client.get_s3().Object(S3_BUCKET, s3_path)
                 mime = s3_obj.content_type
+                sha1 = (s3_obj.metadata or {}).get(CHECKSUM)
             except ClientError as e:
-                # Only treat "object not found" as a stub placeholder.
-                # Anything else (AccessDenied, InternalError, throttling) must
-                # surface so we never silently corrupt the page-label
-                # assignment on a transient S3 failure.
+                # Only treat "object not found" as a stub placeholder. Anything
+                # else (AccessDenied, InternalError, throttling) must surface so
+                # we never silently corrupt the page-label assignment or drop an
+                # ordinal from the SHA1 snapshot on a transient S3 failure.
                 if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
                     ordinal_exts[i] = ""
                     continue
                 raise
+            # Record the fingerprint for every existing ordinal FIRST — before
+            # the extension classification's continues — so download-only and
+            # octet-stream ordinals still count toward duplicate detection.
+            if sha1:
+                sha1_by_ordinal[i] = sha1
             if is_download_only(mime):
                 continue
             if mime in ("application/octet-stream", "binary/octet-stream"):
@@ -306,77 +346,12 @@ def compute_ordinal_exts_and_page_labels(
         else:
             page_labels[ordinal] = ""
 
-    return ordinal_exts, page_labels
-
-
-def read_sha1_by_ordinal(
-    s3_client: S3Client,
-    dpla_id: str,
-    partner: str,
-    num_files: int,
-) -> dict[int, str]:
-    """Read each ordinal's stored SHA1 (the ``CHECKSUM`` S3 user-metadata) in a
-    SINGLE pass over the item's asset list.
-
-    This snapshot is the item's authoritative content fingerprint, and BOTH
-    duplicate detection (:func:`collect_duplicate_source_sha1s`) and P304 page
-    numbering (:func:`compute_sha1_page_numbers`) derive from it. Reading once
-    and sharing the result is deliberate, not incidental: two independent S3
-    passes can DISAGREE (one reads an ordinal's hash, the other transiently
-    fails), and a within-item duplicate that is *detected* but whose page is not
-    *unioned* onto the canonical is exactly how P304 silently drops. One snapshot
-    makes detection and numbering provably consistent — the same producer/
-    consumer-share rule :func:`compute_ordinal_exts_and_page_labels` documents.
-
-    Error contract mirrors that sibling: a genuinely-absent object
-    (404 / NoSuchKey) is skipped; any other S3 error is re-raised so a transient
-    failure fails the item LOUDLY rather than silently under-populating the
-    fingerprint. An object present with empty/absent CHECKSUM metadata is also
-    skipped (ordinal absent from the map) — the caller treats an ordinal with no
-    known SHA1 as its own singleton group, so it still keeps its own
-    title-derived page number and is never mistaken for a page-less file whose
-    P304 should be stripped.
-
-    Single-file items short-circuit to ``{}`` (like the sibling's ``num_files >
-    1`` guard): one file cannot be a WITHIN-item duplicate of itself and has no
-    page number, so the read is pure overhead — and, because it can re-raise,
-    the read would otherwise turn a transient S3 blip into a whole-item failure
-    on the dominant single-file shape. (Cross-item duplication of a lone file is
-    detected separately by process_file's own hash probe, not here.)
-
-    KNOWN RESIDUAL (not a regression; documented, not silently accepted): the
-    SHA1 fingerprint lives only in droppable S3 user-metadata. If a within-item
-    duplicate sibling's CHECKSUM is stripped externally (e.g. a copy_object with
-    MetadataDirective=REPLACE that omits it) BETWEEN a correct run and a re-run,
-    that sibling drops out of the snapshot, the canonical is recomputed without
-    the sibling's page, and the authoritative P304 amend shrinks a
-    previously-correct set. Fixing this needs a fingerprint that survives
-    metadata drift (recompute from bytes, or persist the per-ordinal grouping)
-    — deferred; the add-only "don't shrink" shortcut is rejected because it
-    would also block the legitimate removal of a genuinely-stale P304.
-    """
-    if num_files <= 1:
-        return {}
-    sha1_by_ordinal: dict[int, str] = {}
-    for i in range(1, num_files + 1):
-        s3_path = s3_client.get_media_s3_path(dpla_id, i, partner)
-        try:
-            s3_obj = s3_client.get_s3().Object(S3_BUCKET, s3_path)
-            sha1 = (s3_obj.metadata or {}).get(CHECKSUM)
-        except ClientError as e:
-            # 404/NoSuchKey → tolerated skip; anything else re-raises (see the
-            # error-contract paragraph in the docstring for why loud-fail here).
-            if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
-                continue
-            raise
-        if sha1:
-            sha1_by_ordinal[i] = sha1
-    return sha1_by_ordinal
+    return ordinal_exts, page_labels, sha1_by_ordinal
 
 
 def collect_duplicate_source_sha1s(sha1_by_ordinal: dict[int, str]) -> set[str]:
     """Return SHA1s that appear at TWO OR MORE ordinals in this item's asset
-    list, given a :func:`read_sha1_by_ordinal` snapshot.
+    list, given a :func:`prescan_ordinals` snapshot.
 
     A SHA1 in this set means the source lists the same content at multiple
     ordinals — legitimate within-item / cross-item duplication that must
@@ -396,7 +371,7 @@ def compute_sha1_page_numbers(
     page_labels: dict[int, str],
 ) -> dict[int, list[int]]:
     """Map each ordinal to the COMPLETE sorted set of P304 page numbers its
-    content occupies in this item, from a :func:`read_sha1_by_ordinal` snapshot.
+    content occupies in this item, from a :func:`prescan_ordinals` snapshot.
 
     Page numbers come from the title-derived ``page_labels`` — an ordinal's own
     position in its extension series. SHA1 grouping only adds the UNION: a

--- a/tests/test_wikimedia.py
+++ b/tests/test_wikimedia.py
@@ -13,9 +13,8 @@ from ingest_wikimedia.wikimedia import (
     escape_template_param,
     join,
     collect_duplicate_source_sha1s,
-    compute_ordinal_exts_and_page_labels,
     compute_sha1_page_numbers,
-    read_sha1_by_ordinal,
+    prescan_ordinals,
     extract_page_ordinal_from_commons_title,
     extract_strings,
     extract_strings_dict,
@@ -1045,7 +1044,7 @@ def test_relic_intended_belongs_to_different_item_is_false():
     assert is_same_item_redirect_relic(intended, target, ITEM) is False
 
 
-# compute_ordinal_exts_and_page_labels — uploader-side gap-squashing
+# prescan_ordinals — ext/page-label facet: uploader-side gap-squashing
 def _fake_s3_client(mime_by_ord: dict[int, str | None]) -> MagicMock:
     """Build a mock S3Client whose Object().content_type returns the configured
     MIME per ordinal. None means the object doesn't exist (raises ClientError)."""
@@ -1062,6 +1061,7 @@ def _fake_s3_client(mime_by_ord: dict[int, str | None]) -> MagicMock:
             )
         obj = MagicMock()
         obj.content_type = mime
+        obj.metadata = {}  # this fixture exercises ext/page-label only
         return obj
 
     boto3_resource = MagicMock()
@@ -1084,7 +1084,7 @@ def test_page_labels_dense_jpegs_match_ordinal():
             5: "image/jpeg",
         }
     )
-    exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 5)
+    exts, labels, _ = prescan_ordinals(s3, "abc" * 11, "pa", 5)
     assert exts == {1: ".jpg", 2: ".jpg", 3: ".jpg", 4: ".jpg", 5: ".jpg"}
     assert labels == {1: "1", 2: "2", 3: "3", 4: "4", 5: "5"}
 
@@ -1101,7 +1101,7 @@ def test_page_labels_zero_byte_stub_squashes():
             5: "image/jpeg",
         }
     )
-    exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 5)
+    exts, labels, _ = prescan_ordinals(s3, "abc" * 11, "pa", 5)
     assert exts == {1: ".jpg", 2: ".jpg", 3: "", 4: ".jpg", 5: ".jpg"}
     # ord 1-2 = "1","2"; ord 3 ext="" only one, page_label=""; ord 4-5 = "3","4"
     assert labels == {1: "1", 2: "2", 3: "", 4: "3", 5: "4"}
@@ -1111,13 +1111,14 @@ def test_page_labels_clienterror_treated_as_stub_placeholder():
     # Missing S3 object — ordinal_exts gets "" placeholder per the
     # "every continue path must write a placeholder slot" lesson.
     s3 = _fake_s3_client({1: "image/jpeg", 2: None, 3: "image/jpeg"})
-    exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 3)
+    exts, labels, _ = prescan_ordinals(s3, "abc" * 11, "pa", 3)
     assert exts == {1: ".jpg", 2: "", 3: ".jpg"}
     assert labels == {1: "1", 2: "", 3: "2"}
 
 
-# read_sha1_by_ordinal — the SINGLE S3 pass both duplicate detection and P304
-# page numbering derive from (so they can never diverge and drop a page).
+# prescan_ordinals — sha1_by_ordinal facet. The SINGLE S3 pass both duplicate
+# detection and P304 page numbering derive from (so they can never diverge and
+# drop a page).
 def _fake_s3_client_with_sha1s(sha1_by_ord: dict[int, object]):
     """Mock S3Client whose Object().metadata[CHECKSUM] returns the configured
     value per ordinal. A str value is the stored sha1 ("" = present but empty);
@@ -1131,6 +1132,7 @@ def _fake_s3_client_with_sha1s(sha1_by_ord: dict[int, object]):
         if isinstance(val, Exception):
             raise val
         obj = MagicMock()
+        obj.content_type = "image/jpeg"  # this fixture exercises the sha1 map only
         obj.metadata = {} if val is None else {"sha1": val}
         return obj
 
@@ -1149,54 +1151,93 @@ def _client_error(code: str):
     return ClientError({"Error": {"Code": code, "Message": "x"}}, "HeadObject")
 
 
-def test_read_sha1_by_ordinal_reads_all():
+def _prescan_sha1(s3, dpla_id, partner, num_files):
+    _, _, sha1_by_ordinal = prescan_ordinals(s3, dpla_id, partner, num_files)
+    return sha1_by_ordinal
+
+
+def test_prescan_ordinals_reads_each_object_once():
+    # The whole point of the fusion: content_type (ext/page-label) and CHECKSUM
+    # (sha1) come from ONE boto3 Object per ordinal — one HEAD, not two passes.
     s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: "bbb", 3: "aaa"})
-    assert read_sha1_by_ordinal(s3, "abc" * 11, "pa", 3) == {
-        1: "aaa",
-        2: "bbb",
-        3: "aaa",
-    }
+    exts, labels, sha1 = prescan_ordinals(s3, "abc" * 11, "pa", 3)
+    assert sha1 == {1: "aaa", 2: "bbb", 3: "aaa"}
+    assert exts == {1: ".jpg", 2: ".jpg", 3: ".jpg"}
+    assert labels == {1: "1", 2: "2", 3: "3"}
+    # One Object construction per ordinal — the read was not doubled.
+    assert s3.get_s3.return_value.Object.call_count == 3
 
 
-def test_read_sha1_by_ordinal_skips_empty_and_absent_metadata():
+def test_prescan_sha1_reads_all():
+    s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: "bbb", 3: "aaa"})
+    assert _prescan_sha1(s3, "abc" * 11, "pa", 3) == {1: "aaa", 2: "bbb", 3: "aaa"}
+
+
+def test_prescan_sha1_skips_empty_and_absent_metadata():
     # Present object with empty/absent CHECKSUM → ordinal simply absent from the
     # snapshot (the caller treats it as its own singleton group — never a strip).
     s3 = _fake_s3_client_with_sha1s({1: "", 2: None, 3: "ccc"})
-    assert read_sha1_by_ordinal(s3, "abc" * 11, "pa", 3) == {3: "ccc"}
+    assert _prescan_sha1(s3, "abc" * 11, "pa", 3) == {3: "ccc"}
 
 
-def test_read_sha1_by_ordinal_skips_genuinely_absent_object():
+def test_prescan_sha1_skips_genuinely_absent_object():
     # A 404 / NoSuchKey means the object isn't there (stub) — tolerated skip.
     s3 = _fake_s3_client_with_sha1s({1: _client_error("404"), 2: "bbb"})
-    assert read_sha1_by_ordinal(s3, "abc" * 11, "pa", 2) == {2: "bbb"}
+    assert _prescan_sha1(s3, "abc" * 11, "pa", 2) == {2: "bbb"}
     s3 = _fake_s3_client_with_sha1s({1: _client_error("NoSuchKey"), 2: "bbb"})
-    assert read_sha1_by_ordinal(s3, "abc" * 11, "pa", 2) == {2: "bbb"}
+    assert _prescan_sha1(s3, "abc" * 11, "pa", 2) == {2: "bbb"}
 
 
-def test_read_sha1_by_ordinal_single_file_short_circuits_without_s3():
+def test_prescan_sha1_records_download_only_and_octet_stream_ordinals():
+    # SHA1 is read BEFORE the extension classification's continues, so a
+    # download-only (video) or octet-stream ordinal still contributes its
+    # fingerprint to duplicate detection — the behaviour the standalone SHA1
+    # read had before the two passes were fused into this one.
+    s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: "bbb", 3: "ccc"})
+
+    def get_obj(bucket, path):
+        ord_num = int(path.rsplit("/", 1)[-1].split("_", 1)[0])
+        obj = MagicMock()
+        obj.content_type = {
+            1: "image/jpeg",
+            2: "video/mp4",  # download-only
+            3: "binary/octet-stream",  # placeholder
+        }[ord_num]
+        obj.metadata = {"sha1": {1: "aaa", 2: "bbb", 3: "ccc"}[ord_num]}
+        return obj
+
+    s3.get_s3.return_value.Object.side_effect = get_obj
+    exts, _, sha1 = prescan_ordinals(s3, "abc" * 11, "pa", 3)
+    # ord 2 is download-only (absent from exts); ord 3 is octet-stream ("").
+    assert exts == {1: ".jpg", 3: ""}
+    # ...but all three fingerprints are in the snapshot.
+    assert sha1 == {1: "aaa", 2: "bbb", 3: "ccc"}
+
+
+def test_prescan_sha1_single_file_short_circuits_without_s3():
     # A single-file item can't be a within-item duplicate and has no page
-    # number, so we skip the read entirely — matching the sibling's num_files>1
-    # guard. Critically, this avoids turning a transient S3 blip into a
-    # whole-item failure on the dominant single-file shape (the read re-raises).
+    # number, so we skip the read entirely (num_files <= 1 guard). Critically,
+    # this avoids turning a transient S3 blip into a whole-item failure on the
+    # dominant single-file shape (the read re-raises).
     s3 = _fake_s3_client_with_sha1s({1: _client_error("SlowDown")})
-    assert read_sha1_by_ordinal(s3, "abc" * 11, "pa", 1) == {}
+    assert _prescan_sha1(s3, "abc" * 11, "pa", 1) == {}
     # No S3 object access attempted at all.
     assert s3.get_s3.return_value.Object.call_count == 0
 
 
-def test_read_sha1_by_ordinal_reraises_transient_s3_error():
+def test_prescan_sha1_reraises_transient_s3_error():
     # A transient/permission S3 error must FAIL LOUDLY, not silently drop the
     # ordinal — a dropped ordinal is exactly how a detected duplicate's page goes
-    # un-unioned and P304 gets stripped. Mirrors compute_ordinal_exts_and_page_labels.
+    # un-unioned and P304 gets stripped.
     import pytest
     from botocore.exceptions import ClientError
 
     s3 = _fake_s3_client_with_sha1s({1: "aaa", 2: _client_error("AccessDenied")})
     with pytest.raises(ClientError):
-        read_sha1_by_ordinal(s3, "abc" * 11, "pa", 2)
+        _prescan_sha1(s3, "abc" * 11, "pa", 2)
 
 
-# collect_duplicate_source_sha1s — pure over a read_sha1_by_ordinal snapshot.
+# collect_duplicate_source_sha1s — pure over a prescan_ordinals snapshot.
 def test_collect_duplicate_source_sha1s_all_unique():
     assert collect_duplicate_source_sha1s({1: "aaa", 2: "bbb", 3: "ccc"}) == set()
 
@@ -1316,13 +1357,13 @@ def test_page_labels_non_404_clienterror_propagates():
         {"Error": {"Code": "AccessDenied", "Message": "nope"}}, "HeadObject"
     )
     with pytest.raises(ClientError):
-        compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 3)
+        prescan_ordinals(s3, "abc" * 11, "pa", 3)
 
 
 def test_page_labels_single_file_item_no_pagination():
     # num_files == 1 → no pre-scan, no page label, no (page N) suffix.
     s3 = _fake_s3_client({1: "image/jpeg"})
-    exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 1)
+    exts, labels, _ = prescan_ordinals(s3, "abc" * 11, "pa", 1)
     assert exts == {}
     assert labels == {1: ""}
 
@@ -1338,7 +1379,7 @@ def test_page_labels_mixed_extensions_per_ext_counter():
             5: "image/jpeg",
         }
     )
-    exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 5)
+    exts, labels, _ = prescan_ordinals(s3, "abc" * 11, "pa", 5)
     assert exts == {1: ".jpg", 2: ".pdf", 3: ".jpg", 4: ".pdf", 5: ".jpg"}
     # jpg counter: ord 1→"1", ord 3→"2", ord 5→"3"
     # pdf counter: ord 2→"1", ord 4→"2"
@@ -1348,7 +1389,7 @@ def test_page_labels_mixed_extensions_per_ext_counter():
 def test_page_labels_unique_extension_gets_empty_label():
     # When only one file has a given extension, no (page N) suffix.
     s3 = _fake_s3_client({1: "image/jpeg", 2: "image/jpeg", 3: "application/pdf"})
-    exts, labels = compute_ordinal_exts_and_page_labels(s3, "abc" * 11, "pa", 3)
+    exts, labels, _ = prescan_ordinals(s3, "abc" * 11, "pa", 3)
     assert exts == {1: ".jpg", 2: ".jpg", 3: ".pdf"}
     # ext_counts: .jpg→2, .pdf→1. Only .jpg gets page numbers.
     assert labels == {1: "1", 2: "2", 3: ""}

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -117,9 +117,8 @@ from ingest_wikimedia.wikimedia import (
     MIME_UNKNOWN_EXT,
     build_title_drift_move_reason,
     collect_duplicate_source_sha1s,
-    compute_ordinal_exts_and_page_labels,
     compute_sha1_page_numbers,
-    read_sha1_by_ordinal,
+    prescan_ordinals,
     get_page_title,
     get_wiki_text,
     wikimedia_url,
@@ -2594,18 +2593,13 @@ class Uploader:
 
             files = self.s3_client.get_file_list(partner, dpla_id)
 
-            # Pre-scan via the shared helper so the verifier can reconstruct
-            # the same page-label assignments without duplicating the logic.
-            ordinal_exts, page_labels = compute_ordinal_exts_and_page_labels(
-                self.s3_client, dpla_id, partner, len(files)
-            )
-
-            # Read every ordinal's SHA1 ONCE. Both duplicate detection and the
-            # P304 page-number map derive from this single snapshot, so they can
-            # never disagree — a within-item duplicate that is detected always
-            # has its page unioned onto the canonical (two separate S3 passes
-            # could diverge and drop a page; see read_sha1_by_ordinal).
-            sha1_by_ordinal = read_sha1_by_ordinal(
+            # Single S3 pre-scan (one HEAD per ordinal) over the shared helper,
+            # so the verifier can reconstruct the same page-label assignments
+            # without duplicating the logic. The extension/page-label accounting
+            # and the SHA1 snapshot come from the SAME HEAD per object, so they
+            # can never diverge — a within-item duplicate that is detected always
+            # has its page unioned onto the canonical (see prescan_ordinals).
+            ordinal_exts, page_labels, sha1_by_ordinal = prescan_ordinals(
                 self.s3_client, dpla_id, partner, len(files)
             )
 

--- a/tools/verify_item.py
+++ b/tools/verify_item.py
@@ -5,9 +5,9 @@ sha1 landed at its intended Commons title.
 
 For each ordinal in the item's file_list this script:
   1. reads the S3 object's sha1 + size + content-type,
-  2. uses compute_ordinal_exts_and_page_labels() — the same helper the
-     uploader uses — to determine the Commons page_label the bot would
-     have assigned to that ordinal (gap-squashing logic and all),
+  2. uses prescan_ordinals() — the same helper the uploader uses — to
+     determine the Commons page_label the bot would have assigned to that
+     ordinal (gap-squashing logic and all),
   3. queries the Commons MediaWiki API for the file at the resulting
      intended title and compares its sha1 to S3.
 
@@ -51,9 +51,9 @@ from ingest_wikimedia.s3 import S3_BUCKET, S3Client
 from ingest_wikimedia.tools_context import ToolsContext
 from ingest_wikimedia.wikimedia import (
     check_content_type,
-    compute_ordinal_exts_and_page_labels,
     get_page_title,
     is_download_only,
+    prescan_ordinals,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -179,9 +179,7 @@ def main() -> None:
     # Use the same helper the uploader uses to compute per-ordinal page labels
     # so the intended Commons titles match exactly what the bot uploads to,
     # including the gap-squashing per-extension counter logic.
-    _, page_labels = compute_ordinal_exts_and_page_labels(
-        s3_client_obj, dpla_id, partner, num_files
-    )
+    _, page_labels, _ = prescan_ordinals(s3_client_obj, dpla_id, partner, num_files)
 
     s3 = boto3.client("s3")
     correct = 0


### PR DESCRIPTION
Deferred altitude follow-up from #410 ("single-pass S3 read").

## Problem
For every multi-file item the uploader read each ordinal's S3 object **twice**:
- `compute_ordinal_exts_and_page_labels` read `.content_type` (extension / page-label accounting), and
- `read_sha1_by_ordinal` read `.metadata[CHECKSUM]` (the content fingerprint),

on separate boto3 `Object` instances — **2N HEADs** per item.

## Change
A boto3 `Object` load is a single HEAD that caches every attribute, so both values can be read off one `Object` per ordinal. This replaces the two functions with a single **`prescan_ordinals`** returning `(ordinal_exts, page_labels, sha1_by_ordinal)` from one pass — **N HEADs**.

Beyond halving the requests, reading both facets off the *same* HEAD makes the extension accounting and the SHA1 snapshot **provably consistent** — they can no longer reflect two different observations of the same asset, which is exactly the divergence the P304 machinery must avoid (see `compute_sha1_page_numbers`).

## Behavior-preserving
Verified equivalent to the two prior functions:
- SHA1 is recorded for **every existing ordinal**, read *before* the extension classification's early-`continue`s — so download-only / octet-stream ordinals still contribute their fingerprint to duplicate detection (matched to the old `read_sha1_by_ordinal`).
- 404 / NoSuchKey → empty `ordinal_exts` slot + no SHA1; any other S3 error re-raises loudly; empty/absent CHECKSUM → ordinal absent from the SHA1 map.
- Single-file / empty items skip the S3 pass entirely.
- The pure helpers `collect_duplicate_source_sha1s` and `compute_sha1_page_numbers` are unchanged and still consume the raw maps.

Call sites updated: `tools/uploader.py` (one call replaces two) and `tools/verify_item.py` (unpacks page_labels only — same N HEADs as before, no extra S3 work).

## Deferred (deliberate, not an oversight)
A `/simplify` altitude pass recommended going one notch further — a private single-pass **reader** (`read_ordinal_heads → {ordinal: (mime, sha1)}`) plus *pure* derivations for exts/page-labels and the SHA1 map, so `verify_item` (which needs only page_labels) is never handed a fingerprint and the boundary is symmetric with the existing pure sha1 helpers. That's a genuine improvement, but it's a larger reshaping of the P304 page-number path that #410 fixed across two adversarial-review rounds + a live repair. This PR intentionally makes the **minimal, mechanically-equivalent** transformation (two loops → one) to bank the efficiency win with maximal confidence; the reader/derivation split is a good separate follow-up.

## Verification
- Full `pytest tests/` — **1303 passed** (adds a one-HEAD-per-ordinal assertion and a download-only/octet-stream fingerprint test).
- `ruff check` clean; `ruff format --check` clean.
- `/simplify` (reuse / simplification / efficiency / altitude): efficiency confirmed the 2N→N claim against boto3's lazy-load source; reuse confirmed net de-duplication; the docstring was trimmed of internal restatement per the simplification finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fuses extension/page-label and SHA1 scans into `prescan_ordinals`, performing one S3 read per ordinal instead of two.
- Preserves handling for missing objects, S3 errors, absent checksums, download-only and octet-stream ordinals, single-file items, and empty items.
- Updates uploader and verification call sites and adds coverage for the consolidated scan behavior.

## Validation

- 1,303 tests passing
- Ruff and formatting checks clean

## Operational impact

- No manual pipeline trigger or ECS redeployment required.
- No environment variables, Secrets Manager keys, database migrations, shared infrastructure configuration, or public API endpoints/response shapes changed.
- No security or credential-handling changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->