### PR TITLE
sdc-sync: fail loudly on systemic sidecar failure + retry/surface per-item write errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,17 @@ updates:
     schedule:
       interval: "weekly"
     versioning-strategy: auto
+    ignore:
+      # ruff 0.16 changed its default ruleset (LOG015 "use own logger", BLE001,
+      # stricter isort) in ways that clash with this repo's intentional
+      # root-logger + broad-per-item-except conventions — adopting it would
+      # churn ~40 files for no benefit (see the ruff cap in pyproject.toml).
+      # Stay on 0.15.x: patch bumps still flow; a 0.16 move must be deliberate,
+      # not an auto-bump folded into the weekly grouped PR.
+      - dependency-name: "ruff"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
     groups:
       python-dependencies:
         patterns:

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -673,6 +673,16 @@ def notify_sdc_complete(
         f"ORDINAL NO PAGEID:    {tracker.count(Result.SDC_ORDINALS_SKIPPED_MISSING_PAGEID):,}",
         f"ORDINAL ERRORS:       {tracker.count(Result.SDC_ORDINALS_SKIPPED_ERROR):,}",
     ]
+    # Surface write failures prominently: per-item wbeditentity failures that
+    # survived the retry are otherwise buried among the counters while the run
+    # still reports "complete". A leading flag tells the operator to check the
+    # ERROR log lines ("SDC sync failed after retries") and re-run the affected
+    # items, rather than the failures passing silently.
+    write_failures = tracker.count(Result.SDC_ITEMS_SKIPPED_ERROR) + tracker.count(
+        Result.SDC_ORDINALS_SKIPPED_ERROR
+    )
+    if write_failures:
+        stats_lines.insert(0, f"WRITE FAILURES (see log): {write_failures:,}")
     # Maintain mode also renames title-drifted files to their canonical title;
     # surface those outcomes (only on maintain runs, to keep the regular SDC
     # summary uncluttered). RENAME BLOCKED counts files left non-canonical

--- a/ingest_wikimedia/slack.py
+++ b/ingest_wikimedia/slack.py
@@ -678,9 +678,10 @@ def notify_sdc_complete(
     # still reports "complete". A leading flag tells the operator to check the
     # ERROR log lines ("SDC sync failed after retries") and re-run the affected
     # items, rather than the failures passing silently.
-    write_failures = tracker.count(Result.SDC_ITEMS_SKIPPED_ERROR) + tracker.count(
-        Result.SDC_ORDINALS_SKIPPED_ERROR
-    )
+    # Count ordinal-level failures only. SDC_ITEMS_SKIPPED_ERROR is incremented
+    # when *all* of an item's ordinals already hit SDC_ORDINALS_SKIPPED_ERROR,
+    # so summing the two would double-count a fully-failed item.
+    write_failures = tracker.count(Result.SDC_ORDINALS_SKIPPED_ERROR)
     if write_failures:
         stats_lines.insert(0, f"WRITE FAILURES (see log): {write_failures:,}")
     # Maintain mode also renames title-drifted files to their canonical title;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,12 @@ dev = [
     "coverage>=7.15.2",
     "mypy>=2.3.0",
     "pytest>=9.1.1",
-    "ruff>=0.15.21",
+    # Capped below 0.16: its default ruleset (LOG015 "use own logger", BLE001,
+    # stricter isort) clashes with this repo's intentional root-logger + broad
+    # per-item-except conventions and would churn ~40 files for no benefit. The
+    # ruff CI action resolves this constraint (it ignores uv.lock), so the cap
+    # is what actually pins CI. Bump deliberately if 0.16 is ever adopted.
+    "ruff>=0.15.21,<0.16",
     "types-requests>=2.33.0.20260712",
 ]
 

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -7085,3 +7085,121 @@ def test_partner_item_explicit_null_page_numbers_skips_ordinal(monkeypatch):
     }
     calls = _drive_partner_item(monkeypatch, ordinals=ordinals)
     assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud on systemic sidecar/skip failure (_assert_not_systemic_failure)
