### PR TITLE
uploader: thread download URL into SDC merge so merged P7482 gets its P2699 qualifier

### DIFF
--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -3432,6 +3432,31 @@ def test_merge_sdc_onto_canonical_cross_item_passes_no_page_numbers():
     assert merge_mock.call_args.kwargs["page_numbers"] is None
 
 
+def test_merge_sdc_onto_canonical_threads_download_url_for_p2699():
+    """The merged contributor's per-ordinal download URL is threaded through to
+    merge_item_onto_canonical so its P7482 (source of file) statement gets a
+    P2699 (URL) qualifier — the same one a normally-synced file receives. P2699
+    is not stored in sdc.json (it differs per Commons file), so without this the
+    merged contributor's P7482 would land without its download URL."""
+    uploader = _build_uploader_with_dpla()
+    uploader.s3_client.get_sdc_json.return_value = "{}"
+
+    with patch("tools.sdc_sync.merge_item_onto_canonical") as merge_mock:
+        uploader._merge_sdc_onto_canonical(
+            canonical_mediaid="M42",
+            dpla_id="yyyy",
+            partner="nara",
+            page_label="3",
+            within_item=False,
+            download_url="https://s3.amazonaws.com/NARAprodstorage/x/y_01.JPG",
+        )
+
+    assert (
+        merge_mock.call_args.kwargs["download_url"]
+        == "https://s3.amazonaws.com/NARAprodstorage/x/y_01.JPG"
+    )
+
+
 def test_merge_sdc_onto_canonical_skips_when_no_staged_sdc():
     """Missing / blank sdc.json → best-effort skip, merge not attempted."""
     uploader = _build_uploader_with_dpla()

--- a/tools/uploader.py
+++ b/tools/uploader.py
@@ -710,6 +710,7 @@ class Uploader:
         duplicate_source_sha1s: set[str] | None = None,
         expected_item_titles: set[str] | None = None,
         canonical_page_numbers: list[int] | None = None,
+        download_url: str | None = None,
     ) -> dict:
         """Process one ordinal's source asset and return a per-ordinal result dict.
 
@@ -1002,6 +1003,7 @@ class Uploader:
                             within_item=True,
                             sha1=sha1,
                             canonical_page_numbers=canonical_page_numbers,
+                            download_url=download_url,
                         )
 
                     drift_action = self._resolve_hash_drift(
@@ -1058,6 +1060,7 @@ class Uploader:
                             and existing_title in expected_item_titles,
                             sha1=sha1,
                             canonical_page_numbers=canonical_page_numbers,
+                            download_url=download_url,
                         )
                     if drift_action == DriftResolution.HAND_FIX_COMMUNITY:
                         # Defense-in-depth: the resolver refused a community
@@ -2047,6 +2050,7 @@ class Uploader:
         within_item: bool,
         sha1: str,
         canonical_page_numbers: list[int] | None = None,
+        download_url: str | None = None,
     ) -> dict:
         """Rule #3 (source duplication): centralize our SHA1 onto the earliest
         existing (canonical) Commons file instead of uploading a second
@@ -2129,6 +2133,7 @@ class Uploader:
             page_label=page_label,
             within_item=within_item,
             canonical_page_numbers=canonical_page_numbers,
