### PR TITLE
Defense-in-depth community refusal in _resolve_hash_drift (#408b)

### DIFF
--- a/tests/test_upload_invariant.py
+++ b/tests/test_upload_invariant.py
@@ -401,8 +401,10 @@ def test_drift_resolution_sentinel_contract_pin():
         "MOVED": "moved",
         "MERGE_AND_REDIRECT": "merge_and_redirect",
         "HAND_FIX": "hand_fix",
+        "HAND_FIX_COMMUNITY": "hand_fix_community",
         "ALREADY_CORRECT": "already_correct",
     }
     # ``str, Enum`` subclass preserves string-ness for legacy comparisons.
     assert isinstance(DriftResolution.MERGE_AND_REDIRECT, str)
     assert DriftResolution.HAND_FIX == "hand_fix"
+    assert DriftResolution.HAND_FIX_COMMUNITY == "hand_fix_community"

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -738,6 +738,39 @@ def test_resolve_hash_drift_within_item_sibling_slot_merges_and_redirects():
     assert action == "merge_and_redirect"
 
 
+def test_resolve_hash_drift_refuses_community_file_defense_in_depth():
+    """Defense-in-depth: process_file gates community files out BEFORE calling
+    _resolve_hash_drift, but the resolver independently refuses them too —
+    returning HAND_FIX_COMMUNITY before any drift classification, so no move /
+    merge-redirect path in it can ever touch a community file even if the
+    primary gate is reordered or removed. Proven by asserting get_page (the
+    first step of the real drift logic) and _move_to_correct_title are never
+    reached."""
+    from tools import uploader as um
+
+    uploader = _build_uploader_with_dpla()
+    dpla_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    # Non-DPLA/NARA-shaped title + a non-bot uploader ⇒ community file.
+    community = _drift_existing_file("Grandma's quilt, summer 1932.jpg")
+    intended_title = f"Item - DPLA - {dpla_id} (page 4).jpg"
+    with (
+        patch.object(um, "first_uploader", return_value="SomeVolunteer"),
+        patch("tools.uploader.get_page") as get_page_mock,
+        patch.object(uploader, "_move_to_correct_title") as move_mock,
+    ):
+        action = uploader._resolve_hash_drift(
+            existing_file=community,
+            page_title=intended_title,
+            dpla_id=dpla_id,
+            ordinal=4,
+            expected_item_titles={intended_title},
+        )
+    assert action == DriftResolution.HAND_FIX_COMMUNITY
+    # Short-circuited before any drift classification or mutation.
+    get_page_mock.assert_not_called()
+    move_mock.assert_not_called()
+
+
 def test_resolve_hash_drift_intended_title_occupied_by_different_file_hand_fix():
     """Our SHA1 is at a wrong title and the intended title is occupied by a
     DIFFERENT real file that is NOT one of this item's asset slots — the bot
@@ -1156,10 +1189,17 @@ def test_case3_move_posts_commonsdelinker_when_actual_is_not_sibling():
     uploader = _build_uploader_with_dpla()
     intended = _make_intended_page(_ITEM_PAGE_8, exists=False)
     # Old NARA-bot title from an earlier scheme — not part of current asset list.
+    # Its title lacks the DPLA/NARA shape, so _resolve_hash_drift's
+    # defense-in-depth community check reads the uploader: it's the NARA bot
+    # (ours), so it is NOT a community file and the Case-3 move proceeds.
     legacy_title = "Foo - NAID 99999.jpg"
     expected_titles = {_ITEM_PAGE_8, _ITEM_PAGE_11}
     with (
         patch("tools.uploader.get_page", return_value=intended),
+        patch(
+            "tools.uploader.first_uploader",
+            return_value="US National Archives bot",
+        ),
         patch.object(uploader, "_move_to_correct_title") as mock_move,
     ):
         action = uploader._resolve_hash_drift(
@@ -2098,6 +2138,76 @@ def test_process_file_merge_and_redirect_none_expected_titles_no_crash():
 
     assert result["status"] == "MERGED"
     assert captured["within_item"] is False
+
+
+def test_process_file_routes_resolver_community_outcome_to_hand_fix():
+    """Defense-in-depth wiring: if the primary community gate is bypassed
+    (_is_community_file patched to False here) but _resolve_hash_drift
+    independently returns HAND_FIX_COMMUNITY, process_file must route to
+    _record_community_hand_fix_and_skip (community_file reason) and NOT to the
+    generic rename_blocked hand-fix. This branch never runs in normal flow (the
+    primary gate returns first), so only a test can catch its call site drifting
+    out of sync with the helper signature."""
+    tracker = Tracker()
+    uploader = _process_file_uploader(tracker)
+
+    uploader.s3_client.get_media_s3_path.return_value = "nara/images/a/b/c/d/abc/1_abc"
+    uploader.s3_client.s3_file_exists.return_value = True
+    fake_s3_object = MagicMock()
+    fake_s3_object.content_length = 100
+    fake_s3_object.metadata = {"sha1": "deadbeef" * 5}
+    fake_s3_object.content_type = "image/jpeg"
+    uploader.s3_client.get_s3.return_value.Object.return_value = fake_s3_object
+
+    existing = MagicMock()
+    existing.title.return_value = "Grandma's quilt, summer 1932.jpg"
+
+    title = "File:Ours - DPLA - abcdef1234567890abcdef1234567890 (page 1).jpg"
+    captured = {}
+
+    def fake_record(**kwargs):
+        captured.update(kwargs)
+        return {"status": "HAND_FIX", "title": None, "pageid": None}
+
+    with (
+        patch("tools.uploader.get_wiki_text", return_value="wt"),
+        patch("tools.uploader.find_file_by_hash", return_value=existing),
+        patch("tools.uploader.get_page_title", return_value=title),
+        # Slip past the PRIMARY gate to exercise the resolver's independent layer.
+        patch.object(uploader, "_is_community_file", return_value=False),
+        patch(
+            "tools.uploader.is_dup_sha1_sibling_at_expected_title",
+            return_value=False,
+        ),
+        patch.object(
+            uploader,
+            "_resolve_hash_drift",
+            return_value=DriftResolution.HAND_FIX_COMMUNITY,
+        ),
+        patch.object(
+            uploader, "_record_community_hand_fix_and_skip", side_effect=fake_record
+        ) as record_mock,
+        patch.object(uploader, "_record_hand_fix_and_skip") as generic_mock,
+    ):
+        result = uploader.process_file(
+            dpla_id="abc",
+            title="Ours",
+            item_metadata={},
+            provider={},
+            data_provider={},
+            ordinal=1,
+            partner="nara",
+            page_label="",
+            verbose=False,
+            dry_run=False,
+            expected_item_titles=None,
+        )
+
+    assert result["status"] == "HAND_FIX"
+    record_mock.assert_called_once()
+    assert captured["community_file"] is existing
+    # Must NOT fall through to the generic rename_blocked hand-fix.
+    generic_mock.assert_not_called()
 
 
 def test_process_file_sha1_lock_recheck_skips_on_concurrent_upload(tmp_path):

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -325,6 +325,14 @@ class DriftResolution(str, Enum):
     # invariant is blocked and the bot must not pick a winner. Hand off to a
     # human via the hand-fix.jsonl sidecar; no upload.
     HAND_FIX = "hand_fix"
+    # The existing file is a COMMUNITY upload (non-DPLA/NARA title AND not one
+    # of our bots) — off-limits to every mutating path. Distinct from HAND_FIX
+    # so the caller records it with the ``community_file`` reason rather than
+    # ``rename_blocked``. In normal flow ``process_file`` gates community files
+    # out BEFORE calling ``_resolve_hash_drift``, so this outcome is a
+    # defense-in-depth second layer (see ``_resolve_hash_drift``); it fires only
+    # if that primary gate is ever bypassed or reordered.
+    HAND_FIX_COMMUNITY = "hand_fix_community"
     ALREADY_CORRECT = "already_correct"
 
 
@@ -953,7 +961,10 @@ class Uploader:
                     # BOTH non-DPLA/NARA-shaped in title AND not one of our
                     # bots' uploads. Hand it to a human (distinct reason) and
                     # stop — checked before any drift resolution so no MOVE /
-                    # MERGE_AND_REDIRECT can touch a community file.
+                    # MERGE_AND_REDIRECT can touch a community file. This is the
+                    # PRIMARY layer; _resolve_hash_drift independently refuses
+                    # community files too (DriftResolution.HAND_FIX_COMMUNITY)
+                    # as defense-in-depth.
                     if self._is_community_file(existing_file):
                         return self._record_community_hand_fix_and_skip(
                             partner=partner,
@@ -1047,6 +1058,20 @@ class Uploader:
                             and existing_title in expected_item_titles,
                             sha1=sha1,
                             canonical_page_numbers=canonical_page_numbers,
+                        )
+                    if drift_action == DriftResolution.HAND_FIX_COMMUNITY:
+                        # Defense-in-depth: the resolver refused a community
+                        # file. In normal flow the community gate above already
+                        # returned, so reaching here means that primary gate was
+                        # bypassed — record with the community reason (not
+                        # rename_blocked) so the distinct signal is preserved.
+                        return self._record_community_hand_fix_and_skip(
+                            partner=partner,
+                            dpla_id=dpla_id,
+                            ordinal=ordinal,
+                            our_sha1=sha1,
+                            intended_title=page_title,
+                            community_file=existing_file,
                         )
                     # DriftResolution.HAND_FIX (and any unforeseen sentinel):
                     # our SHA1 is at a wrong title and the intended title is
@@ -1812,8 +1837,33 @@ class Uploader:
           lookup returned IS the file at the intended title under
           whitespace-run normalization (a post-title-truncation artefact of
           ``get_page_title``). No drift to resolve. Caller records SKIPPED.
+
+        - ``HAND_FIX_COMMUNITY`` — **community file**: the existing file isn't
+          ours (see :meth:`_is_community_file`). This is a DEFENSE-IN-DEPTH
+          second layer: ``process_file`` already refuses community files before
+          calling this method, so in normal flow the check below is not reached.
+          It is here so the resolver is correct in isolation — no mutating path
+          in it (the ``_move_to_correct_title`` calls, or the caller's merge on
+          ``MERGE_AND_REDIRECT``) can ever touch a community file even if the
+          primary gate is later reordered or removed. It is checked first,
+          before any other classification.
         """
         actual_filename = existing_file.title(with_ns=False)