+# and per-ordinal transient write retry (_process_one_from_sdc_with_retry).
+# ---------------------------------------------------------------------------
+def test_systemic_failure_raises_when_nothing_synced():
+    from tools import sdc_sync
+    from tools.sdc_sync import SdcSystemicFailure
+
+    sdc_sync.tracker.reset()
+    sdc_sync.tracker.increment(Result.SDC_ITEMS_SKIPPED_ERROR, 820)
+    with pytest.raises(SdcSystemicFailure):
+        sdc_sync._assert_not_systemic_failure(820)
+
+
+def test_systemic_failure_raises_on_high_fraction():
+    from tools import sdc_sync
+    from tools.sdc_sync import SdcSystemicFailure
+
+    sdc_sync.tracker.reset()
+    sdc_sync.tracker.increment(Result.SDC_ITEMS_SYNCED, 40)
+    sdc_sync.tracker.increment(Result.SDC_ITEMS_SKIPPED_ERROR, 60)  # 60/100 >= 0.5
+    with pytest.raises(SdcSystemicFailure):
+        sdc_sync._assert_not_systemic_failure(100)
+
+
+def test_systemic_failure_allows_small_partial():
+    from tools import sdc_sync
+
+    sdc_sync.tracker.reset()
+    sdc_sync.tracker.increment(Result.SDC_ITEMS_SYNCED, 9603)
+    sdc_sync.tracker.increment(Result.SDC_ITEMS_SKIPPED_ERROR, 10)  # 10/9613, synced>0
+    sdc_sync._assert_not_systemic_failure(9613)  # no raise
+
+
+def test_systemic_failure_noop_when_clean_or_empty():
+    from tools import sdc_sync
+
+    sdc_sync.tracker.reset()
+    sdc_sync.tracker.increment(Result.SDC_ITEMS_SYNCED, 100)
+    sdc_sync._assert_not_systemic_failure(100)  # no failures -> no raise
+    sdc_sync.tracker.reset()
+    sdc_sync._assert_not_systemic_failure(0)  # empty worklist -> no raise
+
+
+def test_write_retry_succeeds_after_transient():
+    import pywikibot
+    from tools import sdc_sync
+
+    calls = {"n": 0}
+
+    def flaky(*a, **k):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise pywikibot.exceptions.ServerError("boom")
+
+    with (
+        patch.object(sdc_sync, "process_one_from_sdc", side_effect=flaky),
+        patch.object(sdc_sync.time, "sleep"),
+    ):
+        sdc_sync._process_one_from_sdc_with_retry("M1", "id", {}, None, None)
+    assert calls["n"] == 3
+
+
+def test_write_retry_gives_up_after_max_attempts():
+    import pywikibot
+    from tools import sdc_sync
+
+    calls = {"n": 0}
+
+    def always(*a, **k):
+        calls["n"] += 1
+        raise pywikibot.exceptions.ServerError("boom")
+
+    with (
+        patch.object(sdc_sync, "process_one_from_sdc", side_effect=always),
+        patch.object(sdc_sync.time, "sleep"),
+        pytest.raises(pywikibot.exceptions.ServerError),
+    ):
+        sdc_sync._process_one_from_sdc_with_retry("M1", "id", {}, None, None)
+    assert calls["n"] == sdc_sync._WRITE_RETRY_ATTEMPTS
+
+
+def test_write_retry_does_not_retry_nontransient():
+    from tools import sdc_sync
+
+    calls = {"n": 0}
+
+    def bad(*a, **k):
+        calls["n"] += 1
+        raise ValueError("logic bug")
+
+    with (
+        patch.object(sdc_sync, "process_one_from_sdc", side_effect=bad),
+        patch.object(sdc_sync.time, "sleep"),
+        pytest.raises(ValueError),
+    ):
+        sdc_sync._process_one_from_sdc_with_retry("M1", "id", {}, None, None)
+    assert calls["n"] == 1  # non-transient: no retry
+
+
+def test_write_retry_passes_through_missing_entity():
+    from tools import sdc_sync
+
+    calls = {"n": 0}
+
+    def missing(*a, **k):
+        calls["n"] += 1
+        raise sdc_sync._MissingEntityError("gone")
+
+    with (
+        patch.object(sdc_sync, "process_one_from_sdc", side_effect=missing),
+        patch.object(sdc_sync.time, "sleep"),
+        pytest.raises(sdc_sync._MissingEntityError),
+    ):
+        sdc_sync._process_one_from_sdc_with_retry("M1", "id", {}, None, None)
+    assert calls["n"] == 1  # never retried

