### PR TITLE
Migration: DPLA-staff provenance + normalize preserved institution to bare Q

### DIFF
--- a/ingest_wikimedia/legacy_artwork.py
+++ b/ingest_wikimedia/legacy_artwork.py
@@ -76,6 +76,28 @@ DPLA_BOT_ACCOUNTS: frozenset[str] = frozenset(
     }
 )
 
+# DPLA staff accounts. An edit made by these accounts to a DPLA-authored field
+# is a correction to DPLA's OWN data (e.g. fixing an institution Q-ID), not a
+# third-party community contribution — so for MIGRATION PROVENANCE they are
+# treated like the bot: the value is DPLA-originated and safe to overwrite with
+# canonical SDC, never preserved as a "community" value on the migrated template.
+#
+# Scoped to migration provenance ONLY, and deliberately NOT merged into
+# ``DPLA_BOT_ACCOUNTS``: that set also gates the uploader's community-file
+# ownership check, which keys on a file's original UPLOADER (a different
+# question from "who last edited a metadata field"). Widening it there could
+# change collision handling for staff-uploaded files — out of scope here.
+DPLA_STAFF_ACCOUNTS: frozenset[str] = frozenset(
+    {
+        "Dominic",
+    }
+)
+
+# The account set the migration provenance walker treats as DPLA-originated:
+# automated uploaders + DPLA staff. Default for ``plan_migration`` /
+# ``classify_param_provenance`` / ``migrate_legacy_file``.
+MIGRATION_PROVENANCE_ACCOUNTS: frozenset[str] = DPLA_BOT_ACCOUNTS | DPLA_STAFF_ACCOUNTS
+
 
 def _normalize_account(name: str) -> str:
     """Casefold and collapse underscores to spaces so ``DPLA_bot`` and
@@ -532,15 +554,16 @@ def trace_param_provenance(
 
 def classify_param_provenance(
     provenance: dict[str, str],
-    bot_accounts: frozenset[str] = DPLA_BOT_ACCOUNTS,
+    bot_accounts: frozenset[str] = MIGRATION_PROVENANCE_ACCOUNTS,
 ) -> dict[str, str]:
     """For each param, label its provenance as ``"dpla"`` or
     ``"community"`` based on whose account introduced its current value.
 
     ``bot_accounts`` is parameterised purely so tests can pass a
     custom allowlist. Production callers should accept the module
-    default; new bot accounts get added to :data:`DPLA_BOT_ACCOUNTS`
-    rather than the per-call argument.
+    default (:data:`MIGRATION_PROVENANCE_ACCOUNTS` — bots + DPLA staff);
+    new DPLA-origin accounts get added to :data:`DPLA_BOT_ACCOUNTS` (bots)
+    or :data:`DPLA_STAFF_ACCOUNTS` (staff) rather than the per-call argument.
     """
     bot_set = {_normalize_account(a) for a in bot_accounts}
     return {
@@ -553,7 +576,7 @@ def plan_migration(
     file_title: str,
     revisions: Iterable[RevisionSnapshot],
     canonical_params: dict,
-    bot_accounts: frozenset[str] = DPLA_BOT_ACCOUNTS,
+    bot_accounts: frozenset[str] = MIGRATION_PROVENANCE_ACCOUNTS,
 ) -> MigrationPlan | None:
     """Compute the migration plan for a legacy-Artwork file.
 