+
+        # Defense-in-depth (see the HAND_FIX_COMMUNITY docstring entry above):
+        # never let a community file reach the move / merge-redirect outcomes
+        # below. process_file's own gate already returned for community files in
+        # normal flow, so on the same FilePage this re-check's uploader read is a
+        # pywikibot cache hit, not a second network call — a cheap, independent
+        # second layer on an invariant we never want to breach.
+        if self._is_community_file(existing_file):
+            logging.warning(
+                f"Hash drift for {dpla_id} {ordinal}: "
+                f"[[File:{actual_filename}]] is a COMMUNITY file; refusing to "
+                f"resolve (defense-in-depth — process_file's community gate "
+                f"should have caught this first). Routing to hand-fix."
+            )
+            return DriftResolution.HAND_FIX_COMMUNITY
 
         # Defense-in-depth: if pywikibot's normalized title for the file
         # that carries this SHA1 equals the intended title we're about


### PR DESCRIPTION
Resolves the item PR #408 flagged "for discussion": the community-file gate lives as a pre-gate in `process_file`, separate from the drift-classification logic in `_resolve_hash_drift`.

## Design decision
The literal suggestion — *move* the gate into `_resolve_hash_drift` as an outcome — is in tension with the "never rename/merge/redirect/migrate a community file" invariant: the gate currently runs **first**, before the within-item merge short-circuit and the drift move, so no mutating path can touch a community file. Folding it in as an outcome would run it *after* the within-item short-circuit, leaving that path community-safe only via an implicit (title-shape) coupling.