--- a/tests/test_sdc_sync.py
+++ b/tests/test_sdc_sync.py
@@ -7203,3 +7203,22 @@ def test_write_retry_passes_through_missing_entity():
     ):
         sdc_sync._process_one_from_sdc_with_retry("M1", "id", {}, None, None)
     assert calls["n"] == 1  # never retried
+
+
+def test_write_retry_does_not_retry_fatal_server_error():
+    import pywikibot
+    from tools import sdc_sync
+
+    calls = {"n": 0}
+
+    def fatal(*a, **k):
+        calls["n"] += 1
+        raise pywikibot.exceptions.FatalServerError("fatal")
+
+    with (
+        patch.object(sdc_sync, "process_one_from_sdc", side_effect=fatal),
+        patch.object(sdc_sync.time, "sleep"),
+        pytest.raises(pywikibot.exceptions.FatalServerError),
+    ):
+        sdc_sync._process_one_from_sdc_with_retry("M1", "id", {}, None, None)
+    assert calls["n"] == 1  # FatalServerError is non-recoverable: never retried

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -130,6 +130,29 @@ _workers: int = 1
 # ``args.workers_budget`` at main() time.
 _workers_budget: int = 0
 
+# A partner-mode run whose per-item skips (errors + missing sidecars) reach
+# this fraction of the worklist is treated as a SYSTEMIC failure and aborted
+# loudly rather than emitting a success ``COUNTS:`` marker + green Slack
+# summary. This closes the silent-completion hole seen in the Sinton
+# 2026-07-02 run, which skipped 820/820 items on stale (pre-``ingest_date``)
+# sidecars yet exited 0. Override with SDC_SYSTEMIC_FAIL_FRACTION.
+_SYSTEMIC_FAIL_FRACTION: float = float(
+    os.environ.get("SDC_SYSTEMIC_FAIL_FRACTION", "0.5")
+)
+
+# Bounded application-level retry for a per-ordinal SDC write that fails with a
+# transient error AFTER pywikibot's own maxlag/read-timeout retries are
+# exhausted — a fresh attempt seconds later usually lands (the STS-82
+# 2026-06-16 run lost ~10 files to a transient wbeditentity ServerError
+# mid-run, silently skipped). Only clearly-transient server/network classes
+# are retried; data/logic errors raise on the first attempt so they don't loop.
+_WRITE_RETRY_ATTEMPTS: int = int(os.environ.get("SDC_WRITE_RETRY_ATTEMPTS", "3"))
+_TRANSIENT_WRITE_ERRORS = (
+    pywikibot.exceptions.ServerError,
+    pywikibot.exceptions.TimeoutError,
+    requests.exceptions.RequestException,
+)
+
 # Per-worker WorkerSlotBudget instance. Defaults to a disabled (no-op)
 # budget so ``_worker_slot_budget.acquire()`` is always safe to call even
 # before a worker runs its initializer; _init_partner_worker replaces it
@@ -5373,6 +5396,54 @@ def _get_partner_s3_client():
     return _s3_client
 
 
