### PR TITLE
sdc-sync status: show x/y files for maintain runs

### DIFF
--- a/scripts/wikimedia_upload_status.py
+++ b/scripts/wikimedia_upload_status.py
@@ -97,6 +97,30 @@ SLACK_API_URL = "https://slack.com/api/chat.postMessage"
 _UPLOAD_COMPLETE_PREFIX = "Upload complete"
 _SDC_COMPLETE_PREFIX = "SDC complete"
 
+# One-pass awk over a phase log, emitting eight integers in the fixed order the
+# parser indexes: DPLA-ID, Uploaded, Skipping, COUNTS, Ordinal, HAND-FIX,
+# MERGED, maintain-scope. HAND-FIX/MERGED read $2 — they come from the
+# prefix-less continuation lines of the multi-line ``COUNTS:`` record. The
+# maintain-scope marker is instead a normal PREFIXED log line
+# (``[INFO] <time>: maintain scope: N files``), so its number is ``$(NF-1)`` —
+# the field before the trailing "files", robust to however wide the log-line
+# prefix is (counting from the message start would miss the prefix, which
+# silently zeroed this out in the first draft).
+# CONTRACT: the "maintain scope: N files" wording is shared with
+# tools/sdc_sync.py's _log_maintain_scope(); change them together.
+_SDC_COUNTS_AWK = (
+    "/DPLA ID:/ {d++} "
+    "/Uploaded to/ {u++} "
+    "/Skipping.*Already exists on commons/ {s++} "
+    "/COUNTS:/ {c++} "
+    "/-- Ordinal [0-9]+:/ {o++} "
+    "/UPLOAD_HAND_FIX:/ {hf=$2} "
+    "/UPLOAD_MERGED_TO_CANONICAL:/ {mg=$2} "
+    "/maintain scope: [0-9]+ files/ {mt=$(NF-1)} "
+    "END { print d+0; print u+0; print s+0; print c+0; print o+0; "
+    "print hf+0; print mg+0; print mt+0 }"
+)
+
 # Slack Block Kit caps a single ``section`` block's text element at 3000
 # characters. A hub-busy day with many active sessions can collectively
 # exceed that on row count alone, so the formatter splits across multiple
@@ -140,6 +164,13 @@ def _idle_suffix(now: int, log_mtime: int) -> str:
 # slug shape at runtime to keep that interpolation safe regardless of
 # how callers obtain the label.
 _LABEL_SLUG_RE = re.compile(r"[a-z0-9+\-]+")