@@ -638,7 +661,11 @@ def plan_migration(
                 # renders it in the yellow box — instead of failing the whole
                 # file's import. Same destination as the extension case above:
                 # community content that can't be SDC lands in wikitext.
-                wikitext_preserved_extras[key] = value
+                # Entity-ID params (institution) are normalized to a bare Q so a
+                # community ``{{Institution|wikidata=Q}}`` rides as the renderer-
+                # safe flat ``institution = Q`` rather than a module-breaking
+                # sub-template (see _normalize_preserved_param).
+                wikitext_preserved_extras[key] = _normalize_preserved_param(key, value)
                 continue
             community_imports[key] = value
         else:
@@ -1137,6 +1164,29 @@ def _community_value_unfit_for_sdc(key: str, value: str) -> bool:
     # template) — a literal {{...}} must not be stored as the monolingual value.
     text, _lang = _unwrap_lang_template(value)
     return "{{" in text or "[[" in text
+
+
+def _normalize_preserved_param(key: str, value: str) -> str:
+    """Normalize an entity-ID param value being preserved verbatim onto the
+    migrated ``{{DPLA metadata}}`` template.
+
+    ``institution`` is the only preserved param Module:DPLA feeds to a Wikibase
+    lookup (via ``{{Institution|wikidata=...}}``), which raises a script error on
+    anything that is not a bare Q-ID — and because Scribunto pre-expands template
+    args, a preserved ``{{Institution|wikidata=Q}}`` reaches the renderer as vcard
+    HTML, not an ID. Reduce that shape to its bare ``Q`` so the migrated param is
+    the flat ``institution = Q`` the renderer handles safely, instead of blindly
+    carrying a sub-template into a slot the module treats as an entity ID. Any
+    other key, or an institution value that is not a single
+    ``{{Institution|wikidata=Q}}`` (e.g. free text), is returned unchanged — there
+    is no bare ID to extract and the renderer treats such a value as an opaque
+    literal."""
+    if key == "institution":
+        # _extract_institution_qid handles both the {{Institution|wikidata=Q}}
+        # sub-template and a bare/whitespace-padded Q, returning None for free
+        # text — so a non-ID literal falls through to verbatim preservation.
+        return _extract_institution_qid(value) or value
+    return value
 
 
 def _multi_value_subset_of_canonical(value: str, canonical: str) -> bool:
@@ -2720,7 +2770,7 @@ def migrate_legacy_file(
     data_provider: dict,
     dpla_id: str,
     site,
-    bot_accounts: frozenset[str] = DPLA_BOT_ACCOUNTS,
+    bot_accounts: frozenset[str] = MIGRATION_PROVENANCE_ACCOUNTS,
     summary: str | None = None,
 ) -> MigrationResult:
     """End-to-end legacy-Artwork migration for a single file.
@@ -2856,7 +2906,7 @@ def import_cross_page_community_sdc(
     data_provider: dict,
     dpla_id: str,
     site,
-    bot_accounts: frozenset[str] = DPLA_BOT_ACCOUNTS,
+    bot_accounts: frozenset[str] = MIGRATION_PROVENANCE_ACCOUNTS,
     summary: str | None = None,
 ) -> int:
     """Rescue community-authored, *in-template* metadata from a source page's

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -589,6 +589,75 @@ def test_plan_migration_skips_community_value_that_matches_canonical():
     assert plan.dpla_originated_params["title"] == "A Title"
 
 
+def test_plan_migration_staff_institution_edit_is_dpla_originated_not_preserved():
+    """Q3: an ``institution`` value last set by a DPLA STAFF account (Dominic)
+    is a correction to DPLA's own data, not a third-party contribution — so it
+    classifies dpla-originated (dropped in favour of canonical SDC P195), NOT
+    preserved on the migrated template. Preserving it is exactly what produced
+    the Category:Pages with script errors batch. Uses the default provenance
+    set, which now includes staff via MIGRATION_PROVENANCE_ACCOUNTS."""
+    revs = _make_revs(
+        (1, "DPLA bot", "{{Artwork|Institution={{Institution|wikidata=Q1}}}}"),
+        (2, "Dominic", "{{Artwork|Institution={{Institution|wikidata=Q2}}}}"),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    # The load-bearing property: NOT preserved and NOT imported as community.
+    assert "institution" not in plan.wikitext_preserved_extras
+    assert "institution" not in plan.community_imports
+    # Staff edit is treated as DPLA-originated (overwritten by canonical SDC).
+    assert plan.dpla_originated_params.get("institution") == "{{Institution|wikidata=Q2}}"
+
+
+def test_plan_migration_community_institution_template_normalized_to_bare_qid():
+    """Q1: a genuine third-party ``institution = {{Institution|wikidata=Q}}`` is
+    still preserved (there is no institution->SDC import path yet), but
+    normalized to the bare Q so the migrated param is the renderer-safe flat
+    ``institution = Q`` rather than a sub-template that breaks Module:DPLA."""
+    revs = _make_revs(
+        (1, "DPLA bot", "{{Artwork|title=A Title}}"),
+        (
+            2,
+            "CommunityEditor",
+            "{{Artwork|title=A Title|Institution={{Institution|wikidata=Q105635856}}}}",
+        ),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert plan.wikitext_preserved_extras.get("institution") == "Q105635856"
+
+
+def test_plan_migration_community_institution_plaintext_preserved_verbatim():
+    """A community institution that is NOT a ``{{Institution|wikidata=Q}}`` (free
+    text — no bare Q to extract) is preserved verbatim; the renderer treats it as
+    an opaque literal (and the Module:DPLA belt keeps it from erroring)."""
+    revs = _make_revs(
+        (1, "DPLA bot", "{{Artwork|title=A Title}}"),
+        (
+            2,
+            "CommunityEditor",
+            "{{Artwork|title=A Title|institution=Middle Georgia Archives}}",
+        ),
+    )
+    plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
+    assert plan is not None
+    assert plan.wikitext_preserved_extras.get("institution") == "Middle Georgia Archives"
+
+
+def test_migration_provenance_accounts_extend_bots_with_staff():
+    """The migration provenance default is bots + staff; ``DPLA_BOT_ACCOUNTS``
+    (which also gates the uploader's separate uploader/community-file check) is
+    NOT widened, keeping this scoped to migration provenance."""
+    from ingest_wikimedia.legacy_artwork import (
+        DPLA_STAFF_ACCOUNTS,
+        MIGRATION_PROVENANCE_ACCOUNTS,
+    )
+
+    assert "Dominic" in DPLA_STAFF_ACCOUNTS
+    assert "Dominic" not in DPLA_BOT_ACCOUNTS
+    assert MIGRATION_PROVENANCE_ACCOUNTS == DPLA_BOT_ACCOUNTS | DPLA_STAFF_ACCOUNTS
+
+
 def test_plan_migration_imports_creator_param_that_differs_from_canonical():
     """Regression: canonical 'creator' is a plain string (extract_strings),
     not an {{InFi|Creator|...}} dict. A file whose Artwork template carries

--- a/tests/test_legacy_artwork.py
+++ b/tests/test_legacy_artwork.py
@@ -606,7 +606,9 @@ def test_plan_migration_staff_institution_edit_is_dpla_originated_not_preserved(
     assert "institution" not in plan.wikitext_preserved_extras
     assert "institution" not in plan.community_imports
     # Staff edit is treated as DPLA-originated (overwritten by canonical SDC).
-    assert plan.dpla_originated_params.get("institution") == "{{Institution|wikidata=Q2}}"
+    assert (
+        plan.dpla_originated_params.get("institution") == "{{Institution|wikidata=Q2}}"
+    )
 
 
 def test_plan_migration_community_institution_template_normalized_to_bare_qid():
@@ -641,7 +643,9 @@ def test_plan_migration_community_institution_plaintext_preserved_verbatim():
     )
     plan = plan_migration("File:Foo.jpg", revs, _canonical_params())
     assert plan is not None
-    assert plan.wikitext_preserved_extras.get("institution") == "Middle Georgia Archives"
+    assert (
+        plan.wikitext_preserved_extras.get("institution") == "Middle Georgia Archives"
+    )
 
 
 def test_migration_provenance_accounts_extend_bots_with_staff():


### PR DESCRIPTION
Root-cause (Python-side) fixes for the `Category:Pages with script errors` batch investigated on Commons — 83 DPLA files whose `{{DPLA metadata|institution={{Institution|wikidata=Q}}}}` param makes the live Module:DPLA throw (it feeds the param to a Wikibase lookup, and Scribunto pre-expands the sub-template to vcard HTML, not an entity ID).

## How the bad wikitext got there
The legacy→`{{DPLA metadata}}` migration attributes each template param to whoever last **set its value** and preserves *community*-authored values as wikitext. For these files the institution Q-ID was last set by **`User:Dominic`** (a 2021 bulk "update institution code" pass) → classified community → the raw `{{Institution|wikidata=Q}}` was preserved onto the new template. Institution has no SDC-import path (`LEGACY_IMPORT_PROPERTY` covers only title/description/date/creator — institution was deferred), so it couldn't be lifted to P195 and was kept verbatim.

## Fixes
**Q3 — staff provenance.** A DPLA **staff** edit to a DPLA-authored field is a correction to DPLA's own data, not a third-party contribution, so it should classify as DPLA-originated (dropped in favour of canonical SDC P195), not preserved. Adds `DPLA_STAFF_ACCOUNTS` + `MIGRATION_PROVENANCE_ACCOUNTS = DPLA_BOT_ACCOUNTS | DPLA_STAFF_ACCOUNTS` and points the migration provenance functions' default at it.
- Deliberately **not** merged into `DPLA_BOT_ACCOUNTS`: that set also gates the uploader's community-file check, which keys on a file's *original uploader* — a different question. Widening it there could change SHA1-collision handling for staff-uploaded files. Kept migration-only.

**Q1 — normalize preserved entity-ID params.** When a *genuinely* community institution is still preserved, reduce a `{{Institution|wikidata=Q}}` to its bare `Q` (via the existing `_extract_institution_qid`) so the migrated param is the renderer-safe flat `institution = Q`, never a module-breaking sub-template. Free text passes through verbatim.

## Real-data validation
- **Authoritative provenance recount** using the actual `trace_param_provenance`/`classify_param_provenance` on each affected file's **pre-migration** revisions: **79/83 staff** (now dropped by Q3) + **4/83 genuine community** (Belbury ×2, an IP, PublicDomainFan08 — handled by Q1 / the module belt).
- **`plan_migration` dry-run** on the example file's real history: institution moves from *preserved-on-template* (old) → *dpla_originated / dropped* (new), rendering from canonical SDC.

## Scope notes
- This fixes the migration **going forward**; it does not retroactively touch the 83 already-migrated files (they no longer carry a legacy template, so a re-run won't re-migrate). Those are handled by (a) a separate one-off strip script targeting the 79 staff-provenance params, and (b) the Module:DPLA sandbox belt (universal render-time safety), both tracked separately.

## Tests
4 new (staff→dropped; community-template→bare-Q; community-plaintext→verbatim; provenance-set scoping). Full `pytest tests/` — **1311 passed**; ruff check + format clean. `/simplify` run (reuse: delegate to `_extract_institution_qid`; altitude: scoping/split confirmed correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added dedicated DPLA staff provenance accounts so staff edits to DPLA-authored fields are treated as DPLA-originated (and dropped in favor of canonical SDC data) without changing uploader classification logic.
- Normalized genuinely community-authored institution values preserved in `{{DPLA metadata}}`: converts preserved `{{Institution|wikidata=Q...}}` subtemplates to bare `Q...` where possible, while leaving plaintext institution values unchanged.
- Updated legacy artwork migration provenance handling by expanding the default `bot_accounts` allowlist used across migration planning/import functions to include the new staff accounts.
- Added four unit tests covering staff-vs-community provenance classification, institution template normalization, plaintext preservation, and provenance-account scoping.

Validation classified 79 of 83 affected files as staff-originated and 4 as community-authored; the full test suite passed with 1,311 tests, and Ruff checks passed.

## Operational impact

- Existing migrated files require separate remediation.
- No manual pipeline trigger or ECS redeployment is required.
- No environment variables, AWS Secrets Manager keys, database migrations, shared infrastructure configuration (CodePipeline/CodeBuild/ECS/IAM), public-facing API response shapes, endpoints, or security/credential-handling changes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->