+def _process_one_from_sdc_with_retry(
+    mediaid, dpla_id, sdc_payload, download_url, page_number
+):
+    """``process_one_from_sdc`` with a bounded retry for transient write errors.
+
+    ``wbeditentity`` lands atomically (whole bundle or nothing), and
+    ``process_one_from_sdc`` re-reads the entity and re-diffs on each call, so a
+    retry after a failed write is idempotent — it recomputes and re-posts only
+    what's still missing. Retries apply ONLY to clearly-transient server/network
+    classes (``_TRANSIENT_WRITE_ERRORS``); ``_MissingEntityError`` and
+    ``CsrfRecoveryFailed`` pass straight through (never retried), and any other
+    (data/logic) exception propagates on the first attempt so it can't loop.
+    """
+    for attempt in range(1, _WRITE_RETRY_ATTEMPTS + 1):
+        try:
+            process_one_from_sdc(
+                mediaid,
+                dpla_id,
+                sdc_payload,
+                download_url=download_url,
+                page_number=page_number,
+            )
+            return
+        except (_MissingEntityError, CsrfRecoveryFailed):
+            # Ordering guard: caught (and immediately re-raised) BEFORE the
+            # transient clause so these can never be swept into the retry even
+            # if _TRANSIENT_WRITE_ERRORS is later broadened to a base class they
+            # subclass. CsrfRecoveryFailed is session-fatal (must abort the run,
+            # never retry); _MissingEntityError is a clean per-ordinal skip the
+            # caller classifies. Neither is transient. With today's tuple this
+            # is technically redundant, but it pins the invariant.
+            raise
+        except _TRANSIENT_WRITE_ERRORS:
+            if attempt >= _WRITE_RETRY_ATTEMPTS:
+                raise
+            wait = min(2**attempt, 30)
+            logging.warning(
+                " -- Ordinal write for %s (%s) hit a transient error"
+                " (attempt %d/%d); retrying in %ds.",
+                dpla_id,
+                mediaid,
+                attempt,
+                _WRITE_RETRY_ATTEMPTS,
+                wait,
+            )
+            time.sleep(wait)
+
+
 def _process_one_partner_item(s3, partner, dpla_id, idx, total):
     """Process one DPLA item end-to-end in partner mode — read S3
     sidecars, drive per-ordinal SDC sync against Commons, run the
@@ -5705,12 +5776,8 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
                 continue
             page_number = recorded_pages or None
         try:
-            process_one_from_sdc(
-                mediaid,
-                dpla_id,
-                sdc_payload,
-                download_url=download_url,
-                page_number=page_number,
+            _process_one_from_sdc_with_retry(
+                mediaid, dpla_id, sdc_payload, download_url, page_number
             )
         except _MissingEntityError:
             # Commons says the MediaInfo entity at this M-id doesn't
@@ -5738,7 +5805,7 @@ def _process_one_partner_item(s3, partner, dpla_id, idx, total):
         except Exception:
             logging.exception(
                 f" -- Ordinal {ord_str} ({mediaid}) for {dpla_id}:"
-                " SDC sync failed; skipping ordinal."
+                " SDC sync failed after retries; skipping ordinal."
             )
             tracker.increment(Result.SDC_ORDINALS_SKIPPED_ERROR)
             had_ordinal_error = True
@@ -5975,6 +6042,44 @@ def _run_maintain_parallel(groups, workers):
     )
 
 
+class SdcSystemicFailure(RuntimeError):
+    """A partner-mode run whose per-item skips are dominated by errors or
+    missing sidecars. Raised (instead of emitting a success ``COUNTS:``
+    marker) so the run fails loudly — non-zero exit + ``notify_pipeline_fail``
+    — rather than masquerading as a clean completion."""
+
+
+def _assert_not_systemic_failure(total_items):
+    """Abort a partner-mode run whose item skips (errors + missing sidecars)
+    dominate the worklist — the silent-completion hole (fail loudly).
+
+    Fatal when nothing synced but items failed (a whole-run failure, e.g. every
+    sidecar staged pre-``ingest_date``), or when the failed fraction reaches
+    ``_SYSTEMIC_FAIL_FRACTION``. A handful of per-item failures amid many
+    successes (handled by the per-ordinal retry + surfaced in the summary) is
+    NOT systemic and does not abort the run.
+    """
+    if total_items <= 0:
+        return
+    failed = tracker.count(Result.SDC_ITEMS_SKIPPED_ERROR) + tracker.count(
+        Result.SDC_ITEMS_SKIPPED_NO_SIDECAR
+    )
+    if failed == 0:
+        return
+    synced = tracker.count(Result.SDC_ITEMS_SYNCED) + tracker.count(
+        Result.SDC_ITEMS_PARTIALLY_SYNCED
+    )
+    if synced == 0 or failed / total_items >= _SYSTEMIC_FAIL_FRACTION:
+        msg = (
+            f"SDC sync systemic failure: {failed}/{total_items} items skipped on "
+            f"errors/missing sidecars, {synced} synced. Most likely stale or "
+            "unstaged sidecars — regenerate with a fresh get-ids-* run. Refusing "
+            "to report success."
+        )
+        logging.error(msg)
+        raise SdcSystemicFailure(msg)
+
+
 def _run_partner_mode(partner, ids_file):
     """Drive the SDC phase from precomputed S3 sidecars for a whole partner.
 