+
+
+def _files_progress(num: int, den: int) -> str:
+    """``N / M files, ~P%`` — the shared file-level progress string used by the
+    Upload and SDC branches (maintain-scope, download-log ordinals). Callers
+    guard ``den > 0`` (it also selects which branch applies)."""
+    return f"{num:,} / {den:,} files, ~{num / den * 100:.1f}%"
 
 
 def get_phase_and_progress(
@@ -315,15 +346,14 @@ def get_phase_and_progress(
         "/Downloading [a-z0-9-]+ [a-f0-9]+ [0-9]+ from / {dl++} "
         "END {print (item>0 ? item : dl)}"
     )
-    # One awk pass counts all four marker lines in a single sequential read
-    # of the upload log; the previous code ran four separate `grep -c`
-    # invocations over the same file (plus the COUNTS: probe), which on
-    # multi-GB NARA logs translated to four full sequential reads and four
-    # SSM round-trips of pipeline setup overhead. Output is still four
-    # lines (dpla_id, uploaded, skipping, counts) in the same order as
-    # before, followed by the CSV total from `wc -l`. The download-log
-    # ordinal sum is emitted after a fresh separator so the output sections
-    # stay self-describing.
+    # One awk pass (``_SDC_COUNTS_AWK``) counts all the marker lines in a single
+    # sequential read of the log; the previous code ran several separate
+    # `grep -c` invocations over the same file, which on multi-GB NARA logs
+    # translated to that many full sequential reads and SSM round-trips of
+    # pipeline setup overhead. Output is eight lines (dpla_id, uploaded,
+    # skipping, counts, ordinal, hand-fix, merged, maintain-scope), followed by
+    # the CSV total from `wc -l`. The download-log ordinal sum is emitted after a
+    # fresh separator so the output sections stay self-describing.
     out = ssm_run(
         client,
         f"date +%s; "
@@ -331,16 +361,8 @@ def get_phase_and_progress(
         f"echo {sep}; "
         f"tail -5 {log_path}; "
         f"echo {sep}; "
-        f"awk '"
-        f"/DPLA ID:/ {{d++}} "
-        f"/Uploaded to/ {{u++}} "
-        f"/Skipping.*Already exists on commons/ {{s++}} "
-        f"/COUNTS:/ {{c++}} "
-        f"/-- Ordinal [0-9]+:/ {{o++}} "
-        f"/UPLOAD_HAND_FIX:/ {{hf=$2}} "
-        f"/UPLOAD_MERGED_TO_CANONICAL:/ {{mg=$2}} "
-        f"END {{ print d+0; print u+0; print s+0; print c+0; print o+0; print hf+0; print mg+0 }}"
-        f"' {log_path} 2>/dev/null || printf '0\\n0\\n0\\n0\\n0\\n0\\n0\\n'; "
+        f"awk '{_SDC_COUNTS_AWK}' {log_path} 2>/dev/null "
+        f"|| printf '0\\n0\\n0\\n0\\n0\\n0\\n0\\n0\\n'; "
         f"{csv_count_cmd}; "
         f"echo {sep}; "
         f"DOWNLOG=$(ls -t {log_dir}/*-{label}-download.log 2>/dev/null | head -1); "
@@ -362,14 +384,17 @@ def get_phase_and_progress(
     count_lines = sections[2].strip().splitlines() if len(sections) > 2 else []
 
     # Layout matches the awk-then-wc shell command above: the awk pass emits
-    # seven counts (DPLA-ID, Uploaded, Skipping, COUNTS, Ordinal, HAND-FIX,
-    # MERGED) and then `wc -l` emits the CSV total — eight lines in total.
-    # HAND-FIX / MERGED are read from the terminal ``COUNTS:`` block (the
-    # authoritative tracker values, one per SHA1-uniqueness outcome) so the
+    # eight counts (DPLA-ID, Uploaded, Skipping, COUNTS, Ordinal, HAND-FIX,
+    # MERGED, maintain-scope) and then `wc -l` emits the CSV total — nine lines
+    # in total. HAND-FIX / MERGED are read from the terminal ``COUNTS:`` block
+    # (the authoritative tracker values, one per SHA1-uniqueness outcome) so the
     # completion summary reports those alongside uploaded/skipped rather than
     # only the two happy-path counts. ``ordinal_count`` is the count of
     # ``-- Ordinal N:`` markers in the active log, which the SDC phase emits
     # one of per file (numerator for SDC's file-level progress).
+    # ``maintain_total`` is the enumerated scope a maintain --cat/--file run
+    # logs ("maintain scope: N files"); 0 for partner-mode runs, which have no
+    # such marker (they fall through to the download-log / CSV denominators).
     dpla_id_count = _safe_int(count_lines[0]) if len(count_lines) > 0 else 0
     uploaded_count = _safe_int(count_lines[1]) if len(count_lines) > 1 else 0
     skipped_count = _safe_int(count_lines[2]) if len(count_lines) > 2 else 0
@@ -377,7 +402,8 @@ def get_phase_and_progress(
     ordinal_count = _safe_int(count_lines[4]) if len(count_lines) > 4 else 0
     hand_fix_count = _safe_int(count_lines[5]) if len(count_lines) > 5 else 0
     merged_count = _safe_int(count_lines[6]) if len(count_lines) > 6 else 0
-    total = _safe_int(count_lines[7]) if len(count_lines) > 7 else 0
+    maintain_total = _safe_int(count_lines[7]) if len(count_lines) > 7 else 0
+    total = _safe_int(count_lines[8]) if len(count_lines) > 8 else 0
 
     # Sum of `Item <id>: N ordinals` lines from the download log — the true
     # file count once downloads have completed. 0 when no download log was
@@ -456,8 +482,7 @@ def get_phase_and_progress(
         # found, so legacy sessions still get a readout.
         files_done = uploaded_count + skipped_count
         if total_ordinals > 0:
-            files_pct = f"{files_done / total_ordinals * 100:.1f}"
-            progress = f"{files_done:,} / {total_ordinals:,} files, ~{files_pct}%"
+            progress = _files_progress(files_done, total_ordinals)
         else:
             progress = f"{dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%"
         return (
@@ -475,10 +500,12 @@ def get_phase_and_progress(
         # are available — same rationale as the Upload branch, since
         # multi-page items take proportionally more SDC-write work than
         # 1-image items. Falls back to item-level against the per-partner
-        # ids CSV for legacy no-download-log partner sessions, and to a
-        # bare file count for maintain --cat/--file runs (whose scope is a
-        # Commons category / file list, so the CSV is not a valid
-        # denominator). Terminal completion still reports items, since the
+        # ids CSV for legacy no-download-log partner sessions. Maintain
+        # --cat/--file runs report file-level against their enumerated scope
+        # ("maintain scope: N files", logged at scan time) when present, and
+        # a bare file count otherwise (streaming --cat / legacy logs) — the
+        # per-partner CSV is never a valid denominator for a Commons category
+        # / file-list scope. Terminal completion still reports items, since the
         # tracker's SDC_ITEMS_SYNCED is per item.
         if dpla_id_count == 0:
             start_state = "queued" if waiting_on_slots else "starting..."
@@ -488,23 +515,28 @@ def get_phase_and_progress(
                 f"{_SDC_COMPLETE_PREFIX} ({dpla_id_count:,} items processed)",
                 log_mtime,
             )
-        if total_ordinals > 0 and ordinal_count > 0:
-            files_pct = f"{ordinal_count / total_ordinals * 100:.1f}"
-            progress = f"{ordinal_count:,} / {total_ordinals:,} files, ~{files_pct}%"
+        if maintain_total > 0:
+            # Maintain --cat/--file: the run logged its enumerated scope
+            # ("maintain scope: N files") — a file-level denominator in the same
+            # unit as the per-file "DPLA ID:" markers counted here. Prefer it: it
+            # describes the actual Commons category / file-list scope, unlike the
+            # per-partner CSV (whose mismatch produced the old >100% read). The
+            # scope is a snapshot of a live category, so the % is an estimate.
+            progress = _files_progress(dpla_id_count, maintain_total)
+        elif total_ordinals > 0 and ordinal_count > 0:
+            progress = _files_progress(ordinal_count, total_ordinals)
         elif dpla_id_count <= total:
             # Legacy partner-mode SDC with no download log: the per-partner ids
             # CSV is a valid item denominator and each "DPLA ID:" marker is one
             # item. (dpla_id_count > 0 here — the == 0 case returned above.)
             progress = f"{dpla_id_count:,} / {total:,} items, ~{pct(dpla_id_count)}%"
         else:
-            # Maintain --cat/--file ("lite") mode: the scope is a Commons
-            # category or file list, not the per-partner ids CSV, so `total`
-            # (the {label}.csv wc -l) is a stale/unrelated count — or 0 — and
-            # there's no download log for ordinals. sdc_sync logs one
-            # "DPLA ID:" marker per category-member FILE on this path
-            # (tools/sdc_sync.py), so report that file count alone rather than a
-            # ratio against a denominator that doesn't describe the scope (the
-            # mismatch is what produced the ">100%" readout).
+            # Maintain with no scope marker (streaming --cat, or a legacy log
+            # predating the marker): report the bare per-file count rather than a
+            # ratio against the per-partner CSV, which doesn't describe the
+            # category / file-list scope (the mismatch produced the old >100%
+            # readout). sdc_sync logs one "DPLA ID:" marker per category-member
+            # FILE on this path (tools/sdc_sync.py).
             progress = f"{dpla_id_count:,} files processed"
         return (
             f"SDC syncing ({progress}){slot_suffix}{stale_suffix}",

--- a/tests/test_wikimedia_upload_status.py
+++ b/tests/test_wikimedia_upload_status.py
@@ -154,6 +154,7 @@ def _fake_ssm_for_phase(
     *,
     hand_fix: int = 0,
     merged: int = 0,
+    maintain_scope: int = 0,
     mtime: int = 1700000000,
     now: int | None = None,
     tail: str = "last log line",
@@ -197,8 +198,10 @@ def _fake_ssm_for_phase(
         body = f"{now_val}\n{mtime}\n{sep}\n{tail}\n{sep}\n"
         body += "\n".join(str(n) for n in awk_counts) + "\n"
         # HAND-FIX + MERGED (the real awk reads these from the terminal
-        # COUNTS: block) sit between the 5 awk markers and the wc CSV total.
-        body += f"{hand_fix}\n{merged}\n"
+        # COUNTS: block) then the maintain-scope total ("maintain scope: N
+        # files", 0 for partner-mode runs) sit between the 5 awk markers and
+        # the wc CSV total.
+        body += f"{hand_fix}\n{merged}\n{maintain_scope}\n"
         body += f"{csv_total}\n"
         body += f"{sep}\n{total_ordinals}\n"
         return body
@@ -227,11 +230,12 @@ def test_get_phase_and_progress_retry_label_reads_retry_dir_csvs():
         captured.append(command)
         if len(captured) == 1:
             return "1700000000\n20260601-120000-retry-northwest-heritage-download.log\n"
-        # awk pass: dpla_id=2, uploaded=0, skipping=0, counts=0;
-        # then csv total = 5 (sum of download+upload retry CSVs)
+        # awk pass: dpla_id=2, uploaded=0, skipping=0, counts=0, ordinal=0,
+        # hand_fix=0, merged=0, maintain_scope=0; then csv total = 5 (sum of
+        # download+upload retry CSVs).
         return (
             "1700000000\n1700000000\n__WM_SEP__\nDownloading something\n"
-            "__WM_SEP__\n2\n0\n0\n0\n0\n0\n0\n5\n"
+            "__WM_SEP__\n2\n0\n0\n0\n0\n0\n0\n0\n5\n"
         )
 
     with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake_ssm_run):
@@ -349,6 +353,68 @@ def test_get_phase_and_progress_sdc_maintain_cat_reports_bare_file_count():
     assert phase.startswith("SDC syncing (1,911 files processed)"), phase
     # No bogus denominator, percentage, or "items" unit.
     assert "63" not in phase and "%" not in phase and "items" not in phase
+
+
+def test_get_phase_and_progress_sdc_maintain_reports_scope_ratio():
+    """A maintain run that logged its enumerated scope ("maintain scope: N
+    files") reports file-level progress x / y — same file unit as the per-file
+    "DPLA ID:" numerator — NOT a bare count and NOT the stale per-partner CSV.
+    """
+    from unittest.mock import patch
+
+    from scripts.wikimedia_upload_status import get_phase_and_progress
+
+    fake = _fake_ssm_for_phase(
+        log_filename="20260716-164300-georgia-sdc.log",
+        awk_counts=[1896, 0, 0, 0, 0],  # 1,896 files processed
+        maintain_scope=4000,  # enumerated category scope, logged at scan time
+        csv_total=63,  # stale georgia.csv — must be ignored in favor of scope
+        total_ordinals=0,  # maintain --cat has no download log
+    )
+    with patch("scripts.wikimedia_upload_status.ssm_run", side_effect=fake):
+        phase, _ = get_phase_and_progress(
+            client=None, session="wikimedia-georgia", hub="georgia", label="georgia"
+        )
+    assert phase.startswith("SDC syncing (1,896 / 4,000 files, ~47.4%)"), phase
+    assert "63" not in phase and "items" not in phase  # not the CSV denominator
+
+
+def test_sdc_counts_awk_extracts_fields_from_prefixed_log_lines():
+    """Run the REAL _SDC_COUNTS_AWK against a realistic -sdc.log sample.
+
+    Guards the awk field indices against the log-line prefix. The other tests
+    mock ssm_run with pre-parsed integer lines, so they never exercise the awk —
+    they can't catch a wrong field index. The maintain-scope marker is a normal
+    prefixed record ("[INFO] <time>: maintain scope: N files"), so its number
+    must be read at $(NF-1); reading $3 (the first message word, "maintain")
+    silently yields 0 and makes the whole feature inert — this pins that.
+    """
+    import subprocess
+
+    from scripts.wikimedia_upload_status import _SDC_COUNTS_AWK
+
+    sample = (
+        "[INFO] 16:43:00: maintain scope: 4000 files\n"
+        "[INFO] 16:43:01: DPLA ID: aaaa\n"
+        "[INFO] 16:43:02: -- Ordinal 1: M1\n"
+        "[INFO] 16:43:03: Uploaded to https://commons.wikimedia.org/wiki/File:X.jpg\n"
+        "[INFO] 16:43:04: DPLA ID: bbbb\n"
+        "[INFO] 16:43:05: Skipping cccc 1: Already exists on commons.\n"
+        # The COUNTS: block is logged as "\n" + str(tracker), so its lines have
+        # NO log prefix — that's why HAND-FIX/MERGED read $2, not $(NF-1).
+        "[INFO] 16:43:06: \n"
+        "COUNTS:\n"
+        "UPLOAD_HAND_FIX: 3\n"
+        "UPLOAD_MERGED_TO_CANONICAL: 7\n"
+    )
+    result = subprocess.run(
+        ["awk", _SDC_COUNTS_AWK], input=sample, capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    # order: DPLA-ID, Uploaded, Skipping, COUNTS, Ordinal, HAND-FIX, MERGED, scope
+    assert result.stdout.split() == ["2", "1", "1", "1", "1", "3", "7", "4000"], (
+        result.stdout
+    )
 
 
 def test_get_phase_and_progress_flags_waiting_on_slots():

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -5799,6 +5799,20 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
         tracker.increment(Result.SDC_PAGES_EDITED, len(pages_edited))
 
 
+def _log_maintain_scope(total_files: int) -> None:
+    """Log the enumerated maintain scope into the -sdc.log so the status poller
+    (scripts/wikimedia_upload_status.py) can render an ``x / y files``
+    denominator instead of a bare processed count.
+
+    CONTRACT: the wording is parsed by that poller's ``_SDC_COUNTS_AWK`` regex
+    (``/maintain scope: [0-9]+ files/``, number at ``$(NF-1)``) — change both
+    together. Emitted only where the total is known up front for free (the
+    ``--files`` list and the parallel ``--cat`` enumeration); the streaming
+    ``--cat`` path leaves it unlogged (see there).
+    """
+    logging.info(f"maintain scope: {total_files} files")
+
+
 def _enumerate_maintain_groups(generator, limit):
     """Walk the ``--cat`` page generator once and bucket files by embedded DPLA
     id for parallel maintain.
@@ -6241,6 +6255,11 @@ def main() -> None:
         # ``--count-only`` is a maintain-mode pre-flight: tally how each file
         # would re-link without writing anything.
         tally = _new_maintain_tally(args.maintain and args.count_only)
+        # Scope is the explicit file list (known up front); emit it for the
+        # status poller's "x / y files" denominator. Not for count-only (a
+        # read-only sizing pre-flight that logs nothing else).
+        if args.maintain and not args.count_only:
+            _log_maintain_scope(len(args.files))
         for title in args.files:
             print("\n" + title)
             page = pywikibot.FilePage(site, title)
@@ -6278,12 +6297,23 @@ def main() -> None:
                 f"maintain: {total_files} files in {len(groups)} id-group(s); "
                 f"{_workers} workers."
             )
+            # Emit the enumerated scope into the -sdc.log (the print above only
+            # reaches stdout) so wikimedia_upload_status.py can show an
+            # "x / y files" denominator instead of a bare processed count. It's
+            # the same file-level unit as the per-file "DPLA ID:" markers the
+            # poller counts as the numerator; the count is a snapshot of a live
+            # category, so the status % is an estimate.
+            _log_maintain_scope(total_files)
             _run_maintain_parallel(groups, _workers)
             _emit_maintain_summary(
                 _s3_partner or args.cat, time.time() - start_time, workers=_workers
             )
             return
 
+        # Streaming (non-parallel) --cat: the generator is consumed lazily, so
+        # the total is never materialized — no _log_maintain_scope() here (the
+        # status poller falls back to a bare per-file count). Forcing a scope
+        # marker would require an eager pre-enumeration that defeats streaming.
         tally = _new_maintain_tally(args.maintain and args.count_only)
         for page in generator:
             title = page.title()


### PR DESCRIPTION
## Problem

A maintain-mode SDC run (`sdc-sync --cat` / `--files`, used by `/wikimedia-upload … maintain`) reported progress as **`SDC syncing (N files processed)`** — no `x / y` denominator — while partner-mode runs show `x / y files, ~%`. The status poller (`wikimedia_upload_status.py`) is a pure log-grepper, and the denominators it has for partner mode (the download log's ordinal total, or the per-partner `{label}.csv`) describe the **wrong scope** for a Commons-category / file-list maintain run. Using the CSV had previously produced a `>100%` readout, so it deliberately fell back to a bare count.

## Fix

The total *is* known for the launched maintain paths, just never surfaced into the log the poller reads:
- **Parallel `--cat`** already enumerates the category into id-groups (`total_files`).
- **`--files`** knows `len(args.files)` up front.

Both now log **`maintain scope: N files`** into the `-sdc.log` via a shared `_log_maintain_scope()` helper (the existing "N files in M id-groups" line only reached stdout). The poller parses it as `maintain_total` and renders `x / y files, ~%` — the **same file-level unit** as the per-file `DPLA ID:` markers it counts as the numerator. The **streaming non-parallel `--cat`** path consumes its generator lazily and has no up-front total, so it keeps the bare count (documented in place).

## Notes for review

- **Field index (the subtle one):** the `maintain scope:` marker is a normal *prefixed* log line — `[INFO] <time>: maintain scope: N files` — so its number is read at **`$(NF-1)`** (the field before the trailing `files`), robust to the prefix width. Reading `$3` (the message's first word, `maintain`) silently yields `0` and makes the feature inert; an earlier draft had exactly that bug.
- **Testability:** the counts awk is extracted into a module constant `_SDC_COUNTS_AWK`, and a new test runs it against a realistic prefixed sample. The other status tests mock `ssm_run` with pre-parsed integer lines, so they can't catch an awk field-index regression — this one can.
- **Contract:** the `maintain scope: N files` wording is shared between `_log_maintain_scope()` (producer) and `_SDC_COUNTS_AWK` (consumer); both carry a CONTRACT comment pointing at the other.
- **Cleanup:** the now-triplicated `x / y files, ~%` formatter (Upload branch, SDC-ordinals branch, new maintain branch) is collapsed into `_files_progress()`.
- The `%` is an estimate: the scope is a snapshot of a live category, which can drift during the run.

## Verification

- Empirically confirmed the field bug and the `$(NF-1)` fix against a real log-line shape.
- Full `pytest tests/` green (1307); `ruff check` + `format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds `maintain scope: N files` logging for maintain-mode `--files` and parallel `--cat` runs.
- Updates status polling to report file-level progress using the maintain scope, with fallbacks for other run types.
- Preserves count-only behavior and streaming `--cat` runs without a known total.
- Extracts and tests the SDC counts awk script and consolidates progress formatting.

## Testing

- Added coverage for prefixed log parsing and maintain-scope progress ratios.
- Full test suite and Ruff checks pass.

## Operational impact

- No manual pipeline trigger or ECS redeployment is required.
- No environment variables, secrets, database migrations, shared infrastructure configuration, public API endpoints, or response shapes are changed.
- No security-sensitive behavior is introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->