So instead of relocating the gate, this **keeps the proven early gate as the primary layer and adds an independent second layer**:

- `_resolve_hash_drift` now checks `_is_community_file` as its **first** step and returns a new `DriftResolution.HAND_FIX_COMMUNITY` before any move / merge-redirect classification. The resolver is now **correct in isolation** — no mutating path in it can touch a community file even if the primary gate is later reordered or removed.
- `process_file` routes `HAND_FIX_COMMUNITY` to `_record_community_hand_fix_and_skip` (the distinct `community_file` reason), placed before the generic `rename_blocked` fallthrough.

This converts a previously-implicit safety property into two explicit, independent layers.

## No behavior change for non-community files
`_is_community_file` short-circuits `False` on DPLA/NARA-shaped titles (no network). For a non-shaped file that reaches the resolver, `process_file`'s gate already read the uploader history on the **same** `FilePage`, and pywikibot caches `oldest_file_info` per object — so the resolver's re-check is a **cache hit, not a second network call**.

## Scope note
This is a **maintainability / robustness** change, not a bug fix — the current code enforces the invariant correctly. It was chosen (Option 2 of three) over a full classify-then-act rewrite of the resolver because that path is where #408/#410's subtle bugs lived; a minimal, independently-verifiable second layer banks the hardening without restructuring the invariant-critical path. The full classify-then-act split remains a possible future follow-up.

## Tests
- `test_resolve_hash_drift_refuses_community_file_defense_in_depth` — a real community file (non-shaped title + non-bot uploader) returns `HAND_FIX_COMMUNITY` and **`get_page` / `_move_to_correct_title` are never reached** (proves the short-circuit precedes all classification + mutation).
- `test_process_file_routes_resolver_community_outcome_to_hand_fix` — pins the otherwise-unreachable wiring branch (primary gate bypassed → resolver catches it → community hand-fix, not generic), so the call site can't silently drift out of sync with the helper.
- Updated the `DriftResolution` sentinel-contract pin and `test_case3` (its legacy non-shaped title now supplies a NARA-bot uploader, so the resolver's community re-check reads "ours" and the Case-3 move proceeds).

Full `pytest tests/`: **1305 passed**; `ruff check` + `format --check` clean.

## Review
Adversarially reviewed (invariant / quality / efficiency+coverage). The "never mutate a community file" invariant holds on every path; the guard precedes every mutating outcome; the new outcome is handled exhaustively (fail-safe fallthrough for any unhandled sentinel); no non-community behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds defense-in-depth protection against incorrectly resolving community-file hash drift:

- Introduces `DriftResolution.HAND_FIX_COMMUNITY`.
- Makes `_resolve_hash_drift` short-circuit community files before move or merge classification.
- Routes the outcome through `_record_community_hand_fix_and_skip`.
- Adds coverage for resolver short-circuiting, process routing, enum contract, and legacy Case-3 behavior.

The change preserves existing non-community behavior and uses existing `FilePage` caching to avoid an extra network request. Tests and Ruff checks pass.

No manual pipeline trigger or ECS redeployment is required. No environment variables, secrets, database migrations, shared infrastructure, public API shapes, endpoints, or authentication/credential handling are changed. The security-related impact is limited to safer handling of community files by preventing potentially unsafe automated moves or merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->