@@ -6042,6 +6147,9 @@ def _run_partner_mode(partner, ids_file):
                 tracker.increment(Result.SDC_SLOT_WAIT_SECONDS, slot_wait)
         else:
             _run_partner_mode_parallel(partner, dpla_ids, workers)
+        # Fail loudly if this run's skips are systemic (e.g. stale sidecars)
+        # rather than emitting a spurious success COUNTS: + green summary.
+        _assert_not_systemic_failure(len(dpla_ids))
         completed = True
     except BaseException as exc:
         # The per-ordinal try/except above already swallows every routine

--- a/tools/sdc_sync.py
+++ b/tools/sdc_sync.py
@@ -5405,9 +5405,11 @@ def _process_one_from_sdc_with_retry(
     ``process_one_from_sdc`` re-reads the entity and re-diffs on each call, so a
     retry after a failed write is idempotent — it recomputes and re-posts only
     what's still missing. Retries apply ONLY to clearly-transient server/network
-    classes (``_TRANSIENT_WRITE_ERRORS``); ``_MissingEntityError`` and
-    ``CsrfRecoveryFailed`` pass straight through (never retried), and any other
-    (data/logic) exception propagates on the first attempt so it can't loop.
+    classes (``_TRANSIENT_WRITE_ERRORS``); ``_MissingEntityError``,
+    ``CsrfRecoveryFailed``, and ``FatalServerError`` (a ``ServerError`` subclass
+    pywikibot treats as non-recoverable) pass straight through (never retried),
+    and any other (data/logic) exception propagates on the first attempt so it
+    can't loop.
     """
     for attempt in range(1, _WRITE_RETRY_ATTEMPTS + 1):
         try:
@@ -5419,14 +5421,19 @@ def _process_one_from_sdc_with_retry(
                 page_number=page_number,
             )
             return
-        except (_MissingEntityError, CsrfRecoveryFailed):
+        except (
+            _MissingEntityError,
+            CsrfRecoveryFailed,
+            pywikibot.exceptions.FatalServerError,
+        ):
             # Ordering guard: caught (and immediately re-raised) BEFORE the
-            # transient clause so these can never be swept into the retry even
-            # if _TRANSIENT_WRITE_ERRORS is later broadened to a base class they
-            # subclass. CsrfRecoveryFailed is session-fatal (must abort the run,
+            # transient clause so these are never swept into the retry.
+            # FatalServerError is a ServerError subclass (so it WOULD match
+            # _TRANSIENT_WRITE_ERRORS) that pywikibot itself never retries —
+            # it's non-recoverable, so a retry would predictably fail and waste
+            # attempts. CsrfRecoveryFailed is session-fatal (must abort the run,
             # never retry); _MissingEntityError is a clean per-ordinal skip the
-            # caller classifies. Neither is transient. With today's tuple this
-            # is technically redundant, but it pins the invariant.
+            # caller classifies. This clause must precede the transient one.
             raise
         except _TRANSIENT_WRITE_ERRORS:
             if attempt >= _WRITE_RETRY_ATTEMPTS:

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ dev = [
     { name = "coverage", specifier = ">=7.15.2" },
     { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
-    { name = "ruff", specifier = ">=0.15.21" },
+    { name = "ruff", specifier = ">=0.15.21,<0.16" },
     { name = "types-requests", specifier = ">=2.33.0.20260712" },
 ]
 


### PR DESCRIPTION
## Problem

Two gaps in the SDC-sync phase let failures pass as success (surfaced while triaging the "DPLA uploads in progress" orphans):

1. **Systemic failure reported as success.** A partner-mode run that skips all/most items on errors or missing sidecars still emits a success `COUNTS:` marker and a green Slack summary. The `texas|Sinton Public Library` run on 2026-07-02 skipped **820/820** items on stale (pre-`ingest_date`) sidecars yet exited 0 — the whole batch was left unsynced with no signal.
2. **Per-item write failures silently skipped.** `wbeditentity` failures were dropped after pywikibot's own maxlag/timeout retries with no further attempt and no prominent surfacing. The NARA STS-82 run on 2026-06-16 lost ~10 files to a transient `ServerError` mid-run while reporting completion.

(Note: SDC-only runs already re-stage sidecars via `get-ids` in the launcher, so no launcher change is needed — these are the remaining sync-side gaps.)

## Changes

- **Fail loudly on systemic skip** (`tools/sdc_sync.py`): `_assert_not_systemic_failure()` runs at the end of `_run_partner_mode` and raises `SdcSystemicFailure` when nothing synced but items failed, or when the error/no-sidecar fraction reaches `SDC_SYSTEMIC_FAIL_FRACTION` (default `0.5`). It takes the existing abort path — non-zero exit → the shell's `notify_pipeline_fail` — instead of the spurious success `COUNTS:` + `notify_sdc_complete`. A handful of per-item failures amid many successes is **not** systemic and does not abort.
- **Retry transient per-item writes** (`tools/sdc_sync.py`): `_process_one_from_sdc_with_retry()` wraps `process_one_from_sdc` with a bounded retry (`SDC_WRITE_RETRY_ATTEMPTS`, default 3; exponential backoff) for clearly-transient server/network classes only. `process_one_from_sdc` re-reads the entity and re-diffs each attempt, so retries are idempotent. `_MissingEntityError` / `CsrfRecoveryFailed` pass straight through; data/logic errors raise on the first attempt (never loop).
- **Surface survivors** (`ingest_wikimedia/slack.py`): a leading `WRITE FAILURES (see log)` line in the SDC completion summary when write errors occurred, so partial-run failures aren't buried among the counters.

Both thresholds are env-tunable. The retry wrapper is layered *above* `process_one_from_sdc` (complementary to the CSRF recovery inside `_submit_sdc_write`), not a duplicate.

## Tests

8 new unit tests (systemic-failure thresholds: nothing-synced, high-fraction, small-partial-allowed, clean/empty no-op; retry classification: transient-then-success, give-up-after-max, non-transient no-retry, `_MissingEntityError` pass-through). Full suite: **1319 passed**. `ruff check`/`format` clean. `simplify` reviewed (reuse/simplification/efficiency/altitude) — no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents partner-mode SDC sync from reporting success when failures are systemic, using an environment-configurable `SDC_SYSTEMIC_FAIL_FRACTION` threshold (raises `SdcSystemicFailure` when nothing synced or when a dominant fraction of the work failed/skipped).
- Adds bounded exponential-backoff retries for transient per-ordinal SDC write failures via `SDC_WRITE_RETRY_ATTEMPTS` (retries only for explicitly transient server/network errors; does **not** retry `_MissingEntityError`, `CsrfRecoveryFailed`, or `pywikibot.exceptions.FatalServerError`).
- Updates the SDC Slack completion reporting to surface remaining write failures after retries (the Slack “WRITE FAILURES” count is derived from `Result.SDC_ORDINALS_SKIPPED_ERROR` only to avoid double-counting).
- Adds eight unit tests covering systemic-failure threshold logic and retry behavior.

## Operational impact

- Behavior changes apply on the next deployment; no manual pipeline trigger or ECS redeployment is required beyond the normal rollout.
- Adds environment variables: `SDC_SYSTEMIC_FAIL_FRACTION` and `SDC_WRITE_RETRY_ATTEMPTS`.
- No database migration.
- No shared infrastructure configuration changes (CodePipeline/CodeBuild/ECS/IAM).
- No public-facing API response shape changes or endpoint changes.
- No security-sensitive authentication/authorization, new external data inputs, or credential-handling changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->