+            download_url=download_url,
         )
         if not merge_ok:
             logging.warning(
@@ -2200,10 +2205,18 @@ class Uploader:
         page_label: str,
         within_item: bool,
         canonical_page_numbers: list[int] | None = None,
+        download_url: str | None = None,
     ) -> tuple[bool, bool]:
         """Read this item's staged ``sdc.json`` and merge it onto the canonical
         file's MediaInfo entity via ``sdc_sync.merge_item_onto_canonical``
         (already on ``main`` from PR A).
+
+        ``download_url`` is this ordinal's direct source URL (its ``file-list.txt``
+        entry). It is threaded through so the merged contributor's P7482 (source
+        of file) statement gets its per-ordinal P2699 (URL) qualifier — the same
+        one a normally-synced file receives. P2699 is not stored in ``sdc.json``
+        (it differs per Commons file), so without this the merged contributor's
+        P7482 lands without its download URL.
 
         Imported lazily: ``tools.sdc_sync`` carries heavy module-level state
         (the ``site`` handle the merge writes through) and is only needed on
@@ -2279,6 +2292,7 @@ class Uploader:
                 dpla_id,
                 sdc_payload,
                 page_numbers=page_numbers,
+                download_url=download_url,
                 commons_site=self.site,
             )
             changed = sdc_sync._sdc_writes_total() > writes_before
@@ -2698,7 +2712,7 @@ class Uploader:
             # pageid?, error?}}.
             ordinal_results: dict[str, dict] = {}
 
-            for ordinal, _ in enumerate(
+            for ordinal, media_url in enumerate(
                 tqdm(
                     files, desc="Uploading Files", leave=False, unit="File", ncols=100
                 ),
@@ -2727,6 +2741,7 @@ class Uploader:
                         duplicate_source_sha1s=duplicate_source_sha1s,
                         expected_item_titles=expected_item_titles,
                         canonical_page_numbers=ordinal_pages,
+                        download_url=media_url,
                     )
                     # process_file always returns a dict, but guard defensively:
                     # a NoneType here would crash the whole item's upload loop.


### PR DESCRIPTION
## Problem

When a duplicate DPLA item is centralized onto a canonical Commons file (rule #3, `merge_and_redirect`), the merged contributor's **P7482** (*source of file*) statement lands **without its P2699** (*direct download URL*) qualifier. The canonical owner's own P7482 has one; the merged-in contributor's does not.

Live example — [File:B. P. Coston's Patent Drawing for Chopping Meat and Pulverizing](https://commons.wikimedia.org/wiki/File:B._P._Coston%27s_Patent_Drawing_for_Chopping_Meat_and_Pulverizing_-_DPLA_-_d5d7ee74764bc75852f5dcc0365bba91.jpg): the merged item `0ec536…`'s P7482 carries `P973` (catalog URL) + `P137` (operator) but no `P2699`.

## Root cause

`P2699` is per-Commons-file and is **intentionally not stored in `sdc.json`** (`ingest_wikimedia/sdc.py`, `_build_source_claim`) — it differs per file, so it is materialized at sync-write time, and only when a `download_url` is supplied to `process_one_from_sdc`:

```python
# tools/sdc_sync.py
if prop == "P7482" and download_url:
    claim...["qualifiers"]["P2699"] = [ ... download_url ... ]
```

The uploader's dedup/merge path (`_merge_sdc_onto_canonical` → `merge_item_onto_canonical`) passed **no** `download_url`, so the merged contributor's P7482 never received it. The canonical owner got its P2699 from *its own* normal upload/sync; a merged-in contributor never goes through that path — and a re-run does **not** self-heal, because the merge still passes `None`.

## Fix

Thread the ordinal's source URL (its `file-list.txt` entry — the *same* value `process_one_from_sdc` uses for its own P2699) from `process_item`'s loop through the merge chain:

`process_item` (loop var, previously discarded `_`) → `process_file(download_url=)` → `_merge_and_redirect(download_url=)` → `_merge_sdc_onto_canonical(download_url=)` → `sdc_sync.merge_item_onto_canonical(download_url=)`

This is the **identical chain** `canonical_page_numbers` already travels. `merge_item_onto_canonical` already accepted `download_url` and materializes P2699 from it — this PR only supplies the value.

## Scope

Not related to the reference-reconciliation fix in #422 — this is the #408 PR-C+D dedup path. Severity is low (the file is still correctly sourced via P973 + P137, and the canonical's own download URL is present); this restores parity so a merged contributor's P7482 looks like a normally-synced file's.

## Tests

`test_merge_sdc_onto_canonical_threads_download_url_for_p2699` asserts the uploader forwards `download_url` into `merge_item_onto_canonical`. The downstream P2699 materialization from `download_url` is already covered by `test_amend_p7482_adds_missing_p2699_and_p6108`. Full suite **1344 passed**, ruff clean, `simplify` reviewed (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Threads each ordinal’s source download URL through the uploader’s merge path so merged P7482 statements receive the P2699 direct-download qualifier.
- Adds coverage verifying `download_url` forwarding to `merge_item_onto_canonical`.
- Validation: 1,344 tests passed; ruff is clean.

## Impact

- No manual pipeline trigger or ECS redeployment required.
- No environment variables or AWS Secrets Manager keys changed.
- No database migration.
- No shared infrastructure configuration changed.
- No public API response shapes or endpoints changed.
- No security-sensitive behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->